### PR TITLE
Retry transient deadlocks in Trigger.submit_event/submit_failure

### DIFF
--- a/airflow-core/src/airflow/models/trigger.py
+++ b/airflow-core/src/airflow/models/trigger.py
@@ -37,7 +37,7 @@ from airflow.models.base import Base
 from airflow.models.taskinstance import TaskInstance
 from airflow.serialization.enums import stringify_encoding_keys
 from airflow.triggers.base import BaseTaskEndEvent
-from airflow.utils.retries import run_with_db_retries
+from airflow.utils.retries import retry_db_transaction, run_with_db_retries
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.sqlalchemy import UtcDateTime, get_dialect_name, with_row_locks
 from airflow.utils.state import TaskInstanceState
@@ -270,12 +270,20 @@ class Trigger(Base):
 
     @classmethod
     @provide_session
+    @retry_db_transaction
     def submit_event(cls, trigger_id, event: TriggerEvent, *, session: Session = NEW_SESSION) -> None:
         """
         Fire an event.
 
         Resume all tasks that were in deferred state.
         Send an event to all assets associated to the trigger.
+
+        The per-task-instance UPDATE issued here contends with the scheduler's bulk
+        ``task_instance`` writes (e.g. ``check_trigger_timeouts``) and with other triggerer
+        replicas, so a transient MySQL/InnoDB deadlock (error 1213) is possible. Retrying the
+        transaction keeps a single deadlock from propagating up to ``handle_events`` and killing
+        the triggerer process. The retried body re-reads the still-deferred rows, so it is
+        idempotent. See https://github.com/apache/airflow/issues/65818.
         """
         # Resume deferred tasks
         for task_instance in session.scalars(
@@ -305,6 +313,7 @@ class Trigger(Base):
 
     @classmethod
     @provide_session
+    @retry_db_transaction
     def submit_failure(cls, trigger_id, exc=None, *, session: Session = NEW_SESSION) -> None:
         """
         When a trigger has failed unexpectedly, mark everything that depended on it as failed.
@@ -316,6 +325,11 @@ class Trigger(Base):
         We use a special __fail__ value for next_method to achieve this that
         the runtime code understands as immediate-fail, and pack the error into
         next_kwargs.
+
+        Like :meth:`submit_event`, this mutates ``task_instance`` rows that the scheduler and
+        other triggerer replicas write concurrently, so the transaction is retried on a transient
+        deadlock instead of letting it take down the triggerer. See
+        https://github.com/apache/airflow/issues/65818.
         """
         for task_instance in session.scalars(
             select(TaskInstance).where(

--- a/airflow-core/tests/unit/models/test_trigger.py
+++ b/airflow-core/tests/unit/models/test_trigger.py
@@ -27,6 +27,7 @@ import pytest
 import pytz
 from cryptography.fernet import Fernet
 from sqlalchemy import delete, func, select
+from sqlalchemy.exc import OperationalError
 
 from airflow._shared.timezones import timezone
 from airflow.jobs.job import Job
@@ -339,6 +340,81 @@ def test_submit_failure(session, create_task_instance):
     # Call submit_event
     Trigger.submit_failure(trigger.id, session=session)
     # Check that the task instance is now scheduled to fail
+    updated_task_instance = session.scalar(select(TaskInstance))
+    assert updated_task_instance.state == State.SCHEDULED
+    assert updated_task_instance.next_method == "__fail__"
+
+
+def _deadlock_error() -> OperationalError:
+    """Build an OperationalError that mimics a MySQL/InnoDB deadlock (error 1213)."""
+    return OperationalError(
+        statement="UPDATE task_instance SET state='scheduled', trigger_id=NULL WHERE id = %s",
+        params=("some-ti-id",),
+        orig=Exception("(1213, 'Deadlock found when trying to get lock; try restarting transaction')"),
+    )
+
+
+def test_submit_event_retries_transient_deadlock(session, create_task_instance):
+    """
+    A transient deadlock raised while resuming a deferred task instance is retried rather than
+    propagated. Before this, a single MySQL 1213 in the submit_event -> handle_event_submit path
+    escaped up to the triggerer and killed the process. Regression test for issue #65818.
+    """
+    trigger = Trigger(classpath="airflow.triggers.testing.SuccessTrigger", kwargs={})
+    session.add(trigger)
+    task_instance = create_task_instance(
+        session=session, logical_date=timezone.utcnow(), state=State.DEFERRED
+    )
+    task_instance.trigger_id = trigger.id
+    task_instance.next_kwargs = {"cheesecake": True}
+    session.commit()
+
+    real_handle_event_submit = handle_event_submit
+    calls = {"count": 0}
+
+    def flaky_handle_event_submit(event, *, task_instance, session):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            # Deadlock surfaces on the flush inside handle_event_submit, as in the reported stack.
+            raise _deadlock_error()
+        return real_handle_event_submit(event, task_instance=task_instance, session=session)
+
+    payload = "payload"
+    event = TriggerEvent(payload)
+    with patch("airflow.models.trigger.handle_event_submit", side_effect=flaky_handle_event_submit):
+        Trigger.submit_event(trigger.id, event, session=session)
+
+    # The first attempt deadlocked, the retry resumed the task instance successfully.
+    assert calls["count"] == 2
+    session.refresh(task_instance)
+    assert task_instance.state == State.SCHEDULED
+    assert task_instance.next_kwargs == {"event": payload, "cheesecake": True}
+
+
+def test_submit_failure_retries_transient_deadlock(session, create_task_instance):
+    """
+    submit_failure mutates the same ``task_instance`` rows as submit_event, so it is retried on a
+    transient deadlock too. Regression test for issue #65818.
+    """
+    trigger = Trigger(classpath="airflow.triggers.testing.SuccessTrigger", kwargs={})
+    session.add(trigger)
+    task_instance = create_task_instance(task_id="fake", logical_date=timezone.utcnow(), state=State.DEFERRED)
+    task_instance.trigger_id = trigger.id
+    session.commit()
+
+    calls = {"count": 0}
+
+    def flaky_format_exception(*args, **kwargs):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            # A deadlock while marking the dependent task instances failed must be retried.
+            raise _deadlock_error()
+        return ["RuntimeError: boom\n"]
+
+    with patch("airflow.models.trigger.format_exception", side_effect=flaky_format_exception):
+        Trigger.submit_failure(trigger.id, exc=RuntimeError("boom"), session=session)
+
+    assert calls["count"] == 2
     updated_task_instance = session.scalar(select(TaskInstance))
     assert updated_task_instance.state == State.SCHEDULED
     assert updated_task_instance.next_method == "__fail__"


### PR DESCRIPTION
Retry transient MySQL/InnoDB deadlocks on the triggerer's per-event `task_instance` UPDATE so a single `(1213, 'Deadlock found ...')` no longer takes down the triggerer process.

## Problem

When the triggerer fires an event, it resumes (or fails) the dependent deferred task instances through a single-row UPDATE:

```
handle_events -> Trigger.submit_event -> handle_event_submit -> session.flush()
```

```sql
UPDATE task_instance
SET state='scheduled', scheduled_dttm=..., updated_at=..., trigger_id=NULL, next_kwargs=...
WHERE task_instance.id = '...'
```

That UPDATE contends for `task_instance` row locks with the scheduler's bulk writes (e.g. `SchedulerJobRunner.check_trigger_timeouts`, `Trigger.clean_unused`) and, with more than one triggerer replica, with the other triggerer(s). On MySQL/InnoDB the lock-acquisition order differs between the set-based and row-by-row writers, so InnoDB occasionally aborts one side with `(1213, 'Deadlock found when trying to get lock; try restarting transaction')`.

Neither `submit_event`/`submit_failure` nor anything above them in the triggerer call chain retries or catches this, so the `DBAPIError` propagates up to `TriggerRunnerSupervisor.run` and the triggerer process exits. Deferred tasks are picked up by the other replica, so no task fails, but the restart is noisy at the alerting level and (as reported) the process sometimes has to be `SIGKILL`ed.

Reproduced on 3.1.7/3.1.8 and still reproducing on 3.2.2. This is the single-row path, which is **not** covered by the existing bulk-UPDATE PRs (#65836, #65920) or by the triggerer comms-channel fix (#66412).

## Fix

Decorate `Trigger.submit_event` and `Trigger.submit_failure` with `@retry_db_transaction`, stacked under `@provide_session` exactly like the existing model-side usages (`DagWarning.purge_inactive_dag_warnings`, `RenderedTaskInstanceFields`). This is the same retry-on-deadlock treatment the bulk paths already get via `run_with_db_retries()`; it just extends it to the per-event single-row path.

This is safe and idempotent here:

- Both methods are only ever called from the triggerer **without** an outer session, so `@provide_session` owns the whole transaction — a rollback-and-retry cannot corrupt a caller's transaction.
- On retry the method re-runs its `SELECT ... WHERE state == DEFERRED` and re-applies the state transition, so re-processing the still-deferred rows is idempotent.

This is an incremental mitigation, not a redesign: it does not remove the concurrent-writer contention described in the issue, but it stops a single transient deadlock from killing the triggerer.

## Tests

Added two regression tests in `airflow-core/tests/unit/models/test_trigger.py` that inject a `1213`-style `OperationalError` on the first attempt of each path and assert the transaction is retried and the task instance still ends up `SCHEDULED`.

related: #65818

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
