### PR TITLE
Anchor run_id to logical_date when create_cron_data_intervals is enab…

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/timetable.rst
+++ b/airflow-core/docs/authoring-and-scheduling/timetable.rst
@@ -345,6 +345,12 @@ The time when a Dag run is triggered
 Both trigger and data interval timetables trigger Dag runs at the same time. However, the timestamp for the
 ``run_id`` is different for each. This is because ``run_id`` is based on ``logical_date``.
 
+.. note::
+    For **CronDataIntervalTimetable** and **DeltaDataIntervalTimetable**, ``run_id`` anchoring to
+    ``logical_date`` requires ``[scheduler] create_cron_data_intervals`` to be enabled — this single
+    flag currently gates both. Without it, Dags default to a trigger timetable, whose ``run_id`` is
+    anchored to ``run_after`` instead.
+
 For example, suppose there is a cron expression ``@daily`` or ``0 0 * * *``, which is scheduled to run at 12AM every day. If you enable Dags using the two timetables at 3PM on January
 31st,
 

--- a/airflow-core/docs/installation/upgrading_to_airflow3.rst
+++ b/airflow-core/docs/installation/upgrading_to_airflow3.rst
@@ -384,6 +384,11 @@ These include:
   ``create_cron_data_intervals=True`` explicitly to keep ``CronDataIntervalTimetable``.
   If you don't, the new ``False`` default is fine.
 
+  Setting ``create_cron_data_intervals=True`` also anchors the scheduled ``run_id`` to
+  ``logical_date``, matching Airflow 2's ``run_id`` semantics. If your workflows parse
+  ``run_id`` and assume it reflects the logical date, set this flag rather than relying on
+  the ``run_after``-anchored default.
+
   Set this **before** the upgrade. If you instead change the flag after some
   Airflow 3 dagruns already exist (going
   ``CronTriggerTimetable`` -> ``CronDataIntervalTimetable``), one scheduled run

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -2851,6 +2851,11 @@ scheduler:
         try to schedule, while for **CronDataIntervalTimetable**, the logical date is the beginning of
         the data interval, but the DAG Run will try to schedule at the end of the data interval.
 
+        Enabling this setting also anchors the scheduled ``run_id`` to ``logical_date`` (the data
+        interval start), matching the Airflow 2 ``run_id`` semantics this flag is meant to restore.
+        Deployments that leave this setting at its default (``False``) are unaffected; their ``run_id``
+        continues to be anchored to ``run_after``
+
         When a DAG is switched from **CronTriggerTimetable** to **CronDataIntervalTimetable** (for example,
         by flipping this setting from ``False`` to ``True``), the next scheduled run skips one period past
         the most recent **CronTriggerTimetable** run to avoid colliding with its logical date.

--- a/airflow-core/src/airflow/timetables/interval.py
+++ b/airflow-core/src/airflow/timetables/interval.py
@@ -29,6 +29,7 @@ from airflow.timetables.base import DagRunInfo, DataInterval, Timetable
 
 if TYPE_CHECKING:
     from airflow.timetables.base import TimeRestriction
+    from airflow.utils.types import DagRunType
 
 Delta = datetime.timedelta | relativedelta
 
@@ -128,6 +129,37 @@ class _DataIntervalTimetable(Timetable):
             return None
         end = self._get_next(start)
         return DagRunInfo.interval(start=start, end=end)
+
+    def generate_run_id(
+        self,
+        *,
+        run_type: DagRunType,
+        run_after: DateTime,
+        data_interval: DataInterval | None,
+        **extra: Any,
+    ) -> str:
+        """
+        Anchor the run_id suffix to the data interval start (== logical_date).
+
+        ``_DataIntervalTimetable`` is only instantiated when
+        ``[scheduler] create_cron_data_intervals`` is enabled (see
+        ``_create_timetable`` in ``airflow.sdk.definitions.dag``); that flag's
+        whole purpose is to restore Airflow-2-style semantics, where
+        ``logical_date`` is meaningful and ``run_id`` is derived from it. The
+        base implementation (``Timetable.generate_run_id``) anchors on
+        ``run_after`` instead, which is correct for the AIP-76 default but
+        defeats this opt-in flag for the one part of it callers actually
+        parse: the ``run_id`` string itself.
+
+        Falls back to the base behavior when no data interval is available
+        (e.g. for run types this timetable doesn't schedule intervals for),
+        so this never raises on an unexpected ``None``.
+        """
+        if data_interval is None:
+            return super().generate_run_id(
+                run_type=run_type, run_after=run_after, data_interval=data_interval, **extra
+            )
+        return run_type.generate_run_id(suffix=data_interval.start.isoformat())
 
 
 class CronDataIntervalTimetable(CronMixin, _DataIntervalTimetable):

--- a/airflow-core/tests/unit/timetables/test_interval_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_interval_timetable.py
@@ -28,6 +28,8 @@ from airflow._shared.timezones.timezone import utc
 from airflow.exceptions import AirflowTimetableInvalid
 from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction, Timetable
 from airflow.timetables.interval import CronDataIntervalTimetable, DeltaDataIntervalTimetable
+from airflow.timetables.trigger import CronTriggerTimetable
+from airflow.utils.types import DagRunType
 
 START_DATE = pendulum.DateTime(2021, 9, 4, tzinfo=utc)
 
@@ -711,3 +713,49 @@ def test_fold_scheduling():
         pendulum.datetime(2023, 10, 29, 1, 30, tz=utc),
         pendulum.datetime(2023, 10, 29, 2, 0, tz=utc),  # Locally 3am (not DST).
     )
+
+
+@pytest.mark.parametrize(
+    "timetable",
+    [
+        pytest.param(HOURLY_CRON_TIMETABLE, id="cron"),
+        pytest.param(HOURLY_TIMEDELTA_TIMETABLE, id="timedelta"),
+    ],
+)
+def test_generate_run_id_anchors_to_data_interval_start(timetable: Timetable) -> None:
+    """Regression test for the CREATE_CRON_DATA_INTERVALS run_id gap described in GH issue #71187."""
+    run_id = timetable.generate_run_id(
+        run_type=DagRunType.SCHEDULED,
+        run_after=PREV_DATA_INTERVAL_END,
+        data_interval=PREV_DATA_INTERVAL,
+    )
+    assert run_id == DagRunType.SCHEDULED.generate_run_id(suffix=PREV_DATA_INTERVAL_START.isoformat())
+    assert PREV_DATA_INTERVAL_END.isoformat() not in run_id
+
+
+@pytest.mark.parametrize(
+    "timetable",
+    [
+        pytest.param(HOURLY_CRON_TIMETABLE, id="cron"),
+        pytest.param(HOURLY_TIMEDELTA_TIMETABLE, id="timedelta"),
+    ],
+)
+def test_generate_run_id_falls_back_without_data_interval(timetable: Timetable) -> None:
+    """When no data interval is available, generate_run_id falls back to run_after-anchored behavior."""
+    run_id = timetable.generate_run_id(
+        run_type=DagRunType.MANUAL,
+        run_after=PREV_DATA_INTERVAL_END,
+        data_interval=None,
+    )
+    assert run_id == DagRunType.MANUAL.generate_run_id(suffix=PREV_DATA_INTERVAL_END.isoformat())
+
+
+def test_generate_run_id_default_timetable_unaffected() -> None:
+    """CronTriggerTimetable (the AIP-76 default) must be unaffected by this change."""
+    timetable = CronTriggerTimetable("@hourly", timezone=utc)
+    run_id = timetable.generate_run_id(
+        run_type=DagRunType.SCHEDULED,
+        run_after=PREV_DATA_INTERVAL_END,
+        data_interval=PREV_DATA_INTERVAL,
+    )
+    assert run_id == DagRunType.SCHEDULED.generate_run_id(suffix=PREV_DATA_INTERVAL_END.isoformat())


### PR DESCRIPTION
Closes #71187.

### Problem
`[scheduler] create_cron_data_intervals` restores Airflow 2-style `logical_date`/data-interval
semantics for `CronDataIntervalTimetable` and `DeltaDataIntervalTimetable`, but it doesn't extend
to `run_id`. `generate_run_id()` is only defined once, on the shared base `Timetable` class, and
always anchors to `run_after` — the AIP-76 default. So enabling the flag restores `logical_date`
but silently leaves `run_id` on the new scheme, which breaks any workflow that parses `run_id` to
recover the logical date (a common pattern carried over from Airflow 2).

This is a documented gap, not a regression — `_create_timetable()` in
`airflow.sdk.definitions.dag` confirms `_DataIntervalTimetable` subclasses are only instantiated
when the flag is on, so the fix is naturally scoped by construction rather than an extra
conditional.

### Fix
Adds a `generate_run_id()` override on the shared `_DataIntervalTimetable` base in
`airflow-core/src/airflow/timetables/interval.py`, covering both `CronDataIntervalTimetable` and
`DeltaDataIntervalTimetable` symmetrically. It anchors to `data_interval.start` when a data
interval is available, and falls back to the base (`run_after`-anchored) behavior otherwise, so it
never raises on an unexpected `None`. `CronTriggerTimetable`/`DeltaTriggerTimetable` (the AIP-76
default path) are untouched.

This mirrors the `LogicalDateRunIdTimetable` workaround already posted in the issue by the
reporter, who confirmed it works in their environment — promoted here into core so it applies
without a custom DAG-level subclass.

### Tests
Added three regression tests to `airflow-core/tests/unit/timetables/test_interval_timetable.py`:
- `test_generate_run_id_anchors_to_data_interval_start` — `run_id` anchors to `data_interval.start`
  for both `CronDataIntervalTimetable` and `DeltaDataIntervalTimetable`
- `test_generate_run_id_falls_back_without_data_interval` — falls back correctly when
  `data_interval=None`
- `test_generate_run_id_default_timetable_unaffected` — confirms `CronTriggerTimetable` (default)
  is unaffected, i.e. zero regression to the majority code path

### Docs
- `config.yml`: extended the `create_cron_data_intervals` description to note it now also covers
  `run_id`.
- `authoring-and-scheduling/timetable.rst`: added a scoping note to the `run_id`/`logical_date`
  section — that section previously described this behavior as already true, which it wasn't until
  this PR.
- `installation/upgrading_to_airflow3.rst`: added a note for 2→3 migrators who rely on `run_id`
  reflecting the logical date.

### Verification performed
- `python -m py_compile` on changed files
- `ruff check` / `ruff format --check` against the repo's actual `pyproject.toml` — clean
- Installed the real dependency chain and imported the actual patched classes (not stand-ins) to
  confirm `run_id` anchoring, the `None` fallback, and that `CronTriggerTimetable` is unaffected —
  all as expected
- Best-effort `mypy` (couldn't install the internal `airflow_mypy` plugin outside CI, so treat as a
  strong signal, not equivalent to the CI job)
- **Not run**: the full pytest suite via Breeze (`tests/conftest.py` shells out to `uv` for
  provider dependency metadata, which needs the Breeze/CI environment) — please run
  `breeze testing tests airflow-core/tests/unit/timetables/test_interval_timetable.py` before
  merging

### Open question for maintainers
The issue outlines two possible directions: (1) extend this flag to cover `run_id` (what this PR
does), or (2) a more general `dag_run_policy`-style cluster policy hook, noted in the issue as
possibly the preferred long-term design. This PR takes the smaller-scoped option since it's a pure
addition with low regression risk, but happy to rework toward the hook approach if that's the
preferred direction.

One incidental finding while researching this: `[scheduler] create_delta_data_intervals` is
documented in `config.yml` and listed in the CLI config commands, but I couldn't find anywhere in
`_create_timetable()` (or elsewhere) that actually reads it to gate `DeltaDataIntervalTimetable`
selection — `create_cron_data_intervals` appears to gate both cron and delta branches today.
Flagging in case that's a known issue or I'm missing a call site; didn't want to fix it as a
drive-by in this PR.

Newsfragment will be added as a follow-up commit once this PR has a number, per the contribution
guide.

---

**AI disclosure:** All code, documentation, and test changes in this PR were written by me. An AI
coding tool (Claude) was used only PR description and to run the new regression test cases locally and verify they
pass against the patched code.