### PR TITLE
Use SMTP connection host, port and TLS settings in send_mime_email

### DIFF
--- a/airflow-core/newsfragments/71474.bugfix.rst
+++ b/airflow-core/newsfragments/71474.bugfix.rst
@@ -1,0 +1,1 @@
+``send_mime_email`` now honors the host, port, STARTTLS/SSL, timeout, and retry limit configured on the SMTP connection, falling back to the ``[smtp]`` config only for fields the connection does not set. Previously only the login and password were read from the connection.

--- a/airflow-core/src/airflow/utils/email.py
+++ b/airflow-core/src/airflow/utils/email.py
@@ -251,6 +251,22 @@ def send_mime_email(
             airflow_conn = Connection.get_connection_from_secrets(conn_id)
             smtp_user = airflow_conn.login
             smtp_password = airflow_conn.password
+            # Prefer values set on the connection, falling back to the ``smtp`` config
+            # values above when the connection does not provide them. Extra keys and their
+            # negation mirror the smtp provider's SmtpHook so both paths behave the same.
+            extra = airflow_conn.extra_dejson
+            if airflow_conn.host:
+                smtp_host = airflow_conn.host
+            if airflow_conn.port:
+                smtp_port = airflow_conn.port
+            if "disable_tls" in extra:
+                smtp_starttls = not bool(extra["disable_tls"])
+            if "disable_ssl" in extra:
+                smtp_ssl = not bool(extra["disable_ssl"])
+            if "retry_limit" in extra:
+                smtp_retry_limit = int(extra["retry_limit"])
+            if "timeout" in extra:
+                smtp_timeout = int(extra["timeout"])
         except AirflowException:
             pass
     if smtp_user is None or smtp_password is None:

--- a/airflow-core/tests/unit/utils/test_email.py
+++ b/airflow-core/tests/unit/utils/test_email.py
@@ -257,6 +257,47 @@ class TestEmailSmtp:
         mock_smtp.return_value.sendmail.assert_called_once_with("from", "to", msg.as_string())
         assert mock_smtp.return_value.quit.called
 
+    @mock.patch("smtplib.SMTP")
+    def test_send_mime_conn_id_uses_connection_transport_settings(self, mock_smtp, monkeypatch):
+        monkeypatch.setenv(
+            "AIRFLOW_CONN_SMTP_TEST_CONN",
+            json.dumps(
+                {
+                    "conn_type": "smtp",
+                    "login": "test-user",
+                    "password": "test-password",
+                    "host": "conn-host",
+                    "port": 2525,
+                    "extra": {
+                        "disable_tls": True,
+                        "disable_ssl": True,
+                        "timeout": 99,
+                        "retry_limit": 0,
+                    },
+                }
+            ),
+        )
+        email.send_mime_email("from", "to", MIMEMultipart(), dryrun=False, conn_id="smtp_test_conn")
+        mock_smtp.assert_called_once_with(host="conn-host", port=2525, timeout=99)
+        assert not mock_smtp.return_value.starttls.called
+        mock_smtp.return_value.login.assert_called_once_with("test-user", "test-password")
+
+    @mock.patch("smtplib.SMTP")
+    def test_send_mime_conn_id_falls_back_to_config_for_unset_fields(self, mock_smtp, monkeypatch):
+        monkeypatch.setenv(
+            "AIRFLOW_CONN_SMTP_TEST_CONN",
+            json.dumps(
+                {"conn_type": "smtp", "login": "test-user", "password": "test-password", "host": "conn-host"}
+            ),
+        )
+        email.send_mime_email("from", "to", MIMEMultipart(), dryrun=False, conn_id="smtp_test_conn")
+        mock_smtp.assert_called_once_with(
+            host="conn-host",
+            port=conf.getint("smtp", "SMTP_PORT"),
+            timeout=conf.getint("smtp", "SMTP_TIMEOUT"),
+        )
+        assert mock_smtp.return_value.starttls.called
+
     @mock.patch("smtplib.SMTP_SSL")
     @mock.patch("smtplib.SMTP")
     def test_send_mime_ssl_none_context(self, mock_smtp, mock_smtp_ssl):


### PR DESCRIPTION
`send_mime_email` only read `login` and `password` from the SMTP connection; `host`, `port`, STARTTLS/SSL, `timeout` and `retry_limit` were always taken from the `[smtp]` config, even when a connection provided them. This makes it prefer the connection's values, falling back to config when a field is unset. The extra keys and negation semantics mirror the smtp provider's `SmtpHook` so both paths behave the same.

closes: #34554

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)