### PR TITLE
Mark only a run's most recent asset event as triggering it

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/db/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/common/db/assets.py
@@ -24,6 +24,7 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import subqueryload
 
 from airflow.models.asset import AssetEvent, AssetModel, AssetWatcherModel, association_table
+from airflow.models.dagrun import DagRun
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -56,21 +57,23 @@ def generate_assets_with_last_event_query() -> Select:
     )
 
 
-def resolve_triggering_event_ids(events: Iterable[AssetEvent], *, session: Session) -> dict[int, int]:
+def resolve_triggering_event_refs(
+    events: Iterable[AssetEvent], *, session: Session
+) -> set[tuple[int, str, str]]:
     """
-    Map each dag run id to the id of the asset event that actually triggered it.
+    Return ``(event_id, dag_id, run_id)`` tuples where the asset event actually triggered the run.
 
-    A dag run consumes every asset event queued when it is created, but only the run's most
-    recent consumed event triggers it; earlier consumed events are merely included. Rank each
-    run's consumed events by timestamp (newest wins) so callers can tell the two apart.
+    A dag run consumes every asset event queued when it is created, but only the run's most recent
+    consumed event triggers it; earlier consumed events are merely included.
     """
     run_ids = {run.id for event in events for run in event.created_dagruns}
     if not run_ids:
-        return {}
+        return set()
     ranked_events = (
         select(
-            association_table.c.dag_run_id,
             association_table.c.event_id,
+            DagRun.dag_id,
+            DagRun.run_id,
             func.row_number()
             .over(
                 partition_by=association_table.c.dag_run_id,
@@ -79,12 +82,15 @@ def resolve_triggering_event_ids(events: Iterable[AssetEvent], *, session: Sessi
             .label("rank"),
         )
         .join(AssetEvent, AssetEvent.id == association_table.c.event_id)
+        .join(DagRun, DagRun.id == association_table.c.dag_run_id)
         .where(association_table.c.dag_run_id.in_(run_ids))
         .subquery()
     )
     return {
-        dag_run_id: event_id
-        for dag_run_id, event_id in session.execute(
-            select(ranked_events.c.dag_run_id, ranked_events.c.event_id).where(ranked_events.c.rank == 1)
+        (event_id, dag_id, run_id)
+        for event_id, dag_id, run_id in session.execute(
+            select(ranked_events.c.event_id, ranked_events.c.dag_id, ranked_events.c.run_id).where(
+                ranked_events.c.rank == 1
+            )
         )
     }

--- a/airflow-core/src/airflow/api_fastapi/common/db/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/common/db/assets.py
@@ -17,14 +17,16 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
 from sqlalchemy import func, select
 from sqlalchemy.orm import subqueryload
 
-from airflow.models.asset import AssetEvent, AssetModel, AssetWatcherModel
+from airflow.models.asset import AssetEvent, AssetModel, AssetWatcherModel, association_table
 
 if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
     from sqlalchemy.sql import Select
 
 
@@ -52,3 +54,37 @@ def generate_assets_with_last_event_query() -> Select:
             subqueryload(AssetModel.watchers).joinedload(AssetWatcherModel.trigger),
         )
     )
+
+
+def resolve_triggering_event_ids(events: Iterable[AssetEvent], *, session: Session) -> dict[int, int]:
+    """
+    Map each dag run id to the id of the asset event that actually triggered it.
+
+    A dag run consumes every asset event queued when it is created, but only the run's most
+    recent consumed event triggers it; earlier consumed events are merely included. Rank each
+    run's consumed events by timestamp (newest wins) so callers can tell the two apart.
+    """
+    run_ids = {run.id for event in events for run in event.created_dagruns}
+    if not run_ids:
+        return {}
+    ranked_events = (
+        select(
+            association_table.c.dag_run_id,
+            association_table.c.event_id,
+            func.row_number()
+            .over(
+                partition_by=association_table.c.dag_run_id,
+                order_by=(AssetEvent.timestamp.desc(), AssetEvent.id.desc()),
+            )
+            .label("rank"),
+        )
+        .join(AssetEvent, AssetEvent.id == association_table.c.event_id)
+        .where(association_table.c.dag_run_id.in_(run_ids))
+        .subquery()
+    )
+    return {
+        dag_run_id: event_id
+        for dag_run_id, event_id in session.execute(
+            select(ranked_events.c.dag_run_id, ranked_events.c.event_id).where(ranked_events.c.rank == 1)
+        )
+    }

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/assets.py
@@ -171,7 +171,6 @@ class DagRunAssetReference(StrictBaseModel):
     data_interval_end: datetime | None
     partition_key: str | None
     triggering: bool = Field(
-        default=True,
         description=(
             "Whether this asset event triggered the referenced dag run. Only a run's most recent "
             "consumed asset event triggers it; earlier consumed events are included in the run but "

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/assets.py
@@ -170,6 +170,14 @@ class DagRunAssetReference(StrictBaseModel):
     data_interval_start: datetime | None
     data_interval_end: datetime | None
     partition_key: str | None
+    triggering: bool = Field(
+        default=True,
+        description=(
+            "Whether this asset event triggered the referenced dag run. Only a run's most recent "
+            "consumed asset event triggers it; earlier consumed events are included in the run but "
+            "did not trigger it."
+        ),
+    )
 
 
 class AssetEventResponse(BaseModel):

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -13920,6 +13920,13 @@ components:
           - type: string
           - type: 'null'
           title: Partition Key
+        triggering:
+          type: boolean
+          title: Triggering
+          description: Whether this asset event triggered the referenced dag run.
+            Only a run's most recent consumed asset event triggers it; earlier consumed
+            events are included in the run but did not trigger it.
+          default: true
       additionalProperties: false
       type: object
       required:

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -13926,7 +13926,6 @@ components:
           description: Whether this asset event triggered the referenced dag run.
             Only a run's most recent consumed asset event triggers it; earlier consumed
             events are included in the run but did not trigger it.
-          default: true
       additionalProperties: false
       type: object
       required:
@@ -13939,6 +13938,7 @@ components:
       - data_interval_start
       - data_interval_end
       - partition_key
+      - triggering
       title: DagRunAssetReference
       description: DagRun serializer for asset responses.
     DagRunMutableStates:

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -29,7 +29,7 @@ from airflow._shared.timezones import timezone
 from airflow.api_fastapi.app import get_auth_manager
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity, DagDetails
 from airflow.api_fastapi.common.dagbag import DagBagDep, get_latest_version_of_dag
-from airflow.api_fastapi.common.db.assets import resolve_triggering_event_ids
+from airflow.api_fastapi.common.db.assets import resolve_triggering_event_refs
 from airflow.api_fastapi.common.db.common import SessionDep, paginated_select
 from airflow.api_fastapi.common.parameters import (
     BaseParam,
@@ -378,16 +378,12 @@ def get_asset_events(
     # dependency-applied timeout is still active.
     assets_events = session.scalars(assets_event_select).all()
 
-    # An asset event is linked to every dag run that consumed it, so a run that consumed several
-    # events would otherwise appear as "triggered" on each one. Only a run's most recent consumed
-    # event actually triggers it; the rest were merely included.
-    triggering_event_id_by_run = resolve_triggering_event_ids(assets_events, session=session)
+    triggering_refs = resolve_triggering_event_refs(assets_events, session=session)
     asset_event_responses = []
     for event in assets_events:
-        event_response = AssetEventResponse.model_validate(event)
-        for reference, dag_run in zip(event_response.created_dagruns, event.created_dagruns):
-            reference.triggering = triggering_event_id_by_run.get(dag_run.id) == event.id
-        asset_event_responses.append(event_response)
+        for run in event.created_dagruns:
+            run.triggering = (event.id, run.dag_id, run.run_id) in triggering_refs
+        asset_event_responses.append(AssetEventResponse.model_validate(event))
 
     return AssetEventCollectionResponse(
         asset_events=asset_event_responses,

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -29,6 +29,7 @@ from airflow._shared.timezones import timezone
 from airflow.api_fastapi.app import get_auth_manager
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity, DagDetails
 from airflow.api_fastapi.common.dagbag import DagBagDep, get_latest_version_of_dag
+from airflow.api_fastapi.common.db.assets import resolve_triggering_event_ids
 from airflow.api_fastapi.common.db.common import SessionDep, paginated_select
 from airflow.api_fastapi.common.parameters import (
     BaseParam,
@@ -377,8 +378,19 @@ def get_asset_events(
     # dependency-applied timeout is still active.
     assets_events = session.scalars(assets_event_select).all()
 
+    # An asset event is linked to every dag run that consumed it, so a run that consumed several
+    # events would otherwise appear as "triggered" on each one. Only a run's most recent consumed
+    # event actually triggers it; the rest were merely included.
+    triggering_event_id_by_run = resolve_triggering_event_ids(assets_events, session=session)
+    asset_event_responses = []
+    for event in assets_events:
+        event_response = AssetEventResponse.model_validate(event)
+        for reference, dag_run in zip(event_response.created_dagruns, event.created_dagruns):
+            reference.triggering = triggering_event_id_by_run.get(dag_run.id) == event.id
+        asset_event_responses.append(event_response)
+
     return AssetEventCollectionResponse(
-        asset_events=assets_events,
+        asset_events=asset_event_responses,
         total_entries=total_entries,
     )
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -29,7 +29,6 @@ from airflow._shared.timezones import timezone
 from airflow.api_fastapi.app import get_auth_manager
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity, DagDetails
 from airflow.api_fastapi.common.dagbag import DagBagDep, get_latest_version_of_dag
-from airflow.api_fastapi.common.db.assets import resolve_triggering_event_refs
 from airflow.api_fastapi.common.db.common import SessionDep, paginated_select
 from airflow.api_fastapi.common.parameters import (
     BaseParam,
@@ -75,6 +74,7 @@ from airflow.api_fastapi.core_api.security import (
     requires_access_asset_alias,
     requires_access_dag,
 )
+from airflow.api_fastapi.core_api.services.public.assets import serialize_asset_events
 from airflow.api_fastapi.logging.decorators import action_logging
 from airflow.assets.manager import asset_manager
 from airflow.configuration import conf
@@ -378,15 +378,8 @@ def get_asset_events(
     # dependency-applied timeout is still active.
     assets_events = session.scalars(assets_event_select).all()
 
-    triggering_refs = resolve_triggering_event_refs(assets_events, session=session)
-    asset_event_responses = []
-    for event in assets_events:
-        for run in event.created_dagruns:
-            run.triggering = (event.id, run.dag_id, run.run_id) in triggering_refs
-        asset_event_responses.append(AssetEventResponse.model_validate(event))
-
     return AssetEventCollectionResponse(
-        asset_events=asset_event_responses,
+        asset_events=serialize_asset_events(assets_events, session=session),
         total_entries=total_entries,
     )
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -37,7 +37,7 @@ from airflow.api_fastapi.common.cursors import (
     parse_cursor,
 )
 from airflow.api_fastapi.common.dagbag import DagBagDep, get_dag_for_run, get_latest_version_of_dag
-from airflow.api_fastapi.common.db.assets import resolve_triggering_event_ids
+from airflow.api_fastapi.common.db.assets import resolve_triggering_event_refs
 from airflow.api_fastapi.common.db.common import SessionDep, apply_filters_to_select, paginated_select
 from airflow.api_fastapi.common.db.dag_runs import (
     attach_dag_versions_to_runs,
@@ -292,15 +292,12 @@ def get_upstream_asset_events(
             f"The DagRun with dag_id: `{dag_id}` and run_id: `{dag_run_id}` was not found",
         )
     events = dag_run.consumed_asset_events
-    # Flag, per consumed event, whether it actually triggered the run (its most recent consumed
-    # event) rather than merely being included, so the UI can label the two distinctly.
-    triggering_event_id_by_run = resolve_triggering_event_ids(events, session=session)
+    triggering_refs = resolve_triggering_event_refs(events, session=session)
     asset_events = []
     for event in events:
-        event_response = AssetEventResponse.model_validate(event)
-        for reference, run in zip(event_response.created_dagruns, event.created_dagruns):
-            reference.triggering = triggering_event_id_by_run.get(run.id) == event.id
-        asset_events.append(event_response)
+        for run in event.created_dagruns:
+            run.triggering = (event.id, run.dag_id, run.run_id) in triggering_refs
+        asset_events.append(AssetEventResponse.model_validate(event))
     return AssetEventCollectionResponse(
         asset_events=asset_events,
         total_entries=len(events),

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -37,6 +37,7 @@ from airflow.api_fastapi.common.cursors import (
     parse_cursor,
 )
 from airflow.api_fastapi.common.dagbag import DagBagDep, get_dag_for_run, get_latest_version_of_dag
+from airflow.api_fastapi.common.db.assets import resolve_triggering_event_ids
 from airflow.api_fastapi.common.db.common import SessionDep, apply_filters_to_select, paginated_select
 from airflow.api_fastapi.common.db.dag_runs import (
     attach_dag_versions_to_runs,
@@ -72,7 +73,7 @@ from airflow.api_fastapi.common.parameters import (
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.common.types import Mimetype
 from airflow.api_fastapi.core_api.base import OrmClause
-from airflow.api_fastapi.core_api.datamodels.assets import AssetEventCollectionResponse
+from airflow.api_fastapi.core_api.datamodels.assets import AssetEventCollectionResponse, AssetEventResponse
 from airflow.api_fastapi.core_api.datamodels.common import BulkBody, BulkResponse
 from airflow.api_fastapi.core_api.datamodels.dag_run import (
     BulkDAGRunBody,
@@ -280,7 +281,10 @@ def get_upstream_asset_events(
             DagRun.dag_id == dag_id,
             DagRun.run_id == dag_run_id,
         )
-        .options(joinedload(DagRun.consumed_asset_events).joinedload(AssetEvent.asset))
+        .options(
+            joinedload(DagRun.consumed_asset_events).joinedload(AssetEvent.asset),
+            joinedload(DagRun.consumed_asset_events).subqueryload(AssetEvent.created_dagruns),
+        )
     )
     if dag_run is None:
         raise HTTPException(
@@ -288,8 +292,17 @@ def get_upstream_asset_events(
             f"The DagRun with dag_id: `{dag_id}` and run_id: `{dag_run_id}` was not found",
         )
     events = dag_run.consumed_asset_events
+    # Flag, per consumed event, whether it actually triggered the run (its most recent consumed
+    # event) rather than merely being included, so the UI can label the two distinctly.
+    triggering_event_id_by_run = resolve_triggering_event_ids(events, session=session)
+    asset_events = []
+    for event in events:
+        event_response = AssetEventResponse.model_validate(event)
+        for reference, run in zip(event_response.created_dagruns, event.created_dagruns):
+            reference.triggering = triggering_event_id_by_run.get(run.id) == event.id
+        asset_events.append(event_response)
     return AssetEventCollectionResponse(
-        asset_events=events,
+        asset_events=asset_events,
         total_entries=len(events),
     )
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -37,7 +37,6 @@ from airflow.api_fastapi.common.cursors import (
     parse_cursor,
 )
 from airflow.api_fastapi.common.dagbag import DagBagDep, get_dag_for_run, get_latest_version_of_dag
-from airflow.api_fastapi.common.db.assets import resolve_triggering_event_refs
 from airflow.api_fastapi.common.db.common import SessionDep, apply_filters_to_select, paginated_select
 from airflow.api_fastapi.common.db.dag_runs import (
     attach_dag_versions_to_runs,
@@ -73,7 +72,7 @@ from airflow.api_fastapi.common.parameters import (
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.common.types import Mimetype
 from airflow.api_fastapi.core_api.base import OrmClause
-from airflow.api_fastapi.core_api.datamodels.assets import AssetEventCollectionResponse, AssetEventResponse
+from airflow.api_fastapi.core_api.datamodels.assets import AssetEventCollectionResponse
 from airflow.api_fastapi.core_api.datamodels.common import BulkBody, BulkResponse
 from airflow.api_fastapi.core_api.datamodels.dag_run import (
     BulkDAGRunBody,
@@ -102,6 +101,7 @@ from airflow.api_fastapi.core_api.security import (
     requires_access_dag_run_bulk,
     requires_access_dag_run_clear_bulk,
 )
+from airflow.api_fastapi.core_api.services.public.assets import serialize_asset_events
 from airflow.api_fastapi.core_api.services.public.dag_run import (
     BulkDagRunService,
     DagRunWaiter,
@@ -292,14 +292,8 @@ def get_upstream_asset_events(
             f"The DagRun with dag_id: `{dag_id}` and run_id: `{dag_run_id}` was not found",
         )
     events = dag_run.consumed_asset_events
-    triggering_refs = resolve_triggering_event_refs(events, session=session)
-    asset_events = []
-    for event in events:
-        for run in event.created_dagruns:
-            run.triggering = (event.id, run.dag_id, run.run_id) in triggering_refs
-        asset_events.append(AssetEventResponse.model_validate(event))
     return AssetEventCollectionResponse(
-        asset_events=asset_events,
+        asset_events=serialize_asset_events(events, session=session),
         total_entries=len(events),
     )
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/assets.py
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from airflow.api_fastapi.common.db.assets import resolve_triggering_event_refs
+from airflow.api_fastapi.core_api.datamodels.assets import AssetEventResponse
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from airflow.models.asset import AssetEvent
+
+
+def serialize_asset_events(events: Sequence[AssetEvent], *, session: Session) -> list[AssetEventResponse]:
+    """
+    Serialize asset events, flagging on each created dag run whether this event triggered it.
+
+    Only a run's most recent consumed event triggers it; the rest were merely included. The flag is
+    resolved per ``(event_id, dag_id, run_id)`` tuple and set on the run before validation so the response
+    carries it.
+    """
+    triggering_refs = resolve_triggering_event_refs(events, session=session)
+    asset_events = []
+    for event in events:
+        for run in event.created_dagruns:
+            run.triggering = (event.id, run.dag_id, run.run_id) in triggering_refs
+        asset_events.append(AssetEventResponse.model_validate(event))
+    return asset_events

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -4473,6 +4473,12 @@ export const $DagRunAssetReference = {
                 }
             ],
             title: 'Partition Key'
+        },
+        triggering: {
+            type: 'boolean',
+            title: 'Triggering',
+            description: "Whether this asset event triggered the referenced dag run. Only a run's most recent consumed asset event triggers it; earlier consumed events are included in the run but did not trigger it.",
+            default: true
         }
     },
     additionalProperties: false,

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -4477,13 +4477,12 @@ export const $DagRunAssetReference = {
         triggering: {
             type: 'boolean',
             title: 'Triggering',
-            description: "Whether this asset event triggered the referenced dag run. Only a run's most recent consumed asset event triggers it; earlier consumed events are included in the run but did not trigger it.",
-            default: true
+            description: "Whether this asset event triggered the referenced dag run. Only a run's most recent consumed asset event triggers it; earlier consumed events are included in the run but did not trigger it."
         }
     },
     additionalProperties: false,
     type: 'object',
-    required: ['run_id', 'dag_id', 'logical_date', 'start_date', 'end_date', 'state', 'data_interval_start', 'data_interval_end', 'partition_key'],
+    required: ['run_id', 'dag_id', 'logical_date', 'start_date', 'end_date', 'state', 'data_interval_start', 'data_interval_end', 'partition_key', 'triggering'],
     title: 'DagRunAssetReference',
     description: 'DagRun serializer for asset responses.'
 } as const;

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1154,7 +1154,7 @@ export type DagRunAssetReference = {
     /**
      * Whether this asset event triggered the referenced dag run. Only a run's most recent consumed asset event triggers it; earlier consumed events are included in the run but did not trigger it.
      */
-    triggering?: boolean;
+    triggering: boolean;
 };
 
 /**

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1151,6 +1151,10 @@ export type DagRunAssetReference = {
     data_interval_start: string | null;
     data_interval_end: string | null;
     partition_key: string | null;
+    /**
+     * Whether this asset event triggered the referenced dag run. Only a run's most recent consumed asset event triggers it; earlier consumed events are included in the run but did not trigger it.
+     */
+    triggering?: boolean;
 };
 
 /**

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -153,6 +153,7 @@
     "tooltip": "Press {{hotkey}} for fullscreen"
   },
   "generateToken": "Generate Token",
+  "includedIn": "Included in",
   "key": "Key",
   "logicalDate": "Logical Date",
   "logout": "Logout",

--- a/airflow-core/src/airflow/ui/src/components/Assets/TriggeredRuns.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Assets/TriggeredRuns.test.tsx
@@ -1,0 +1,86 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { DagRunAssetReference } from "openapi/requests/types.gen";
+import { Wrapper } from "src/utils/Wrapper";
+
+import { TriggeredRuns } from "./TriggeredRuns";
+
+const makeRun = (overrides: Partial<DagRunAssetReference>): DagRunAssetReference =>
+  ({
+    dag_id: "dag_1",
+    data_interval_end: null,
+    data_interval_start: null,
+    end_date: null,
+    logical_date: null,
+    partition_key: null,
+    run_id: "run_1",
+    start_date: "2025-01-01T00:00:00Z",
+    state: "success",
+    triggering: true,
+    ...overrides,
+  }) satisfies DagRunAssetReference;
+
+describe("TriggeredRuns", () => {
+  it("labels a triggering run as triggered", () => {
+    render(<TriggeredRuns dagRuns={[makeRun({ triggering: true })]} />, { wrapper: Wrapper });
+
+    expect(screen.getByText(/triggered dagRun_one/u)).toBeInTheDocument();
+    expect(screen.queryByText(/includedIn/u)).not.toBeInTheDocument();
+  });
+
+  it("labels a non-triggering run as included", () => {
+    render(<TriggeredRuns dagRuns={[makeRun({ triggering: false })]} />, { wrapper: Wrapper });
+
+    expect(screen.getByText(/includedIn dagRun_one/u)).toBeInTheDocument();
+    expect(screen.queryByText(/triggered dagRun/u)).not.toBeInTheDocument();
+  });
+
+  it("splits a mix of triggering and included runs into separate labels", () => {
+    render(
+      <TriggeredRuns
+        dagRuns={[
+          makeRun({ dag_id: "dag_triggered", run_id: "r1", triggering: true }),
+          makeRun({ dag_id: "dag_included", run_id: "r2", triggering: false }),
+        ]}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    expect(screen.getByText(/triggered dagRun_one/u)).toBeInTheDocument();
+    expect(screen.getByText(/includedIn dagRun_one/u)).toBeInTheDocument();
+  });
+
+  it("groups multiple included runs behind a single count label", () => {
+    render(
+      <TriggeredRuns
+        dagRuns={[
+          makeRun({ dag_id: "dag_a", run_id: "r1", triggering: false }),
+          makeRun({ dag_id: "dag_b", run_id: "r2", triggering: false }),
+        ]}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    expect(screen.getByText(/2 includedIn dagRun_other/u)).toBeInTheDocument();
+  });
+});

--- a/airflow-core/src/airflow/ui/src/components/Assets/TriggeredRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Assets/TriggeredRuns.tsx
@@ -77,8 +77,8 @@ export const TriggeredRuns = ({ dagRuns }: Props) => {
 
   // An asset event is linked to every run that consumed it, but only a run's most recent consumed
   // event triggered it (backend flag). The rest were merely included, so label them accordingly.
-  const triggeredRuns = dagRuns.filter((dagRun) => dagRun.triggering !== false);
-  const includedRuns = dagRuns.filter((dagRun) => dagRun.triggering === false);
+  const triggeredRuns = dagRuns.filter((dagRun) => dagRun.triggering);
+  const includedRuns = dagRuns.filter((dagRun) => !dagRun.triggering);
 
   return (
     <Flex direction="column" gap={1}>

--- a/airflow-core/src/airflow/ui/src/components/Assets/TriggeredRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Assets/TriggeredRuns.tsx
@@ -28,16 +28,18 @@ type Props = {
   readonly dagRuns?: Array<DagRunAssetReference>;
 };
 
-export const TriggeredRuns = ({ dagRuns }: Props) => {
+const DagRunGroup = ({
+  dagRuns,
+  prefix,
+}: {
+  readonly dagRuns: Array<DagRunAssetReference>;
+  readonly prefix: string;
+}) => {
   const { t: translate } = useTranslation("common");
-
-  if (dagRuns === undefined || dagRuns.length === 0) {
-    return undefined;
-  }
 
   return dagRuns.length === 1 ? (
     <Flex flexWrap="wrap" gap={1}>
-      <Text flexShrink={0}>{`${translate("triggered")} ${translate("dagRun_one")}`}: </Text>
+      <Text flexShrink={0}>{`${prefix} ${translate("dagRun_one")}`}: </Text>
       <StateBadge state={dagRuns[0]?.state as DagRunState} />
       <RouterLink overflowWrap="anywhere" to={`/dags/${dagRuns[0]?.dag_id}/runs/${dagRuns[0]?.run_id}`}>
         {dagRuns[0]?.dag_id}
@@ -48,14 +50,14 @@ export const TriggeredRuns = ({ dagRuns }: Props) => {
     <Popover.Root autoFocus={false} lazyMount unmountOnExit>
       <Popover.Trigger asChild>
         <Button variant="outline">
-          {`${dagRuns.length} ${translate("triggered")} ${translate("dagRun_other", { count: dagRuns.length })}`}
+          {`${dagRuns.length} ${prefix} ${translate("dagRun_other", { count: dagRuns.length })}`}
         </Button>
       </Popover.Trigger>
       <Popover.Content css={{ "--popover-bg": "colors.bg.emphasized" }} width="fit-content">
         <Popover.Arrow />
         <Popover.Body>
           {dagRuns.map((dagRun) => (
-            <Flex gap={1} key={dagRun.dag_id} my={2}>
+            <Flex gap={1} key={`${dagRun.dag_id}-${dagRun.run_id}`} my={2}>
               <StateBadge state={dagRun.state as DagRunState} />
               <RouterLink to={`/dags/${dagRun.dag_id}/runs/${dagRun.run_id}`}>{dagRun.dag_id}</RouterLink>
             </Flex>
@@ -63,5 +65,29 @@ export const TriggeredRuns = ({ dagRuns }: Props) => {
         </Popover.Body>
       </Popover.Content>
     </Popover.Root>
+  );
+};
+
+export const TriggeredRuns = ({ dagRuns }: Props) => {
+  const { t: translate } = useTranslation("common");
+
+  if (dagRuns === undefined || dagRuns.length === 0) {
+    return undefined;
+  }
+
+  // An asset event is linked to every run that consumed it, but only a run's most recent consumed
+  // event triggered it (backend flag). The rest were merely included, so label them accordingly.
+  const triggeredRuns = dagRuns.filter((dagRun) => dagRun.triggering !== false);
+  const includedRuns = dagRuns.filter((dagRun) => dagRun.triggering === false);
+
+  return (
+    <Flex direction="column" gap={1}>
+      {triggeredRuns.length > 0 ? (
+        <DagRunGroup dagRuns={triggeredRuns} prefix={translate("triggered")} />
+      ) : undefined}
+      {includedRuns.length > 0 ? (
+        <DagRunGroup dagRuns={includedRuns} prefix={translate("includedIn")} />
+      ) : undefined}
+    </Flex>
   );
 };

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
@@ -832,7 +832,7 @@ class TestGetAssetEvents(TestAssets):
         session.commit()
         assert len(assets) == 2
 
-        with assert_queries_count(3):
+        with assert_queries_count(4):
             response = test_client.get("/assets/events")
 
         assert response.status_code == 200
@@ -861,6 +861,7 @@ class TestGetAssetEvents(TestAssets):
                             "data_interval_start": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
                             "data_interval_end": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
                             "partition_key": None,
+                            "triggering": True,
                         }
                     ],
                     "timestamp": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
@@ -890,6 +891,7 @@ class TestGetAssetEvents(TestAssets):
                             "data_interval_start": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
                             "data_interval_end": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
                             "partition_key": None,
+                            "triggering": True,
                         }
                     ],
                     "timestamp": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
@@ -898,6 +900,34 @@ class TestGetAssetEvents(TestAssets):
             ],
             "total_entries": 2,
         }
+
+    def test_only_most_recent_consumed_event_is_flagged_as_triggering(self, test_client, session):
+        """A run consuming several events marks only its most recent consumed event as triggering it."""
+        self.create_assets(num=1)
+        older_event = AssetEvent(id=1, asset_id=1, extra={}, timestamp=DEFAULT_DATE)
+        newer_event = AssetEvent(id=2, asset_id=1, extra={}, timestamp=DEFAULT_DATE + timedelta(days=1))
+        session.add_all([older_event, newer_event])
+        dag_run = DagRun(
+            dag_id="source_dag_id",
+            run_id="run_1",
+            run_type=DagRunType.MANUAL,
+            logical_date=DEFAULT_DATE + timedelta(days=1),
+            start_date=DEFAULT_DATE,
+            data_interval=(DEFAULT_DATE, DEFAULT_DATE),
+            state=DagRunState.SUCCESS,
+        )
+        dag_run.end_date = DEFAULT_DATE
+        session.add(dag_run)
+        session.flush()
+        dag_run.consumed_asset_events.extend([older_event, newer_event])
+        session.commit()
+
+        response = test_client.get("/assets/events")
+
+        assert response.status_code == 200
+        events = {event["id"]: event for event in response.json()["asset_events"]}
+        assert events[1]["created_dagruns"][0]["triggering"] is False
+        assert events[2]["created_dagruns"][0]["triggering"] is True
 
     def test_should_respond_401(self, unauthenticated_test_client):
         response = unauthenticated_test_client.get("/assets/events")
@@ -1049,6 +1079,7 @@ class TestGetAssetEvents(TestAssets):
                             "data_interval_start": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
                             "data_interval_end": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
                             "partition_key": None,
+                            "triggering": True,
                         }
                     ],
                     "timestamp": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
@@ -1078,6 +1109,7 @@ class TestGetAssetEvents(TestAssets):
                             "data_interval_start": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
                             "data_interval_end": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
                             "partition_key": None,
+                            "triggering": True,
                         }
                     ],
                     "timestamp": from_datetime_to_zulu_without_ms(DEFAULT_DATE),

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -2015,6 +2015,58 @@ class TestGetDagRunAssetTriggerEvents:
         }
         assert response.json() == expected_response
 
+    @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
+    @pytest.mark.parametrize("num_events", [1, 5])
+    def test_query_count_does_not_scale_with_consumed_events(
+        self, num_events, test_client, dag_maker, session
+    ):
+        """A run consuming N asset events must not issue a query per event (guard against N+1)."""
+        asset1 = Asset(name="ds1", uri="file:///da1")
+        with dag_maker(
+            dag_id="source_dag", start_date=START_DATE1, schedule=timedelta(days=1), session=session
+        ):
+            EmptyOperator(task_id="task", outlets=[asset1])
+        source_run = dag_maker.create_dagrun()
+        ti = source_run.task_instances[0]
+        asset1_id = session.scalar(select(AssetModel.id).where(AssetModel.uri == asset1.uri))
+
+        events = [
+            AssetEvent(
+                asset_id=asset1_id,
+                source_task_id=ti.task_id,
+                source_dag_id=ti.dag_id,
+                source_run_id=ti.run_id,
+                source_map_index=ti.map_index,
+                timestamp=START_DATE1 + timedelta(minutes=index),
+            )
+            for index in range(num_events)
+        ]
+        session.add_all(events)
+
+        with dag_maker(
+            dag_id="TEST_DAG_ID", start_date=START_DATE1, schedule=timedelta(days=1), session=session
+        ):
+            pass
+        consuming_run = dag_maker.create_dagrun(run_id="TEST_DAG_RUN_ID", run_type=DagRunType.ASSET_TRIGGERED)
+        for event in events:
+            consuming_run.consumed_asset_events.append(event)
+        session.commit()
+
+        # Constant regardless of the number of consumed events (parametrized 1 vs 5).
+        with assert_queries_count(4):
+            response = test_client.get("/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID/upstreamAssetEvents")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["total_entries"] == num_events
+        # Only the run's most recent consumed event triggered it; the rest were merely included.
+        triggering_by_event = {
+            event["id"]: event["created_dagruns"][0]["triggering"] for event in payload["asset_events"]
+        }
+        newest_event_id = max(event.id for event in events)
+        assert triggering_by_event[newest_event_id] is True
+        assert all(value is False for eid, value in triggering_by_event.items() if eid != newest_event_id)
+
     def test_should_respond_401(self, unauthenticated_test_client):
         response = unauthenticated_test_client.get(
             "/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID/upstreamAssetEvents",

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -1975,7 +1975,7 @@ class TestGetDagRunAssetTriggerEvents:
         session.commit()
         assert event.timestamp
 
-        with assert_queries_count(3):
+        with assert_queries_count(4):
             response = test_client.get(
                 "/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID/upstreamAssetEvents",
             )
@@ -2005,6 +2005,7 @@ class TestGetDagRunAssetTriggerEvents:
                             "start_date": from_datetime_to_zulu_without_ms(dr.start_date),
                             "state": "running",
                             "partition_key": partition_key,
+                            "triggering": True,
                         }
                     ],
                     "partition_key": partition_key,

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -534,12 +534,12 @@ class DagRunAssetReference(BaseModel):
     data_interval_end: Annotated[datetime | None, Field(title="Data Interval End")]
     partition_key: Annotated[str | None, Field(title="Partition Key")]
     triggering: Annotated[
-        bool | None,
+        bool,
         Field(
             description="Whether this asset event triggered the referenced dag run. Only a run's most recent consumed asset event triggers it; earlier consumed events are included in the run but did not trigger it.",
             title="Triggering",
         ),
-    ] = True
+    ]
 
 
 class DagRunMutableStates(str, Enum):

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -533,6 +533,13 @@ class DagRunAssetReference(BaseModel):
     data_interval_start: Annotated[datetime | None, Field(title="Data Interval Start")]
     data_interval_end: Annotated[datetime | None, Field(title="Data Interval End")]
     partition_key: Annotated[str | None, Field(title="Partition Key")]
+    triggering: Annotated[
+        bool | None,
+        Field(
+            description="Whether this asset event triggered the referenced dag run. Only a run's most recent consumed asset event triggers it; earlier consumed events are included in the run but did not trigger it.",
+            title="Triggering",
+        ),
+    ] = True
 
 
 class DagRunMutableStates(str, Enum):

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -370,6 +370,7 @@ class TestAssetsOperations:
         data_interval_start=datetime.datetime(2025, 1, 1, 0, 0, 0),
         data_interval_end=datetime.datetime(2025, 1, 1, 0, 0, 0),
         partition_key=None,
+        triggering=True,
     )
 
     asset_event_response = AssetEventResponse(


### PR DESCRIPTION
Fixes the misleading "Triggered Dag Run" attribution in the Asset Events view.

An asset event is linked to every dag run that consumed it, so when a run consumed several events the UI showed "Triggered Dag Run" on each of them — making it look as though more runs had been created than actually were. Now only a run's most recent consumed event is labelled "Triggered Dag Run"; the earlier consumed events are labelled "Included in Dag Run".

The `/assets/events` endpoint flags the triggering event per run (ranking each run's consumed events by timestamp) and exposes it as a `triggering` field on `DagRunAssetReference`; the Asset Events UI renders the "triggered" and "included" groups accordingly.

Scope: this covers the attribution/labelling half of the issue. The separate "older events silently ignored" scheduling behaviour was addressed by #62501 and is out of scope here.

closes: #56749

##### Screenshots (Asset Events view) — _to attach_
- Before: several events under one run each showing "Triggered Dag Run"
- After: newest event "Triggered Dag Run", earlier ones "Included in Dag Run"

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)