### PR TITLE
Add preset filters to the Dags list page

### DIFF
--- a/airflow-core/src/airflow/ui/src/constants/localStorage.test.ts
+++ b/airflow-core/src/airflow/ui/src/constants/localStorage.test.ts
@@ -18,7 +18,11 @@
  */
 import { afterEach, describe, expect, it } from "vitest";
 
-import { pruneLegacyDependencyKeys, SHOW_ALL_DEPENDENCIES_KEY } from "./localStorage";
+import {
+  pruneLegacyDependencyKeys,
+  pruneLegacyTagFilterKeys,
+  SHOW_ALL_DEPENDENCIES_KEY,
+} from "./localStorage";
 
 describe("pruneLegacyDependencyKeys", () => {
   afterEach(() => {
@@ -46,6 +50,32 @@ describe("pruneLegacyDependencyKeys", () => {
     pruneLegacyDependencyKeys();
 
     expect(globalThis.localStorage.getItem(SHOW_ALL_DEPENDENCIES_KEY)).toBe("false");
+    expect(globalThis.localStorage.length).toBe(1);
+  });
+});
+
+describe("pruneLegacyTagFilterKeys", () => {
+  afterEach(() => {
+    globalThis.localStorage.clear();
+  });
+
+  it("removes the legacy tag-filter keys, leaving everything else intact", () => {
+    globalThis.localStorage.setItem("tags", JSON.stringify(["a", "b"]));
+    globalThis.localStorage.setItem("tags_match_mode", JSON.stringify("all"));
+    globalThis.localStorage.setItem(SHOW_ALL_DEPENDENCIES_KEY, "true");
+
+    pruneLegacyTagFilterKeys();
+
+    expect(globalThis.localStorage.getItem("tags")).toBeNull();
+    expect(globalThis.localStorage.getItem("tags_match_mode")).toBeNull();
+    expect(globalThis.localStorage.getItem(SHOW_ALL_DEPENDENCIES_KEY)).toBe("true");
+  });
+
+  it("is a no-op when there are no legacy keys", () => {
+    globalThis.localStorage.setItem(SHOW_ALL_DEPENDENCIES_KEY, "false");
+
+    pruneLegacyTagFilterKeys();
+
     expect(globalThis.localStorage.length).toBe(1);
   });
 });

--- a/airflow-core/src/airflow/ui/src/constants/localStorage.ts
+++ b/airflow-core/src/airflow/ui/src/constants/localStorage.ts
@@ -62,3 +62,11 @@ export const pruneLegacyDependencyKeys = (storage: Storage = globalThis.localSto
 
   staleKeys.forEach((key) => storage.removeItem(key));
 };
+
+// One-time cleanup of the per-browser tag-filter persistence (`tags` / `tags_match_mode`) that
+// predates preset filters (#63273). Tags are URL-driven now like every other filter, and preset
+// filters own cross-navigation persistence, so these keys are stale.
+export const pruneLegacyTagFilterKeys = (storage: Storage = globalThis.localStorage): void => {
+  storage.removeItem("tags");
+  storage.removeItem("tags_match_mode");
+};

--- a/airflow-core/src/airflow/ui/src/main.tsx
+++ b/airflow-core/src/airflow/ui/src/main.tsx
@@ -29,7 +29,7 @@ import * as ReactRouterDOM from "react-router-dom";
 import * as ReactJSXRuntime from "react/jsx-runtime";
 
 import type { HTTPExceptionResponse } from "openapi/requests/types.gen";
-import { pruneLegacyDependencyKeys } from "src/constants/localStorage";
+import { pruneLegacyDependencyKeys, pruneLegacyTagFilterKeys } from "src/constants/localStorage";
 import { ChakraCustomProvider } from "src/context/ChakraCustomProvider";
 import { ColorModeProvider } from "src/context/colorMode";
 import { ShortcutRegistryProvider } from "src/context/keyboardShortcuts";
@@ -97,6 +97,7 @@ axios.interceptors.response.use(
 );
 
 pruneLegacyDependencyKeys();
+pruneLegacyTagFilterKeys();
 
 createRoot(document.querySelector("#root") as HTMLDivElement).render(
   <StrictMode>

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/DagsFilters.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/DagsFilters.test.tsx
@@ -143,4 +143,10 @@ describe("Paused filter with hide_paused_dags_by_default enabled", () => {
 
     expect(await screen.findByLabelText("dagDetails.team")).toBeInTheDocument();
   });
+
+  it("renders the preset filters menu", async () => {
+    render(<AppWrapper initialEntries={["/dags"]} />);
+
+    expect(await screen.findByTestId("preset-filters-button")).toBeInTheDocument();
+  });
 });

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/DagsFilters.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/DagsFilters.tsx
@@ -16,12 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, HStack } from "@chakra-ui/react";
+import { HStack } from "@chakra-ui/react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSearchParams } from "react-router-dom";
 
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
+import { PresetFiltersMenu } from "src/components/PresetFiltersMenu";
 import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
 import { useConfig } from "src/queries/useConfig";
 import { useDagTagsInfinite } from "src/queries/useDagTagsInfinite";
@@ -233,9 +234,8 @@ export const DagsFilters = () => {
       {multiTeamEnabled ? (
         <TeamFilter onChange={handleTeamsChange} selectedTeams={selectedTeams} />
       ) : undefined}
-      <Box marginInlineStart="auto">
-        <FavoriteFilter onChange={handleFavoriteChange} value={favoriteValue} />
-      </Box>
+      <FavoriteFilter onChange={handleFavoriteChange} value={favoriteValue} />
+      <PresetFiltersMenu />
     </HStack>
   );
 };

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/useTagFilter.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/useTagFilter.test.tsx
@@ -63,46 +63,16 @@ describe("useTagFilter — initial state", () => {
     expect(result.current.tagFilterMode).toBe("all");
   });
 
-  it("falls back to localStorage when URL has no tags", () => {
+  it("ignores legacy tag values left in localStorage (URL is the only source)", () => {
     localStorage.setItem("tags", JSON.stringify(["saved-tag-1", "saved-tag-2"]));
-
-    const { result } = renderHook(() => useTagFilter(), {
-      wrapper: createWrapper(),
-    });
-
-    expect(result.current.selectedTags).toEqual(["saved-tag-1", "saved-tag-2"]);
-  });
-
-  it("restores match mode from localStorage when using saved tags with 2+ tags", () => {
-    localStorage.setItem("tags", JSON.stringify(["tag-a", "tag-b"]));
     localStorage.setItem("tags_match_mode", JSON.stringify("all"));
 
     const { result } = renderHook(() => useTagFilter(), {
       wrapper: createWrapper(),
     });
 
-    expect(result.current.tagFilterMode).toBe("all");
-  });
-
-  it("restores match mode from localStorage even with fewer than 2 tags", () => {
-    localStorage.setItem("tags", JSON.stringify(["only-one"]));
-    localStorage.setItem("tags_match_mode", JSON.stringify("all"));
-
-    const { result } = renderHook(() => useTagFilter(), {
-      wrapper: createWrapper(),
-    });
-
-    expect(result.current.tagFilterMode).toBe("all");
-  });
-
-  it("URL tags take precedence over localStorage", () => {
-    localStorage.setItem("tags", JSON.stringify(["saved-tag"]));
-
-    const { result } = renderHook(() => useTagFilter(), {
-      wrapper: createWrapper(["/?tags=url-tag"]),
-    });
-
-    expect(result.current.selectedTags).toEqual(["url-tag"]);
+    expect(result.current.selectedTags).toEqual([]);
+    expect(result.current.tagFilterMode).toBe("any");
   });
 });
 
@@ -119,16 +89,16 @@ describe("useTagFilter — setSelectedTags", () => {
     expect(result.current.selectedTags).toEqual(["new-tag-1", "new-tag-2"]);
   });
 
-  it("saves tags to localStorage", () => {
+  it("does not persist tags to localStorage", () => {
     const { result } = renderHook(() => useTagFilter(), {
       wrapper: createWrapper(),
     });
 
     act(() => {
-      result.current.setSelectedTags(["persisted-tag"]);
+      result.current.setSelectedTags(["some-tag"]);
     });
 
-    expect(JSON.parse(localStorage.getItem("tags") ?? "[]")).toEqual(["persisted-tag"]);
+    expect(localStorage.getItem("tags")).toBeNull();
   });
 
   it("clears tags when given empty array", () => {
@@ -211,7 +181,7 @@ describe("useTagFilter — setTagFilterMode", () => {
     expect(result.current.tagFilterMode).toBe("all");
   });
 
-  it("persists mode to localStorage", () => {
+  it("does not persist mode to localStorage", () => {
     const { result } = renderHook(() => useTagFilter(), {
       wrapper: createWrapper(["/?tags=a&tags=b"]),
     });
@@ -220,7 +190,7 @@ describe("useTagFilter — setTagFilterMode", () => {
       result.current.setTagFilterMode("all");
     });
 
-    expect(JSON.parse(localStorage.getItem("tags_match_mode") ?? '"any"')).toBe("all");
+    expect(localStorage.getItem("tags_match_mode")).toBeNull();
   });
 });
 

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/useTagFilter.ts
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/useTagFilter.ts
@@ -17,7 +17,6 @@
  * under the License.
  */
 import { useSearchParams } from "react-router-dom";
-import { useLocalStorage } from "usehooks-ts";
 
 import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
 
@@ -27,20 +26,10 @@ type TagMatchMode = "all" | "any";
 
 export const useTagFilter = () => {
   const [searchParams, setSearchParams] = useSearchParams();
-  const [savedTags, setSavedTags] = useLocalStorage<Array<string>>(TAGS, []);
-  const [savedTagMatchMode, setSavedTagMatchMode] = useLocalStorage<TagMatchMode>(TAGS_MATCH_MODE, "any");
 
-  const urlTags = searchParams.getAll(TAGS);
+  const selectedTags = searchParams.getAll(TAGS);
   const urlMatchMode = searchParams.get(TAGS_MATCH_MODE);
-
-  // URL params take precedence; fall back to localStorage when URL has no tags.
-  const selectedTags = urlTags.length > 0 ? urlTags : savedTags;
-  const tagFilterMode: TagMatchMode =
-    urlMatchMode === null
-      ? urlTags.length === 0
-        ? savedTagMatchMode
-        : "any"
-      : (urlMatchMode as TagMatchMode);
+  const tagFilterMode: TagMatchMode = urlMatchMode === null ? "any" : (urlMatchMode as TagMatchMode);
 
   const setSelectedTags = (tags: Array<string>) => {
     searchParams.delete(TAGS);
@@ -49,14 +38,12 @@ export const useTagFilter = () => {
     });
     searchParams.delete(OFFSET);
     setSearchParams(searchParams);
-    setSavedTags(tags);
   };
 
   const setTagFilterMode = (mode: TagMatchMode) => {
     searchParams.set(TAGS_MATCH_MODE, mode);
     searchParams.delete(OFFSET);
     setSearchParams(searchParams);
-    setSavedTagMatchMode(mode);
   };
 
   return { selectedTags, setSelectedTags, setTagFilterMode, tagFilterMode };


### PR DESCRIPTION

The Dags list page hand-rolls its own filter row (`DagsFilters`) rather than going through the shared `FilterBar`, so the save/restore/pin-default views added in #68484 never reached it. Users reported that filters like status / run state / favorites / needs-review reset on every navigation away from `/dags` (issue #66933).

`PresetFiltersMenu` already reads and writes `useSearchParams` and persists per `pathname` to `localStorage` — no FilterBar-specific plumbing. It drops into `DagsFilters` unchanged. Every Dags-page filter (`paused`, `favorite`, `last_dag_run_state`, `dag_run_state`, `needs_review`, `tags`, `tags_match_mode`, `teams`, `timetable_type`, `name_pattern`) is already a URL param, so a saved preset restores them faithfully; the table sort is captured by the same `tableSortKey(pathname)` side-channel `PresetFiltersMenu` already uses on other pages.

For that faithful restore to actually hold, the `tags` filter needed one fix: it also persisted its selection to `localStorage` (added in #63273) which isn't consistent with how other filters behave, which shadowed the URL — applying a preset that omitted tags kept the previously selected tags instead of clearing them. Preset filters now own cross-navigation persistence for every filter, so this PR drops the tag-specific `localStorage` persistence (`tags` / `tags_match_mode` are purely URL-driven like the rest) and prunes the now-stale keys from users' browsers on load (`pruneLegacyTagFilterKeys`, mirroring the existing `pruneLegacyDependencyKeys`).

The bookmark button sits at the far-right end of the `DagsFilters` row, grouped with the Favorite filter so the two stay on the same line, mirroring where it sits on `FilterBar`-based pages.

closes: #66933

<!--
Screenshots omitted: visual verification against a running dev server was blocked
by local infra issues (react-syntax-highlighter@16 / refractor@5 ESM interop under
vitest; dayjs.tz init order in `vite preview` on this workspace). The mounted
component is identical to the `PresetFiltersMenu` that already ships on FilterBar
pages via #68484, so the visual is unchanged — it just appears one more place.
-->

https://github.com/user-attachments/assets/c6ade57b-2695-4afb-926a-1f82a3076673



##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
