### PR TITLE
Fix Asset Event table titles showing a raw translation key

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -17,8 +17,8 @@
   },
   "asset_one": "Asset",
   "asset_other": "Assets",
-  "assetEvent_one": "$t(asset_one) Event",
-  "assetEvent_other": "$t(asset_one) Events",
+  "assetEvent_one": "$t(common:asset_one) Event",
+  "assetEvent_other": "$t(common:asset_one) Events",
   "assetInactive": {
     "tooltip": "Upstream asset has been deactivated; the scheduler is holding partition evaluation until it is reactivated."
   },
@@ -34,8 +34,8 @@
   "collapseAllExtra": "Collapse all extra JSON",
   "collapseDetailsPanel": "Collapse Details Panel",
   "consumingAsset": "Consuming Asset",
-  "createdAssetEvent_one": "Created $t(assetEvent_one)",
-  "createdAssetEvent_other": "Created $t(assetEvent_other)",
+  "createdAssetEvent_one": "Created $t(common:assetEvent_one)",
+  "createdAssetEvent_other": "Created $t(common:assetEvent_other)",
   "dag_one": "Dag",
   "dag_other": "Dags",
   "dagDetails": {
@@ -297,8 +297,8 @@
     "hotkey": "s",
     "show": "Show Source"
   },
-  "sourceAssetEvent_one": "Source $t(assetEvent_one)",
-  "sourceAssetEvent_other": "Source $t(assetEvent_other)",
+  "sourceAssetEvent_one": "Source $t(common:assetEvent_one)",
+  "sourceAssetEvent_other": "Source $t(common:assetEvent_other)",
   "startDate": "Start Date",
   "state": "State",
   "states": {


### PR DESCRIPTION
Asset Events tables render their titles as raw i18n keys instead of readable text:
- Asset page (a specific asset's events): **"asset_one Events"** instead of "Asset Events"
- Run page: **"Source assetEvent_other"** instead of "Source Asset Events"
- Task Instance page: **"Created assetEvent_other"** instead of "Created Asset Events"

The shared Asset Events table (`components/Assets/AssetEvents.tsx`) resolves these titles with `useTranslation(["dashboard", "common", "dag"])`, whose default namespace is **`dashboard`**. In `en/common.json` these keys reference their labels through nested `$t()` (introduced by the translation DRY refactor #68285), e.g. `"assetEvent_other": "$t(asset_one) Events"` and `"sourceAssetEvent_other": "Source $t(assetEvent_other)"`. An **unqualified** nested `$t(...)` resolves against the consuming hook's default namespace (`dashboard`), where those keys don't exist, so the title falls back to the raw key.

This keeps the DRY nesting and fixes it by **qualifying the nested references with the `common` namespace** (`$t(common:asset_one)`, `$t(common:assetEvent_other)`, …), so they resolve in `common` regardless of the consuming component's default namespace.

Verified with i18next directly: all three keys now render "Asset Event(s)" / "Source Asset Event(s)" / "Created Asset Event(s)" for every count, both in the `dashboard`-default context and with the full namespace array.

Note: only `en` uses the nested form; the other locales currently duplicate the strings inline. Migrating them to the same nested/DRY structure is separate follow-up work.

related: #68285

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)