### PR TITLE
disable external entities in SAML idp response parsing

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -399,8 +399,11 @@ class BaseSessionFactory(LoggingMixin):
             )
             self.log.debug("idp_response.content= %s", idp_response.content)
             self.log.debug("xpath= %s", xpath)
-        # Extract SAML Assertion from the returned HTML / XML
-        xml = etree.fromstring(idp_response.content)
+        # Extract SAML Assertion from the returned HTML / XML. The response is remote
+        # content from the IdP endpoint, so parse it with external entity resolution and
+        # network access disabled to avoid XXE (local file disclosure, entity-expansion).
+        parser = etree.XMLParser(resolve_entities=False, no_network=True, load_dtd=False)
+        xml = etree.fromstring(idp_response.content, parser=parser)
         saml_assertion = xml.xpath(xpath)
         if isinstance(saml_assertion, list):
             if len(saml_assertion) == 1:

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_base_aws.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_base_aws.py
@@ -847,6 +847,39 @@ class TestAwsBaseHook:
 
         assert "TOPSECRET" not in str(assertion)
 
+    def test_saml_assertion_parsing_does_not_resolve_internal_entities(self):
+        internal_entity_response = (
+            b'<?xml version="1.0"?>'
+            b'<!DOCTYPE r [<!ENTITY payload "INJECTED">]>'
+            b"<r><assertion>&payload;</assertion></r>"
+        )
+
+        saml_config = {
+            "idp_url": "https://my-idp.local.corp",
+            "idp_auth_method": "http_spegno_auth",
+            "saml_response_xpath": "//assertion/text()",
+        }
+
+        orig_import = __import__
+
+        def import_mock(name, *args, **kwargs):
+            if name == "requests_gssapi":
+                return mock.Mock()
+            return orig_import(name, *args, **kwargs)
+
+        factory = BaseSessionFactory(conn=None)
+        with (
+            mock.patch("builtins.__import__", side_effect=import_mock),
+            mock.patch.object(factory, "_get_idp_response") as mock_idp,
+        ):
+            mock_idp.return_value.content = internal_entity_response
+            try:
+                assertion = factory._fetch_saml_assertion_using_http_spegno_auth(saml_config)
+            except ValueError:
+                assertion = ""
+
+        assert "INJECTED" not in str(assertion)
+
     @mock_aws
     def test_expand_role(self):
         conn = boto3.client("iam", region_name="us-east-1")

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_base_aws.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_base_aws.py
@@ -812,6 +812,41 @@ class TestAwsBaseHook:
             ),
         ]
 
+    def test_saml_assertion_parsing_does_not_resolve_external_entities(self, tmp_path):
+        secret_file = tmp_path / "secret.txt"
+        secret_file.write_text("TOPSECRET")
+        xxe_response = (
+            '<?xml version="1.0"?>'
+            f'<!DOCTYPE r [<!ENTITY xxe SYSTEM "file://{secret_file}">]>'
+            "<r><assertion>&xxe;</assertion></r>"
+        ).encode()
+
+        saml_config = {
+            "idp_url": "https://my-idp.local.corp",
+            "idp_auth_method": "http_spegno_auth",
+            "saml_response_xpath": "//assertion/text()",
+        }
+
+        orig_import = __import__
+
+        def import_mock(name, *args, **kwargs):
+            if name == "requests_gssapi":
+                return mock.Mock()
+            return orig_import(name, *args, **kwargs)
+
+        factory = BaseSessionFactory(conn=None)
+        with (
+            mock.patch("builtins.__import__", side_effect=import_mock),
+            mock.patch.object(factory, "_get_idp_response") as mock_idp,
+        ):
+            mock_idp.return_value.content = xxe_response
+            try:
+                assertion = factory._fetch_saml_assertion_using_http_spegno_auth(saml_config)
+            except ValueError:
+                assertion = ""
+
+        assert "TOPSECRET" not in str(assertion)
+
     @mock_aws
     def test_expand_role(self):
         conn = boto3.client("iam", region_name="us-east-1")


### PR DESCRIPTION
`_fetch_saml_assertion_using_http_spegno_auth` parses the IdP HTTP response with lxml's default parser, which resolves external entities, so an IdP endpoint (a malicious or on-path one) can return a DOCTYPE whose `SYSTEM` entity reads a local file into the extracted assertion, or a nested-entity payload that exhausts worker memory. The response is remote content rather than trusted local config, so it should be parsed with entity resolution and network access off. This parses it with a hardened `XMLParser(resolve_entities=False, no_network=True, load_dtd=False)`.

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.