### PR TITLE
Add TypeScript SDK dependency security checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -371,6 +371,24 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
 
+  - package-ecosystem: npm
+    cooldown:
+      default-days: 7
+    directory: /ts-sdk
+    schedule:
+      interval: "weekly"
+    groups:
+      ts-sdk-package-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      ts-sdk-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
   - package-ecosystem: "uv"
     cooldown:
       default-days: 4

--- a/.github/workflows/ts-sdk-dependency-review.yml
+++ b/.github/workflows/ts-sdk-dependency-review.yml
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+name: TypeScript SDK dependency review
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "ts-sdk/package.json"
+      - "ts-sdk/pnpm-lock.yaml"
+      - ".github/workflows/ts-sdk-dependency-review.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ts-sdk-dependency-review-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    name: Reject vulnerable dependency changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4.9.0
+        with:
+          fail-on-severity: high


### PR DESCRIPTION
## Why

The TypeScript SDK currently has no automated updates for known vulnerable packages and no pull request gate for newly introduced vulnerable dependencies.

## What

- Add grouped Dependabot version and security updates for `ts-sdk`.
- Add a least-privilege dependency review workflow for manifest and lockfile changes.
- Reject dependency changes with known high or critical vulnerabilities.
- Pin the dependency review action to an immutable commit SHA.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Codex GPT-5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
