### PR TITLE
UI: Show owning team in asset dependency popovers

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/db/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/common/db/assets.py
@@ -23,11 +23,20 @@ from typing import TYPE_CHECKING
 from sqlalchemy import func, select
 from sqlalchemy.orm import selectinload
 
-from airflow.models.asset import AssetEvent, AssetModel, AssetWatcherModel, association_table
+from airflow.api_fastapi.common.db.dags import eager_load_teams
+from airflow.models.asset import (
+    AssetEvent,
+    AssetModel,
+    AssetWatcherModel,
+    DagScheduleAssetReference,
+    TaskOutletAssetReference,
+    association_table,
+)
 from airflow.models.dagrun import DagRun
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
+    from sqlalchemy.orm.strategy_options import _AbstractLoad
     from sqlalchemy.sql import Select
 
 
@@ -48,8 +57,7 @@ def generate_assets_with_last_event_query() -> Select:
         .outerjoin(max_asset_event_id_query, AssetModel.id == max_asset_event_id_query.c.asset_id)
         .outerjoin(AssetEvent, AssetEvent.id == max_asset_event_id_query.c.max_asset_event_id)
         .options(
-            selectinload(AssetModel.scheduled_dags),
-            selectinload(AssetModel.producing_tasks),
+            *eager_load_asset_reference_teams(),
             selectinload(AssetModel.consuming_tasks),
             selectinload(AssetModel.aliases),
             selectinload(AssetModel.watchers).joinedload(AssetWatcherModel.trigger),
@@ -94,3 +102,17 @@ def resolve_triggering_event_refs(
             )
         )
     }
+
+
+def eager_load_asset_reference_teams() -> tuple[_AbstractLoad, ...]:
+    """
+    Loader options for an ``AssetModel`` query whose response exposes reference ``team_name``.
+
+    Covers the two references that serialize a team: scheduled Dags and producing tasks.
+    The Dag each one points at is only traversed in multi-team mode, so single-team
+    deployments load the references alone -- see :func:`eager_load_teams`.
+    """
+    return (
+        selectinload(AssetModel.scheduled_dags).options(*eager_load_teams(DagScheduleAssetReference.dag)),
+        selectinload(AssetModel.producing_tasks).options(*eager_load_teams(TaskOutletAssetReference.dag)),
+    )

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/assets.py
@@ -50,6 +50,7 @@ class DagScheduleAssetReference(StrictBaseModel):
     dag_id: str
     created_at: datetime
     updated_at: datetime
+    team_name: str | None = None
 
 
 class TaskInletAssetReference(StrictBaseModel):
@@ -68,6 +69,7 @@ class TaskOutletAssetReference(StrictBaseModel):
     task_id: str
     created_at: datetime
     updated_at: datetime
+    team_name: str | None = None
 
 
 class LastAssetEventResponse(BaseModel):

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -3154,6 +3154,11 @@ components:
           type: string
           format: date-time
           title: Updated At
+        team_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Team Name
       additionalProperties: false
       type: object
       required:
@@ -4712,6 +4717,11 @@ components:
           type: string
           format: date-time
           title: Updated At
+        team_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Team Name
       additionalProperties: false
       type: object
       required:

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -14053,6 +14053,11 @@ components:
           type: string
           format: date-time
           title: Updated At
+        team_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Team Name
       additionalProperties: false
       type: object
       required:
@@ -16168,6 +16173,11 @@ components:
           type: string
           format: date-time
           title: Updated At
+        team_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Team Name
       additionalProperties: false
       type: object
       required:

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -29,6 +29,7 @@ from airflow._shared.timezones import timezone
 from airflow.api_fastapi.app import get_auth_manager
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity, DagDetails
 from airflow.api_fastapi.common.dagbag import DagBagDep, get_latest_version_of_dag
+from airflow.api_fastapi.common.db.assets import eager_load_asset_reference_teams
 from airflow.api_fastapi.common.db.common import SessionDep, paginated_select
 from airflow.api_fastapi.common.parameters import (
     BaseParam,
@@ -211,8 +212,7 @@ def get_assets(
     # The below type annotation is acceptable on SQLA2.1, but not on 2.0
     assets_rows: Result[Unpack[tuple[AssetModel, int, datetime]]] = session.execute(  # type: ignore[type-arg]
         assets_select.options(
-            subqueryload(AssetModel.scheduled_dags),
-            subqueryload(AssetModel.producing_tasks),
+            *eager_load_asset_reference_teams(),
             subqueryload(AssetModel.consuming_tasks),
             subqueryload(AssetModel.aliases),
             subqueryload(AssetModel.watchers).joinedload(AssetWatcherModel.trigger),
@@ -590,8 +590,7 @@ def get_asset(
         select(AssetModel)
         .where(AssetModel.id == asset_id)
         .options(
-            joinedload(AssetModel.scheduled_dags),
-            joinedload(AssetModel.producing_tasks),
+            *eager_load_asset_reference_teams(),
             joinedload(AssetModel.consuming_tasks),
             joinedload(AssetModel.watchers).joinedload(AssetWatcherModel.trigger),
         )

--- a/airflow-core/src/airflow/models/asset.py
+++ b/airflow-core/src/airflow/models/asset.py
@@ -39,6 +39,7 @@ from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from airflow._shared.timezones import timezone
+from airflow.configuration import conf as airflow_conf
 from airflow.models.base import Base, StringID
 from airflow.utils.sqlalchemy import UtcDateTime
 
@@ -605,6 +606,14 @@ class DagScheduleAssetReference(Base):
     asset = relationship("AssetModel", back_populates="scheduled_dags")
     dag = relationship("DagModel", back_populates="schedule_asset_references")
 
+    @property
+    def team_name(self) -> str | None:
+        """Name of the team owning the Dag scheduled by this asset, or ``None``."""
+        # Gate before touching ``dag``: single-team deployments must not pay for the load.
+        if not airflow_conf.getboolean("core", "multi_team"):
+            return None
+        return self.dag.team_name if self.dag else None
+
     queue_records = relationship(
         "AssetDagRunQueue",
         primaryjoin="""and_(
@@ -661,6 +670,15 @@ class TaskOutletAssetReference(Base):
     )
 
     asset = relationship("AssetModel", back_populates="producing_tasks")
+    dag = relationship("DagModel", viewonly=True)
+
+    @property
+    def team_name(self) -> str | None:
+        """Name of the team owning the Dag producing this asset, or ``None``."""
+        # Gate before touching ``dag``: single-team deployments must not pay for the load.
+        if not airflow_conf.getboolean("core", "multi_team"):
+            return None
+        return self.dag.team_name if self.dag else None
 
     __tablename__ = "task_outlet_asset_reference"
     __table_args__ = (

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -4564,6 +4564,17 @@ export const $DagScheduleAssetReference = {
             type: 'string',
             format: 'date-time',
             title: 'Updated At'
+        },
+        team_name: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Team Name'
         }
     },
     additionalProperties: false,
@@ -7740,6 +7751,17 @@ export const $TaskOutletAssetReference = {
             type: 'string',
             format: 'date-time',
             title: 'Updated At'
+        },
+        team_name: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Team Name'
         }
     },
     additionalProperties: false,

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1193,6 +1193,7 @@ export type DagScheduleAssetReference = {
     dag_id: string;
     created_at: string;
     updated_at: string;
+    team_name?: string | null;
 };
 
 /**
@@ -1938,6 +1939,7 @@ export type TaskOutletAssetReference = {
     task_id: string;
     created_at: string;
     updated_at: string;
+    team_name?: string | null;
 };
 
 /**

--- a/airflow-core/src/airflow/ui/src/pages/AssetsList/DependencyPopover.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/AssetsList/DependencyPopover.test.tsx
@@ -1,0 +1,102 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { DagScheduleAssetReference, TaskOutletAssetReference } from "openapi-gen/requests/types.gen";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import i18n from "src/i18n/config";
+import { Wrapper } from "src/utils/Wrapper";
+
+import { DependencyPopover } from "./DependencyPopover";
+
+const mockConfig: Record<string, unknown> = { multi_team: false };
+
+vi.mock("src/queries/useConfig", () => ({
+  useConfig: (key: string) => mockConfig[key],
+}));
+
+const scheduledDags = [
+  {
+    created_at: "2024-01-01T00:00:00Z",
+    dag_id: "dag_a",
+    team_name: "team-a",
+    updated_at: "2024-01-01T00:00:00Z",
+  },
+] as Array<DagScheduleAssetReference>;
+
+const producingTasks = [
+  {
+    created_at: "2024-01-01T00:00:00Z",
+    dag_id: "dag_b",
+    task_id: "task_b",
+    team_name: "team-b",
+    updated_at: "2024-01-01T00:00:00Z",
+  },
+] as Array<TaskOutletAssetReference>;
+
+describe("DependencyPopover", () => {
+  afterEach(() => {
+    mockConfig.multi_team = false;
+  });
+
+  it("shows the owning team next to each scheduled Dag when multi-team is enabled", async () => {
+    mockConfig.multi_team = true;
+    render(
+      <Wrapper>
+        <DependencyPopover dependencies={scheduledDags} type="Dag" />
+      </Wrapper>,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => expect(screen.getByRole("link", { name: "dag_a" })).toBeInTheDocument());
+    expect(screen.getByText(i18n.t("common:dagDetails.team"))).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "team-a" })).toHaveAttribute("href", "/dags?teams=team-a");
+  });
+
+  it("shows the owning team next to each producing task when multi-team is enabled", async () => {
+    mockConfig.multi_team = true;
+    render(
+      <Wrapper>
+        <DependencyPopover dependencies={producingTasks} type="Task" />
+      </Wrapper>,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => expect(screen.getByRole("link", { name: "dag_b.task_b" })).toBeInTheDocument());
+    expect(screen.getByText(i18n.t("common:dagDetails.team"))).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "team-b" })).toHaveAttribute("href", "/dags?teams=team-b");
+  });
+
+  it("does not show the team when multi-team is disabled", async () => {
+    render(
+      <Wrapper>
+        <DependencyPopover dependencies={scheduledDags} type="Dag" />
+      </Wrapper>,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => expect(screen.getByRole("link", { name: "dag_a" })).toBeInTheDocument());
+    expect(screen.queryByText(i18n.t("common:dagDetails.team"))).not.toBeInTheDocument();
+    expect(screen.queryByText("team-a")).not.toBeInTheDocument();
+  });
+});

--- a/airflow-core/src/airflow/ui/src/pages/AssetsList/DependencyPopover.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/AssetsList/DependencyPopover.tsx
@@ -16,15 +16,44 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Button } from "@chakra-ui/react";
+import { Button, HStack, Icon, VisuallyHidden } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
+import { FiUsers } from "react-icons/fi";
 
 import type { DagScheduleAssetReference, TaskOutletAssetReference } from "openapi/requests/types.gen";
-import { Popover, RouterLink } from "src/components/ui";
+import { TeamName } from "src/components/TeamName";
+import { Popover, RouterLink, Tooltip } from "src/components/ui";
+import { useShowTeam } from "src/hooks/useShowTeam";
 
 type Props = {
   readonly dependencies: Array<DagScheduleAssetReference | TaskOutletAssetReference>;
   readonly type: "Dag" | "Task";
+};
+
+// Elsewhere a team sits under a "Team" column header or detail-row label; the popover has no such
+// heading, so the icon marks the link as a team rather than a second Dag link. ``FiUsers`` is the
+// same icon the teams filter uses.
+const IconTeamName = ({ teamName }: { readonly teamName?: string | null }) => {
+  const { t: translate } = useTranslation("common");
+  const showTeam = useShowTeam(teamName);
+
+  if (!showTeam) {
+    return undefined;
+  }
+
+  return (
+    <Tooltip content={translate("dagDetails.team")}>
+      <HStack gap={1}>
+        <Icon color="fg.muted">
+          <FiUsers />
+        </Icon>
+        {/* The icon is the only cue that this link is a team rather than another Dag, and Chakra
+            hides icons from assistive tech, so the label is announced separately. */}
+        <VisuallyHidden>{translate("dagDetails.team")}</VisuallyHidden>
+        <TeamName teamName={teamName} />
+      </HStack>
+    </Tooltip>
+  );
 };
 
 export const DependencyPopover = ({ dependencies, type }: Props) => {
@@ -56,9 +85,10 @@ export const DependencyPopover = ({ dependencies, type }: Props) => {
             }
 
             return (
-              <RouterLink display="block" key={key} py={2} to={link}>
-                {label}
-              </RouterLink>
+              <HStack gap={2} justifyContent="space-between" key={key} py={2}>
+                <RouterLink to={link}>{label}</RouterLink>
+                <IconTeamName teamName={dependency.team_name} />
+              </HStack>
             );
           })}
         </Popover.Body>

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
@@ -40,8 +40,10 @@ from airflow.models.asset import (
     TaskOutletAssetReference,
 )
 from airflow.models.base import ID_LEN
+from airflow.models.dagbundle import DagBundleModel
 from airflow.models.dagrun import DagRun
 from airflow.models.serialized_dag import SerializedDagModel
+from airflow.models.team import Team
 from airflow.models.trigger import Trigger
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.sdk import Asset
@@ -59,6 +61,7 @@ from tests_common.test_utils.db import (
     clear_db_dags,
     clear_db_logs,
     clear_db_runs,
+    clear_db_teams,
 )
 from tests_common.test_utils.format_datetime import from_datetime_to_zulu_without_ms
 from tests_common.test_utils.logs import check_last_log
@@ -292,6 +295,7 @@ class TestAssets:
         clear_db_assets()
         clear_db_runs()
         clear_db_dags()
+        clear_db_teams()
         clear_db_dag_bundles()
         clear_db_logs()
 
@@ -527,6 +531,67 @@ class TestGetAssets(TestAssets):
         assert response.status_code == 400
         msg = "Ordering with 'fake' is disallowed or the attribute does not exist on the model"
         assert response.json()["detail"] == msg
+
+    def _create_assets_with_team_references(self, session, num: int = 2):
+        bundle = DagBundleModel(name="team-bundle-assets")
+        bundle.teams.append(Team(name="team-assets"))
+        session.add(bundle)
+        session.flush()
+        assets = [
+            AssetModel(name=f"asset{i}", uri=f"s3://bucket/asset{i}", group="asset") for i in range(num)
+        ]
+        session.add_all(assets)
+        session.add_all(AssetActive.for_asset(asset) for asset in assets)
+        session.flush()
+        for i, asset in enumerate(assets):
+            session.add_all(
+                [
+                    DagModel(dag_id=f"scheduled_dag{i}", bundle_name="team-bundle-assets"),
+                    DagModel(dag_id=f"producing_dag{i}", bundle_name="team-bundle-assets"),
+                    DagScheduleAssetReference(dag_id=f"scheduled_dag{i}", asset=asset),
+                    TaskOutletAssetReference(dag_id=f"producing_dag{i}", task_id="task1", asset=asset),
+                ]
+            )
+        session.commit()
+
+    def test_assets_references_team_name_none_without_multi_team(self, test_client, session):
+        """Without multi-team enabled, references keep ``team_name`` of ``None`` and no lookup happens."""
+        self._create_assets_with_team_references(session)
+
+        response = test_client.get("/assets")
+        assert response.status_code == 200
+        assets = {asset["name"]: asset for asset in response.json()["assets"]}
+        assert assets["asset0"]["scheduled_dags"][0]["team_name"] is None
+        assert assets["asset0"]["producing_tasks"][0]["team_name"] is None
+
+    @conf_vars({("core", "multi_team"): "True"})
+    def test_assets_references_include_team_name(self, test_client, session):
+        """With multi-team enabled, the owning team is attached to scheduled Dags and producing tasks."""
+        self._create_assets_with_team_references(session)
+
+        response = test_client.get("/assets")
+        assert response.status_code == 200
+        assets = {asset["name"]: asset for asset in response.json()["assets"]}
+        assert assets["asset0"]["scheduled_dags"][0]["team_name"] == "team-assets"
+        assert assets["asset0"]["producing_tasks"][0]["team_name"] == "team-assets"
+
+    @conf_vars({("core", "multi_team"): "True"})
+    def test_query_count_with_multi_team(self, test_client, session):
+        """Resolving reference ``team_name`` must not add a query per referencing Dag.
+
+        A missing loader option does not raise: :attr:`DagModel.team_name` falls back to the
+        cached ``get_team_name`` resolver instead of tripping ``lazy="raise"``, so only a pinned
+        count catches the regression.
+        """
+        self._create_assets_with_team_references(session, num=5)
+
+        with assert_queries_count(9):
+            response = test_client.get("/assets")
+
+        assert response.status_code == 200
+        assets = {asset["name"]: asset for asset in response.json()["assets"]}
+        assert assets["asset4"]["scheduled_dags"][0]["team_name"] == "team-assets"
+        assert assets["asset4"]["producing_tasks"][0]["team_name"] == "team-assets"
 
     @pytest.mark.parametrize(
         ("params", "expected_assets"),

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
@@ -139,6 +139,30 @@ def _create_assets_with_watchers(session, num: int = 2) -> list[AssetModel]:
     return assets
 
 
+def _create_assets_with_team_references(session, num: int = 2, refs_per_asset: int = 1) -> list[AssetModel]:
+    """Create ``num`` assets, each scheduling and produced by ``refs_per_asset`` team-owned Dags."""
+    bundle = DagBundleModel(name="team-bundle-assets")
+    bundle.teams.append(Team(name="team-assets"))
+    session.add(bundle)
+    session.flush()
+    assets = [AssetModel(name=f"asset{i}", uri=f"s3://bucket/asset{i}", group="asset") for i in range(num)]
+    session.add_all(assets)
+    session.add_all(AssetActive.for_asset(asset) for asset in assets)
+    session.flush()
+    for i, asset in enumerate(assets):
+        for j in range(refs_per_asset):
+            session.add_all(
+                [
+                    DagModel(dag_id=f"scheduled_dag{i}_{j}", bundle_name="team-bundle-assets"),
+                    DagModel(dag_id=f"producing_dag{i}_{j}", bundle_name="team-bundle-assets"),
+                    DagScheduleAssetReference(dag_id=f"scheduled_dag{i}_{j}", asset=asset),
+                    TaskOutletAssetReference(dag_id=f"producing_dag{i}_{j}", task_id="task1", asset=asset),
+                ]
+            )
+    session.commit()
+    return assets
+
+
 def _create_assets_with_sensitive_extra(session, num: int = 2) -> None:
     assets = [
         AssetModel(
@@ -532,31 +556,9 @@ class TestGetAssets(TestAssets):
         msg = "Ordering with 'fake' is disallowed or the attribute does not exist on the model"
         assert response.json()["detail"] == msg
 
-    def _create_assets_with_team_references(self, session, num: int = 2):
-        bundle = DagBundleModel(name="team-bundle-assets")
-        bundle.teams.append(Team(name="team-assets"))
-        session.add(bundle)
-        session.flush()
-        assets = [
-            AssetModel(name=f"asset{i}", uri=f"s3://bucket/asset{i}", group="asset") for i in range(num)
-        ]
-        session.add_all(assets)
-        session.add_all(AssetActive.for_asset(asset) for asset in assets)
-        session.flush()
-        for i, asset in enumerate(assets):
-            session.add_all(
-                [
-                    DagModel(dag_id=f"scheduled_dag{i}", bundle_name="team-bundle-assets"),
-                    DagModel(dag_id=f"producing_dag{i}", bundle_name="team-bundle-assets"),
-                    DagScheduleAssetReference(dag_id=f"scheduled_dag{i}", asset=asset),
-                    TaskOutletAssetReference(dag_id=f"producing_dag{i}", task_id="task1", asset=asset),
-                ]
-            )
-        session.commit()
-
     def test_assets_references_team_name_none_without_multi_team(self, test_client, session):
         """Without multi-team enabled, references keep ``team_name`` of ``None`` and no lookup happens."""
-        self._create_assets_with_team_references(session)
+        _create_assets_with_team_references(session)
 
         response = test_client.get("/assets")
         assert response.status_code == 200
@@ -567,7 +569,7 @@ class TestGetAssets(TestAssets):
     @conf_vars({("core", "multi_team"): "True"})
     def test_assets_references_include_team_name(self, test_client, session):
         """With multi-team enabled, the owning team is attached to scheduled Dags and producing tasks."""
-        self._create_assets_with_team_references(session)
+        _create_assets_with_team_references(session)
 
         response = test_client.get("/assets")
         assert response.status_code == 200
@@ -583,7 +585,7 @@ class TestGetAssets(TestAssets):
         cached ``get_team_name`` resolver instead of tripping ``lazy="raise"``, so only a pinned
         count catches the regression.
         """
-        self._create_assets_with_team_references(session, num=5)
+        _create_assets_with_team_references(session, num=5)
 
         with assert_queries_count(9):
             response = test_client.get("/assets")
@@ -1681,6 +1683,24 @@ class TestGetAssetEndpoint(TestAssets):
             ],
             "last_asset_event": {"id": None, "timestamp": None},
         }
+
+    @conf_vars({("core", "multi_team"): "True"})
+    def test_query_count_with_multi_team(self, test_client, session):
+        """Resolving reference ``team_name`` must not add a query per referencing Dag.
+
+        A missing loader option does not raise: :attr:`DagModel.team_name` falls back to the
+        cached ``get_team_name`` resolver instead of tripping ``lazy="raise"``, so only a pinned
+        count catches the regression.
+        """
+        asset = _create_assets_with_team_references(session, num=1, refs_per_asset=5)[0]
+
+        with assert_queries_count(8):
+            response = test_client.get(f"/assets/{asset.id}")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert {ref["team_name"] for ref in body["scheduled_dags"]} == {"team-assets"}
+        assert {ref["team_name"] for ref in body["producing_tasks"]} == {"team-assets"}
 
     def test_should_respond_401(self, unauthenticated_test_client):
         response = unauthenticated_test_client.get("/assets/1")

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_assets.py
@@ -34,7 +34,10 @@ from airflow.models.asset import (
     AssetWatcherModel,
     DagScheduleAssetReference,
     PartitionedAssetKeyLog,
+    TaskOutletAssetReference,
 )
+from airflow.models.dagbundle import DagBundleModel
+from airflow.models.team import Team
 from airflow.models.trigger import Trigger
 from airflow.partition_mappers.base import RollupMapper
 from airflow.partition_mappers.temporal import StartOfHourMapper
@@ -44,12 +47,15 @@ from airflow.sdk.definitions.asset import Asset
 from airflow.sdk.definitions.timetables.assets import PartitionedAssetTimetable
 
 from tests_common.test_utils.asserts import assert_queries_count
+from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import (
     clear_db_apdr,
     clear_db_assets,
+    clear_db_dag_bundles,
     clear_db_dags,
     clear_db_pakl,
     clear_db_serialized_dags,
+    clear_db_teams,
 )
 
 pytestmark = pytest.mark.db_test
@@ -61,6 +67,8 @@ def cleanup():
     clear_db_serialized_dags()
     clear_db_apdr()
     clear_db_pakl()
+    clear_db_teams()
+    clear_db_dag_bundles()
 
 
 class TestNextRunAssets:
@@ -778,3 +786,36 @@ class TestGetAssetsUi:
 
         with assert_queries_count(8):
             assert test_client.get("/assets").status_code == 200
+
+    @conf_vars({("core", "multi_team"): "True"})
+    def test_query_count_with_multi_team(self, test_client, session):
+        """Resolving reference ``team_name`` must not add a query per referencing Dag.
+
+        A missing loader option does not raise: :attr:`DagModel.team_name` falls back to the
+        cached ``get_team_name`` resolver instead of tripping ``lazy="raise"``, so only a pinned
+        count catches the regression.
+        """
+        bundle = DagBundleModel(name="team-bundle")
+        bundle.teams.append(Team(name="owning-team"))
+        session.add(bundle)
+        session.flush()
+
+        assets = [AssetModel(name=f"asset{i}", uri=f"s3://bucket/asset{i}", group="asset") for i in range(5)]
+        session.add_all(assets)
+        session.add_all(AssetActive.for_asset(asset) for asset in assets)
+        session.flush()
+
+        for i, asset in enumerate(assets):
+            session.add(DagModel(dag_id=f"scheduled_dag{i}", bundle_name="team-bundle"))
+            session.add(DagModel(dag_id=f"producing_dag{i}", bundle_name="team-bundle"))
+            session.add(DagScheduleAssetReference(dag_id=f"scheduled_dag{i}", asset=asset))
+            session.add(TaskOutletAssetReference(dag_id=f"producing_dag{i}", task_id="task", asset=asset))
+        session.commit()
+
+        with assert_queries_count(12):
+            response = test_client.get("/assets")
+
+        assert response.status_code == 200
+        assets_by_name = {asset["name"]: asset for asset in response.json()["assets"]}
+        assert assets_by_name["asset0"]["scheduled_dags"][0]["team_name"] == "owning-team"
+        assert assets_by_name["asset0"]["producing_tasks"][0]["team_name"] == "owning-team"

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -606,6 +606,7 @@ class DagScheduleAssetReference(BaseModel):
     dag_id: Annotated[str, Field(title="Dag Id")]
     created_at: Annotated[datetime, Field(title="Created At")]
     updated_at: Annotated[datetime, Field(title="Updated At")]
+    team_name: Annotated[str | None, Field(title="Team Name")] = None
 
 
 class DagStatsStateResponse(BaseModel):
@@ -1100,6 +1101,7 @@ class TaskOutletAssetReference(BaseModel):
     task_id: Annotated[str, Field(title="Task Id")]
     created_at: Annotated[datetime, Field(title="Created At")]
     updated_at: Annotated[datetime, Field(title="Updated At")]
+    team_name: Annotated[str | None, Field(title="Team Name")] = None
 
 
 class TaskStateStoreBody(BaseModel):


### PR DESCRIPTION
Tracing data lineage across a multi-team deployment means jumping between assets and the Dags and tasks that produce or schedule them, without any signal of who owns each one. Surfacing the owning team directly in the "Scheduled Dags" and "Producing Tasks" popovers on the assets list makes ownership obvious while following those links, so operators know who to reach without opening each Dag.

The team is resolved in a single batched lookup and only when multi-team support is enabled, so single-team deployments issue no extra query and see no change.

## Screenshots

### Dags

<img width="1845" height="217" alt="Screenshot 2026-08-11 at 12 23 05 PM" src="https://github.com/user-attachments/assets/081a6c96-1895-4c8c-9366-becca1fb1cac" />

### Tasks

<img width="1834" height="214" alt="Screenshot 2026-08-11 at 12 23 13 PM" src="https://github.com/user-attachments/assets/39cc7e42-6191-4d5f-b439-1823a5c2fe2d" />

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
