### PR TITLE
Stop KubernetesPodOperator hanging on pods with sidecar containers

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -1330,7 +1330,9 @@ class KubernetesPodOperator(BaseOperator):
         if pod_phase != PodPhase.SUCCEEDED or should_keep:
             self.patch_already_checked(remote_pod, reraise=False)
 
-        if istio_enabled or self.do_xcom_push:
+        # A pod abandoned while its sidecars still run never reaches a terminal phase, so read the
+        # outcome off the base container instead of the phase it is stuck in.
+        if istio_enabled or self.do_xcom_push or pod_phase not in PodPhase.terminal_states:
             failed = not container_is_succeeded(remote_pod, self.base_container_name)
         else:
             failed = pod_phase != PodPhase.SUCCEEDED

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/container.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/container.py
@@ -71,6 +71,19 @@ def container_is_completed(pod: V1Pod, container_name: str) -> bool:
     return container_status.state.terminated is not None
 
 
+def has_sidecar_containers(pod: V1Pod, base_container_name: str) -> bool:
+    """
+    Examine V1Pod ``pod`` to determine whether it declares containers besides ``base_container_name``.
+
+    A pod whose sidecars outlive the base container never leaves the ``Running`` phase, so its base
+    container rather than the pod phase determines when the task is finished. Init containers are
+    reported separately by ``spec.init_containers`` and so do not count here.
+    """
+    if not pod or not pod.spec or not pod.spec.containers:
+        return False
+    return any(container.name != base_container_name for container in pod.spec.containers)
+
+
 def container_is_succeeded(pod: V1Pod, container_name: str) -> bool:
     """
     Examine V1Pod ``pod`` to determine whether ``container_name`` is completed and succeeded.

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -51,6 +51,7 @@ from airflow.providers.cncf.kubernetes.utils.container import (
     container_is_terminated,
     container_is_wait,
     get_container_status,
+    has_sidecar_containers,
 )
 from airflow.providers.cncf.kubernetes.utils.xcom_sidecar import PodDefaults
 from airflow.providers.common.compat.sdk import AirflowException, timezone
@@ -823,7 +824,9 @@ class PodManager(LoggingMixin):
             remote_pod = self.read_pod(pod)
             if remote_pod.status.phase in PodPhase.terminal_states:
                 break
-            if (istio_enabled or do_xcom_push) and container_is_completed(remote_pod, container_name):
+            if (
+                istio_enabled or do_xcom_push or has_sidecar_containers(remote_pod, container_name)
+            ) and container_is_completed(remote_pod, container_name):
                 self.log.info(
                     "Container '%s' completed but pod %s still has phase %s "
                     "(likely due to a sidecar container). Skipping waiting for pod completion.",

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -1229,6 +1229,61 @@ class TestKubernetesPodOperator:
             k.execute(context=context)
 
     @pytest.mark.parametrize(
+        ("base_container_exit_code", "expect_failure"),
+        [
+            pytest.param(0, False, id="base-succeeded"),
+            pytest.param(1, True, id="base-failed"),
+        ],
+    )
+    @patch(f"{POD_MANAGER_CLASS}.delete_pod")
+    @patch(f"{POD_MANAGER_CLASS}.await_pod_completion")
+    @patch(f"{KPO_MODULE}.KubernetesPodOperator.find_pod")
+    def test_cleanup_with_user_sidecar_uses_base_container_status(
+        self,
+        find_pod_mock,
+        await_pod_completion_mock,
+        delete_pod_mock,
+        base_container_exit_code,
+        expect_failure,
+    ):
+        """
+        A user-supplied sidecar leaves the pod in Running after the base container exits, so cleanup
+        has to read the outcome off the base container rather than the non-terminal pod phase.
+        """
+        base_status = MagicMock()
+        base_status.name = "base"
+        base_status.state.terminated.exit_code = base_container_exit_code
+        base_status.state.terminated.message = "task failed" if base_container_exit_code else None
+
+        sidecar_status = MagicMock()
+        sidecar_status.name = "sidecar"
+        sidecar_status.state.running = True
+        sidecar_status.state.terminated = None
+
+        remote_pod = MagicMock()
+        remote_pod.status.phase = "Running"
+        remote_pod.status.container_statuses = [base_status, sidecar_status]
+        remote_pod.metadata.name = "pod-with-user-sidecar"
+        remote_pod.metadata.namespace = "default"
+        base_spec, sidecar_spec = MagicMock(), MagicMock()
+        base_spec.name, sidecar_spec.name = "base", "sidecar"
+        remote_pod.spec.containers = [base_spec, sidecar_spec]
+
+        await_pod_completion_mock.return_value = remote_pod
+        find_pod_mock.return_value = remote_pod
+
+        k = KubernetesPodOperator(task_id="task")
+
+        context = create_context(k)
+        context["ti"].xcom_push = MagicMock()
+
+        if expect_failure:
+            with pytest.raises(AirflowException, match="task failed"):
+                k.execute(context=context)
+        else:
+            k.execute(context=context)
+
+    @pytest.mark.parametrize(
         ("task_kwargs", "should_be_deleted"),
         [
             pytest.param({}, True, id="default"),  # default values

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_container.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_container.py
@@ -25,7 +25,37 @@ from airflow.providers.cncf.kubernetes.utils.container import (
     container_is_running,
     container_is_succeeded,
     container_is_terminated,
+    has_sidecar_containers,
 )
+
+
+def pod_with_containers(*names: str, init_containers: tuple[str, ...] = ()) -> SimpleNamespace:
+    return SimpleNamespace(
+        spec=SimpleNamespace(
+            containers=[SimpleNamespace(name=name) for name in names],
+            init_containers=[SimpleNamespace(name=name) for name in init_containers],
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    ("remote_pod", "result"),
+    [
+        pytest.param(None, False, id="None remote_pod"),
+        pytest.param(SimpleNamespace(spec=None), False, id="None remote_pod.spec"),
+        pytest.param(pod_with_containers(), False, id="empty remote_pod.spec.containers"),
+        pytest.param(pod_with_containers("base"), False, id="base container only"),
+        pytest.param(pod_with_containers("base", "sidecar"), True, id="base and sidecar"),
+        pytest.param(pod_with_containers("base", "istio-proxy"), True, id="base and istio proxy"),
+        pytest.param(
+            pod_with_containers("base", init_containers=("init",)),
+            False,
+            id="init containers are not sidecars",
+        ),
+    ],
+)
+def test_has_sidecar_containers(remote_pod, result):
+    assert has_sidecar_containers(remote_pod, "base") is result
 
 
 @pytest.mark.parametrize(

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
@@ -58,6 +58,7 @@ def pod_factory():
         terminated: bool = False,
         waiting_reason: str | None = None,
         waiting_message: str | None = None,
+        sidecar_names: tuple[str, ...] = (),
     ) -> mock.MagicMock:
         pod = mock.MagicMock()
         pod.status.phase = pod_phase
@@ -69,8 +70,13 @@ def pod_factory():
             mock.MagicMock(reason=waiting_reason, message=waiting_message or "") if waiting_reason else None
         )
         pod.status.container_statuses = [cs]
-        c_spec = mock.MagicMock(name=container_name)
-        pod.spec.containers = [c_spec]
+        # ``name`` is reserved by the MagicMock constructor, so it has to be assigned afterwards for
+        # ``spec.containers[*].name`` to read back as the container name rather than a child mock.
+        pod.spec.containers = []
+        for name in (container_name, *sidecar_names):
+            c_spec = mock.MagicMock()
+            c_spec.name = name
+            pod.spec.containers.append(c_spec)
         return pod
 
     return _make
@@ -1366,6 +1372,25 @@ class TestPodManager:
 
         result = self.pod_manager.await_pod_completion(
             pod=mock.MagicMock(), istio_enabled=False, container_name="base", do_xcom_push=True
+        )
+
+        assert result is running2
+        assert mock_sleep.call_count == 1
+
+    @mock.patch("time.sleep")
+    def test_await_pod_completion_breaks_on_user_sidecar_container_completed(self, mock_sleep, pod_factory):
+        """A user-supplied sidecar keeps the pod Running, so the completed base container ends the wait."""
+        running1 = pod_factory(
+            pod_phase=PodPhase.RUNNING, container_name="base", terminated=False, sidecar_names=("sidecar",)
+        )
+        running2 = pod_factory(
+            pod_phase=PodPhase.RUNNING, container_name="base", terminated=True, sidecar_names=("sidecar",)
+        )
+
+        self.pod_manager.read_pod = mock.MagicMock(side_effect=[running1, running2])
+
+        result = self.pod_manager.await_pod_completion(
+            pod=mock.MagicMock(), istio_enabled=False, container_name="base", do_xcom_push=False
         )
 
         assert result is running2


### PR DESCRIPTION
A `KubernetesPodOperator` pod that runs a sidecar alongside `base` never finishes. The base
container exits, the sidecar keeps running, the pod stays in `Running`, and the task waits on
it forever.

`await_pod_completion` already knew how to stop waiting on the base container, but only when
istio or the XCom sidecar was involved. Any other sidecar fell through to waiting on the pod
phase.

closes: #39693

### The second site

Fixing the wait loop alone makes things worse, so this touches two places. `cleanup()` decided
success from the pod phase under the same `istio_enabled or do_xcom_push` condition, so a pod
handed back in `Running` would have been read as failed — trading the hang for a spurious
failure.

`istio_enabled` and `do_xcom_push` turn out to be two spellings of one thing: there is a
sidecar, so the base container is what matters. `is_istio_enabled` is itself just a check for
an extra container named `istio-proxy`. So the wait loop now asks that question directly via
`has_sidecar_containers`, and istio and the XCom sidecar fall out as ordinary cases.

Worth noting the deferrable path already worked this way — the triggerer's
`define_container_state` resolves state from `base_container_name` and stops waiting when it
terminates. The synchronous path was the odd one out.

### What deliberately did not change

`cleanup()` is narrowed to pods that never reached a terminal phase rather than to all
multi-container pods. Judging every sidecar pod by its base container would also mean a
*failing* sidecar stops failing the task, which is a much bigger semantic change than this bug
needs. Pods that do reach `Succeeded`/`Failed` keep exactly the outcome they have today.

Init containers are reported under `spec.init_containers`, so they never count as sidecars.

### Tests

- `test_await_pod_completion_breaks_on_user_sidecar_container_completed` — the reported
  scenario. Fails without the change (loops until it runs out of pods to read).
- `test_cleanup_with_user_sidecar_uses_base_container_status` — mirrors the existing XCom
  sidecar test. `base-succeeded` fails without the change; `base-failed` is the guard that the
  fix does not over-correct into passing genuinely failed tasks.
- `test_has_sidecar_containers` — the helper, including init containers and the empty/None
  guards.
- `test_await_pod_completion_waits_for_pod_phase_without_sidecars` from #64962 is unchanged and
  still passes; a pod with only `base` still waits for the pod phase.

One fixture fix came along with this: `pod_factory` built container specs with
`mock.MagicMock(name=container_name)`, where `name` is consumed by the MagicMock constructor
rather than set as an attribute, so `spec.containers[*].name` read back as a child mock instead
of the container name. Nothing depended on it before, but the sidecar check does.

Ran the full `providers/cncf/kubernetes` unit suite plus the two dependent providers that import
these modules (amazon `test_eks.py`, google `test_kubernetes_engine.py`) — no regressions.

Happy to add a `docs/changelog.rst` entry if the behaviour change is worth calling out; read it
as a routine bug fix, so left it out per the providers changelog guidance.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
