### PR TITLE
Fix only_new clear missing tasks after run_on_latest_version

### DIFF
--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -272,10 +272,10 @@ def _get_new_task_ids(
     session: Session,
 ) -> list[str]:
     """
-    Get task ids for newly added tasks in the latest DAG version.
+    Get task ids for tasks present in the latest DAG version but missing a TI on this run.
 
-    This is a read-only operation that compares the current DAG version
-    with the latest DAG version to identify new tasks.
+    This is a read-only operation that compares the run's existing TaskInstance
+    rows with the latest DAG version to identify new tasks.
 
     :param dag_id: The dag_id for the DAG
     :param run_id: The run_id for the DAG run
@@ -295,15 +295,12 @@ def _get_new_task_ids(
     if not latest_dag:
         raise ValueError(f"Latest DAG version for '{dag_id}' not found")
 
-    # Use created_dag_version_id directly to get the DAG version the run was
-    # originally created with. We cannot use get_dag_for_run here because it
-    # falls back to the latest version when bundle_version is not set (e.g.
-    # LocalDagBundle), which would make current_dag == latest_dag and the diff
-    # always empty.
-    current_dag = None
-    if dag_run.created_dag_version_id:
-        current_dag = scheduler_dagbag.get_dag(version_id=dag_run.created_dag_version_id, session=session)
-    new_task_ids = set(latest_dag.task_ids) - set(current_dag.task_ids) if current_dag else set()
+    # Determine missing tasks from the run's actual TaskInstance rows.
+    # Do not diff against created_dag_version_id: clear(..., run_on_latest_version=True)
+    # can mutate that pointer to the latest version without creating TIs for tasks
+    # added between the run's original version and latest (see apache/airflow#71455).
+    existing_task_ids = {ti.task_id for ti in dag_run.get_task_instances(session=session)}
+    new_task_ids = set(latest_dag.task_ids) - existing_task_ids
 
     return list(new_task_ids)
 

--- a/airflow-core/tests/unit/models/test_cleartasks.py
+++ b/airflow-core/tests/unit/models/test_cleartasks.py
@@ -951,6 +951,79 @@ class TestClearTasks:
 
         assert count == 0
 
+    def test_clear_only_new_after_partial_run_on_latest_version(self, dag_maker, session):
+        """only_new must still find real new tasks after a prior run_on_latest_version clear.
+
+        Repro for apache/airflow#71455: clearing a subset with run_on_latest_version=True on a
+        running/queued DagRun bumps created_dag_version_id to latest without creating TIs for
+        tasks added in that version (verify_integrity is only called for finished DagRuns).
+        only_new must inspect actual TI rows, not trust created_dag_version_id.
+        """
+        with dag_maker(
+            "test_clear_only_new_after_partial_latest",
+            bundle_version="v1",
+        ) as dag:
+            EmptyOperator(task_id="0")
+            EmptyOperator(task_id="1")
+        dr = dag_maker.create_dagrun(
+            state=State.RUNNING,
+            run_type=DagRunType.SCHEDULED,
+        )
+
+        old_dag_version = DagVersion.get_latest_version(dr.dag_id)
+        ti0, ti1 = sorted(dr.task_instances, key=lambda ti: ti.task_id)
+        for ti in (ti0, ti1):
+            ti.refresh_from_task(dag.get_task(ti.task_id))
+            ti.state = TaskInstanceState.SUCCESS
+            session.merge(ti)
+        # Leave the DagRun itself running/queued so clear() takes the non-finished path
+        # that mutates created_dag_version_id without verify_integrity.
+        dr.state = DagRunState.RUNNING
+        session.merge(dr)
+        session.flush()
+
+        with dag_maker(
+            "test_clear_only_new_after_partial_latest",
+            bundle_version="v2",
+        ) as dag:
+            EmptyOperator(task_id="0")
+            EmptyOperator(task_id="1")
+            EmptyOperator(task_id="2")
+
+        new_dag_version = DagVersion.get_latest_version(dr.dag_id)
+        assert old_dag_version.id != new_dag_version.id
+
+        clear_task_instances([ti0], session, run_on_latest_version=True)
+        session.commit()
+
+        dr_after = session.scalar(
+            select(DagRun).where(DagRun.dag_id == dr.dag_id, DagRun.run_id == dr.run_id)
+        )
+        assert dr_after.created_dag_version_id == new_dag_version.id
+        assert {ti.task_id for ti in dr_after.task_instances} == {"0", "1"}
+
+        new_tis = dag.clear(
+            run_id=dr.run_id,
+            only_new=True,
+            dry_run=True,
+            session=session,
+        )
+        assert sorted(new_tis) == ["2"]
+
+        count = dag.clear(
+            run_id=dr.run_id,
+            only_new=True,
+            session=session,
+        )
+        assert count == 1
+
+        session.expire_all()
+        updated_dr = session.scalar(
+            select(DagRun).where(DagRun.dag_id == dr.dag_id, DagRun.run_id == dr.run_id)
+        )
+        assert {ti.task_id for ti in updated_dr.task_instances} == {"0", "1", "2"}
+
+
     def test_clear_normal_task_includes_setup_and_teardown(self, dag_maker):
         with dag_maker("test_clear_normal_task_includes_setup_and_teardown") as dag:
             setup_t = EmptyOperator(task_id="setup_t").as_setup()


### PR DESCRIPTION
Fix `only_new` clear silently missing newly added tasks after a prior `run_on_latest_version` clear.

`_get_new_task_ids` previously diffed the latest Dag against `created_dag_version_id`. Clearing a **running/queued** DagRun with `run_on_latest_version=True` bumps that pointer to latest without calling `verify_integrity`, so TaskInstances are not created for tasks added between the original version and latest. The version diff then becomes empty even when tasks are truly missing.

Note: on finished DagRuns, `run_on_latest_version` already calls `verify_integrity`, which creates missing TIs. The gap addressed here is the running/queued path (and any case where `created_dag_version_id` no longer reflects the run's actual TI set).

This change determines missing tasks from the DagRun's actual TaskInstance rows instead of trusting `created_dag_version_id`.

closes: #71455

## Testing

- `uv run --project airflow-core pytest airflow-core/tests/unit/models/test_cleartasks.py::TestClearTasks::test_clear_only_new_after_partial_run_on_latest_version airflow-core/tests/unit/models/test_cleartasks.py::TestClearTasks::test_clear_only_new_tasks airflow-core/tests/unit/models/test_cleartasks.py::TestClearTasks::test_clear_only_new_tasks_dry_run airflow-core/tests/unit/models/test_cleartasks.py::TestClearTasks::test_clear_only_new_no_new_tasks -q`

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.