### PR TITLE
Let the agent retry on a rejected DataFusion query instead of failing

### DIFF
--- a/providers/common/ai/src/airflow/providers/common/ai/toolsets/datafusion.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/toolsets/datafusion.py
@@ -228,7 +228,10 @@ class DataFusionToolset(AbstractToolset[Any]):
             )
         except SQLSafetyError as ex:
             log.warning("query failed SQL safety validation: %s", ex)
-            raise
+            raise ModelRetry(
+                f"error: {ex!s}. Only read-only SELECT-family queries are allowed unless "
+                "allow_writes is enabled; check the SQL syntax and statement type, then try again."
+            ) from ex
         except QueryExecutionException as ex:
             if self._is_retryable_query_error(ex):
                 raise ModelRetry(

--- a/providers/common/ai/tests/unit/common/ai/toolsets/test_datafusion.py
+++ b/providers/common/ai/tests/unit/common/ai/toolsets/test_datafusion.py
@@ -225,7 +225,7 @@ class TestDataFusionToolsetQuery:
         ts = DataFusionToolset([cfg])
         ts._engine = _make_mock_engine()
 
-        with pytest.raises(SQLSafetyError, match="Statement type 'Create' is not allowed"):
+        with pytest.raises(ModelRetry, match="Statement type 'Create' is not allowed"):
             asyncio.run(
                 ts.call_tool(
                     "query",
@@ -234,6 +234,22 @@ class TestDataFusionToolsetQuery:
                     tool=MagicMock(spec=ToolsetTool),
                 )
             )
+
+    def test_sql_syntax_error_raises_model_retry(self):
+        cfg = _make_mock_datasource_config()
+        ts = DataFusionToolset([cfg])
+        ts._engine = _make_mock_engine()
+
+        with pytest.raises(ModelRetry) as exc_info:
+            asyncio.run(
+                ts.call_tool(
+                    "query",
+                    {"sql": "SELECT * FROM t WHERE"},
+                    ctx=MagicMock(spec=RunContext),
+                    tool=MagicMock(spec=ToolsetTool),
+                )
+            )
+        assert isinstance(exc_info.value.__cause__, SQLSafetyError)
 
     def test_allows_create_table_when_writes_enabled(self):
         cfg = _make_mock_datasource_config()


### PR DESCRIPTION
### Summary

`DataFusionToolset._query()` catches `SQLSafetyError` (raised when generated SQL fails safety validation), logs it, and re-raises it unchanged. Nothing between here and pydantic-ai's tool manager catches a plain `SQLSafetyError` -- only `ModelRetry` is special-cased -- so it propagates all the way out and fails the task outright.

Every other query-error path in this same method already gives the agent a chance to self-correct. This PR updates `SQLSafetyError` handling to follow suit, allowing the agent the opportunity to fix its mistake instead of crashing the task.

### Change

- `DataFusionToolset._query()`: `SQLSafetyError` now raises `ModelRetry` (with
  the validation message) instead of propagating raw, matching how
  `QueryExecutionException` and `SQLToolset` already behave.
- Updated `test_blocks_create_table_by_default` to assert on `ModelRetry`
  instead of the old crash-through `SQLSafetyError`.
- Added `test_sql_syntax_error_raises_model_retry_not_crash`, covering the case
  that actually motivated this fix: a plain syntax typo, not a deliberate write
  attempt, verified against the real `SQLSafetyError` cause via `__cause__`.