### PR TITLE
Include server error detail in Task SDK API error tracebacks

### DIFF
--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -211,10 +211,9 @@ def raise_on_4xx_5xx_with_note(response: httpx.Response):
         e.add_note(
             f"Correlation-id={response.headers.get('correlation-id', None) or response.request.headers.get('correlation-id', 'no-correlation-id')}"
         )
-        # ServerResponseError keeps the server's error payload as structured ``detail`` behind a
-        # generic message; attach it as a note too so the details survive in tracebacks that
-        # propagate uncaught to a generic logger (e.g. the executor), not only where a handler
-        # logs ``e.detail`` explicitly.
+        # .detail sits behind the generic message and only reaches logs where a handler
+        # logs it by hand. Add it as a note too, so uncaught paths (e.g. the executor) keep it.
+
         detail = getattr(e, "detail", None)
         if detail is not None:
             e.add_note(f"Server error detail: {detail!r}")

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -211,6 +211,13 @@ def raise_on_4xx_5xx_with_note(response: httpx.Response):
         e.add_note(
             f"Correlation-id={response.headers.get('correlation-id', None) or response.request.headers.get('correlation-id', 'no-correlation-id')}"
         )
+        # ServerResponseError keeps the server's error payload as structured ``detail`` behind a
+        # generic message; attach it as a note too so the details survive in tracebacks that
+        # propagate uncaught to a generic logger (e.g. the executor), not only where a handler
+        # logs ``e.detail`` explicitly.
+        detail = getattr(e, "detail", None)
+        if detail is not None:
+            e.add_note(f"Server error detail: {detail!r}")
         raise
 
 

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -200,9 +200,7 @@ class TestClient:
 
     @pytest.mark.skipif(sys.version_info < (3, 11), reason="Exception notes (PEP 678) require Python 3.11")
     def test_server_error_detail_added_as_note(self):
-        """The structured ``detail`` is attached as an exception note so it survives in tracebacks
-        that propagate uncaught to a generic logger (e.g. the executor), where only the generic
-        ``str(exc)`` message would otherwise be shown."""
+         """Notes survive uncaught propagation, handled sites still log detail directly."""
         responses = [httpx.Response(404, json={"detail": {"message": "Invalid input"}})]
         client = make_client_w_responses(responses)
 

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import pickle
+import sys
 from datetime import datetime, timezone as dt_timezone
 from typing import TYPE_CHECKING
 from unittest import mock
@@ -196,6 +197,24 @@ class TestClient:
         assert unpickled.detail == {"message": "Invalid input"}
         assert unpickled.response.status_code == 404
         assert unpickled.request.url == "http://error"
+
+    @pytest.mark.skipif(sys.version_info < (3, 11), reason="Exception notes (PEP 678) require Python 3.11")
+    def test_server_error_detail_added_as_note(self):
+        """The structured ``detail`` is attached as an exception note so it survives in tracebacks
+        that propagate uncaught to a generic logger (e.g. the executor), where only the generic
+        ``str(exc)`` message would otherwise be shown."""
+        responses = [httpx.Response(404, json={"detail": {"message": "Invalid input"}})]
+        client = make_client_w_responses(responses)
+
+        with pytest.raises(ServerResponseError) as exc_info:
+            client.get("http://error")
+
+        err = exc_info.value
+        assert err.args == ("Server returned error",)
+        assert any(
+            note.startswith("Server error detail:") and "Invalid input" in note
+            for note in getattr(err, "__notes__", [])
+        ), err.__notes__
 
     def test_retry_handling_unrecoverable_error(self):
         with time_machine.travel("2023-01-01T00:00:00Z", tick=False):

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -200,7 +200,7 @@ class TestClient:
 
     @pytest.mark.skipif(sys.version_info < (3, 11), reason="Exception notes (PEP 678) require Python 3.11")
     def test_server_error_detail_added_as_note(self):
-         """Notes survive uncaught propagation, handled sites still log detail directly."""
+        """Notes survive uncaught propagation, handled sites still log detail directly."""
         responses = [httpx.Response(404, json={"detail": {"message": "Invalid input"}})]
         client = make_client_w_responses(responses)
 


### PR DESCRIPTION
Internal SDK API client errors raise `ServerResponseError`, which keeps the server's error payload as structured `.detail` behind a generic message so handlers can log it as a structured field. #51079 deliberately removed the eager `log.warning("Server error", detail=err.detail)` from `get_json_error` to avoid redundant warning + error logs for the same operation — so the detail is now surfaced only where a handler catches the error and logs `e.detail` explicitly (e.g. `VariableOperations`). On paths where the error propagates **uncaught** to a generic logger — the executor / celery `trace_task` — only `str(exc)` (`"Server returned error"`) is shown and the detail is lost. That's the case in #57961 (the `TaskInstanceOperations.start()` path).

This attaches the structured detail as an **exception note**, following the same `add_note` pattern already used for the correlation-id in `raise_on_4xx_5xx_with_note`. A note only surfaces when a traceback is actually formatted — i.e. on uncaught propagation — so, unlike appending detail to `__str__` (attempted in the now-stale #63368), it does **not** reintroduce the redundant per-operation logging that #51079 removed: handled sites still log `e.detail` once, structured, with no traceback. `.detail` and the generic message are unchanged. Exception notes require Python 3.11+, consistent with the existing correlation-id note (the reporter is on 3.12).

closes: #57961
related: #51079, #63368

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)