### PR TITLE
Update providers metadata 2026-08-10

### DIFF
--- a/generated/provider_metadata.json
+++ b/generated/provider_metadata.json
@@ -4575,6 +4575,10 @@
         "10.20.0": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-28T06:43:08Z"
+        },
+        "10.21.0": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-10T15:32:05Z"
         }
     },
     "cohere": {
@@ -8217,6 +8221,10 @@
         "22.2.2": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-10T16:30:24Z"
+        },
+        "22.3.0": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-10T15:32:04Z"
         }
     },
     "grpc": {


### PR DESCRIPTION
Adds metadata entries for the two providers released in the 2026-08-08 wave:

- `apache-airflow-providers-cncf-kubernetes` 10.21.0
- `apache-airflow-providers-google` 22.3.0

Generated with `breeze release-management generate-providers-metadata --refresh-constraints-and-airflow-releases`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)