### PR TITLE
Add a budget argument to AnthropicAgentSessionOperator

### DIFF
--- a/providers/anthropic/docs/operators/anthropic.rst
+++ b/providers/anthropic/docs/operators/anthropic.rst
@@ -147,9 +147,13 @@ Parameters
 * ``poll_interval`` — seconds between session status checks.
 * ``timeout`` — seconds to wait for a terminal status; defaults to 24 hours.
 * ``vault_ids`` — vault IDs providing MCP/credential access to the session.
+* ``budget`` -- spend ceiling for the session, in US dollars (``25.00``) or as the raw API
+  payload (a mapping). Templated, so it can come from a Variable, a params entry, or
+  an upstream XCom. See `Session budgets`_ below.
 * ``session_resources`` — files, GitHub repos, or memory stores to mount (forwarded to
   ``sessions.create`` as ``resources``; renamed to avoid the reserved ``BaseOperator.resources``).
-* ``session_kwargs`` — extra keyword arguments forwarded to ``sessions.create``.
+* ``session_kwargs`` — extra keyword arguments forwarded to ``sessions.create``. Setting
+  ``budget`` here as well as via the ``budget`` argument is rejected.
 
 .. note::
 
@@ -163,10 +167,9 @@ Parameters
 Session budgets
 """""""""""""""
 
-Pass a `session budget
-<https://platform.claude.com/docs/en/managed-agents/overview>`__ through
-``session_kwargs`` to cap what a single session may spend. The session stops issuing new
-model requests once its tracked list cost reaches the ceiling:
+``budget`` bounds what a single session may spend. The session stops issuing new model
+requests once its tracked list cost reaches the ceiling. A number or numeric string is read
+as **US dollars**:
 
 .. code-block:: python
 
@@ -175,14 +178,33 @@ model requests once its tracked list cost reaches the ceiling:
         agent_id="agt_...",
         environment_id="env_...",
         message="Summarise yesterday's incidents.",
-        session_kwargs={
-            "budget": {
-                "type": "limit",
-                # Minor units as an integer string: "2500" is $25.00.
-                "max_list_cost": {"amount": "2500", "currency": "USD"},
-            }
-        },
+        budget=25.00,  # 25.00 USD
+        retries=0,
     )
+
+The field is templated, so the ceiling can come from a Variable
+(``budget="{{ var.value.max_agent_spend }}"``) and be changed without editing the Dag.
+Amounts are converted through :class:`~decimal.Decimal`, never binary float, and anything
+finer than a cent is rejected rather than silently rounded.
+
+Pass a mapping instead to send the raw API payload, for a budget shape the provider has not
+caught up with. Today the API accepts only ``type: "limit"`` and ``currency: "USD"``, so the
+mapping form is an escape hatch for future additions rather than something needed now:
+
+.. code-block:: python
+
+    budget = {"type": "limit", "max_list_cost": {"amount": "2500", "currency": "USD"}}
+
+To raise or remove a ceiling on a session that is already running, use
+:meth:`~airflow.providers.anthropic.hooks.anthropic.AnthropicHook.update_session`. Only the
+keywords you pass are sent, because the API distinguishes *omitted* (preserve) from
+``None`` (clear):
+
+.. code-block:: python
+
+    hook = AnthropicHook()
+    hook.update_session(session_id, budget=50.00)  # raise the ceiling
+    hook.update_session(session_id, budget=None)  # remove it entirely
 
 On a ``message`` run, a session that stops this way raises
 :class:`~airflow.providers.anthropic.exceptions.AnthropicSessionBudgetExceeded`, a subclass
@@ -196,6 +218,13 @@ rather than treated as a fault.
     continues until ``timeout`` (24 hours by default), and the task then fails with
     ``AnthropicAgentSessionTimeout`` -- a misleading error for a session that stopped
     deliberately. Set a shorter ``timeout`` when combining ``outcome`` with a budget.
+
+.. note::
+
+    On an ``outcome`` run, completion is judged from the session's ``outcome_evaluations``
+    before the idle event is consulted, so a budget stop is reported as whatever verdict the
+    outcome recorded and raises the generic ``AnthropicAgentSessionError``. Catch
+    ``AnthropicSessionBudgetExceeded`` only on ``message`` runs.
 
 .. warning::
 

--- a/providers/anthropic/src/airflow/providers/anthropic/hooks/anthropic.py
+++ b/providers/anthropic/src/airflow/providers/anthropic/hooks/anthropic.py
@@ -18,6 +18,9 @@ from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Mapping
+from copy import deepcopy
+from decimal import Decimal, InvalidOperation
 from enum import Enum
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
@@ -52,6 +55,7 @@ if TYPE_CHECKING:
     from anthropic.types.beta import (
         BetaEnvironment,
         BetaManagedAgentsAgent,
+        BetaManagedAgentsBudgetLimitParam,
         BetaManagedAgentsSession,
         environment_create_params,
     )
@@ -122,6 +126,49 @@ OUTCOME_FAILURE_RESULTS = frozenset({"failed", "max_iterations_reached", "interr
 
 # ``session.status_idle`` stop reason emitted when a session stops against its budget.
 BUDGET_REACHED = "budget_reached"
+
+# What a caller may pass as a session budget: an amount in USD, or the raw API payload.
+BudgetSpec = str | int | float | Decimal | Mapping[str, Any]
+
+
+def build_budget(budget: BudgetSpec) -> BetaManagedAgentsBudgetLimitParam:
+    """
+    Normalize a session budget into the API's ``max_list_cost`` payload.
+
+    A scalar is read as **US dollars** (``25``, ``25.0`` and ``"25.00"`` all mean $25.00).
+    The API wants minor units as an integer decimal string, so the conversion runs through
+    :class:`~decimal.Decimal` (never binary float) and rejects an amount finer than a cent
+    rather than silently rounding money. A mapping is deep-copied and otherwise returned
+    unchanged, so a raw payload the provider has not caught up with stays usable without a
+    provider release.
+
+    .. warning::
+        The ceiling is a stop trigger, not a cap: it is checked between model requests, so
+        a request already in flight can carry the session well past it.
+    """
+    if isinstance(budget, Mapping):
+        # Deep, not ``dict()``: a shallow copy leaves the nested ``max_list_cost`` aliased
+        # to the caller's object, so a later edit of the returned payload would reach back
+        # into a templated operator field.
+        # Cast, not validate: a raw payload is accepted precisely so a caller can reach a
+        # field this provider does not model yet, so its shape cannot be checked here.
+        return cast("BetaManagedAgentsBudgetLimitParam", deepcopy(dict(budget)))
+    try:
+        dollars = Decimal(str(budget))
+    except (InvalidOperation, ValueError) as e:
+        raise ValueError(f"Invalid budget {budget!r}: not a decimal amount in USD.") from e
+    if not dollars.is_finite() or dollars <= 0:
+        raise ValueError(f"Invalid budget {budget!r}: must be a positive USD amount.")
+    minor_units = dollars * 100
+    if minor_units != minor_units.to_integral_value():
+        raise ValueError(
+            f"Invalid budget {budget!r}: amounts finer than a cent are not representable. "
+            "Pass a mapping if you need the raw payload."
+        )
+    return {
+        "type": "limit",
+        "max_list_cost": {"amount": str(int(minor_units)), "currency": "USD"},
+    }
 
 
 def _create_session_error(message: str, stop_reason: str | None) -> AnthropicAgentSessionError:
@@ -570,11 +617,43 @@ class AnthropicHook(BaseHook):
         return environment
 
     def create_session(self, agent: str, environment_id: str, **kwargs: Any) -> BetaManagedAgentsSession:
-        """Start a session against a pre-created agent + environment."""
+        """
+        Start a session against a pre-created agent + environment.
+
+        A ``budget`` keyword accepts an amount in USD as well as the raw API payload; see
+        :func:`build_budget`.
+        """
         self._require_first_party("Managed Agents")
+        if "budget" in kwargs:
+            if kwargs["budget"] is None:
+                # ``SessionCreateParams.budget`` is not Optional -- unlike the update
+                # params, create has no "clear the ceiling" semantics, and sending
+                # ``"budget": null`` is rejected. Treat None as "no budget".
+                kwargs.pop("budget")
+            else:
+                kwargs["budget"] = build_budget(kwargs["budget"])
         return self._first_party_conn.beta.sessions.create(
             agent=agent, environment_id=environment_id, **kwargs
         )
+
+    def update_session(self, session_id: str, **kwargs: Any) -> BetaManagedAgentsSession:
+        """
+        Update a live session -- raise or clear its ``budget``, swap ``agent`` tools, retitle.
+
+        Only the keywords you pass are sent, which matters because the API distinguishes
+        *omitted* (preserve) from ``None`` (clear). So ``update_session(sid)`` changes
+        nothing, while ``update_session(sid, budget=None)`` removes the ceiling -- the
+        escape hatch for a session stopped by a model with no list price, which raising the
+        budget cannot unblock.
+
+        ``budget`` accepts an amount in USD or the raw payload (see :func:`build_budget`).
+        ``agent={"tools": [...]}`` is a **full replacement** of the tool list, not a merge,
+        and needs the ``mid-conversation-tool-changes-2026-07-01`` beta.
+        """
+        self._require_first_party("Managed Agents")
+        if kwargs.get("budget") is not None:
+            kwargs["budget"] = build_budget(kwargs["budget"])
+        return self._first_party_conn.beta.sessions.update(session_id, **kwargs)
 
     def get_session(self, session_id: str) -> BetaManagedAgentsSession:
         """Retrieve a session (carries its current ``status``)."""

--- a/providers/anthropic/src/airflow/providers/anthropic/operators/agent.py
+++ b/providers/anthropic/src/airflow/providers/anthropic/operators/agent.py
@@ -26,12 +26,14 @@ from airflow.providers.anthropic.exceptions import AnthropicAgentSessionTimeout
 from airflow.providers.anthropic.hooks.anthropic import (
     AnthropicHook,
     _create_session_error,
+    build_budget,
     validate_execute_complete_event,
 )
 from airflow.providers.anthropic.triggers.agent import AnthropicAgentSessionTrigger
 from airflow.providers.common.compat.sdk import BaseOperator, conf
 
 if TYPE_CHECKING:
+    from airflow.providers.anthropic.hooks.anthropic import BudgetSpec
     from airflow.providers.common.compat.sdk import Context
 
 
@@ -85,17 +87,24 @@ class AnthropicAgentSessionOperator(BaseOperator):
     :param session_resources: Session resources (files, GitHub repos, memory stores). Named
         ``session_resources`` to avoid colliding with the reserved ``BaseOperator.resources``;
         forwarded to ``sessions.create`` as ``resources``.
-    :param session_kwargs: Extra keyword arguments forwarded to ``sessions.create``, such as
-        ``budget`` (a spend ceiling for the session). A session that stops against its
-        budget raises
+    :param budget: Spend ceiling for the session. A number or numeric string is read as
+        **US dollars** (``budget=25`` is $25.00); a mapping is passed through as the raw
+        API payload. On a ``message`` run, a session that stops against it raises
         :class:`~airflow.providers.anthropic.exceptions.AnthropicSessionBudgetExceeded`.
-        The ceiling is a stop trigger rather than a cap -- it is checked between model
-        requests, so an in-flight request can carry the session past it. Airflow
-        ``retries`` also each start a new session with a fresh budget, so prefer
-        ``retries=0`` when a budget is set.
+        On an ``outcome`` run completion is judged from ``outcome_evaluations`` before the
+        idle event is consulted, so a budget stop surfaces as the outcome verdict and the
+        generic ``AnthropicAgentSessionError`` instead.
+
+        .. warning::
+            The ceiling is a stop trigger, not a cap. It is checked between model requests,
+            so a request already in flight runs to completion and the session can finish
+            well above the limit. Airflow ``retries`` also each start a new session with a
+            fresh budget, so prefer ``retries=0`` when a budget is set.
+    :param session_kwargs: Extra keyword arguments forwarded to ``sessions.create``. Setting
+        ``budget`` here as well as via the ``budget`` argument is rejected.
     """
 
-    template_fields: Sequence[str] = ("agent_id", "environment_id", "message", "outcome")
+    template_fields: Sequence[str] = ("agent_id", "environment_id", "message", "outcome", "budget")
 
     def __init__(
         self,
@@ -108,6 +117,7 @@ class AnthropicAgentSessionOperator(BaseOperator):
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
         poll_interval: float = 30,
         timeout: float = 24 * 60 * 60,
+        budget: BudgetSpec | None = None,
         vault_ids: list[str] | None = None,
         session_resources: list[dict[str, Any]] | None = None,
         session_kwargs: dict[str, Any] | None = None,
@@ -122,6 +132,7 @@ class AnthropicAgentSessionOperator(BaseOperator):
         self.deferrable = deferrable
         self.poll_interval = poll_interval
         self.timeout = timeout
+        self.budget = budget
         self.vault_ids = vault_ids
         self.session_resources = session_resources
         self.session_kwargs = session_kwargs or {}
@@ -138,6 +149,14 @@ class AnthropicAgentSessionOperator(BaseOperator):
         if self.outcome is not None and not {"description", "rubric"} <= self.outcome.keys():
             raise ValueError("'outcome' must include both 'description' and 'rubric'.")
         create_kwargs: dict[str, Any] = dict(self.session_kwargs)
+        if self.budget is not None:
+            if "budget" in create_kwargs:
+                raise ValueError(
+                    "Set the budget either via 'budget' or via session_kwargs['budget'], not both."
+                )
+            # Normalize eagerly so a malformed amount fails before a session (and its
+            # server-side container) is allocated.
+            create_kwargs["budget"] = build_budget(self.budget)
         if self.vault_ids:
             create_kwargs["vault_ids"] = self.vault_ids
         if self.session_resources:

--- a/providers/anthropic/tests/unit/anthropic/hooks/test_anthropic.py
+++ b/providers/anthropic/tests/unit/anthropic/hooks/test_anthropic.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+from decimal import Decimal
 from unittest import mock
 
 import pytest
@@ -36,6 +37,7 @@ from airflow.providers.anthropic.hooks.anthropic import (
     SessionPollResult,
     SessionStatus,
     _create_session_error,
+    build_budget,
     evaluate_session_state,
     validate_execute_complete_event,
 )
@@ -218,6 +220,105 @@ class TestPollSessionCompletion:
             assert named_cause in poll_result.error_message
         # The inverse matters just as much: the generic advice must not appear here.
         assert "autonomous agent" not in poll_result.error_message
+
+
+class TestBuildBudget:
+    @pytest.mark.parametrize(
+        ("amount", "expected_minor_units"),
+        [
+            pytest.param(25, "2500", id="int-dollars"),
+            pytest.param(25.0, "2500", id="float-dollars"),
+            pytest.param("25.00", "2500", id="str-dollars"),
+            pytest.param(Decimal("25.00"), "2500", id="decimal-dollars"),
+            pytest.param(0.07, "7", id="float-cents-no-binary-artifact"),
+            pytest.param("0.01", "1", id="one-cent"),
+            pytest.param(1234.56, "123456", id="mixed"),
+        ],
+    )
+    def test_scalar_is_usd_dollars(self, amount, expected_minor_units):
+        assert build_budget(amount) == {
+            "type": "limit",
+            "max_list_cost": {"amount": expected_minor_units, "currency": "USD"},
+        }
+
+    def test_mapping_passes_through_unchanged(self):
+        # The escape hatch for a payload shape the provider has not caught up with. Uses a
+        # currently-valid payload: the API accepts only type "limit" and currency "USD".
+        raw = {"type": "limit", "max_list_cost": {"amount": "500", "currency": "USD"}}
+        assert build_budget(raw) == raw
+
+    def test_mapping_is_deep_copied_not_aliased(self):
+        # A shallow copy would leave max_list_cost aliased to the caller's dict, so editing
+        # the returned payload would reach back into a templated operator field.
+        raw = {"type": "limit", "max_list_cost": {"amount": "500", "currency": "USD"}}
+        built = build_budget(raw)
+        built["type"] = "mutated"
+        built["max_list_cost"]["amount"] = "999999"
+        assert raw == {"type": "limit", "max_list_cost": {"amount": "500", "currency": "USD"}}
+
+    @pytest.mark.parametrize(
+        ("amount", "match"),
+        [
+            pytest.param(0, "positive", id="zero"),
+            pytest.param(-5, "positive", id="negative"),
+            pytest.param("abc", "not a decimal", id="not-a-number"),
+            pytest.param(True, "not a decimal", id="bool-is-not-an-amount"),
+            pytest.param("0.001", "finer than a cent", id="sub-cent"),
+            pytest.param(float("inf"), "positive", id="infinity"),
+        ],
+    )
+    def test_rejects_bad_amounts(self, amount, match):
+        with pytest.raises(ValueError, match=match):
+            build_budget(amount)
+
+
+class TestUpdateSession:
+    def test_only_passes_supplied_keys(self):
+        # The API distinguishes omitted (preserve) from None (clear), so an unmentioned
+        # field must not be sent at all.
+        hook, client = _make_hook()
+        hook.update_session("sess_1", title="renamed")
+        client.beta.sessions.update.assert_called_once_with("sess_1", title="renamed")
+
+    def test_explicit_none_budget_clears(self):
+        hook, client = _make_hook()
+        hook.update_session("sess_1", budget=None)
+        client.beta.sessions.update.assert_called_once_with("sess_1", budget=None)
+
+    def test_normalizes_a_dollar_amount(self):
+        hook, client = _make_hook()
+        hook.update_session("sess_1", budget=25)
+        client.beta.sessions.update.assert_called_once_with(
+            "sess_1", budget={"type": "limit", "max_list_cost": {"amount": "2500", "currency": "USD"}}
+        )
+
+    @pytest.mark.parametrize("platform", ["bedrock", "vertex", "foundry"])
+    def test_unavailable_on_non_first_party(self, platform):
+        hook, _ = _make_hook(extra={"platform": platform})
+        with pytest.raises(AnthropicError, match="Managed Agents is not available"):
+            hook.update_session("sess_1", title="x")
+
+
+class TestCreateSessionBudget:
+    def test_normalizes_a_dollar_amount(self):
+        hook, client = _make_hook()
+        hook.create_session(agent="ag", environment_id="env", budget="25.00")
+        assert client.beta.sessions.create.call_args.kwargs["budget"] == {
+            "type": "limit",
+            "max_list_cost": {"amount": "2500", "currency": "USD"},
+        }
+
+    def test_no_budget_key_when_not_requested(self):
+        hook, client = _make_hook()
+        hook.create_session(agent="ag", environment_id="env")
+        assert "budget" not in client.beta.sessions.create.call_args.kwargs
+
+    def test_drops_a_none_budget(self):
+        # SessionCreateParams.budget is not Optional, so "budget": null is rejected -- but
+        # budget=None is the idiom update_session teaches for clearing a ceiling.
+        hook, client = _make_hook()
+        hook.create_session(agent="ag", environment_id="env", budget=None)
+        assert "budget" not in client.beta.sessions.create.call_args.kwargs
 
 
 class TestCreateSessionError:

--- a/providers/anthropic/tests/unit/anthropic/operators/test_agent.py
+++ b/providers/anthropic/tests/unit/anthropic/operators/test_agent.py
@@ -38,6 +38,19 @@ def _context():
     return {"ti": mock.MagicMock()}
 
 
+def _create_op(**kwargs) -> AnthropicAgentSessionOperator:
+    # deferrable=False explicitly: the default reads operators.default_deferrable, which
+    # would send these through defer() instead of the synchronous path.
+    return AnthropicAgentSessionOperator(
+        task_id="a",
+        agent_id="ag",
+        environment_id="env",
+        message="hi",
+        deferrable=False,
+        **kwargs,
+    )
+
+
 def test_requires_exactly_one_of_message_or_outcome():
     op = AnthropicAgentSessionOperator(task_id="a", agent_id="ag", environment_id="env")
     with pytest.raises(ValueError, match="exactly one"):
@@ -197,6 +210,54 @@ class TestExecute:
         assert exc.value.trigger.session_id == "sess_1"
         assert exc.value.method_name == "execute_complete"
         hook.wait_for_session.assert_not_called()
+
+
+class TestBudgetParam:
+    @mock.patch.object(AnthropicAgentSessionOperator, "hook", new_callable=mock.PropertyMock)
+    def test_dollar_amount_is_converted_to_minor_units(self, mock_hook_prop):
+        hook = mock.MagicMock(spec=AnthropicHook)
+        mock_hook_prop.return_value = hook
+        _create_op(budget=25).execute(_context())
+        assert hook.create_session.call_args.kwargs["budget"] == {
+            "type": "limit",
+            "max_list_cost": {"amount": "2500", "currency": "USD"},
+        }
+
+    @mock.patch.object(AnthropicAgentSessionOperator, "hook", new_callable=mock.PropertyMock)
+    def test_mapping_passes_through(self, mock_hook_prop):
+        hook = mock.MagicMock(spec=AnthropicHook)
+        mock_hook_prop.return_value = hook
+        raw = {"type": "limit", "max_list_cost": {"amount": "750", "currency": "USD"}}
+        _create_op(budget=raw).execute(_context())
+        assert hook.create_session.call_args.kwargs["budget"] == raw
+
+    @mock.patch.object(AnthropicAgentSessionOperator, "hook", new_callable=mock.PropertyMock)
+    def test_no_budget_key_when_unset(self, mock_hook_prop):
+        hook = mock.MagicMock(spec=AnthropicHook)
+        mock_hook_prop.return_value = hook
+        _create_op().execute(_context())
+        assert "budget" not in hook.create_session.call_args.kwargs
+
+    @mock.patch.object(AnthropicAgentSessionOperator, "hook", new_callable=mock.PropertyMock)
+    def test_conflicting_budget_sources_rejected(self, mock_hook_prop):
+        hook = mock.MagicMock(spec=AnthropicHook)
+        mock_hook_prop.return_value = hook
+        op = _create_op(budget=25, session_kwargs={"budget": {"type": "limit"}})
+        with pytest.raises(ValueError, match="not both"):
+            op.execute(_context())
+        hook.create_session.assert_not_called()
+
+    @mock.patch.object(AnthropicAgentSessionOperator, "hook", new_callable=mock.PropertyMock)
+    def test_invalid_amount_fails_before_allocating_a_session(self, mock_hook_prop):
+        # A bad amount must not leave a server-side container running.
+        hook = mock.MagicMock(spec=AnthropicHook)
+        mock_hook_prop.return_value = hook
+        with pytest.raises(ValueError, match="positive"):
+            _create_op(budget=-1).execute(_context())
+        hook.create_session.assert_not_called()
+
+    def test_budget_is_templated(self):
+        assert "budget" in AnthropicAgentSessionOperator.template_fields
 
 
 class TestExecuteComplete:


### PR DESCRIPTION
## Problem

Session budgets were reachable only as a raw payload through `session_kwargs`:

```python
session_kwargs={
    "budget": {"type": "limit", "max_list_cost": {"amount": "2500", "currency": "USD"}}
}
```

Minor units as an integer string is the right wire format but a poor authoring surface, and
being buried in a passthrough dict meant the ceiling could not be templated.

## Solution

`budget` is now a first-class templated argument. A number or numeric string is read as
**US dollars**, so the ceiling can come from a Variable and change without editing the Dag:

```python
AnthropicAgentSessionOperator(
    task_id="research",
    agent_id="agt_...",
    environment_id="env_...",
    message="Summarise yesterday's incidents.",
    budget=25.00,
    retries=0,
)
```

A mapping is still accepted verbatim for a payload shape the provider has not caught up
with.

Conversion runs through `Decimal` built from `str()`, never binary float, so `0.07` yields
`"7"` rather than a rounding artifact. An amount finer than a cent is rejected instead of
silently rounded: quietly changing an amount of money is worse than refusing it. The
operator normalizes before creating the session, so a bad amount fails without leaving a
server-side container allocated. Setting the budget both ways at once is rejected rather
than one silently winning.

`AnthropicHook.update_session` fills a gap that predates budgets -- the hook wrapped
create, retrieve and archive but never update. It forwards only the keywords the caller
passes, because the API distinguishes *omitted* (preserve) from `None` (clear):

```python
hook.update_session(session_id, budget=50.00)  # raise the ceiling
hook.update_session(session_id, budget=None)  # remove it entirely
```

Removing it is the only escape for a session stopped by a model with no list price, which
raising the ceiling cannot unblock. The same call carries the `agent={"tools": [...]}`
replacement behind the mid-conversation-tool-changes beta.

## Gotchas

**Units differ between the two forms.** A scalar is dollars; a mapping's `amount` is minor
units, so `budget=25` and `{"amount": "25"}` are 100x apart. Both are documented at the
point of use.

**`AnthropicSessionBudgetExceeded` fires on `message` runs only.** An `outcome` run is
judged from `outcome_evaluations` before the idle event is consulted, so a budget stop there
surfaces as the outcome verdict and the generic `AnthropicAgentSessionError`.

**Retries multiply spend.** Each Airflow retry starts a new session with a fresh budget, so
`retries=2` with a $25 ceiling can spend $75. Prefer `retries=0`, or raise the budget on the
existing session rather than retrying.
