### PR TITLE
Add ConnectionNotFoundError to the TypeScript SDK

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/language-sdks/typescript.rst
+++ b/airflow-core/docs/authoring-and-scheduling/language-sdks/typescript.rst
@@ -174,7 +174,9 @@ The ``TaskClient`` surface
   with no default.
 * ``getConnection(connId)`` — returns a ``ConnectionResult`` with fields ``id`` and ``type``, plus the
   optional fields ``host``, ``schema``, ``login``, ``password``, ``port``, and ``extra`` (each may be
-  missing or ``null``), or ``null`` when the connection does not exist.
+  missing or ``null``), or ``null`` when the connection does not exist;
+  ``getConnectionOrThrow(connId)`` throws ``ConnectionNotFoundError`` instead, matching Python
+  ``BaseHook.get_connection``.
 * ``getXCom<T>({key, ...})`` — reads an XCom value, or ``null`` when it is missing. The locator fields
   (``dagId``, ``runId``, ``taskId``, ``mapIndex``) default to the current task; pass ``taskId`` to read an
   upstream task's XCom. See :ref:`typescript-sdk/types` for how the stored JSON maps to JavaScript types.

--- a/ts-sdk/README.md
+++ b/ts-sdk/README.md
@@ -177,11 +177,11 @@ Options:
 
 Every task handler receives a `TaskClient` for task-time Airflow data access:
 
-| Method                                    | Description         |
-| ----------------------------------------- | ------------------- |
-| `getVariable(key)` / `getVariableOrThrow` | Airflow Variables   |
-| `getXCom(opts)` / `setXCom(opts)`         | XCom read/write     |
-| `getConnection(connId)`                   | Airflow Connections |
+| Method                                           | Description         |
+| ------------------------------------------------ | ------------------- |
+| `getVariable(key)` / `getVariableOrThrow`        | Airflow Variables   |
+| `getXCom(opts)` / `setXCom(opts)`                | XCom read/write     |
+| `getConnection(connId)` / `getConnectionOrThrow` | Airflow Connections |
 
 Locator fields such as `dagId`, `runId`, and `taskId` default to the
 current task context when omitted.

--- a/ts-sdk/src/coordinator/client.ts
+++ b/ts-sdk/src/coordinator/client.ts
@@ -22,7 +22,7 @@ import type { LogChannel } from "./log-channel.js";
 import type { TaskContext } from "../sdk/task.js";
 import type { TaskClient } from "../sdk/client.js";
 import type { ConnectionResult, GetXComOpts, SetXComOpts } from "../sdk/client-types.js";
-import { VariableNotFoundError } from "../sdk/client.js";
+import { ConnectionNotFoundError, VariableNotFoundError } from "../sdk/client.js";
 import type {
   GetVariable,
   GetXCom,
@@ -137,6 +137,12 @@ export function createCoordinatorClient(
       return rpc("GetConnection", "ConnectionResult", msg, (body) =>
         fromWireConnection(body as unknown as WireConnectionResult),
       );
+    },
+
+    async getConnectionOrThrow(connId: string): Promise<ConnectionResult> {
+      const connection = await client.getConnection(connId);
+      if (connection == null) throw new ConnectionNotFoundError(connId);
+      return connection;
     },
   };
   return client;

--- a/ts-sdk/src/index.ts
+++ b/ts-sdk/src/index.ts
@@ -18,7 +18,7 @@
  */
 
 export { registerTask, listRegisteredTasks } from "./sdk/registry.js";
-export { VariableNotFoundError } from "./sdk/client.js";
+export { ConnectionNotFoundError, VariableNotFoundError } from "./sdk/client.js";
 export { startCoordinator, SUPERVISOR_API_VERSION } from "./coordinator/index.js";
 export type { TaskClient } from "./sdk/client.js";
 export type { ConnectionResult, GetXComOpts, JsonValue, SetXComOpts } from "./sdk/client-types.js";

--- a/ts-sdk/src/sdk/client.ts
+++ b/ts-sdk/src/sdk/client.ts
@@ -75,8 +75,20 @@ export interface TaskClient {
    *
    * Returns `null` when the connection does not exist. Throws on any other
    * error.
+   *
+   * This is intentionally JS-friendly behavior. Use
+   * {@link getConnectionOrThrow} when missing connections should raise.
    */
   getConnection(connId: string): Promise<ConnectionResult | null>;
+
+  /**
+   * Look up an Airflow Connection by ID and raise when it is missing.
+   *
+   * This matches Python `BaseHook.get_connection` behavior.
+   *
+   * @throws {@link ConnectionNotFoundError} when the connection does not exist.
+   */
+  getConnectionOrThrow(connId: string): Promise<ConnectionResult>;
 }
 
 /** Error thrown by {@link TaskClient.getVariableOrThrow}. */
@@ -84,5 +96,13 @@ export class VariableNotFoundError extends Error {
   constructor(public readonly key: string) {
     super(`Variable not found: ${key}`);
     this.name = "VariableNotFoundError";
+  }
+}
+
+/** Error thrown by {@link TaskClient.getConnectionOrThrow}. */
+export class ConnectionNotFoundError extends Error {
+  constructor(public readonly connId: string) {
+    super(`Connection not found: ${connId}`);
+    this.name = "ConnectionNotFoundError";
   }
 }

--- a/ts-sdk/tests/coordinator/client.test.ts
+++ b/ts-sdk/tests/coordinator/client.test.ts
@@ -18,6 +18,7 @@
  */
 
 import { describe, it, expect } from "vitest";
+import { ConnectionNotFoundError } from "../../src/sdk/client.js";
 import { createCoordinatorClient } from "../../src/coordinator/client.js";
 import type { CommChannel } from "../../src/coordinator/comm-channel.js";
 import type { TaskContext } from "../../src/sdk/task.js";
@@ -240,5 +241,30 @@ describe("getConnection", () => {
   it("returns null for missing connections", async () => {
     const c = client([{ body: { type: "ErrorResponse", error: "CONNECTION_NOT_FOUND" } }]);
     expect(await c.getConnection("missing")).toBeNull();
+  });
+});
+
+describe("getConnectionOrThrow", () => {
+  it("returns the connection when present", async () => {
+    const c = client([
+      { body: { type: "ConnectionResult", conn_id: "warehouse", conn_type: "postgres" } },
+    ]);
+
+    await expect(c.getConnectionOrThrow("warehouse")).resolves.toMatchObject({
+      id: "warehouse",
+      type: "postgres",
+    });
+  });
+
+  it("throws ConnectionNotFoundError on a missing connection", async () => {
+    const c = client([{ body: { type: "ErrorResponse", error: "CONNECTION_NOT_FOUND" } }]);
+    const result = c.getConnectionOrThrow("missing");
+    await expect(result).rejects.toThrow(ConnectionNotFoundError);
+    await expect(result).rejects.toThrow(/Connection not found: missing/);
+  });
+
+  it("propagates non-not-found errors instead of ConnectionNotFoundError", async () => {
+    const c = client([{ body: { type: "ErrorResponse", error: "API_SERVER_ERROR" } }]);
+    await expect(c.getConnectionOrThrow("warehouse")).rejects.toThrow(/API_SERVER_ERROR/);
   });
 });

--- a/ts-sdk/tests/public-api.test.ts
+++ b/ts-sdk/tests/public-api.test.ts
@@ -28,6 +28,7 @@ import type {
   TaskRegistration,
 } from "../src/index.js";
 import {
+  ConnectionNotFoundError,
   listRegisteredTasks,
   registerTask,
   startCoordinator,
@@ -47,6 +48,11 @@ describe("public API", () => {
     expect(err).toBeInstanceOf(Error);
     expect(err.name).toBe("VariableNotFoundError");
     expect(err.key).toBe("missing");
+
+    const connErr = new ConnectionNotFoundError("missing_conn");
+    expect(connErr).toBeInstanceOf(Error);
+    expect(connErr.name).toBe("ConnectionNotFoundError");
+    expect(connErr.connId).toBe("missing_conn");
   });
 
   it("exports the coordinator runtime entrypoint", () => {
@@ -102,6 +108,9 @@ describe("public API", () => {
     }>();
     expectTypeOf<TaskClient["getConnection"]>().toEqualTypeOf<
       (connId: string) => Promise<ConnectionResult | null>
+    >();
+    expectTypeOf<TaskClient["getConnectionOrThrow"]>().toEqualTypeOf<
+      (connId: string) => Promise<ConnectionResult>
     >();
     expectTypeOf<TaskClient["getXCom"]>().toEqualTypeOf<
       <T = unknown>(opts: GetXComOpts) => Promise<T | null>


### PR DESCRIPTION
## Why

The TS SDK `TaskClient` exposes both `getVariable` (returns `null`) and `getVariableOrThrow` (raises `VariableNotFoundError`), but Connections only had the null-returning `getConnection`, so a task that requires a Connection has to hand-write the absence check and has no typed error to catch.

## How

- `getConnectionOrThrow` is a thin wrapper over `getConnection`, exactly how `getVariableOrThrow` wraps `getVariable`.
- Purely additive: `getConnection` keeps its null-returning contract, and no wire protocol changes.
- Mirrors the Go SDK, which already ships a `ConnectionNotFound` sentinel next to `VariableNotFound`.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
