### PR TITLE
Fix 500 when combining last-run and any-run Dag state filters

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/parameters.py
+++ b/airflow-core/src/airflow/api_fastapi/common/parameters.py
@@ -39,6 +39,7 @@ from pydantic import AfterValidator, BaseModel, NonNegativeInt
 from sqlalchemy import Column, String, and_, func, not_, or_, select as sql_select, true as sql_true
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.inspection import inspect
+from sqlalchemy.orm import aliased
 from sqlalchemy.sql.functions import FunctionElement
 
 from airflow._shared.timezones import timezone
@@ -1480,10 +1481,13 @@ class _AnyDagRunStateFilter(BaseParam[DagRunState | None]):
         if self.value is None and self.skip_none:
             return select
 
-        # EXISTS resolves each Dag via the (dag_id, state) index instead of scanning every run in the state.
+        # Alias DagRun so this EXISTS subquery cannot auto-correlate to a DagRun the outer query
+        # may already reference (e.g. the last_dag_run_state filter), which would strip the
+        # subquery's FROM and raise. EXISTS resolves each Dag via the (dag_id, state) index.
+        any_run = aliased(DagRun)
         has_run_in_state = (
-            sql_select(DagRun.dag_id)
-            .where(DagRun.dag_id == DagModel.dag_id, DagRun.state == self.value)
+            sql_select(any_run.dag_id)
+            .where(any_run.dag_id == DagModel.dag_id, any_run.state == self.value)
             .exists()
         )
         return select.where(has_run_in_state)

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dags.py
@@ -175,6 +175,24 @@ class TestGetDagRuns(TestPublicDagEndpoint):
         assert any_state.status_code == 200
         assert [dag["dag_id"] for dag in any_state.json()["dags"]] == [DAG1_ID]
 
+    @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
+    def test_last_and_any_run_state_filters_combined(self, test_client, session):
+        # Regression: combining the last-run and any-run state filters must return the
+        # intersection, not raise. The any-run EXISTS subquery must not correlate to the
+        # DagRun the last-run filter joins into the outer query.
+        latest_run = session.scalar(
+            select(DagRun).where(DagRun.dag_id == DAG1_ID, DagRun.run_id == "run_id_5")
+        )
+        latest_run.state = DagRunState.FAILED
+        session.commit()
+
+        response = test_client.get(
+            "/dags",
+            params={"last_dag_run_state": "failed", "dag_run_state": "failed", "dag_ids": [DAG1_ID]},
+        )
+        assert response.status_code == 200
+        assert [dag["dag_id"] for dag in response.json()["dags"]] == [DAG1_ID]
+
     @pytest.fixture
     def setup_hitl_data(self, create_task_instance: TaskInstance, session: Session):
         """Setup HITL test data for parametrized tests."""


### PR DESCRIPTION
The Dags list supports two run-state filters: `last_dag_run_state` (the Dag's latest run is in the state) and `dag_run_state` (the Dag has any run in the state). Applying both at once (e.g. `failed` + `failed`) returned a **500** instead of the intersection.

**Cause:** the any-run filter (`_AnyDagRunStateFilter`) built its `EXISTS` subquery with an un-aliased `DagRun`. When the outer query also references `DagRun` (the `last_dag_run_state` filter adds `WHERE DagRun.state == …`), SQLAlchemy auto-correlates the subquery's `DagRun` to the outer one, stripping the subquery's FROM and raising `InvalidRequestError` -> 500. Each filter alone worked, which is why it slipped through.

**Fix:** alias `DagRun` in the subquery so it resolves its own runs independently of the outer query. The combined filter now returns the intersection.

Added a regression test covering the combined case (the existing tests only exercised each filter separately).

The any-run-state filter is new (related: #70292, #70293), so this needs to ride along to 3.3.1 via the backport label.


closes: https://github.com/apache/airflow/issues/71367
##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)