### PR TITLE
Sync drifted generated files on v3-3-test (samba docs, uv.lock specifiers)

### DIFF
--- a/providers/samba/docs/index.rst
+++ b/providers/samba/docs/index.rst
@@ -104,8 +104,8 @@ PIP package                                 Version required
 ``smbprotocol``                             ``>=1.5.0``
 ==========================================  ==================
 
-Optional cross provider package dependencies
---------------------------------------------
+Cross provider package dependencies
+-----------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -114,32 +114,15 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-samba[google]
+    pip install apache-airflow-providers-samba[common.compat]
 
 
-====================================================================================================  ==========
-Dependent package                                                                                     Extra
-====================================================================================================  ==========
-`apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_  ``google``
-====================================================================================================  ==========
-
-Optional dependencies
----------------------
-
-These extras install optional third-party libraries that enable additional features of the provider.
-Install them when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-samba[google]
-
-
-============  =================================================
-Extra         Dependencies
-============  =================================================
-``google``    ``apache-airflow-providers-google``
-``kerberos``  ``krb5>=0.8.0``, ``smbprotocol[kerberos]>=1.5.0``
-============  =================================================
+==================================================================================================================  =================
+Dependent package                                                                                                   Extra
+==================================================================================================================  =================
+`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
+`apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_                ``google``
+==================================================================================================================  =================
 
 Downloading official packages
 -----------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -2952,7 +2952,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "akeyless", specifier = ">=5.0.0" },
-    { name = "akeyless-cloud-id", marker = "extra == 'cloud-id'" },
+    { name = "akeyless-cloud-id", marker = "extra == 'cloud-id'", specifier = ">=0.3.0" },
     { name = "apache-airflow", editable = "." },
     { name = "apache-airflow-providers-common-compat", editable = "providers/common/compat" },
 ]
@@ -3906,7 +3906,7 @@ dev = [
     { name = "apache-airflow-providers-common-compat", editable = "providers/common/compat" },
     { name = "apache-airflow-providers-openlineage", editable = "providers/openlineage" },
     { name = "apache-airflow-task-sdk", editable = "task-sdk" },
-    { name = "pyspark" },
+    { name = "pyspark", specifier = ">=4.0.0" },
 ]
 docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "devel-common" }]
 
@@ -4442,7 +4442,7 @@ dev = [
     { name = "llama-index-embeddings-openai", specifier = ">=0.6.0" },
     { name = "llama-index-llms-openai", specifier = ">=0.6.0" },
     { name = "pydantic-ai-skills", specifier = ">=0.11.0" },
-    { name = "pydantic-ai-slim", extras = ["mcp"] },
+    { name = "pydantic-ai-slim", extras = ["mcp"], specifier = ">=2.0.0" },
     { name = "sqlglot", specifier = ">=30.0.0" },
 ]
 docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "devel-common" }]
@@ -8330,7 +8330,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest" }]
+dev = [{ name = "pytest", specifier = ">=9.1.1" }]
 
 [[package]]
 name = "apache-airflow-scripts"


### PR DESCRIPTION
`v3-3-test` HEAD has two generated files out of sync with their generators, which fails the full-repo static-check on **every** v3-3-test PR (e.g. #71371):

- `providers/samba/docs/index.rst` — regenerated by `update-providers-build-files` (samba's cross-provider deps moved `google` -> `common.compat` without the docs being regenerated).
- `uv.lock` — `uv lock` fills in dev-dependency specifiers (`pyspark>=4.0.0`, `pydantic-ai-slim[mcp]>=2.0.0`, `pytest>=9.1.1`) that the pyprojects already declare.

Both reproduce on clean `v3-3-test` (no other changes), so this is pre-existing branch drift, not any single PR. This just runs the generators and commits their output to unblock the branch.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)