### PR TITLE
Add a prek hook to keep ts-sdk/docs/package.json versions in sync with ts-sdk/package.json

### DIFF
--- a/scripts/ci/prek/check_ts_sdk_docs_package_version_in_sync.py
+++ b/scripts/ci/prek/check_ts_sdk_docs_package_version_in_sync.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Fail if ts-sdk/package.json and ts-sdk/docs/package.json pin a shared dependency to
+different version strings (compared literally, not as resolved semver ranges — so
+``^3.1.2`` and ``3.1.2`` still count as drift).
+
+Run from the repo root:
+
+    uv run --project scripts python scripts/ci/prek/check_ts_sdk_docs_package_version_in_sync.py
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+from common_prek_utils import AIRFLOW_ROOT_PATH
+
+TS_SDK_PACKAGE_JSON = "ts-sdk/package.json"
+TS_SDK_DOCS_PACKAGE_JSON = "ts-sdk/docs/package.json"
+
+DEPENDENCY_SECTIONS = ("dependencies", "devDependencies", "peerDependencies", "optionalDependencies")
+
+
+def load_dependencies(path: pathlib.Path, repo_root: pathlib.Path) -> dict[str, str] | str:
+    """Flatten every dependency section into ``{name: version}``, or return an error message."""
+    label = path.relative_to(repo_root) if path.is_relative_to(repo_root) else path
+    if not path.exists():
+        return f"{label} does not exist"
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        return f"{label} is not valid JSON: {exc}"
+
+    seen_in: dict[str, str] = {}
+    deps: dict[str, str] = {}
+    for section in DEPENDENCY_SECTIONS:
+        for name, version in data.get(section, {}).items():
+            if not isinstance(version, str):
+                return (
+                    f"{label} pins {name!r} to a non-string version in its {section!r} section: {version!r}"
+                )
+            if name in seen_in and deps[name] != version:
+                return (
+                    f"{label} pins {name!r} to different versions in its own "
+                    f"{seen_in[name]!r} ({deps[name]!r}) and {section!r} ({version!r}) sections"
+                )
+            seen_in[name] = section
+            deps[name] = version
+    return deps
+
+
+def check_sync(repo_root: pathlib.Path) -> tuple[int, str]:
+    """Compare shared dependency versions between the ts-sdk and ts-sdk/docs package.json files."""
+    sdk_path = repo_root / TS_SDK_PACKAGE_JSON
+    docs_path = repo_root / TS_SDK_DOCS_PACKAGE_JSON
+
+    sdk_result = load_dependencies(sdk_path, repo_root)
+    docs_result = load_dependencies(docs_path, repo_root)
+
+    errors = [result for result in (sdk_result, docs_result) if isinstance(result, str)]
+    if errors:
+        return 1, "\n".join(f"ERROR: {error}" for error in errors)
+
+    sdk_deps: dict[str, str] = sdk_result  # type: ignore[assignment]
+    docs_deps: dict[str, str] = docs_result  # type: ignore[assignment]
+
+    shared = sorted(set(sdk_deps) & set(docs_deps))
+    if not shared:
+        return (
+            0,
+            f"OK: {TS_SDK_PACKAGE_JSON} and {TS_SDK_DOCS_PACKAGE_JSON} share no dependencies to compare.",
+        )
+
+    mismatched = [name for name in shared if sdk_deps[name] != docs_deps[name]]
+    if not mismatched:
+        return (
+            0,
+            f"OK: {len(shared)} shared dependencies are pinned to the same version in "
+            f"{TS_SDK_PACKAGE_JSON} and {TS_SDK_DOCS_PACKAGE_JSON}.",
+        )
+
+    name_col = max(len(name) for name in mismatched)
+    value_col = max(len(TS_SDK_PACKAGE_JSON), *(len(sdk_deps[name]) for name in mismatched))
+    lines = [
+        f"ERROR: Dependency versions drifted between {TS_SDK_PACKAGE_JSON} and {TS_SDK_DOCS_PACKAGE_JSON}:",
+        "",
+        f"  {'PACKAGE':<{name_col}}  {TS_SDK_PACKAGE_JSON:<{value_col}}  {TS_SDK_DOCS_PACKAGE_JSON}",
+    ]
+    for name in mismatched:
+        lines.append(f"  {name:<{name_col}}  {sdk_deps[name]:<{value_col}}  {docs_deps[name]}")
+    lines += [
+        "",
+        "Update the drifting package(s) to pin the same version in both files.",
+    ]
+    return 1, "\n".join(lines)
+
+
+def main() -> int:
+    exit_code, report = check_sync(AIRFLOW_ROOT_PATH)
+    print(report)
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/prek/check_ts_sdk_docs_package_version_in_sync.py
+++ b/scripts/ci/prek/check_ts_sdk_docs_package_version_in_sync.py
@@ -15,6 +15,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# /// script
+# requires-python = ">=3.10,<3.11"
+# dependencies = [
+#   "tabulate>=0.9.0",
+# ]
+# ///
 """
 Fail if ts-sdk/package.json and ts-sdk/docs/package.json pin a shared dependency to
 different version strings (compared literally, not as resolved semver ranges — so

--- a/scripts/ci/prek/check_ts_sdk_docs_package_version_in_sync.py
+++ b/scripts/ci/prek/check_ts_sdk_docs_package_version_in_sync.py
@@ -32,6 +32,7 @@ import pathlib
 import sys
 
 from common_prek_utils import AIRFLOW_ROOT_PATH
+from tabulate import tabulate
 
 TS_SDK_PACKAGE_JSON = "ts-sdk/package.json"
 TS_SDK_DOCS_PACKAGE_JSON = "ts-sdk/docs/package.json"
@@ -97,16 +98,15 @@ def check_sync(repo_root: pathlib.Path) -> tuple[int, str]:
             f"{TS_SDK_PACKAGE_JSON} and {TS_SDK_DOCS_PACKAGE_JSON}.",
         )
 
-    name_col = max(len(name) for name in mismatched)
-    value_col = max(len(TS_SDK_PACKAGE_JSON), *(len(sdk_deps[name]) for name in mismatched))
+    table = tabulate(
+        [(name, sdk_deps[name], docs_deps[name]) for name in mismatched],
+        headers=["PACKAGE", TS_SDK_PACKAGE_JSON, TS_SDK_DOCS_PACKAGE_JSON],
+        tablefmt="github",
+    )
     lines = [
         f"ERROR: Dependency versions drifted between {TS_SDK_PACKAGE_JSON} and {TS_SDK_DOCS_PACKAGE_JSON}:",
         "",
-        f"  {'PACKAGE':<{name_col}}  {TS_SDK_PACKAGE_JSON:<{value_col}}  {TS_SDK_DOCS_PACKAGE_JSON}",
-    ]
-    for name in mismatched:
-        lines.append(f"  {name:<{name_col}}  {sdk_deps[name]:<{value_col}}  {docs_deps[name]}")
-    lines += [
+        table,
         "",
         "Update the drifting package(s) to pin the same version in both files.",
     ]

--- a/scripts/tests/ci/prek/test_check_ts_sdk_docs_package_version_in_sync.py
+++ b/scripts/tests/ci/prek/test_check_ts_sdk_docs_package_version_in_sync.py
@@ -1,0 +1,170 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from check_ts_sdk_docs_package_version_in_sync import check_sync, load_dependencies
+
+LONG_VERSION = "^3.1.2-some-very-long-prerelease-tag-that-exceeds-the-header-width"
+
+
+def _write_package_json(path: Path, content: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(content))
+
+
+def _write_tree(root: Path, *, sdk_package: dict, docs_package: dict) -> None:
+    _write_package_json(root / "ts-sdk" / "package.json", sdk_package)
+    _write_package_json(root / "ts-sdk" / "docs" / "package.json", docs_package)
+
+
+def _setup_missing_docs_file(root: Path) -> None:
+    _write_package_json(root / "ts-sdk" / "package.json", {"dependencies": {}})
+
+
+def _setup_malformed_docs_json(root: Path) -> None:
+    _write_package_json(root / "ts-sdk" / "package.json", {"dependencies": {}})
+    docs_path = root / "ts-sdk" / "docs" / "package.json"
+    docs_path.parent.mkdir(parents=True, exist_ok=True)
+    docs_path.write_text("{not valid json")
+
+
+@pytest.mark.parametrize(
+    ("sdk_package", "docs_package", "expected_exit_code", "expected_substrings", "unexpected_substrings"),
+    [
+        pytest.param(
+            {"dependencies": {"@msgpack/msgpack": "^3.1.2"}},
+            {"devDependencies": {"@msgpack/msgpack": "^3.1.2"}},
+            0,
+            ["OK: 1 shared dependencies"],
+            [],
+            id="all-shared-dependencies-in-sync",
+        ),
+        pytest.param(
+            {"dependencies": {"@msgpack/msgpack": "^3.1.2"}},
+            {"devDependencies": {"@msgpack/msgpack": "^3.1.3"}},
+            1,
+            ["@msgpack/msgpack", "^3.1.2", "^3.1.3"],
+            [],
+            id="shared-dependency-drift-is-flagged",
+        ),
+        pytest.param(
+            {"dependencies": {"@msgpack/msgpack": LONG_VERSION}},
+            {"devDependencies": {"@msgpack/msgpack": "^3.1.3"}},
+            1,
+            [f"{LONG_VERSION}  ^3.1.3"],
+            [],
+            id="drift-report-column-widens-for-long-version-strings",
+        ),
+        pytest.param(
+            {"dependencies": {"@msgpack/msgpack": {"nested": "object"}}},
+            {"devDependencies": {"@msgpack/msgpack": "^3.1.2"}},
+            1,
+            ["@msgpack/msgpack", "non-string version"],
+            [],
+            id="non-string-version-is-reported-instead-of-crashing",
+        ),
+        pytest.param(
+            # ^3.1.2 and 3.1.2 resolve to the same semver but are still flagged: the check
+            # compares pinned strings, not resolved ranges.
+            {"dependencies": {"@msgpack/msgpack": "^3.1.2"}},
+            {"devDependencies": {"@msgpack/msgpack": "3.1.2"}},
+            1,
+            ["@msgpack/msgpack"],
+            [],
+            id="semver-compatible-but-different-string-is-still-flagged",
+        ),
+        pytest.param(
+            {"devDependencies": {"typescript": "^6.0.2", "vitest": "^4.1.7"}},
+            {"devDependencies": {"typescript": "^6.0.2"}},
+            0,
+            [],
+            ["vitest"],
+            id="dependency-present-in-only-one-file-is-ignored",
+        ),
+        pytest.param(
+            {"devDependencies": {"vitest": "^4.1.7"}},
+            {"devDependencies": {"typedoc": "^0.28.20"}},
+            0,
+            ["share no dependencies"],
+            [],
+            id="no-shared-dependencies-passes",
+        ),
+    ],
+)
+def test_check_sync(
+    tmp_path: Path,
+    sdk_package: dict,
+    docs_package: dict,
+    expected_exit_code: int,
+    expected_substrings: list[str],
+    unexpected_substrings: list[str],
+):
+    _write_tree(tmp_path, sdk_package=sdk_package, docs_package=docs_package)
+    exit_code, report = check_sync(tmp_path)
+    assert exit_code == expected_exit_code
+    for substring in expected_substrings:
+        assert substring in report
+    for substring in unexpected_substrings:
+        assert substring not in report
+
+
+@pytest.mark.parametrize(
+    ("setup", "expected_substrings"),
+    [
+        pytest.param(
+            _setup_missing_docs_file, ["ts-sdk/docs/package.json", "does not exist"], id="missing-file"
+        ),
+        pytest.param(
+            _setup_malformed_docs_json, ["ts-sdk/docs/package.json", "not valid JSON"], id="malformed-json"
+        ),
+    ],
+)
+def test_check_sync_error_scenarios(tmp_path: Path, setup, expected_substrings: list[str]):
+    setup(tmp_path)
+    exit_code, report = check_sync(tmp_path)
+    assert exit_code == 1
+    for substring in expected_substrings:
+        assert substring in report
+
+
+@pytest.mark.parametrize(
+    ("dev_version", "peer_version", "expect_conflict"),
+    [
+        pytest.param("^0.28.1", "^0.29.0", True, id="different-versions-across-sections-conflict"),
+        pytest.param("^0.28.1", "^0.28.1", False, id="same-version-across-sections-is-not-a-conflict"),
+    ],
+)
+def test_same_file_cross_section_versions(
+    tmp_path: Path, dev_version: str, peer_version: str, expect_conflict: bool
+):
+    path = tmp_path / "package.json"
+    _write_package_json(
+        path,
+        {"devDependencies": {"esbuild": dev_version}, "peerDependencies": {"esbuild": peer_version}},
+    )
+    result = load_dependencies(path, tmp_path)
+    if expect_conflict:
+        assert isinstance(result, str)
+        assert "esbuild" in result
+        assert "devDependencies" in result
+        assert "peerDependencies" in result
+    else:
+        assert result == {"esbuild": dev_version}

--- a/scripts/tests/ci/prek/test_check_ts_sdk_docs_package_version_in_sync.py
+++ b/scripts/tests/ci/prek/test_check_ts_sdk_docs_package_version_in_sync.py
@@ -69,7 +69,7 @@ def _setup_malformed_docs_json(root: Path) -> None:
             {"dependencies": {"@msgpack/msgpack": LONG_VERSION}},
             {"devDependencies": {"@msgpack/msgpack": "^3.1.3"}},
             1,
-            [f"{LONG_VERSION}  ^3.1.3"],
+            [LONG_VERSION, "^3.1.3"],
             [],
             id="drift-report-column-widens-for-long-version-strings",
         ),

--- a/ts-sdk/.pre-commit-config.yaml
+++ b/ts-sdk/.pre-commit-config.yaml
@@ -49,6 +49,16 @@ repos:
         additional_dependencies: ['pnpm@10.28.1']
         pass_filenames: false
         require_serial: true
+      - id: check-ts-sdk-docs-package-version-in-sync
+        name: Check ts-sdk/docs package.json versions match ts-sdk/package.json
+        entry: ../scripts/ci/prek/check_ts_sdk_docs_package_version_in_sync.py
+        language: python
+        files: >
+          (?x)
+          ^package\.json$|
+          ^docs/package\.json$
+        pass_filenames: false
+        require_serial: true
       - id: compile-ts-sdk
         name: Compile TypeScript SDK
         entry: ./scripts/ci/prek/compile_ts_sdk.py


### PR DESCRIPTION


- follow-up: https://github.com/apache/airflow/pull/70812#discussion_r3762627512

## Why

#70812 split `ts-sdk/docs` into its own `package.json` so TypeDoc's doc-only dependencies stay out of the SDK's toolchain, but nothing stops the two files from pinning different versions of the dependencies they share (`@msgpack/msgpack`, `@types/node`, `typescript`).

## What

- Add a prek hook that compares every dependency name shared between `ts-sdk/package.json` and `ts-sdk/docs/package.json` and fails if the pinned version strings differ.
- Register the hook in `ts-sdk/.pre-commit-config.yaml`, scoped to run when either file changes.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code Sonnet 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
