### PR TITLE
Allow upgrades with NUL in serialized Dags

### DIFF
--- a/airflow-core/src/airflow/migrations/versions/0089_3_2_0_change_serialized_dag_data_column_to_jsonb.py
+++ b/airflow-core/src/airflow/migrations/versions/0089_3_2_0_change_serialized_dag_data_column_to_jsonb.py
@@ -38,6 +38,17 @@ branch_labels = None
 depends_on = None
 airflow_version = "3.2.0"
 
+# Protect escaped backslashes before removing active U+0000 escapes so literal ``\u0000`` text survives.
+_SANITIZED_DATA_TO_JSONB = r"""
+            replace(
+                replace(
+                    replace(data::text, '\\', chr(1)),
+                    '\u0000', ''
+                ),
+                chr(1), '\\'
+            )::JSONB
+"""
+
 
 def upgrade():
     """Apply Change serialized_dag data column to JSONB for PostgreSQL."""
@@ -56,13 +67,11 @@ def upgrade():
                 """)
             )
 
-        # Convert the data column from JSON to JSONB
-        # This is safe because the column already contains JSON data
         op.execute(
-            """
+            f"""
             ALTER TABLE serialized_dag
             ALTER COLUMN data TYPE JSONB
-            USING data::JSONB
+            USING {_SANITIZED_DATA_TO_JSONB}
             """
         )
 

--- a/airflow-core/tests/unit/migrations/test_0089_change_serialized_dag_data_column_to_jsonb.py
+++ b/airflow-core/tests/unit/migrations/test_0089_change_serialized_dag_data_column_to_jsonb.py
@@ -1,0 +1,83 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+
+from airflow import settings
+
+from tests_common.test_utils.paths import AIRFLOW_CORE_SOURCES_PATH
+
+_MIGRATION_PATH = (
+    Path(AIRFLOW_CORE_SOURCES_PATH)
+    / "airflow/migrations/versions/0089_3_2_0_change_serialized_dag_data_column_to_jsonb.py"
+)
+_spec = importlib.util.spec_from_file_location("migration_0089", _MIGRATION_PATH)
+_migration = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+_spec.loader.exec_module(_migration)  # type: ignore[union-attr]
+
+_TABLE = "_test_serialized_dag_jsonb_conversion"
+
+
+@pytest.mark.db_test
+@pytest.mark.backend("postgres")
+def test_nul_is_stripped_and_literal_escape_survives_jsonb_conversion():
+    nul_delimiter = "@@" + chr(0) + "@@"
+    literal_escape_delimiter = "@@" + chr(92) + "u0000@@"
+    drop = f"DROP TABLE IF EXISTS {_TABLE}"
+
+    with settings.engine.begin() as conn:
+        conn.execute(sa.text(drop))
+        conn.execute(sa.text(f"CREATE TABLE {_TABLE} (id int PRIMARY KEY, data JSON)"))
+        conn.execute(
+            sa.text(f"INSERT INTO {_TABLE} VALUES (1, CAST(:data AS JSON))"),
+            {"data": json.dumps({"delimiter": nul_delimiter})},
+        )
+        conn.execute(
+            sa.text(f"INSERT INTO {_TABLE} VALUES (2, CAST(:data AS JSON))"),
+            {"data": json.dumps({"delimiter": literal_escape_delimiter})},
+        )
+
+    try:
+        with settings.engine.connect() as conn:
+            with pytest.raises(sa.exc.DataError):
+                conn.execute(sa.text(f"SELECT data::JSONB FROM {_TABLE}")).all()
+            conn.rollback()
+
+        with settings.engine.begin() as conn:
+            conn.execute(
+                sa.text(
+                    f"""
+                    ALTER TABLE {_TABLE}
+                    ALTER COLUMN data TYPE JSONB
+                    USING {_migration._SANITIZED_DATA_TO_JSONB}
+                    """
+                )
+            )
+            rows = dict(conn.execute(sa.text(f"SELECT id, data::text FROM {_TABLE}")).all())
+
+        assert json.loads(rows[1]) == {"delimiter": "@@@@"}
+        assert json.loads(rows[2]) == {"delimiter": literal_escape_delimiter}
+    finally:
+        with settings.engine.begin() as conn:
+            conn.execute(sa.text(drop))


### PR DESCRIPTION
PostgreSQL accepts U+0000 escapes in `JSON`, but rejects them when migration 0089 casts `serialized_dag.data` to `JSONB`. This blocks upgrades from Airflow 3.1 when a serialized Dag contains a NUL character.

This draft applies the sanitization approach established by [#69064](https://github.com/apache/airflow/pull/69064) to migration 0089:

- protect escaped backslashes so JSON strings containing the literal escape spelling are preserved;
- strip active U+0000 escapes before the JSONB cast;
- add a PostgreSQL regression test covering both cases.

## Decision needed

#69064 strips U+0000 from historical XCom and DagRun data because PostgreSQL JSONB cannot represent it. Applying the same policy to `serialized_dag` is semantically different: a delimiter such as `"@@\0@@"` becomes `"@@@@"`, changing the Dag definition.

This draft asks whether lossy sanitization is acceptable for this migration or whether serialized Dag data needs a different policy. Migration-only sanitization may also not address a later reserialization of the same Dag into JSONB, so the final scope depends on that policy decision.

closes: #65379

## Tests

- `breeze run --backend postgres pytest airflow-core/tests/unit/migrations/test_0089_change_serialized_dag_data_column_to_jsonb.py -xvs`
- `prek run --from-ref main --stage pre-commit`
- `prek run --from-ref main --stage manual --skip compile-ui-assets-dev --skip view-skill-eval`
- `breeze testing core-tests --run-in-parallel`

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5.6)

Generated-by: Codex (GPT-5.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
