### PR TITLE
Let a watcher trigger keep state when several assets watch it

### DIFF
--- a/airflow-core/docs/core-concepts/asset-state-store.rst
+++ b/airflow-core/docs/core-concepts/asset-state-store.rst
@@ -153,9 +153,9 @@ Deletes *all* asset state store keys for the asset.
 Using ``asset_state_store`` inside a Watcher Trigger
 -----------------------------------------------------
 
-:class:`~airflow.triggers.base.BaseEventTrigger` subclasses (watcher triggers) can read and write asset state store directly from within ``run()``. The triggerer injects ``self.asset_state_store`` before ``run()`` is called, scoped to the asset the trigger is watching. It is not available during ``__init__`` or ``serialize()``, only access it from within ``run()``.
+:class:`~airflow.triggers.base.BaseEventTrigger` subclasses (watcher triggers) can read and write asset state store directly from within ``run()``. The triggerer injects ``self.asset_state_store`` before ``run()`` is called, scoped to the assets that watch the trigger. It is not available during ``__init__`` or ``serialize()``, only access it from within ``run()``.
 
-Unlike task-based access (where the asset is identified by an inlet or outlet declaration), the accessor in a watcher trigger is automatically bound to the watched asset, so no subscripting is needed.
+Unlike task-based access (where the asset is identified by an inlet or outlet declaration), a watcher trigger never names its asset, so the shorthand is bound for it and no subscripting is needed.
 
 .. code-block:: python
 
@@ -218,6 +218,27 @@ The corresponding :class:`~airflow.sdk.definitions.asset.AssetWatcher` wires the
     ...
 
 ``self.asset_state_store`` behaves identically to the per-asset accessor described in the task sections above: ``get``, ``set``, ``delete``, and ``clear`` are all available. Values written by the trigger are visible to any task that declares ``my_asset`` as an inlet or outlet, and vice versa.
+
+Triggers are deduplicated by their classpath and arguments, so several assets watching identical triggers share one, and that trigger is handed one accessor per asset. The shorthand above raises a ``ValueError`` in that case, because there is no single asset to bind to. A trigger that keeps state has to handle it, and cannot follow the error's advice to subscript, since it does not know its assets. Size ``self.asset_state_store`` to tell the cases apart, and iterate it to reach each accessor:
+
+.. code-block:: python
+
+    async def run(self) -> AsyncIterator[TriggerEvent]:
+        while True:
+            # The oldest cursor, so a write that reached only some assets repeats rather than skips.
+            seen = [accessor.get("last_seen_id") for accessor in self.asset_state_store]
+            last_seen = min((value for value in seen if value is not None), default=0)
+
+            new_id = self._poll_for_new_record(source=self.source, last_seen=last_seen)
+            if new_id is not None:
+                for accessor in self.asset_state_store:
+                    accessor.set("last_seen_id", new_id)
+                yield TriggerEvent({"status": "success", "record_id": new_id})
+                return
+
+            await asyncio.sleep(self.waiter_delay)
+
+``len(self.asset_state_store)`` reports how many assets watch the trigger, for a trigger that would rather keep no state than keep it for several assets at once.
 
 .. note::
 

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -25,6 +25,7 @@ from collections.abc import Generator, Iterable, Iterator, Mapping, Sequence
 from contextvars import ContextVar
 from datetime import datetime, timedelta, timezone
 from functools import cache
+from itertools import chain
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, overload
 from uuid import UUID
 
@@ -852,6 +853,10 @@ class AssetStateStoreAccessors:
 
     For tasks with exactly one concrete inlet or outlet, the accessor methods (``get``,
     ``set``, ``delete``, ``clear``) can be called directly without subscripting.
+
+    Callers that do not know their assets up front, such as a trigger shared by several
+    asset watchers, can use ``len()`` to tell whether the direct methods apply and iterate
+    to reach every accessor in turn.
     """
 
     def __init__(self, inlets: list, outlets: list | None = None) -> None:
@@ -889,6 +894,13 @@ class AssetStateStoreAccessors:
         except KeyError:
             raise KeyError(f"{key!r} is not in this task's inlets or outlets")
         raise TypeError(f"Expected Asset, AssetNameRef, or AssetUriRef; got {type(key).__name__}")
+
+    def __len__(self) -> int:
+        return self._total
+
+    def __iter__(self) -> Iterator[AssetStateStoreAccessor]:
+        """Iterate the per asset accessors, for callers that address every asset in turn."""
+        return chain(self._by_name.values(), self._by_uri.values())
 
     def _single_accessor(self) -> AssetStateStoreAccessor:
         if self._total != 1:

--- a/task-sdk/tests/task_sdk/execution_time/test_context.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_context.py
@@ -1980,6 +1980,42 @@ class TestAssetStateStoreAccessors:
         with pytest.raises(ValueError, match="2 concrete inlets and outlets"):
             AssetStateStoreAccessors([a1, a2]).get("watermark")
 
+    def test_len_reports_the_accessor_count(self):
+        a1 = Asset(name="asset_one", uri="s3://one")
+        a2 = Asset(name="asset_two", uri="s3://two")
+
+        assert len(AssetStateStoreAccessors([a1])) == 1
+        assert len(AssetStateStoreAccessors([a1, a2])) == 2
+        assert len(AssetStateStoreAccessors([])) == 0
+
+    def test_len_counts_a_uri_ref_alongside_a_name(self):
+        assert (
+            len(AssetStateStoreAccessors([Asset(name="one", uri="s3://one"), AssetUriRef("s3://two")])) == 2
+        )
+
+    def test_iter_yields_every_accessor(self):
+        a1 = Asset(name="asset_one", uri="s3://one")
+        a2 = Asset(name="asset_two", uri="s3://two")
+        accessors = AssetStateStoreAccessors([a1, a2])
+
+        assert list(accessors) == [accessors[a1], accessors[a2]]
+
+    def test_iter_yields_name_and_uri_accessors(self):
+        asset = Asset(name="by_name", uri="s3://one")
+        ref = AssetUriRef("s3://two")
+
+        accessors = AssetStateStoreAccessors([asset, ref])
+
+        assert list(accessors) == [accessors[asset], accessors[ref]]
+
+    def test_iter_is_independent_per_call(self):
+        accessors = AssetStateStoreAccessors([Asset(name="one", uri="s3://one")])
+
+        assert list(accessors) == list(accessors)
+
+    def test_iter_is_empty_without_assets(self):
+        assert list(AssetStateStoreAccessors([])) == []
+
     def test_alias_inlet_resolves_to_concrete_assets(self, mock_supervisor_comms):
         alias = AssetAlias(name="my_alias")
         mock_supervisor_comms.send.return_value = AssetsByAliasResult(


### PR DESCRIPTION
# Rationale for this change

Two teams watch the same `orders` feed. Their triggers are identical, so Airflow keeps one trigger row serving both, on purpose: two pollers would hammer the source. It gets one accessor per asset, but the watcher example in our docs assumes only one:

```python
last_seen = self.asset_state_store.get("last_seen_id", default=0)
```

It raises `ValueError: Task has 2 concrete inlets and outlets — use context['asset_state_store'][MY_ASSET] to specify which`, and neither team's pipeline runs. A trigger cannot take that advice: it has no `context`, and never learns its assets, since it is rebuilt from `serialize()` kwargs that name none.

# What changes are included in this PR?

`len()` and iteration on `AssetStateStoreAccessors`, so a trigger can ask how many assets it serves and reach each.

```python
seen = [a.get("last_seen_id") for a in self.asset_state_store]
last_seen = min((v for v in seen if v is not None), default=0)  # oldest: a partial
...                            # write repeats a record rather than skipping one
for a in self.asset_state_store:
    a.set("last_seen_id", new_id)
```

# Are these changes tested?

Live, on Postgres with api-server, dag-processor, scheduler and triggerer as separate processes. Two assets watch the docs' `PollEventsTrigger` unmodified, polling a file; both land on one trigger row.

<details><summary>Before and after</summary>

```console
--- on main: the trigger cannot start ---
[error] Trigger ID 1 exited with error Task has 2 concrete inlets and outlets
[error] Trigger exited without sending an event. Dependent tasks will be failed.
$ grep -c "exited with error Task has 2 concrete" triggerer.log
29        # in 59s; with this change, 0

# both runs: echo record-1 > $AIRFLOW_HOME/feed.txt && sleep 30, then
$ psql -c "SELECT a.name, count(e.id) FROM asset a
           LEFT JOIN asset_event e ON e.asset_id=a.id GROUP BY a.name"
 orders_api    | 0 -> 1   # asset_state_store holds "record-1" for each
 orders_mirror | 0 -> 1
$ psql -c "SELECT dag_id, state FROM dag_run"
 (none) -> docs_team_a | running, docs_team_b | running
```

</details>

Six unit tests cover `len` and iteration; all fail on `main`.

# Are there any user-facing changes?

One asset behaves as before; several can now keep state at all. `get`/`set`/`delete`/`clear` still raise for several.

#71354's `aget`/`aset`/`adelete`/`aclear` hit the same `_single_accessor` and raise here too; the two compose. First consumer: #71751.
