### PR TITLE
Docs execution API version check via side effects in AGENTS.md

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/AGENTS.md
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/AGENTS.md
@@ -32,6 +32,17 @@ uv run --active --group codegen --project apache-airflow-task-sdk --directory ta
 - Don't use keyword arguments with `endpoint()` — use positional: `endpoint("/path", ["GET"])`.
 - Don't add changes to already-released version files.
 - Don't forget response converters for new fields in nested objects.
+- Don't branch business logic by comparing the negotiated API version to a date/version string. For this case, subclass `VersionChangeWithSideEffects` for the version change and check its `is_applied` flag instead:
+
+  ```python
+  class AddArgBindingsToTIRunContext(VersionChangeWithSideEffects): ...
+
+
+  def _client_supports_arg_bindings() -> bool:
+      return AddArgBindingsToTIRunContext.is_applied
+  ```
+
+  See [Cadwyn's docs](https://docs.cadwyn.dev/concepts/version_changes/#version-changes-with-side-effects).
 
 ### Adding a New Feature End-to-End
 


### PR DESCRIPTION
- related: https://github.com/apache/airflow/pull/69757

https://github.com/apache/airflow/pull/69757 introduced the first "business logic act different based on the client version" pattern.

We should guide the best practice down (define as `VersionChangeWithSideEffects` and check against the `is_applied` flag) in case agents (or us) use the anti-pattern (check against date) in the future.