### PR TITLE
Prevent debugger hangs on lazy task context values

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -462,7 +462,14 @@ def _delete_variable(key: str) -> None:
     SecretCache.invalidate_variable(key)
 
 
-class ConnectionAccessor:
+class _NonIterableAccessor:
+    """Keep debugger iteration probes from falling through dynamic ``__getattr__`` methods."""
+
+    def __iter__(self) -> Iterator[Any]:
+        raise TypeError(f"'{type(self).__name__}' object is not iterable")
+
+
+class ConnectionAccessor(_NonIterableAccessor):
     """Wrapper to access Connection entries in template."""
 
     def __getattr__(self, conn_id: str) -> Any:
@@ -493,7 +500,7 @@ class ConnectionAccessor:
             return default_conn
 
 
-class VariableAccessor:
+class VariableAccessor(_NonIterableAccessor):
     """Wrapper to access Variable values in template."""
 
     def __init__(self, deserialize_json: bool) -> None:
@@ -920,7 +927,7 @@ class AssetStateStoreAccessors:
         return f"<AssetStateStoreAccessors [{', '.join(parts)}]>"
 
 
-class MacrosAccessor:
+class MacrosAccessor(_NonIterableAccessor):
     """Wrapper to access Macros module lazily."""
 
     _macros_module = None

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -227,6 +227,16 @@ class TaskRunnerMarker:
     """Marker for listener hooks, to properly detect from which component they are called."""
 
 
+class _DeferredDateTimeContextValue(lazy_object_proxy.Proxy):
+    """Lazy previous-run datetime that debugger inspection does not resolve."""
+
+    def __repr__(self) -> str:
+        return "<deferred datetime context value>"
+
+    def __iter__(self) -> Iterator[Any]:
+        raise TypeError(f"'{type(self).__name__}' object is not iterable")
+
+
 # TODO: Move this entire class into a separate file:
 #  `airflow/sdk/execution_time/task_instance.py`
 #   or `airflow/sdk/execution_time/runtime_ti.py`
@@ -364,10 +374,10 @@ class RuntimeTaskInstance(TaskInstance):
                 ),
                 "task_instance_key_str": f"{self.task.dag_id}__{self.task.task_id}__{dag_run.run_id}",
                 "task_reschedule_count": from_server.task_reschedule_count or 0,
-                "prev_start_date_success": lazy_object_proxy.Proxy(
+                "prev_start_date_success": _DeferredDateTimeContextValue(
                     lambda: coerce_datetime(get_previous_dagrun_success(self.id).start_date)
                 ),
-                "prev_end_date_success": lazy_object_proxy.Proxy(
+                "prev_end_date_success": _DeferredDateTimeContextValue(
                     lambda: coerce_datetime(get_previous_dagrun_success(self.id).end_date)
                 ),
             }
@@ -395,10 +405,10 @@ class RuntimeTaskInstance(TaskInstance):
                         # keys that depend on data_interval
                         "data_interval_end": coerce_datetime(dag_run.data_interval_end),
                         "data_interval_start": coerce_datetime(dag_run.data_interval_start),
-                        "prev_data_interval_start_success": lazy_object_proxy.Proxy(
+                        "prev_data_interval_start_success": _DeferredDateTimeContextValue(
                             lambda: coerce_datetime(get_previous_dagrun_success(self.id).data_interval_start)
                         ),
-                        "prev_data_interval_end_success": lazy_object_proxy.Proxy(
+                        "prev_data_interval_end_success": _DeferredDateTimeContextValue(
                             lambda: coerce_datetime(get_previous_dagrun_success(self.id).data_interval_end)
                         ),
                     }

--- a/task-sdk/tests/task_sdk/execution_time/test_context.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_context.py
@@ -86,6 +86,7 @@ from airflow.sdk.execution_time.context import (
     AssetStateStoreAccessors,
     ConnectionAccessor,
     InletEventsAccessors,
+    MacrosAccessor,
     OutletEventAccessor,
     OutletEventAccessors,
     TaskStateStoreAccessor,
@@ -234,6 +235,17 @@ class TestAirflowContextHelpers:
             with pytest.raises(TypeError) as error:
                 context_to_airflow_vars({})
             assert str(error.value) == "key <1> must be string"
+
+
+@pytest.mark.parametrize(
+    "accessor",
+    [ConnectionAccessor(), VariableAccessor(deserialize_json=False), MacrosAccessor()],
+    ids=["connection", "variable", "macros"],
+)
+def test_dynamic_accessors_are_explicitly_non_iterable(accessor):
+    assert hasattr(accessor, "__iter__")
+    with pytest.raises(TypeError, match=f"'{type(accessor).__name__}' object is not iterable"):
+        iter(accessor)
 
 
 class TestConnectionAccessor:

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -173,6 +173,7 @@ from airflow.sdk.execution_time.task_runner import (
     RuntimeTaskInstance,
     TaskRunnerMarker,
     _defer_task,
+    _DeferredDateTimeContextValue,
     _execute_task,
     _make_task_span,
     _push_xcom_if_needed,
@@ -207,6 +208,21 @@ def get_inline_dag(dag_id: str, task: BaseOperator) -> DAG:
     task.dag = dag
 
     return dag
+
+
+def test_deferred_datetime_context_value_debugger_inspection_does_not_resolve():
+    resolved = []
+    expected = datetime(2026, 1, 1, tzinfo=dt_timezone.utc)
+    value = _DeferredDateTimeContextValue(lambda: resolved.append(True) or expected)
+
+    assert repr(value) == "<deferred datetime context value>"
+    assert resolved == []
+    with pytest.raises(TypeError, match="'_DeferredDateTimeContextValue' object is not iterable"):
+        iter(value)
+    assert resolved == []
+
+    assert value == expected
+    assert resolved == [True]
 
 
 class CustomOperator(BaseOperator):


### PR DESCRIPTION
Debuggers such as debugpy inspect local variables by probing for `__iter__` and calling `repr()`. Airflow's dynamic task-context accessors can treat those probes as connection, variable, or macro lookups, while the lazy previous-run datetime values can resolve during representation. Both paths may make an Execution API request before the task callable starts and leave the debugger waiting.

This change makes the dynamic accessors explicitly non-iterable and gives the lazy previous-run datetime values a representation that does not resolve the proxy. Normal attribute access and lazy datetime resolution are unchanged. The implementation deliberately avoids filtering all dunder names, which could break existing variable, connection, or macro keys.

Regression tests cover the connection, variable, and macro accessors as well as lazy datetime inspection and subsequent normal resolution.

Validation:

- `task-sdk/tests/task_sdk/execution_time/test_context.py`: 173 passed
- Focused Task SDK debugger regressions: 4 passed
- Existing context construction and lazy-loading tests: 3 passed
- Ruff lint and format checks
- Airflow pre-commit and manual `prek` checks, including mypy
- Airflow selective CI check for the committed diff

closes: #51861

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes - OpenAI Codex

Generated-by: OpenAI Codex following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
