### PR TITLE
Respect run on latest version when clearing a running Dag run

### DIFF
--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -380,6 +380,13 @@ def clear_task_instances(
     from airflow.models.dagbag import DBDagBag
 
     scheduler_dagbag = DBDagBag(load_op_links=False)
+    latest_dag_versions: dict[str, DagVersion | None] = {}
+
+    def get_cached_latest_dag_version(dag_id: str) -> DagVersion | None:
+        if dag_id not in latest_dag_versions:
+            latest_dag_versions[dag_id] = DagVersion.get_latest_version(dag_id, session=session)
+        return latest_dag_versions[dag_id]
+
     for ti in tis:
         ti.prepare_db_for_next_try(session)
 
@@ -418,14 +425,17 @@ def clear_task_instances(
             ti.state = None
             ti.external_executor_id = None
             ti.clear_next_method_args()
-            # Match DagVersion to latest serialized DAG when run_on_latest_version.
-            if run_on_latest_version:
-                latest_dag_version = DagVersion.get_latest_version(ti.dag_id, session=session)
-                if latest_dag_version is not None:
-                    ti.dag_version_id = latest_dag_version.id
-            session.merge(ti)
+        # Match DagVersion to latest serialized DAG when run_on_latest_version. This includes a task that
+        # was running: it is retried from this same row, so leaving it on the old version would silently
+        # re-run the code the dag run started with.
+        if run_on_latest_version:
+            latest_dag_version = get_cached_latest_dag_version(ti.dag_id)
+            if latest_dag_version is not None:
+                ti.dag_version_id = latest_dag_version.id
+        session.merge(ti)
 
-    if dag_run_state is not False and tis:
+    reset_dag_runs = dag_run_state is not False
+    if tis and (reset_dag_runs or run_on_latest_version):
         from airflow.models.dagrun import (  # Avoid circular import
             DagRun,
             dagrun_trace_attributes,
@@ -447,58 +457,54 @@ def clear_task_instances(
                 )
             )
         ).all()
-        dag_run_state = DagRunState(dag_run_state)  # Validate the state value.
+        if reset_dag_runs:
+            dag_run_state = DagRunState(dag_run_state)  # Validate the state value.
         for dr in drs:
-            # Always update clear_number and queued_at when clearing tasks, regardless of state
-            dr.clear_number += 1
-            dr.queued_at = timezone.utcnow()
-            dr.context_carrier = new_dagrun_trace_carrier(
-                task_span_detail_level=dr.conf.get(TASK_SPAN_DETAIL_LEVEL_KEY) if dr.conf else None,
-                attributes=dagrun_trace_attributes(dr),
-                force_sampled=trace_sampled_override(dr.conf),
-                parent_context=parent_trace_context(dr.conf),
-            )
+            was_finished = dr.state in State.finished_dr_states
+            if reset_dag_runs:
+                # Always update clear_number and queued_at when clearing tasks, regardless of state
+                dr.clear_number += 1
+                dr.queued_at = timezone.utcnow()
+                dr.context_carrier = new_dagrun_trace_carrier(
+                    task_span_detail_level=dr.conf.get(TASK_SPAN_DETAIL_LEVEL_KEY) if dr.conf else None,
+                    attributes=dagrun_trace_attributes(dr),
+                    force_sampled=trace_sampled_override(dr.conf),
+                    parent_context=parent_trace_context(dr.conf),
+                )
 
-            _recalculate_dagrun_queued_at_deadlines(dr, dr.queued_at, session)
+                _recalculate_dagrun_queued_at_deadlines(dr, dr.queued_at, session)
 
-            if dr.state in State.finished_dr_states:
-                dr.state = dag_run_state
-                dr.start_date = timezone.utcnow()
-                if run_on_latest_version:
-                    dr_dag = scheduler_dagbag.get_latest_version_of_dag(dr.dag_id, session=session)
-                    dag_version = DagVersion.get_latest_version(dr.dag_id, session=session)
-                    if dag_version:
-                        # Change the dr.created_dag_version_id so the scheduler doesn't reject this
-                        # version when it sets the dag_run.dag
-                        dr.created_dag_version_id = dag_version.id
-                        dr.dag = dr_dag
-                        dr.verify_integrity(session=session, dag_version_id=dag_version.id)
-                        # Only cleared TIs get latest dag_version_id above; do not rewrite others.
-                else:
-                    dr_dag = scheduler_dagbag.get_dag_for_run(dag_run=dr, session=session)
+                if was_finished:
+                    dr.state = dag_run_state
+                    dr.start_date = timezone.utcnow()
+
+            # The run is moved to the latest version whatever its state and whether or not its own state
+            # is being reset — the cleared TIs are pinned to that version above, so leaving the run behind
+            # would have the scheduler resolve the run from one version while its tasks run another.
+            # An unchanged serialized dag on a newer bundle refreshes the latest DagVersion row in place
+            # instead of adding one, so a matching version id does not mean the bundle is current either.
+            if run_on_latest_version:
+                dr_dag = scheduler_dagbag.get_latest_version_of_dag(dr.dag_id, session=session)
+                dag_version = get_cached_latest_dag_version(dr.dag_id)
                 if not dr_dag:
                     log.warning("No serialized dag found for dag '%s'", dr.dag_id)
-                if dr_dag and not dr_dag.disable_bundle_versioning and run_on_latest_version:
-                    bundle_version = dr.dag_model.bundle_version
-                    if bundle_version is not None and run_on_latest_version:
-                        dr.bundle_version = bundle_version
-                if dag_run_state == DagRunState.QUEUED:
-                    dr.last_scheduling_decision = None
-                    dr.start_date = None
-            elif run_on_latest_version:
-                # Queued/running DagRun: update DR to latest version/bundle for workloads that use it.
-                dag_version = DagVersion.get_latest_version(dr.dag_id, session=session)
-                if dag_version and dr.created_dag_version_id != dag_version.id:
-                    dr_dag = scheduler_dagbag.get_latest_version_of_dag(dr.dag_id, session=session)
-                    if not dr_dag:
-                        log.warning("No serialized dag found for dag '%s'", dr.dag_id)
-                    else:
-                        dr.created_dag_version_id = dag_version.id
-                        dr.dag = dr_dag
-                        if not dr_dag.disable_bundle_versioning:
-                            bundle_version = dr.dag_model.bundle_version
-                            if bundle_version is not None:
-                                dr.bundle_version = bundle_version
+                elif dag_version:
+                    # Change the dr.created_dag_version_id so the scheduler doesn't reject this
+                    # version when it sets the dag_run.dag
+                    dr.created_dag_version = dag_version
+                    dr.created_dag_version_id = dag_version.id
+                    dr.dag = dr_dag
+                    dr.verify_integrity(session=session, dag_version_id=dag_version.id)
+                    # Only cleared TIs get latest dag_version_id above; do not rewrite others.
+                    dr.bundle_version = (
+                        None if dr_dag.disable_bundle_versioning else dr.dag_model.bundle_version
+                    )
+            elif was_finished and not scheduler_dagbag.get_dag_for_run(dag_run=dr, session=session):
+                log.warning("No serialized dag found for dag '%s'", dr.dag_id)
+
+            if reset_dag_runs and was_finished and dag_run_state == DagRunState.QUEUED:
+                dr.last_scheduling_decision = None
+                dr.start_date = None
     for ti in tis:
         ti.context_carrier = new_task_run_carrier(ti.dag_run.context_carrier)
     session.flush()

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -492,7 +492,6 @@ def clear_task_instances(
                     # Change the dr.created_dag_version_id so the scheduler doesn't reject this
                     # version when it sets the dag_run.dag
                     dr.created_dag_version = dag_version
-                    dr.created_dag_version_id = dag_version.id
                     dr.dag = dr_dag
                     dr.verify_integrity(session=session, dag_version_id=dag_version.id)
                     # Only cleared TIs get latest dag_version_id above; do not rewrite others.

--- a/airflow-core/tests/unit/models/test_cleartasks.py
+++ b/airflow-core/tests/unit/models/test_cleartasks.py
@@ -23,14 +23,17 @@ import random
 import pytest
 from sqlalchemy import func, select
 
+from airflow.models.dag import DagModel
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagrun import DagRun
+from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import TaskInstance, TaskInstance as TI, clear_task_instances
 from airflow.models.taskinstancehistory import TaskInstanceHistory
 from airflow.models.taskreschedule import TaskReschedule
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.sensors.python import PythonSensor
 from airflow.serialization.definitions.dag import SerializedDAG
+from airflow.serialization.serialized_objects import LazyDeserializedDAG
 from airflow.utils.session import create_session
 from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
@@ -786,6 +789,166 @@ class TestClearTasks:
         assert tis["0"].dag_version_id == new_dag_version.id
         assert tis["1"].dag_version_id == old_dag_version.id
         assert dr_after.created_dag_version_id == new_dag_version.id
+
+    @pytest.mark.parametrize("run_on_latest_version", [True, False])
+    def test_clear_running_dag_run_with_run_on_latest_version(
+        self, run_on_latest_version, dag_maker, session
+    ):
+        with dag_maker(
+            "test_clear_running_dr",
+            start_date=DEFAULT_DATE,
+            catchup=True,
+            bundle_version="v1",
+        ) as dag:
+            EmptyOperator(task_id="0")
+            EmptyOperator(task_id="1")
+        dr = dag_maker.create_dagrun(state=State.RUNNING, run_type=DagRunType.SCHEDULED)
+        old_dag_version = DagVersion.get_latest_version(dr.dag_id)
+
+        ti0, ti1 = sorted(dr.task_instances, key=lambda ti: ti.task_id)
+        ti0.state = TaskInstanceState.RUNNING
+        ti1.state = TaskInstanceState.SUCCESS
+        session.merge(ti0)
+        session.merge(ti1)
+        session.flush()
+
+        with dag_maker(
+            "test_clear_running_dr",
+            start_date=DEFAULT_DATE,
+            catchup=True,
+            bundle_version="v2",
+        ):
+            EmptyOperator(task_id="0")
+            EmptyOperator(task_id="1")
+            EmptyOperator(task_id="2")
+        new_dag_version = DagVersion.get_latest_version(dag.dag_id)
+        assert old_dag_version.id != new_dag_version.id
+
+        qry = session.scalars(select(TI).where(TI.dag_id == dag.dag_id).order_by(TI.task_id)).all()
+        clear_task_instances(qry, session, run_on_latest_version=run_on_latest_version)
+        session.commit()
+
+        dr = session.scalar(select(DagRun).where(DagRun.dag_id == dag.dag_id))
+        assert dr.state == DagRunState.RUNNING
+        tis = {ti.task_id: ti for ti in dr.task_instances}
+        assert tis["0"].state == TaskInstanceState.RESTARTING
+        expected_version = new_dag_version if run_on_latest_version else old_dag_version
+        assert tis["0"].dag_version_id == expected_version.id
+        assert tis["1"].dag_version_id == expected_version.id
+        assert dr.created_dag_version_id == expected_version.id
+        assert dr.bundle_version == expected_version.bundle_version
+        assert ("2" in tis) is run_on_latest_version
+
+    @pytest.mark.parametrize("dr_state", [DagRunState.SUCCESS, DagRunState.RUNNING])
+    def test_clear_run_on_latest_version_without_resetting_dag_run(self, dr_state, dag_maker, session):
+        """``reset_dag_runs=False`` leaves the run's state alone but must not leave its version behind."""
+        with dag_maker(
+            "test_clear_no_reset",
+            start_date=DEFAULT_DATE,
+            catchup=True,
+            bundle_version="v1",
+        ) as dag:
+            EmptyOperator(task_id="0")
+        dr = dag_maker.create_dagrun(state=dr_state, run_type=DagRunType.SCHEDULED)
+        old_dag_version = DagVersion.get_latest_version(dr.dag_id)
+        clear_number = dr.clear_number
+
+        ti = dr.task_instances[0]
+        ti.state = TaskInstanceState.FAILED
+        session.merge(ti)
+        session.flush()
+
+        with dag_maker(
+            "test_clear_no_reset",
+            start_date=DEFAULT_DATE,
+            catchup=True,
+            bundle_version="v2",
+        ):
+            EmptyOperator(task_id="0")
+            EmptyOperator(task_id="1")
+        new_dag_version = DagVersion.get_latest_version(dag.dag_id)
+        assert old_dag_version.id != new_dag_version.id
+
+        clear_task_instances([ti], session, dag_run_state=False, run_on_latest_version=True)
+        session.commit()
+
+        dr = session.scalar(select(DagRun).where(DagRun.dag_id == dag.dag_id))
+        assert dr.state == dr_state
+        assert dr.clear_number == clear_number
+        assert dr.created_dag_version_id == new_dag_version.id
+        assert dr.bundle_version == "v2"
+        tis = {ti.task_id: ti for ti in dr.task_instances}
+        assert tis["0"].dag_version_id == new_dag_version.id
+        assert "1" in tis
+
+    def test_clear_run_on_latest_version_refreshes_bundle_when_dag_unchanged(self, dag_maker, session):
+        """A newer bundle updates the latest DagVersion in place, so its id cannot gate the refresh."""
+        with dag_maker(
+            "test_clear_bundle_only_change",
+            start_date=DEFAULT_DATE,
+            catchup=True,
+            bundle_version="v1",
+        ) as dag:
+            EmptyOperator(task_id="0")
+        dr = dag_maker.create_dagrun(state=State.RUNNING, run_type=DagRunType.SCHEDULED)
+        old_dag_version_id = DagVersion.get_latest_version(dr.dag_id).id
+        assert dr.bundle_version == "v1"
+
+        ti = dr.task_instances[0]
+        ti.state = TaskInstanceState.FAILED
+        session.merge(ti)
+        session.flush()
+
+        SerializedDagModel.write_dag(
+            LazyDeserializedDAG(data=dag_maker.get_serialized_data()),
+            bundle_name="dag_maker",
+            bundle_version="v2",
+            session=session,
+        )
+        session.get(DagModel, dag.dag_id).bundle_version = "v2"
+        session.flush()
+        assert DagVersion.get_latest_version(dag.dag_id).id == old_dag_version_id
+
+        clear_task_instances([ti], session, run_on_latest_version=True)
+        session.commit()
+
+        dr = session.scalar(select(DagRun).where(DagRun.dag_id == dag.dag_id))
+        assert dr.bundle_version == "v2"
+
+    def test_clear_run_on_latest_version_unpins_disabled_bundle_versioning(self, dag_maker, session):
+        with dag_maker(
+            "test_clear_disable_bundle_versioning",
+            start_date=DEFAULT_DATE,
+            catchup=True,
+            bundle_version="v1",
+        ) as dag:
+            EmptyOperator(task_id="0")
+        dr = dag_maker.create_dagrun(state=State.RUNNING, run_type=DagRunType.SCHEDULED)
+        old_dag_version = DagVersion.get_latest_version(dr.dag_id)
+        assert dr.bundle_version == "v1"
+
+        ti = dr.task_instances[0]
+        ti.state = TaskInstanceState.FAILED
+        session.merge(ti)
+        session.flush()
+
+        with dag_maker(
+            "test_clear_disable_bundle_versioning",
+            start_date=DEFAULT_DATE,
+            catchup=True,
+            bundle_version="v2",
+            disable_bundle_versioning=True,
+        ):
+            EmptyOperator(task_id="0")
+        new_dag_version = DagVersion.get_latest_version(dag.dag_id)
+        assert old_dag_version.id != new_dag_version.id
+
+        clear_task_instances([ti], session, run_on_latest_version=True)
+        session.commit()
+
+        dr = session.scalar(select(DagRun).where(DagRun.dag_id == dag.dag_id))
+        assert dr.created_dag_version_id == new_dag_version.id
+        assert dr.bundle_version is None
 
     def test_clear_only_new_tasks(self, dag_maker, session):
         """Test that only_new queues only newly added tasks without clearing existing ones."""


### PR DESCRIPTION
run_on_latest_version should have the same meaning for running and queued Dag runs, and when callers preserve a finished run's state. Otherwise cleared running tasks can retry against stale code while the Dag run still points at an older serialized Dag or bundle.

Keeping the run, cleared task instances, integrity checks, and bundle selection aligned preserves the user's explicit rerun choice without rewriting unrelated task-version history.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (5.6 Sol)

Generated-by: Codex (5.6 Sol) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)