### PR TITLE
Refactor AdvancedSearchToggle and SearchBar components for improved clarity and functionality

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/AdvancedSearchToggle.tsx
+++ b/airflow-core/src/airflow/ui/src/components/AdvancedSearchToggle.tsx
@@ -39,43 +39,6 @@ export const AdvancedSearchToggle = ({
 }: AdvancedSearchToggleProps) => {
   const { t: translate } = useTranslation("common");
 
-  const button =
-    variant === "addon" ? (
-      <Box
-        alignItems="center"
-        alignSelf="stretch"
-        aria-label="Toggle match-anywhere search"
-        aria-pressed={enabled}
-        as="button"
-        bg={enabled ? "colorPalette.solid" : "gray.muted"}
-        borderRightRadius="full"
-        color={enabled ? "colorPalette.contrast" : "colorPalette.fg"}
-        colorPalette={enabled ? "brand" : "gray"}
-        cursor="pointer"
-        data-testid="advanced-search-toggle"
-        display="flex"
-        onClick={() => onToggle(!enabled)}
-        // Keep focus on the FilterPill input so toggling does not collapse the pill.
-        onMouseDown={(event) => event.preventDefault()}
-        px={3}
-      >
-        <LuRegex />
-      </Box>
-    ) : (
-      <IconButton
-        aria-label="Toggle match-anywhere search"
-        aria-pressed={enabled}
-        data-testid="advanced-search-toggle"
-        flexShrink={0}
-        onClick={() => onToggle(!enabled)}
-        onMouseDown={(event) => event.preventDefault()}
-        size={size}
-        variant={enabled ? "solid" : "outline"}
-      >
-        <LuRegex />
-      </IconButton>
-    );
-
   return (
     <Tooltip
       content={
@@ -88,7 +51,41 @@ export const AdvancedSearchToggle = ({
       portalled
       showArrow
     >
-      {button}
+      {variant === "addon" ? (
+        <Box
+          alignItems="center"
+          alignSelf="stretch"
+          aria-label="Toggle match-anywhere search"
+          aria-pressed={enabled}
+          as="button"
+          bg={enabled ? "colorPalette.solid" : "gray.muted"}
+          borderRightRadius="full"
+          color={enabled ? "colorPalette.contrast" : "colorPalette.fg"}
+          colorPalette={enabled ? "brand" : "gray"}
+          cursor="pointer"
+          data-testid="advanced-search-toggle"
+          display="flex"
+          onClick={() => onToggle(!enabled)}
+          // Keep focus on the FilterPill input so toggling does not collapse the pill.
+          onMouseDown={(event) => event.preventDefault()}
+          px={3}
+        >
+          <LuRegex />
+        </Box>
+      ) : (
+        <IconButton
+          aria-label="Toggle match-anywhere search"
+          aria-pressed={enabled}
+          data-testid="advanced-search-toggle"
+          flexShrink={0}
+          onClick={() => onToggle(!enabled)}
+          onMouseDown={(event) => event.preventDefault()}
+          size={size}
+          variant={enabled ? "solid" : "ghost"}
+        >
+          <LuRegex />
+        </IconButton>
+      )}
     </Tooltip>
   );
 };

--- a/airflow-core/src/airflow/ui/src/components/SearchBar.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SearchBar.tsx
@@ -16,16 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { CloseButton, HStack, Input, InputGroup, Kbd, type InputGroupProps } from "@chakra-ui/react";
+import { Box, Icon, Input, InputGroup, type InputGroupProps } from "@chakra-ui/react";
 import { useEffect, useRef, useState, type ChangeEvent } from "react";
 import { useTranslation } from "react-i18next";
-import { FiSearch } from "react-icons/fi";
+import { FiSearch, FiX } from "react-icons/fi";
 import { useDebouncedCallback } from "use-debounce";
 
 import { AdvancedSearchToggle, type AdvancedSearchToggleProps } from "src/components/AdvancedSearchToggle";
 import { SHORTCUTS } from "src/context/keyboardShortcuts";
 import { useShortcut } from "src/hooks/useShortcut";
 import { getMetaKey } from "src/utils";
+
+import { IconButton } from "./ui";
 
 const debounceDelay = 200;
 
@@ -83,49 +85,37 @@ export const SearchBar = ({
     options: { enabled: !hotkeyDisabled, preventDefault: true },
   });
 
-  const inputGroup = (
+  return (
     <InputGroup
       colorPalette="brand"
       {...props}
       endElement={
-        <>
-          {Boolean(value) ? (
-            <CloseButton
-              aria-label={translate("search.clear")}
-              data-testid="clear-search"
-              onClick={clearSearch}
-              size="xs"
-            />
-          ) : undefined}
-          {!hotkeyDisabled && (
-            <Kbd size="sm">
-              {metaKey}
-              {translate("search.hotkey")}
-            </Kbd>
-          )}
-        </>
+        Boolean(value) || advancedSearch ? (
+          <Box alignItems="center" bg="bg" display="flex" gap={1} mr={-2}>
+            {Boolean(value) ? (
+              <IconButton
+                data-testid="clear-search"
+                label={translate("search.clear")}
+                onClick={clearSearch}
+                size="xs"
+                variant="ghost"
+              >
+                <FiX />
+              </IconButton>
+            ) : undefined}
+            {advancedSearch ? <AdvancedSearchToggle size="xs" {...advancedSearch} /> : undefined}
+          </Box>
+        ) : undefined
       }
-      startElement={<FiSearch />}
+      startElement={<Icon as={FiSearch} color="fg.subtle" />}
     >
       <Input
         data-testid="search-dags"
         onChange={onSearchChange}
-        placeholder={placeholder}
-        pr={150}
+        placeholder={`${placeholder}${hotkeyDisabled ? undefined : ` (${metaKey}${translate("search.hotkey")})`}`}
         ref={searchRef}
         value={value}
       />
     </InputGroup>
-  );
-
-  if (!advancedSearch) {
-    return inputGroup;
-  }
-
-  return (
-    <HStack alignItems="center" gap={2}>
-      {inputGroup}
-      <AdvancedSearchToggle {...advancedSearch} />
-    </HStack>
   );
 };


### PR DESCRIPTION


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

- Visually simplified the Searchbar component without removing any functionality. 
  - Moved the `AdvancedSearchToggle` inside the search box container to make it obvious that it is directly tied to the functionality of the search before hovering to reveal the tooltip
  - Moved the keyboard shortcut to the placeholder text. The `Kbd` component stands out too much visually.
- Gave the "clear search" icon button a tooltip
- Simplified component code with a single `return`
- Searchbar tests continue to pass

### Before:
<img width="687" height="300" alt="Zight Recording 2026-08-11 at 05 51 47 PM" src="https://github.com/user-attachments/assets/5311f486-50ca-42b7-9f57-988c73424349" />

### After:
<img width="693" height="300" alt="Zight Recording 2026-08-11 at 05 52 23 PM" src="https://github.com/user-attachments/assets/614c72c5-c85e-4f13-917e-3ce261e0a47d" />

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
