### PR TITLE
fix: preserve extra link XCom keys across task retries

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -291,6 +291,10 @@ def ti_run(
                 xcom_query = xcom_query.where(XComModel.map_index == map_index)
 
             xcom_keys = list(session.scalars(xcom_query))
+            # Preserve extra link XCom keys across retries. Extra links are backed
+            # by XCom rows with keys starting with "_link_", and clearing them on
+            # retry would lose the per-attempt links for earlier attempts.
+            xcom_keys = [k for k in xcom_keys if not k.startswith("_link_")]
         task_reschedule_count = (
             session.scalar(
                 select(func.count(TaskReschedule.id)).where(TaskReschedule.ti_id == task_instance_id)


### PR DESCRIPTION
When a task instance transitions to running, the execution API collects every XCom key for that task instance into `TIRunContext.xcom_keys_to_clear`, and the worker deletes each one. There is no filter — the only exemption is deferral.

This means a retry deletes the `_link_*` rows written by every previous attempt. An extra link can only ever resolve for the attempt that ran last. This collides with #65661 (try-aware extra-links endpoint), which made the read path attempt-aware while the write path still guarantees only the latest attempt's row exists.

**Fix**: Filter out XCom keys starting with `_link_` (the default `xcom_key` prefix for `BaseOperatorLink`) from the `xcom_keys_to_clear` list. This preserves per-attempt extra link rows across retries, allowing the try-aware endpoint to resolve links for any attempt.

Fixes #71471.
