### PR TITLE
Link registry modules to the guide section that documents them

### DIFF
--- a/dev/registry/extract_parameters.py
+++ b/dev/registry/extract_parameters.py
@@ -54,6 +54,7 @@ from pathlib import Path
 import yaml
 from extract_metadata import fetch_provider_inventory, read_inventory
 from registry_contract_models import validate_modules_catalog, validate_provider_parameters
+from registry_tools.docs_guides import attach_guide_urls, collect_guide_anchors
 from registry_tools.types import (
     BASE_CLASS_IMPORTS,
     CLASS_LEVEL_CATEGORY_OVERRIDES,
@@ -95,6 +96,7 @@ class Module:
     provider_id: str
     provider_name: str
     supports_durable_execution: bool
+    guide_url: str | None = None
 
 
 def get_category(integration_name: str) -> str:
@@ -453,6 +455,16 @@ def _resolve_dotted_path(class_path: str) -> tuple[str, str, object] | None:
     return module_path, name, obj
 
 
+def read_guide_docs(docs_dir: Path) -> dict[str, str]:
+    """Read a provider's authored reST docs from the working tree, keyed by path relative to ``docs_dir``."""
+    if not docs_dir.is_dir():
+        return {}
+    return {
+        path.relative_to(docs_dir).as_posix(): path.read_text(encoding="utf-8")
+        for path in sorted(docs_dir.rglob("*.rst"))
+    }
+
+
 def discover_classes_from_provider(
     provider_yaml_path: Path,
     base_classes: dict[str, type],
@@ -690,6 +702,9 @@ def discover_classes_from_provider(
                 "provider_name": provider_name,
             }
         )
+
+    guide_docs = read_guide_docs(provider_yaml_path.parent / "docs")
+    attach_guide_urls(discovered, collect_guide_anchors(guide_docs), base_docs_url)
 
     return discovered
 

--- a/dev/registry/extract_versions.py
+++ b/dev/registry/extract_versions.py
@@ -59,6 +59,7 @@ except ImportError:
     sys.exit(1)
 
 from extract_metadata import fetch_provider_inventory, read_connection_urls, resolve_connection_docs_url
+from registry_tools.docs_guides import attach_guide_urls, collect_guide_anchors
 from registry_tools.types import (
     CLASS_LEVEL_CATEGORY_OVERRIDES,
     CLASS_LEVEL_SECTIONS,
@@ -129,6 +130,21 @@ def git_show(tag: str, path: str) -> str | None:
         return None
 
 
+def git_ls_tree(tag: str, prefix: str) -> list[str]:
+    """List the file paths under a prefix at a specific git tag."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-tree", "-r", "--name-only", tag, "--", prefix],
+            capture_output=True,
+            text=True,
+            cwd=AIRFLOW_ROOT,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        return []
+    return [line for line in result.stdout.splitlines() if line]
+
+
 def git_tag_exists(tag: str) -> bool:
     """Check if a git tag exists locally."""
     result = subprocess.run(
@@ -179,6 +195,27 @@ def get_source_file_path(layout: str, dir_path: str, module_path: str) -> str:
     if layout == "new":
         return f"providers/{dir_path}/src/{rel_file}"
     return f"providers/src/{rel_file}"
+
+
+def read_guide_docs(tag: str, layout: str, dir_path: str) -> dict[str, str]:
+    """Read a provider's authored reST docs at a tag, keyed by path relative to its docs dir.
+
+    Only the per-provider layout keeps docs beside the provider; under the old flat
+    layout they lived in a top-level ``docs/`` tree, so those tags get no guide
+    links rather than links guessed from a path that moved.
+    """
+    if layout != "new":
+        return {}
+
+    docs_prefix = f"providers/{dir_path}/docs/"
+    docs: dict[str, str] = {}
+    for path in git_ls_tree(tag, docs_prefix):
+        if not path.endswith(".rst"):
+            continue
+        content = git_show(tag, path)
+        if content:
+            docs[path[len(docs_prefix) :]] = content
+    return docs
 
 
 def parse_pyproject_toml_content(content: str, layout: str) -> dict[str, Any]:
@@ -381,6 +418,8 @@ def extract_modules_from_yaml(
                     "category": category,
                 }
             )
+
+    attach_guide_urls(modules, collect_guide_anchors(read_guide_docs(tag, layout, dir_path)), base_docs_url)
 
     return modules
 

--- a/dev/registry/registry_contract_models.py
+++ b/dev/registry/registry_contract_models.py
@@ -112,6 +112,8 @@ class ModuleContract(BaseModel):
     provider_id: str | None = None
     provider_name: str | None = None
     supports_durable_execution: bool = False
+    # Only set for classes a how-to guide documents in a section of their own.
+    guide_url: str | None = None
 
 
 class ModulesCatalogContract(BaseModel):

--- a/dev/registry/registry_tools/docs_guides.py
+++ b/dev/registry/registry_tools/docs_guides.py
@@ -1,0 +1,124 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Map a provider's classes to the how-to guide sections that document them.
+
+A module's ``docs_url`` points at generated API reference, which tells a reader
+what the arguments are but not how the thing is meant to be used. The prose
+guides carry that, and they already mark it: a how-to guide documents one class
+per section, titled with the class name (``HookToolset``, ``SQLToolset``).
+
+So the mapping is read back out of the guides rather than curated anywhere: a
+hand-maintained class-to-guide table would rot silently every time a guide is
+split, renamed, or a class is dropped, and a rotten link is worse than none.
+Callers supply the reST they can see (a git tag, or the working tree) and get
+back only the anchors those sources actually contain.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+# reST underlines an (optionally overlined) section title with a run of one
+# punctuation character, at least as long as the title itself.
+_ADORNMENT_CHARS = "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+
+# Only titles opening with a class name as an inline literal are treated as
+# documenting it, so prose headings ("Bounded query results") never produce a link.
+_LEADING_CLASS_LITERAL = re.compile(r"^``([A-Za-z_][A-Za-z0-9_]*)``")
+
+
+def slugify_section_anchor(title: str) -> str:
+    """Return the HTML id Sphinx gives a section with this title.
+
+    Mirrors docutils' ``make_id``: lower-case, every run of non-alphanumeric
+    characters becomes a single hyphen, and leading/trailing hyphens are
+    dropped -- e.g. the section titled ``HookToolset`` is served at
+    ``#hooktoolset``.
+    """
+    return re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+
+
+def _class_name_from_title(title: str) -> str | None:
+    """Return the class a section title leads with, or None if it names prose.
+
+    A guide marks a section as being *about a class* by opening its title with the
+    class as an inline literal -- ``HookToolset``, or
+    ``AgentOperator`` & ``@task.agent`` where one section covers the operator and
+    its decorator. Requiring that markup is what keeps a single-word prose heading
+    ("Guidelines") from claiming to document a class of the same name, and it is a
+    convention the guides already follow rather than one imposed on them.
+    """
+    match = _LEADING_CLASS_LITERAL.match(title)
+    return match.group(1) if match else None
+
+
+def _is_adornment(line: str) -> bool:
+    """Whether a line is a reST title overline/underline rather than a title."""
+    return bool(line) and len(set(line)) == 1 and line[0] in _ADORNMENT_CHARS
+
+
+def _extract_section_titles(text: str) -> list[str]:
+    """Return every section title in a reST document, in document order."""
+    titles = []
+    lines = text.splitlines()
+    for index, line in enumerate(lines[:-1]):
+        title = line.strip()
+        # Guides title these sections with an inline literal (``HookToolset``),
+        # so a title can legitimately start with an adornment character; only a
+        # line that is *entirely* one repeated character is an adornment.
+        if not title or _is_adornment(title):
+            continue
+        underline = lines[index + 1].strip()
+        if len(underline) >= len(title) and _is_adornment(underline):
+            titles.append(title)
+    return titles
+
+
+def collect_guide_anchors(docs: Mapping[str, str]) -> dict[str, str]:
+    """Map class name -> ``<page>.html#<anchor>`` for every documented class.
+
+    ``docs`` maps a page path relative to the provider's docs directory (e.g.
+    ``toolsets.rst``) to its reST source. When two pages document the same class
+    name, the first page in sorted order wins, so a rebuild of the same sources
+    always produces the same link.
+    """
+    anchors: dict[str, str] = {}
+    for page in sorted(docs):
+        page_url = re.sub(r"\.rst$", ".html", page)
+        for title in _extract_section_titles(docs[page]):
+            class_name = _class_name_from_title(title)
+            if not class_name or class_name in anchors:
+                continue
+            anchors[class_name] = f"{page_url}#{slugify_section_anchor(title)}"
+    return anchors
+
+
+def attach_guide_urls(modules: list[dict[str, Any]], anchors: Mapping[str, str], base_docs_url: str) -> int:
+    """Set ``guide_url`` on every module a guide section documents.
+
+    Mutates ``modules`` in place; returns how many got a link.
+    """
+    attached = 0
+    for module in modules:
+        anchor = anchors.get(module["name"])
+        if not anchor:
+            continue
+        module["guide_url"] = f"{base_docs_url.rstrip('/')}/{anchor}"
+        attached += 1
+    return attached

--- a/dev/registry/tests/test_docs_guides.py
+++ b/dev/registry/tests/test_docs_guides.py
@@ -1,0 +1,155 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+from registry_tools.docs_guides import (
+    attach_guide_urls,
+    collect_guide_anchors,
+    slugify_section_anchor,
+)
+
+TOOLSETS_GUIDE = """
+.. _howto/toolsets:
+
+Toolsets: Airflow hooks as AI agent tools
+==========================================
+
+Intro prose.
+
+``HookToolset``
+---------------
+
+How to use it.
+
+Guidelines
+^^^^^^^^^^
+
+More prose.
+
+.. _bounded-query-results:
+
+Bounded query results
+^^^^^^^^^^^^^^^^^^^^^
+
+``SQLToolset`` bounds that.
+
+``DataFusionToolset``
+---------------------
+
+Another one.
+"""
+
+
+@pytest.mark.parametrize(
+    ("title", "expected"),
+    [
+        # Verified against the published guide: the section titled ``HookToolset``
+        # is served at .../toolsets.html#hooktoolset.
+        ("HookToolset", "hooktoolset"),
+        ("AgentSkillsToolset", "agentskillstoolset"),
+        ("Bounded query results", "bounded-query-results"),
+        ("Agent_Skills", "agent-skills"),
+        ("Direct PydanticAI MCP toolsets", "direct-pydanticai-mcp-toolsets"),
+        ("``AgentOperator`` & ``@task.agent``", "agentoperator-task-agent"),
+    ],
+)
+def test_slugify_section_anchor_matches_sphinx_ids(title, expected):
+    assert slugify_section_anchor(title) == expected
+
+
+def test_collect_guide_anchors_finds_class_named_sections_at_any_depth():
+    anchors = collect_guide_anchors({"toolsets.rst": TOOLSETS_GUIDE})
+
+    assert anchors == {
+        "HookToolset": "toolsets.html#hooktoolset",
+        "DataFusionToolset": "toolsets.html#datafusiontoolset",
+    }
+
+
+def test_collect_guide_anchors_ignores_prose_headings():
+    anchors = collect_guide_anchors({"toolsets.rst": TOOLSETS_GUIDE})
+
+    # "Guidelines" is shaped like a class name but isn't marked up as one.
+    assert "Guidelines" not in anchors
+    assert "Bounded query results" not in anchors
+
+
+def test_collect_guide_anchors_ignores_classes_only_mentioned_in_prose():
+    # SQLToolset appears in the guide's body but has no section of its own, so
+    # there is no anchor to link to.
+    assert "SQLToolset" not in collect_guide_anchors({"toolsets.rst": TOOLSETS_GUIDE})
+
+
+def test_collect_guide_anchors_keeps_nested_page_paths():
+    guide = "``AgentOperator``\n-----------------\n\nProse.\n"
+
+    assert collect_guide_anchors({"operators/agent.rst": guide}) == {
+        "AgentOperator": "operators/agent.html#agentoperator"
+    }
+
+
+def test_collect_guide_anchors_prefers_first_page_in_sorted_order():
+    guide = "``SQLToolset``\n--------------\n\nProse.\n"
+
+    anchors = collect_guide_anchors({"toolsets.rst": guide, "operators/sql.rst": guide})
+
+    assert anchors["SQLToolset"] == "operators/sql.html#sqltoolset"
+
+
+def test_collect_guide_anchors_handles_a_title_covering_more_than_the_class():
+    # Verified against the published guide: this heading is served at
+    # .../operators/agent.html#agentoperator-task-agent, so the anchor comes from
+    # the whole title while the class name comes from the leading literal.
+    guide = "``AgentOperator`` & ``@task.agent``\n===================================\n\nProse.\n"
+
+    assert collect_guide_anchors({"operators/agent.rst": guide}) == {
+        "AgentOperator": "operators/agent.html#agentoperator-task-agent"
+    }
+
+
+def test_collect_guide_anchors_requires_a_long_enough_underline():
+    # An underline shorter than the title isn't a section in reST, so it must not
+    # produce a link to an anchor Sphinx never emitted.
+    assert collect_guide_anchors({"toolsets.rst": "``HookToolset``\n---\n\nProse.\n"}) == {}
+
+
+def test_attach_guide_urls_only_links_documented_classes():
+    modules = [
+        {"name": "HookToolset", "docs_url": "https://example.test/_api/hook/index.html"},
+        {"name": "UndocumentedToolset", "docs_url": "https://example.test/_api/other/index.html"},
+    ]
+
+    attached = attach_guide_urls(
+        modules,
+        {"HookToolset": "toolsets.html#hooktoolset"},
+        "https://airflow.apache.org/docs/apache-airflow-providers-common-ai/0.7.0",
+    )
+
+    assert attached == 1
+    assert modules[0]["guide_url"] == (
+        "https://airflow.apache.org/docs/apache-airflow-providers-common-ai/0.7.0/toolsets.html#hooktoolset"
+    )
+    assert "guide_url" not in modules[1]
+
+
+def test_attach_guide_urls_does_not_double_up_the_base_separator():
+    modules = [{"name": "HookToolset"}]
+
+    attach_guide_urls(modules, {"HookToolset": "toolsets.html#hooktoolset"}, "https://example.test/docs/")
+
+    assert modules[0]["guide_url"] == "https://example.test/docs/toolsets.html#hooktoolset"

--- a/dev/registry/tests/test_extract_parameters.py
+++ b/dev/registry/tests/test_extract_parameters.py
@@ -526,6 +526,26 @@ class TestDiscoverClassesFromProvider:
         assert operators[0]["import_path"] == "airflow.providers.amazon.aws.operators.s3.FakeOperator"
         assert operators[0]["provider_id"] == "amazon"
 
+    def test_guide_section_becomes_a_guide_url(self, provider_yaml_path, base_classes):
+        """A class documented by a section of its own gets a link to that section;
+        one that is only in the API reference keeps just its ``docs_url``."""
+        docs_dir = provider_yaml_path.parent / "docs" / "operators"
+        docs_dir.mkdir(parents=True)
+        (docs_dir / "s3.rst").write_text("``FakeOperator``\n----------------\n\nProse.\n")
+
+        with (
+            patch("extract_parameters.PROVIDERS_DIR", provider_yaml_path.parent.parent),
+            patch("extract_parameters.importlib.import_module", side_effect=self._mock_import),
+        ):
+            result = discover_classes_from_provider(provider_yaml_path, base_classes)
+
+        by_name = {r["name"]: r for r in result}
+        assert by_name["FakeOperator"]["guide_url"] == (
+            "https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable"
+            "/operators/s3.html#fakeoperator"
+        )
+        assert "guide_url" not in by_name["FakeSensor"]
+
     def test_discovers_sensor(self, provider_yaml_path, base_classes):
         with (
             patch("extract_parameters.PROVIDERS_DIR", provider_yaml_path.parent.parent),

--- a/dev/registry/tests/test_extract_versions.py
+++ b/dev/registry/tests/test_extract_versions.py
@@ -210,3 +210,57 @@ class TestExtractVersionDataConnectionTypes:
 
         assert result is not None
         assert result["connection_types"][0]["external_services"] == ["openai", "anthropic"]
+
+
+class TestExtractModulesGuideUrls:
+    """A class the provider's guides document in a section of its own must get a
+    ``guide_url`` for every version, not just the latest. A superseded version's
+    page is rendered only from the per-version file this module writes, so a link
+    resolved on the latest path alone disappears the moment a new version lands.
+    """
+
+    PROVIDER_YAML = {
+        "toolsets": [
+            {
+                "integration-name": "Test",
+                "python-modules": ["airflow.providers.test.toolsets.hook"],
+            }
+        ]
+    }
+    SOURCE = 'class HookToolset:\n    """A toolset."""\n'
+    GUIDE = "``HookToolset``\n---------------\n\nProse.\n"
+
+    def _extract(self, layout="new", docs_paths=("providers/test/docs/toolsets.rst",)):
+        def fake_git_show(_tag, path):
+            if path.endswith("toolsets.rst"):
+                return self.GUIDE
+            return self.SOURCE if path.endswith(".py") else None
+
+        with (
+            patch("extract_versions.git_ls_tree", autospec=True, return_value=list(docs_paths)),
+            patch("extract_versions.git_show", autospec=True, side_effect=fake_git_show),
+        ):
+            return extract_modules_from_yaml(
+                self.PROVIDER_YAML, "providers-test/1.0.0", layout, "test", "test", "1.0.0"
+            )
+
+    def test_documented_class_gets_a_versioned_guide_url(self):
+        modules = self._extract()
+
+        assert [m["name"] for m in modules] == ["HookToolset"]
+        assert modules[0]["guide_url"] == (
+            "https://airflow.apache.org/docs/apache-airflow-providers-test/1.0.0/toolsets.html#hooktoolset"
+        )
+
+    def test_undocumented_class_gets_no_guide_url(self):
+        modules = self._extract(docs_paths=())
+
+        assert [m["name"] for m in modules] == ["HookToolset"]
+        assert "guide_url" not in modules[0]
+
+    def test_old_layout_gets_no_guide_url(self):
+        # Pre-per-provider tags kept docs in a top-level tree, so there is no
+        # provider-relative page path to build a link from.
+        modules = self._extract(layout="old")
+
+        assert "guide_url" not in modules[0]

--- a/dev/registry/tests/test_registry_contract_models.py
+++ b/dev/registry/tests/test_registry_contract_models.py
@@ -101,6 +101,17 @@ def test_module_contract_preserves_supports_durable_execution_true():
     assert validated["modules"][0]["supports_durable_execution"] is True
 
 
+def test_module_contract_omits_guide_url_for_undocumented_classes():
+    validated = validate_modules_catalog({"modules": [_module_payload()]})
+    assert "guide_url" not in validated["modules"][0]
+
+
+def test_module_contract_round_trips_guide_url():
+    guide_url = "https://example.invalid/docs/toolsets.html#exampletoolset"
+    validated = validate_modules_catalog({"modules": [_module_payload(guide_url=guide_url)]})
+    assert validated["modules"][0]["guide_url"] == guide_url
+
+
 def test_connection_type_contract_defaults_external_services_to_empty_list():
     """Legacy connection-types entries (provider.yaml without `external-services`)
     must still validate, with the field defaulting to an empty list."""

--- a/registry/AGENTS.md
+++ b/registry/AGENTS.md
@@ -462,6 +462,24 @@ They run inside Breeze where all providers are installed. `extract_metadata.py` 
 the CI workflow can run the fast scripts (metadata, ~30s per provider) without spinning
 up Breeze, while parameter/connection extraction is a separate step.
 
+### How a module gets a "Guide" link
+
+A module card links to the how-to guide section that documents it, alongside the
+generated API reference. Nothing declares that link: `registry_tools/docs_guides.py`
+reads the provider's own `docs/*.rst` and matches a class to a section when the
+section's title *opens with the class name as an inline literal* — ``` ``HookToolset`` ```
+or ``` ``AgentOperator`` & ``@task.agent`` ```. The anchor is derived from the whole
+title the way docutils derives its HTML id.
+
+That convention is what the guides already do, and it is deliberately the only
+signal: a hand-maintained class-to-guide table would keep pointing at sections
+that have since been renamed or split, and a link that lands on the wrong section
+is worse than no link. A class documented only in prose gets no Guide link.
+
+Both extraction paths resolve it — `extract_parameters.py` from the working tree
+for the latest release, `extract_versions.py` from the git tag for superseded ones
+— because a superseded version's page is rendered only from its own metadata file.
+
 ### Relationship to `run_provider_yaml_files_check.py`
 
 `scripts/in_container/run_provider_yaml_files_check.py` (run by the

--- a/registry/src/css/main.css
+++ b/registry/src/css/main.css
@@ -3522,6 +3522,7 @@ main {
 }
 
 .provider-detail-page .module-actions .docs-link,
+.provider-detail-page .module-actions .guide-link,
 .provider-detail-page .module-actions .source-link {
   display: inline-flex;
   align-items: center;
@@ -3536,6 +3537,14 @@ main {
 }
 
 .provider-detail-page .module-actions .docs-link:hover {
+  color: var(--color-cyan-300);
+}
+
+.provider-detail-page .module-actions .guide-link {
+  color: var(--accent-secondary);
+}
+
+.provider-detail-page .module-actions .guide-link:hover {
   color: var(--color-cyan-300);
 }
 

--- a/registry/src/provider-version.njk
+++ b/registry/src/provider-version.njk
@@ -420,6 +420,12 @@ eleventyComputed:
                 <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
               </a>
               {% endif %}
+              {% if module.guide_url %}
+              <a href="{{ module.guide_url }}" target="_blank" rel="noopener" class="guide-link" title="How-to guide section for {{ module.name }}">
+                Guide
+                <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+              </a>
+              {% endif %}
               {% if module.source_url %}
               <a href="{{ module.source_url }}" target="_blank" rel="noopener" class="source-link">
                 Source


### PR DESCRIPTION
A module card offers only generated API reference, which lists arguments but never says how the thing is meant to be used. The prose guides say it, and they already mark which class each section is about by titling that section with the class name -- so the pointer exists in the docs and just wasn't being read.

Resolving it from the guides rather than from a declared list is deliberate: a hand-maintained class-to-guide table goes stale silently every time a guide is split or renamed, and a link that lands on the wrong section is worse than no link at all. A class documented only in prose gets no link.

Both extraction paths resolve it, since a superseded version's page is rendered only from its own per-version metadata.

<img width="2050" height="446" alt="image" src="https://github.com/user-attachments/assets/a1c89ee4-08ad-4887-b1f4-4ca035afdc12" />


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Generated-by: [Claude] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
