### PR TITLE
fix(pre-commit): remove invalid --project flag from prek datamodel hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1370,7 +1370,7 @@ repos:
       - id: generate-tasksdk-datamodels
         name: Generate Datamodels for TaskSDK client
         language: python
-        entry: uv run -p 3.12 --no-progress --active --group codegen --project apache-airflow-task-sdk --directory task-sdk -s dev/generate_task_sdk_models.py
+        entry: uv run -p 3.12 --no-progress --active --group codegen --directory task-sdk -s dev/generate_task_sdk_models.py
         pass_filenames: false
         files: ^airflow-core/src/airflow/api_fastapi/execution_api/.*\.py$
         require_serial: true
@@ -1379,8 +1379,8 @@ repos:
         language: python
         entry: >
           bash -c '
-          uv run -p 3.12 --no-dev --no-progress --active --group codegen --project apache-airflow-ctl --directory airflow-ctl/ datamodel-codegen &&
-           uv run -p 3.12 --no-dev --no-progress --active --group codegen --project apache-airflow-ctl --directory airflow-ctl/ datamodel-codegen --input="../airflow-core/src/airflow/api_fastapi/auth/managers/simple/openapi/v2-simple-auth-manager-generated.yaml" --output="src/airflowctl/api/datamodels/auth_generated.py"'
+          uv run -p 3.12 --no-dev --no-progress --active --group codegen --directory airflow-ctl/ datamodel-codegen &&
+           uv run -p 3.12 --no-dev --no-progress --active --group codegen --directory airflow-ctl/ datamodel-codegen --input="../airflow-core/src/airflow/api_fastapi/auth/managers/simple/openapi/v2-simple-auth-manager-generated.yaml" --output="src/airflowctl/api/datamodels/auth_generated.py"'
         pass_filenames: false
         files:
           (?x)


### PR DESCRIPTION
## Description

uv 0.12 rejects `--project` when given a distribution name instead of a project directory or `pyproject.toml`. The two `generate-*-datamodels` prek hooks in `.pre-commit-config.yaml` pass both `--project <dist-name>` (invalid) and `--directory <dir>` (correct). Since `--directory` already identifies the target, the `--project` flag is redundant and breaks `prek run` under uv 0.12.

Removed:
- `--project apache-airflow-task-sdk` from `generate-tasksdk-datamodels`
- `--project apache-airflow-ctl` from `generate-airflowctl-datamodels`

Closes #71377
