### PR TITLE
fix(kubernetes): do not fail task when xcom sidecar kill fails after successful XCom read

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -987,7 +987,13 @@ class PodManager(LoggingMixin):
             result = self.extract_xcom_json(pod)
             return result
         finally:
-            self.extract_xcom_kill(pod)
+            try:
+                self.extract_xcom_kill(pod)
+            except PodCommandException:
+                self.log.warning(
+                    "Failed to kill xcom sidecar container; XCom value was already successfully retrieved.",
+                    exc_info=True,
+                )
 
     @generic_api_retry
     def extract_xcom_json(self, pod: V1Pod) -> str:

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
@@ -1292,8 +1292,30 @@ class TestPodManager:
             match=r"container is not running! Not possible to read xcom from pod:",
         ):
             self.pod_manager.extract_xcom(pod=mock_pod)
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.kubernetes_stream")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.extract_xcom_kill")
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.container_is_running",
+        return_value=True,
+    )
+    def test_extract_xcom_kill_failure_does_not_fail_task(
+        self, mock_container_is_running, mock_exec_xcom_kill, mock_kubernetes_stream
+    ):
+        """test that XCom value is returned even when extract_xcom_kill raises PodCommandException."""
+        from airflow.providers.cncf.kubernetes.utils.pod_manager import PodCommandException
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.container_is_terminated")
+        xcom_json = """{"a": "true"}"""
+        mock_pod = MagicMock()
+        mock_client = MagicMock()
+        mock_client.peek_stderr.return_value = ""
+        mock_client.read_all.return_value = xcom_json
+        mock_kubernetes_stream.return_value = mock_client
+        mock_exec_xcom_kill.side_effect = PodCommandException("Permission denied")
+        ret = self.pod_manager.extract_xcom(pod=mock_pod)
+        assert ret == xcom_json
+        assert mock_exec_xcom_kill.call_count == 1
+
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.container_is_terminated")    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.container_is_terminated")
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.container_is_running")
     def test_await_xcom_sidecar_container_timeout(
         self, mock_container_is_running, mock_container_is_terminated


### PR DESCRIPTION
### Issue

Closes #71369

### Problem

When `KubernetesPodOperator` is used with `do_xcom_push=True`, the XCom sidecar container starts and the XCom value is **read successfully** from `/airflow/xcom/return.json`. However, the subsequent `extract_xcom_kill` step attempts to terminate the sidecar via `kill -2` over `kubectl exec`, which fails with `Permission denied` on certain container runtimes (e.g., k3s/containerd).

Because `extract_xcom_kill` is called in the `finally` block of `extract_xcom`, the `PodCommandException` propagates and **discards the already-retrieved XCom value**, causing the task to be marked as `Failed` despite the payload being successfully read.

### Fix

Wrap `extract_xcom_kill` in an inner try/except in the `finally` block. Since the XCom value has already been successfully retrieved, a failure to clean up the sidecar is a non-fatal issue — the sidecar will be cleaned up when the pod is deleted (per `on_finish_action`). The exception is logged as a warning instead of failing the task.

### Test

Added `test_extract_xcom_kill_failure_does_not_fail_task` which verifies that when `extract_xcom_kill` raises `PodCommandException`, the `extract_xcom` method still returns the successfully-read XCom value.