### PR TITLE
fix: allow in-flight DagRuns to continue when DAG is paused

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -726,7 +726,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 .join(TI.dag_run)
                 .where(DR.state == DagRunState.RUNNING)
                 .join(TI.dag_model)
-                .where(~DM.is_paused)
                 .where(TI.state == TaskInstanceState.SCHEDULED)
                 .where(DM.bundle_name.is_not(None))
                 .join(

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -758,7 +758,6 @@ class DagRun(Base, LoggingMixin):
             .join(DagModel, DagModel.dag_id == cls.dag_id)
             .join(BackfillDagRun, BackfillDagRun.dag_run_id == DagRun.id, isouter=True)
             .where(
-                DagModel.is_paused == false(),
                 DagModel.is_stale == false(),
             )
             .order_by(


### PR DESCRIPTION
### Problem

When a DAG is paused while it has an active (running) DagRun — e.g. one started via manual trigger before the pause, or a manual trigger on an already-paused DAG that got an initial burst of tasks dispatched — the scheduler stops scheduling further task instances for that run. The run does not fail and logs no error; it simply stalls indefinitely in `running` state with remaining tasks stuck in `scheduled`, `queued_when=None`, never sent to the executor.

This happens because `is_paused` is checked as a single gate that governs both "should new DagRuns be created" and "should ready task instances in existing DagRuns be scheduled." The two are conflated.

### Root cause

Two places filter by `is_paused` to block task scheduling, when only DagRun creation should be blocked:

1. **`scheduler_job_runner.py`** — `_executable_task_instances_to_queued()`: The task scheduling query filters out ALL task instances of paused DAGs via `.where(~DM.is_paused)`, including those belonging to already-RUNNING DagRuns.

2. **`dagrun.py`** — `get_running_dag_runs_to_examine()`: The method that selects RUNNING DagRuns for scheduling examination filters out all DagRuns of paused DAGs via `DagModel.is_paused == false()`.

### Fix

- Remove `.where(~DM.is_paused)` from the task scheduling query in `scheduler_job_runner.py`
- Remove `DagModel.is_paused == false()` from `get_running_dag_runs_to_examine()` in `dagrun.py`

**Preserved**: `DagModel.dags_needing_dagruns()` still filters by `is_paused == false()`, so paused DAGs cannot create **new** DagRuns. The `_update_dag_run_state_for_paused_dags` timer still runs every 60s for edge cases. The QUEUED DagRun filter in `dagrun.py` (line 818) also retains its `is_paused` check, so queued runs for paused DAGs are not promoted.

### Related issue

Closes #71381