### PR TITLE
Fix airflowctl traceback when a proxy returns a non-JSON error

### DIFF
--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -106,6 +106,15 @@ def safe_call_command(function: Callable, args: Iterable[Arg]) -> None:
                 "If you need help, run the command with --help."
             )
         sys.exit(1)
+    except httpx.HTTPStatusError as e:
+        # Only a JSON error body becomes a ServerResponseError, so everything else lands here.
+        content_type = e.response.headers.get("content-type", "unset")
+        rich.print(f"[red]Unrecognised error response: {e}[/red]")
+        rich.print(
+            f"[red]No error message could be read from the response (content-type: {content_type}). "
+            "It may have been produced by a proxy or gateway in front of the API server.[/red]"
+        )
+        sys.exit(1)
 
 
 class DefaultHelpParser(argparse.ArgumentParser):

--- a/airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py
@@ -514,6 +514,35 @@ class TestCliConfigMethods:
 
         assert ctx.value.code == 1
 
+    @pytest.mark.parametrize(
+        ("headers", "expected_content_type"),
+        [
+            pytest.param({"content-type": "text/html"}, "text/html", id="html-error-page"),
+            pytest.param({}, "unset", id="no-content-type"),
+        ],
+    )
+    def test_safe_call_command_exits_non_zero_for_non_json_error_response(
+        self, headers, expected_content_type, capsys
+    ):
+        request = httpx.Request("GET", "http://localhost:8080/api/v2/dags")
+        response = httpx.Response(
+            502,
+            request=request,
+            headers=headers,
+            content=b"<html><head><title>502 Bad Gateway</title></head></html>",
+        )
+
+        def raise_error(_args):
+            response.raise_for_status()
+
+        with pytest.raises(SystemExit) as ctx:
+            safe_call_command(raise_error, args=argparse.Namespace())
+
+        assert ctx.value.code == 1
+        output = capsys.readouterr().out
+        assert "502" in output
+        assert expected_content_type in output
+
     def test_add_to_parser_drops_type_for_boolean_optional_action(self):
         """Test add_to_parser removes type for BooleanOptionalAction."""
         parser = argparse.ArgumentParser()


### PR DESCRIPTION
## Summary

`safe_call_command` catches `ServerResponseError` but not the `httpx.HTTPStatusError` it inherits from, and only a JSON error body ever becomes a `ServerResponseError`. Every other error response therefore escapes as an unhandled exception, and the user gets a traceback where a message belongs.

Those responses come from whatever sits in front of the API server rather than from Airflow — a reverse proxy returning its own `text/html` 502 during a restart, or an SSO gateway answering with a login page. Since the traceback names httpx, it reads as a client bug. The command now exits 1 with the status and the response's content type, enough to place the blame correctly.

Independent of #70936, which widens the media-type check in the API client.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)