### PR TITLE
fix(git): fetch working copy from bare mirror before checkout to support promoting to a new tracking_ref SHA [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/providers/git/src/airflow/providers/git/bundles/git.py
+++ b/providers/git/src/airflow/providers/git/bundles/git.py
@@ -212,6 +212,7 @@ class GitDagBundle(BaseDagBundle):
                 raise RuntimeError("Error cloning repository") from e
             except InvalidGitRepositoryError as e:
                 raise RuntimeError(f"Invalid git repository at {self.repo_path}") from e
+            self.repo.remotes.origin.fetch()
             self.repo.git.checkout(self.tracking_ref)
             self._log.debug("bundle initialize", version=self.version)
             if self.version:


### PR DESCRIPTION
Closes #71388

## Problem

`GitDagBundle` supports pinning `tracking_ref` to a full commit SHA (see #69735). Rolling back to an older SHA works reliably, but **promoting** to a new SHA that was pushed after the bundle's local storage was first populated fails.

The working clone lives at a stable path (`self.repo_path`), and `_clone_repo_if_required()` only clones if that path doesn't already exist. On a restart with surviving storage, the stale working clone is reopened, not re-fetched. Only the **bare mirror** is fetched (`_clone_bare_repo_if_required`). As a result, `self.repo.git.checkout(self.tracking_ref)` in `_initialize()` raises `GitCommandError: fatal: reference is not a tree: <sha>` when the new SHA isn't yet an object in the stale working clone.

## Fix

Fetch the working copy from the bare mirror **before** the checkout call in `_initialize()`. The bare mirror is already up-to-date (fetched earlier in the same method), so this pulls the new SHA into the working clone so the checkout succeeds.

## Verification

- [x] Confirmed the failing code path: checkout runs before the working copy is refreshed in the no-version path.
- [x] The fix adds `self.repo.remotes.origin.fetch()` immediately before the checkout, matching the pattern already used in the versioned path and `refresh()`.