### PR TITLE
Document how clearing tasks works with task state store on durable operators

### DIFF
--- a/providers/amazon/docs/operators/redshift/redshift_data.rst
+++ b/providers/amazon/docs/operators/redshift/redshift_data.rst
@@ -99,6 +99,12 @@ the statement id won't be there for the next retry, and the operator will submit
 instead of reconnecting. Avoid running cleanup on a schedule shorter than your longest
 ``retry_delay``.
 
+Clearing a task is treated the same as a retry, which matters specifically for a task whose
+statement already succeeded: clearing does not delete the stored statement id, so the next attempt
+reads it back and returns immediately without submitting the SQL again. See
+:doc:`apache-airflow:core-concepts/resumable-tasks` for why, and for the
+``[state_store] clear_on_success`` setting that restores "clearing always resubmits."
+
 To opt out and always submit fresh SQL on retry, set ``durable=False``:
 
 .. code-block:: python

--- a/providers/amazon/docs/operators/redshift/redshift_data.rst
+++ b/providers/amazon/docs/operators/redshift/redshift_data.rst
@@ -105,6 +105,10 @@ reads it back and returns immediately without submitting the SQL again. See
 :doc:`apache-airflow:core-concepts/resumable-tasks` for why, and for the
 ``[state_store] clear_on_success`` setting that restores "clearing always resubmits."
 
+This is most reliable for deferred tasks (``deferrable=True``); clearing a task that's actively
+polling synchronously can cancel the statement via ``on_kill`` before the next attempt gets a
+chance to reconnect -- see :doc:`apache-airflow:core-concepts/resumable-tasks` for why.
+
 To opt out and always submit fresh SQL on retry, set ``durable=False``:
 
 .. code-block:: python

--- a/providers/apache/spark/docs/operators.rst
+++ b/providers/apache/spark/docs/operators.rst
@@ -215,6 +215,12 @@ See :doc:`connections/spark-submit` for how to configure these fields.
     Crash recovery in cluster mode requires Airflow 3.3+ (``task_state_store`` support). On earlier
     versions the operator falls back to the previous behavior of always submitting fresh.
 
+Clearing a task is treated the same as a retry, which matters specifically for a task whose driver
+already succeeded: clearing does not delete the stored driver ID, so the next attempt reads it
+back and returns immediately without resubmitting. See
+:doc:`apache-airflow:core-concepts/resumable-tasks` for why, and for the
+``[state_store] clear_on_success`` setting that restores "clearing always resubmits."
+
 Tracking driver status via Kubernetes API
 """"""""""""""""""""""""""""""""""""""""""
 

--- a/providers/apache/spark/docs/operators.rst
+++ b/providers/apache/spark/docs/operators.rst
@@ -221,6 +221,10 @@ back and returns immediately without resubmitting. See
 :doc:`apache-airflow:core-concepts/resumable-tasks` for why, and for the
 ``[state_store] clear_on_success`` setting that restores "clearing always resubmits."
 
+This is most reliable for deferred tasks (``deferrable=True``); clearing a task that's actively
+polling synchronously can cancel the driver via ``on_kill`` before the next attempt gets a chance
+to reconnect -- see :doc:`apache-airflow:core-concepts/resumable-tasks` for why.
+
 Tracking driver status via Kubernetes API
 """"""""""""""""""""""""""""""""""""""""""
 

--- a/providers/databricks/docs/operators/run_now.rst
+++ b/providers/databricks/docs/operators/run_now.rst
@@ -118,6 +118,10 @@ and returns immediately without triggering a new run. See
 :doc:`apache-airflow:core-concepts/resumable-tasks` for why, and for the
 ``[state_store] clear_on_success`` setting that restores "clearing always resubmits."
 
+This is most reliable for deferred tasks (``deferrable=True``); clearing a task that's actively
+polling synchronously can cancel the run via ``on_kill`` before the next attempt gets a chance to
+reconnect -- see :doc:`apache-airflow:core-concepts/resumable-tasks` for why.
+
 To opt out and always trigger a fresh run on retry, set ``durable=False``:
 
 .. code-block:: python

--- a/providers/databricks/docs/operators/run_now.rst
+++ b/providers/databricks/docs/operators/run_now.rst
@@ -112,6 +112,12 @@ when someone runs ``airflow state-store clean``. If a task's ``retry_delay`` is 
 run id won't be there for the next retry, and the operator will trigger a fresh run instead of
 reconnecting. Avoid running cleanup on a schedule shorter than your longest ``retry_delay``.
 
+Clearing a task is treated the same as a retry, which matters specifically for a task whose run
+already succeeded: clearing does not delete the stored run id, so the next attempt reads it back
+and returns immediately without triggering a new run. See
+:doc:`apache-airflow:core-concepts/resumable-tasks` for why, and for the
+``[state_store] clear_on_success`` setting that restores "clearing always resubmits."
+
 To opt out and always trigger a fresh run on retry, set ``durable=False``:
 
 .. code-block:: python

--- a/providers/databricks/docs/operators/submit_run.rst
+++ b/providers/databricks/docs/operators/submit_run.rst
@@ -196,6 +196,10 @@ and returns immediately without submitting a new run. See
 :doc:`apache-airflow:core-concepts/resumable-tasks` for why, and for the
 ``[state_store] clear_on_success`` setting that restores "clearing always resubmits."
 
+This is most reliable for deferred tasks (``deferrable=True``); clearing a task that's actively
+polling synchronously can cancel the run via ``on_kill`` before the next attempt gets a chance to
+reconnect -- see :doc:`apache-airflow:core-concepts/resumable-tasks` for why.
+
 To opt out and always submit a fresh run on retry, set ``durable=False``:
 
 .. code-block:: python

--- a/providers/databricks/docs/operators/submit_run.rst
+++ b/providers/databricks/docs/operators/submit_run.rst
@@ -190,6 +190,12 @@ when someone runs ``airflow state-store clean``. If a task's ``retry_delay`` is 
 run id won't be there for the next retry, and the operator will submit a fresh run instead of
 reconnecting. Avoid running cleanup on a schedule shorter than your longest ``retry_delay``.
 
+Clearing a task is treated the same as a retry, which matters specifically for a task whose run
+already succeeded: clearing does not delete the stored run id, so the next attempt reads it back
+and returns immediately without submitting a new run. See
+:doc:`apache-airflow:core-concepts/resumable-tasks` for why, and for the
+``[state_store] clear_on_success`` setting that restores "clearing always resubmits."
+
 To opt out and always submit a fresh run on retry, set ``durable=False``:
 
 .. code-block:: python

--- a/providers/snowflake/docs/operators/snowflake.rst
+++ b/providers/snowflake/docs/operators/snowflake.rst
@@ -189,6 +189,12 @@ between, the handles won't be there for the next retry, and the operator will su
 fresh instead of reconnecting. Avoid running cleanup on a schedule shorter than your longest
 ``retry_delay``.
 
+Clearing a task is treated the same as a retry, which matters specifically for a task whose
+statements already succeeded: clearing does not delete the stored handles, so the next attempt
+reads them back and returns immediately without submitting the SQL again. See
+:doc:`apache-airflow:core-concepts/resumable-tasks` for why, and for the
+``[state_store] clear_on_success`` setting that restores "clearing always resubmits."
+
 To opt out and always submit fresh SQL on retry, set ``durable=False``:
 
 .. code-block:: python

--- a/providers/snowflake/docs/operators/snowflake.rst
+++ b/providers/snowflake/docs/operators/snowflake.rst
@@ -195,6 +195,10 @@ reads them back and returns immediately without submitting the SQL again. See
 :doc:`apache-airflow:core-concepts/resumable-tasks` for why, and for the
 ``[state_store] clear_on_success`` setting that restores "clearing always resubmits."
 
+This is most reliable for deferred tasks (``deferrable=True``); clearing a task that's actively
+polling synchronously can cancel the statements via ``on_kill`` before the next attempt gets a
+chance to reconnect -- see :doc:`apache-airflow:core-concepts/resumable-tasks` for why.
+
 To opt out and always submit fresh SQL on retry, set ``durable=False``:
 
 .. code-block:: python


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

Same as https://github.com/apache/airflow/pull/71356 but for providers.

Clearing a task whose external job already succeeded returns without resubmitting, since state store rows survive a clear. Rather than duplicate the explanation per operator, each doc gets a one-line pointer to the shared core-concepts writeup, plus the `clear_on_success` setting that restores "clearing always resubmits."

Touches `SparkSubmitOperator`, `RedshiftDataOperator`, `DatabricksRunNowOperator`, `DatabricksSubmitRunOperator`, and `SnowflakeSqlApiOperator`.


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
