### PR TITLE
Recover the revoked-token check from a stale DB connection (fixes idle-timeout 500)

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/base_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/base_auth_manager.py
@@ -22,13 +22,16 @@ import logging
 import warnings
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
+from contextlib import suppress
 from enum import Enum
 from functools import cache, cached_property
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
 
 from jwt import InvalidTokenError
 from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
 
+from airflow import settings
 from airflow.api_fastapi.auth.managers.models.base_user import BaseUser
 from airflow.api_fastapi.auth.managers.models.resource_details import (
     ConnectionDetails,
@@ -161,7 +164,7 @@ class BaseAuthManager(Generic[T], LoggingMixin, metaclass=ABCMeta):
             log.error("JWT token is not valid: %s", e)
             raise e
 
-        if (jti := payload.get("jti")) and RevokedToken.is_revoked(jti):
+        if (jti := payload.get("jti")) and self._is_token_revoked(jti):
             raise InvalidTokenError("Token has been revoked")
 
         try:
@@ -169,6 +172,35 @@ class BaseAuthManager(Generic[T], LoggingMixin, metaclass=ABCMeta):
         except (ValueError, KeyError) as e:
             log.error("Couldn't deserialize user from token, JWT token is not valid: %s", e)
             raise InvalidTokenError(str(e))
+
+    @staticmethod
+    def _is_token_revoked(jti: str) -> bool:
+        """
+        Return whether the token ``jti`` has been revoked, tolerating a stale DB connection.
+
+        This is the first database access in the auth path and runs on the shared scoped
+        session. A prior request (for example FAB's ``deserialize_user``) can leave that session
+        bound to a connection the database later drops on idle timeout (MySQL error 4031,
+        "disconnected ... because of inactivity"). The connection is never re-checked-out, so
+        ``pool_pre_ping`` / ``pool_recycle`` cannot detect it and the first request after an idle
+        period fails with a 500. On any ``SQLAlchemyError`` we discard the poisoned scoped session
+        and retry once on a fresh connection, mirroring the recovery
+        ``FabAuthManager.deserialize_user`` gained in #62919. See #71395.
+        """
+        try:
+            return RevokedToken.is_revoked(jti)
+        except SQLAlchemyError:
+            log.warning(
+                "Revoked-token check failed on a stale DB session; discarding the scoped "
+                "session and retrying once on a fresh connection.",
+                exc_info=True,
+            )
+            # settings.Session is Optional and only set once the DB is configured; guard so the
+            # discard is a no-op (rather than a crash) if it is missing.
+            if (session_registry := settings.Session) is not None:
+                with suppress(Exception):
+                    session_registry.remove()
+            return RevokedToken.is_revoked(jti)
 
     def get_fastapi_middlewares(self) -> list[tuple[_MiddlewareFactory[Any], dict[str, Any]]]:
         """

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/test_base_auth_manager.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/test_base_auth_manager.py
@@ -22,6 +22,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from jwt import InvalidTokenError
+from sqlalchemy.exc import OperationalError
 
 from airflow.api_fastapi.auth.managers.base_auth_manager import BaseAuthManager, T
 from airflow.api_fastapi.auth.managers.models.base_user import BaseUser
@@ -332,6 +333,73 @@ class TestBaseAuthManager:
             await auth_manager.get_user_from_token(token)
 
         mock_is_revoked.assert_called_once_with("some-jti")
+
+    @staticmethod
+    def _stale_connection_error() -> OperationalError:
+        """Mimic MySQL error 4031 raised when a pooled connection was dropped on idle timeout."""
+        return OperationalError(
+            statement="SELECT EXISTS (SELECT 1 FROM revoked_token WHERE jti = %s)",
+            params=("some-jti",),
+            orig=Exception("(4031, 'The client was disconnected by the server because of inactivity.')"),
+        )
+
+    @patch("airflow.api_fastapi.auth.managers.base_auth_manager.settings.Session")
+    @patch("airflow.models.revoked_token.RevokedToken.is_revoked")
+    @patch(
+        "airflow.api_fastapi.auth.managers.base_auth_manager.BaseAuthManager._get_token_validator",
+        autospec=True,
+    )
+    @patch.object(EmptyAuthManager, "deserialize_user")
+    @pytest.mark.asyncio
+    async def test_get_user_from_token_recovers_from_stale_session_on_revoked_check(
+        self, mock_deserialize_user, mock__get_token_validator, mock_is_revoked, mock_session, auth_manager
+    ):
+        """
+        The revoked-token check must survive a stale pooled DB connection: on SQLAlchemyError it
+        discards the scoped session and retries once, so the first request after an idle period
+        succeeds instead of returning 500. Regression test for issue #71395.
+        """
+        token = "token"
+        payload = {"jti": "some-jti"}
+        user = BaseAuthManagerUserTest(name="test")
+        signer = AsyncMock(spec=JWTValidator)
+        signer.avalidated_claims.return_value = payload
+        mock__get_token_validator.return_value = signer
+        mock_deserialize_user.return_value = user
+        # First check hits the poisoned connection, the retry runs on a fresh one.
+        mock_is_revoked.side_effect = [self._stale_connection_error(), False]
+
+        result = await auth_manager.get_user_from_token(token)
+
+        assert result == user
+        assert mock_is_revoked.call_count == 2
+        # The poisoned scoped session was discarded before the retry.
+        mock_session.remove.assert_called_once_with()
+        mock_deserialize_user.assert_called_once_with(payload)
+
+    @patch("airflow.api_fastapi.auth.managers.base_auth_manager.settings.Session")
+    @patch("airflow.models.revoked_token.RevokedToken.is_revoked")
+    @patch(
+        "airflow.api_fastapi.auth.managers.base_auth_manager.BaseAuthManager._get_token_validator",
+        autospec=True,
+    )
+    @pytest.mark.asyncio
+    async def test_get_user_from_token_revoked_after_stale_session_retry(
+        self, mock__get_token_validator, mock_is_revoked, mock_session, auth_manager
+    ):
+        """A revocation confirmed by the retry is still honored after recovering the session."""
+        token = "token"
+        payload = {"jti": "some-jti"}
+        signer = AsyncMock(spec=JWTValidator)
+        signer.avalidated_claims.return_value = payload
+        mock__get_token_validator.return_value = signer
+        mock_is_revoked.side_effect = [self._stale_connection_error(), True]
+
+        with pytest.raises(InvalidTokenError, match="Token has been revoked"):
+            await auth_manager.get_user_from_token(token)
+
+        assert mock_is_revoked.call_count == 2
+        mock_session.remove.assert_called_once_with()
 
     @patch(
         "airflow.api_fastapi.auth.managers.base_auth_manager.BaseAuthManager._get_token_validator",


### PR DESCRIPTION
Recover the JWT revoked-token check from a stale pooled DB connection so the first authenticated request after an idle period no longer returns HTTP 500.

Issue: https://github.com/apache/airflow/issues/71395

## Problem

With MySQL as the metadata DB and the FAB auth manager, the first authenticated request after the api-server sits idle longer than MySQL's `wait_timeout` fails with HTTP 500. The exception is an `OperationalError` (MySQL error 4031, *"The client was disconnected by the server because of inactivity"*) raised from `RevokedToken.is_revoked` inside `BaseAuthManager.get_user_from_token`. The immediately following request succeeds, because the failed query resets the pooled connection — so in production it looks like intermittent 500s after overnight idle periods.

### Root cause

1. The FAB auth manager shares core's scoped `settings.Session`. A prior request (e.g. `FabAuthManager.deserialize_user`, or FAB's Flask views) can leave that scoped session bound to a connection the database later drops on idle timeout. Because the connection is never returned to the pool, there is **no checkout event** — `pool_pre_ping` / `pool_recycle` cannot help.
2. This exact failure mode was reported in #62903 and fixed by #62919, which added a discard-and-retry recovery to `FabAuthManager.deserialize_user`.
3. But 3.2.0 introduced the JWT revocation check (#61339 / AIP-84): `RevokedToken.is_revoked` in `get_user_from_token` now runs **before** `deserialize_user`, so it is the first thing to touch the poisoned scoped session — and it had no recovery logic. The 500 that #62919 fixed is back, just raised one step earlier in the auth path.

## Fix

Give the revoked-token check the same recovery `deserialize_user` already has: on `SQLAlchemyError`, discard the scoped session (`settings.Session.remove()`) and retry the check once on a fresh connection. The recovery is factored into a small `BaseAuthManager._is_token_revoked` helper so `get_user_from_token` stays readable.

This is the per-call-site variant proposed in the issue (the one that has been running in production for several weeks and eliminated these 500s). It is minimal and mirrors the established #62919 pattern rather than introducing a new session-management abstraction. A persistent DB error still surfaces — only a single transient stale-connection error is absorbed.

## Tests

Added two regression tests in `test_base_auth_manager.py`. Both raise a 4031-style `OperationalError` on the first `is_revoked` call and assert the scoped session is discarded (`settings.Session.remove()`) and the check is retried exactly once:

- retry returns *not revoked* → the request is served transparently;
- retry returns *revoked* → `InvalidTokenError("Token has been revoked")` is still raised.

related: #71395

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
