### PR TITLE
Make KPO durable execution inert below Airflow 3.3

### DIFF
--- a/providers/cncf/kubernetes/docs/operators.rst
+++ b/providers/cncf/kubernetes/docs/operators.rst
@@ -216,9 +216,11 @@ To always create a fresh pod on retry rather than reattaching, set ``durable=Fal
         durable=False,
     )
 
-Durable execution requires Airflow 3.3 or newer, since it relies on the task state store. On
-earlier Airflow versions ``durable=True`` (the default) falls back to the same label-search
-reattach behavior this operator has always used.
+Durable execution requires Airflow 3.3 or newer, since it relies on the task state store. Below
+3.3, ``durable`` has no effect at all: setting it explicitly only emits a warning, and its value is
+ignored either way. The deprecated ``reattach_on_restart`` parameter (default ``True``) is the
+only lever there, and it falls back to the same label-search reattach behavior this operator has
+always used -- unchanged from before this feature existed.
 
 The pod identity persisted in task state store isn't deleted automatically, that only happens
 when someone runs ``airflow state-store clean``. If a task's ``retry_delay`` is longer than
@@ -229,9 +231,11 @@ search can often still find the same pod, but it loses the unambiguous reconnect
 exposure to ``FoundMoreThanOnePodFailure`` if a genuine duplicate pod exists by then. Avoid
 running cleanup on a schedule shorter than your longest ``retry_delay``.
 
-``durable`` supersedes the deprecated ``reattach_on_restart`` parameter -- passing
-``reattach_on_restart`` still works but emits ``AirflowProviderDeprecationWarning`` (on Airflow
-3.3+) and maps its value onto ``durable``.
+``durable`` supersedes the deprecated ``reattach_on_restart`` parameter on Airflow 3.3+, where
+passing ``reattach_on_restart`` still works and maps its value onto ``durable``. Below 3.3,
+``reattach_on_restart`` remains the only working option, since ``durable`` is a no-op there.
+Either way, passing it emits an ``AirflowProviderDeprecationWarning``, since the parameter will be
+removed once this provider's minimum supported Airflow version reaches 3.3.
 
 How does XCom work?
 ^^^^^^^^^^^^^^^^^^^

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -86,7 +86,7 @@ from airflow.providers.cncf.kubernetes.utils.pod_manager import (
     PodPhase,
     detect_pod_terminate_early_issues,
 )
-from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_1_PLUS
+from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_1_PLUS, AIRFLOW_V_3_3_PLUS
 from airflow.providers.common.compat.sdk import XCOM_RETURN_KEY, AirflowSkipException, conf
 
 if AIRFLOW_V_3_1_PLUS:
@@ -176,16 +176,17 @@ class KubernetesPodOperator(BaseOperator):
     :param in_cluster: run kubernetes client with in_cluster configuration.
     :param cluster_context: context that points to kubernetes cluster.
         Ignored when in_cluster is True. If None, current-context is used. (templated)
-    :param reattach_on_restart: deprecated for Airflow 3.3+, use ``durable`` instead. If the worker dies
-        while the pod is running, reattach and monitor during the next try. If False, always create a
-        new pod for each try.
+    :param reattach_on_restart: deprecated, use ``durable`` instead. If the worker dies while the pod
+        is running, reattach and monitor during the next try. If False, always create a new pod for
+        each try. Below Airflow 3.3, this remains the only way to control that behavior, since
+        ``durable`` has no effect there.
     :param durable: if the worker dies while the pod is running, reattach and monitor during the next
         try instead of creating a duplicate pod. If False, always create a new pod for each try.
-        Supersedes ``reattach_on_restart``; on Airflow 3.3+ the reconnection uses a persisted pod
-        identity in task state store instead of a label search, removing the ambiguity failure a label
-        search can hit when more than one matching pod exists. Defaults to ``True``. On Airflow
-        versions below 3.3, ``durable`` still works but falls back to the same label-search reattach
-        behavior as ``reattach_on_restart``, since task state store is unavailable.
+        Supersedes ``reattach_on_restart`` on Airflow 3.3+, where the reconnection uses a persisted
+        pod identity in task state store instead of a label search. Defaults to ``True`` on Airflow
+        3.3+. Below 3.3, ``durable`` has no effect -- setting it explicitly only emits a warning --
+        and ``reattach_on_restart`` (default ``True``) is the only lever, using the same
+        label-search reattach mechanism it always has.
     :param labels: labels to apply to the Pod. (templated)
     :param startup_timeout_seconds: timeout in seconds to startup the pod after pod was scheduled.
     :param startup_check_interval_seconds: interval in seconds to check if the pod has already started
@@ -340,7 +341,7 @@ class KubernetesPodOperator(BaseOperator):
         cluster_context: str | None = None,
         labels: dict | None = None,
         reattach_on_restart: bool | None = None,
-        durable: bool = True,
+        durable: bool | None = None,
         startup_timeout_seconds: int = 120,
         startup_check_interval_seconds: int = 5,
         schedule_timeout_seconds: int | None = None,
@@ -402,12 +403,33 @@ class KubernetesPodOperator(BaseOperator):
         if reattach_on_restart is not None:
             # Kept as a real named parameter (not **kwargs) so `default_args` still applies correctly.
             warnings.warn(
-                "`reattach_on_restart` is deprecated and will be removed in a future release. "
-                "Use `durable` instead.",
+                "`reattach_on_restart` is deprecated and will be removed once this provider's "
+                "minimum supported Airflow version reaches 3.3. "
+                + (
+                    "Use `durable` instead."
+                    if AIRFLOW_V_3_3_PLUS
+                    else "On Airflow 3.3+, use `durable` instead."
+                ),
                 AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
-            durable = reattach_on_restart
+        if AIRFLOW_V_3_3_PLUS:
+            if durable is None:
+                # durable takes precedence when set, even against a conflicting
+                # reattach_on_restart; reattach_on_restart only fills the gap when durable itself
+                # was never touched.
+                durable = True if reattach_on_restart is None else reattach_on_restart
+        else:
+            if durable is not None:
+                # durable itself has no effect below 3.3 -- there's no task state store to persist
+                # a pod identity to, so only reattach_on_restart's label-search fallback is real
+                # there.
+                warnings.warn(
+                    "`durable` has no effect on Airflow versions below 3.3.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            durable = True if reattach_on_restart is None else reattach_on_restart
         super().__init__(**kwargs)
         self.kubernetes_conn_id = kubernetes_conn_id
         self.do_xcom_push = do_xcom_push

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -86,7 +86,7 @@ from airflow.providers.cncf.kubernetes.utils.pod_manager import (
     PodPhase,
     detect_pod_terminate_early_issues,
 )
-from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_1_PLUS, AIRFLOW_V_3_3_PLUS
+from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_1_PLUS
 from airflow.providers.common.compat.sdk import XCOM_RETURN_KEY, AirflowSkipException, conf
 
 if AIRFLOW_V_3_1_PLUS:
@@ -401,13 +401,12 @@ class KubernetesPodOperator(BaseOperator):
     ) -> None:
         if reattach_on_restart is not None:
             # Kept as a real named parameter (not **kwargs) so `default_args` still applies correctly.
-            if AIRFLOW_V_3_3_PLUS:
-                warnings.warn(
-                    "`reattach_on_restart` is deprecated and will be removed in a future release. "
-                    "Use `durable` instead.",
-                    AirflowProviderDeprecationWarning,
-                    stacklevel=2,
-                )
+            warnings.warn(
+                "`reattach_on_restart` is deprecated and will be removed in a future release. "
+                "Use `durable` instead.",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
             durable = reattach_on_restart
         super().__init__(**kwargs)
         self.kubernetes_conn_id = kubernetes_conn_id

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -2566,6 +2566,16 @@ class TestKubernetesPodOperator:
         assert result.metadata.name == pod_2.metadata.name
 
 
+_REATTACH_DEPRECATION_MESSAGE_PREFIX = (
+    "`reattach_on_restart` is deprecated and will be removed once this provider's "
+    "minimum supported Airflow version reaches 3.3. "
+)
+REATTACH_DEPRECATION_MESSAGE_PRE_3_3 = (
+    _REATTACH_DEPRECATION_MESSAGE_PREFIX + "On Airflow 3.3+, use `durable` instead."
+)
+REATTACH_DEPRECATION_MESSAGE_3_3_PLUS = _REATTACH_DEPRECATION_MESSAGE_PREFIX + "Use `durable` instead."
+
+
 @pytest.mark.skipif(
     not AIRFLOW_V_3_3_PLUS, reason="durable execution (task_state_store) requires Airflow 3.3+"
 )
@@ -2580,6 +2590,12 @@ class TestKubernetesPodOperatorDurableExecution:
         yield
 
         patch.stopall()
+
+    def test_warning_message_recommends_durable_directly_on_3_3_plus(self):
+        with pytest.warns(
+            AirflowProviderDeprecationWarning, match=f"^{re.escape(REATTACH_DEPRECATION_MESSAGE_3_3_PLUS)}$"
+        ):
+            KubernetesPodOperator(task_id="task", reattach_on_restart=True)
 
     def test_durable_fresh_submit_persists_pod_identity(self):
         k = KubernetesPodOperator(
@@ -2779,7 +2795,9 @@ class TestKubernetesPodOperatorDurableExecution:
 
     @pytest.mark.parametrize("reattach_value", [True, False])
     def test_reattach_on_restart_deprecation_maps_to_durable(self, reattach_value):
-        with pytest.warns(AirflowProviderDeprecationWarning, match="reattach_on_restart"):
+        with pytest.warns(
+            AirflowProviderDeprecationWarning, match=f"^{re.escape(REATTACH_DEPRECATION_MESSAGE_3_3_PLUS)}$"
+        ):
             k = KubernetesPodOperator(
                 task_id="task",
                 reattach_on_restart=reattach_value,
@@ -2787,18 +2805,22 @@ class TestKubernetesPodOperatorDurableExecution:
         assert k.durable is reattach_value
         assert k.reattach_on_restart is reattach_value
 
-    def test_reattach_on_restart_and_durable_conflict_reattach_on_restart_wins(self):
-        with pytest.warns(AirflowProviderDeprecationWarning, match="reattach_on_restart"):
+    def test_durable_wins_over_conflicting_reattach_on_restart(self):
+        with pytest.warns(
+            AirflowProviderDeprecationWarning, match=f"^{re.escape(REATTACH_DEPRECATION_MESSAGE_3_3_PLUS)}$"
+        ):
             k = KubernetesPodOperator(
                 task_id="task",
                 durable=False,
                 reattach_on_restart=True,
             )
-        assert k.durable is True
-        assert k.reattach_on_restart is True
+        assert k.durable is False
+        assert k.reattach_on_restart is False
 
     def test_reattach_on_restart_via_default_args_reaches_durable(self, dag_maker):
-        with pytest.warns(AirflowProviderDeprecationWarning, match="reattach_on_restart"):
+        with pytest.warns(
+            AirflowProviderDeprecationWarning, match=f"^{re.escape(REATTACH_DEPRECATION_MESSAGE_3_3_PLUS)}$"
+        ):
             with dag_maker(dag_id="test_reattach_default_args", default_args={"reattach_on_restart": False}):
                 k = KubernetesPodOperator(task_id="task")
         assert k.durable is False
@@ -2806,6 +2828,52 @@ class TestKubernetesPodOperatorDurableExecution:
 
     def test_supports_durable_execution_marker(self):
         assert KubernetesPodOperator._KubernetesPodOperator__supports_durable_execution is True
+
+
+class TestKubernetesPodOperatorDurableBelow3_3:
+    @pytest.mark.parametrize("durable_value", [True, False])
+    def test_durable_has_no_effect(self, durable_value):
+        with mock.patch("airflow.providers.cncf.kubernetes.operators.pod.AIRFLOW_V_3_3_PLUS", False):
+            with pytest.warns(
+                UserWarning, match=r"^`durable` has no effect on Airflow versions below 3\.3\.$"
+            ):
+                k = KubernetesPodOperator(task_id="task", durable=durable_value)
+        # old default (reattach_on_restart's default was True), untouched by the ignored durable value.
+        assert k.durable is True
+        assert k.reattach_on_restart is True
+
+    @pytest.mark.parametrize("reattach_value", [True, False])
+    def test_reattach_on_restart_still_works(self, reattach_value):
+        with mock.patch("airflow.providers.cncf.kubernetes.operators.pod.AIRFLOW_V_3_3_PLUS", False):
+            with pytest.warns(
+                AirflowProviderDeprecationWarning,
+                match=f"^{re.escape(REATTACH_DEPRECATION_MESSAGE_PRE_3_3)}$",
+            ):
+                k = KubernetesPodOperator(task_id="task", reattach_on_restart=reattach_value)
+        assert k.reattach_on_restart is reattach_value
+
+    def test_reattach_on_restart_wins_over_durable(self):
+        with mock.patch("airflow.providers.cncf.kubernetes.operators.pod.AIRFLOW_V_3_3_PLUS", False):
+            with pytest.warns(
+                AirflowProviderDeprecationWarning,
+                match=f"^{re.escape(REATTACH_DEPRECATION_MESSAGE_PRE_3_3)}$",
+            ):
+                k = KubernetesPodOperator(task_id="task", durable=False, reattach_on_restart=True)
+        assert k.reattach_on_restart is True
+
+    def test_default_rettach_on_restart_is_true(self):
+        with mock.patch("airflow.providers.cncf.kubernetes.operators.pod.AIRFLOW_V_3_3_PLUS", False):
+            k = KubernetesPodOperator(task_id="task")
+        assert k.durable is True
+        assert k.reattach_on_restart is True
+
+    def test_warns_on_every_supported_airflow_version(self):
+        with mock.patch("airflow.providers.cncf.kubernetes.operators.pod.AIRFLOW_V_3_3_PLUS", False):
+            with pytest.warns(
+                AirflowProviderDeprecationWarning,
+                match=f"^{re.escape(REATTACH_DEPRECATION_MESSAGE_PRE_3_3)}$",
+            ):
+                KubernetesPodOperator(task_id="task", reattach_on_restart=True)
 
 
 class TestSuppress:


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

### Summary

`durable`, KPO's crash-recovery parameter, currently behaves identically on every supported Airflow version -- including below 3.3, where the task state store it's meant to rely on doesn't exist. This PR makes `durable` a genuine no-op below 3.3 and fixes the scope of its deprecation warning.

### Why

Raised on this PR by elad:

> Durable is functionality that works only in 3.3+ while we made the parameter working for earlier versions. I'd like to avoid a case where users of 3.1 expect durable functionality just because of the parameter name.

Before this change, `durable=True` on a pre-3.3 install fell back to the same label-search reattach mechanism `reattach_on_restart` always used -- so the parameter technically "worked," but under a name that implies a stronger, task-state-store-backed guarantee it can't actually deliver there. Below 3.3, that's a coincidence of implementation, not a documented contract.

Separately, the deprecation warning for `reattach_on_restart` was gated to fire only on Airflow 3.3+. Provider deprecations are scoped to this provider's own release schedule, not the caller's Airflow version -- the parameter will be removed in a future amazon-provider-style release regardless of which Airflow version anyone runs. Gating the warning meant a 3.0-3.2 user could stay silent right up until removal, then hit a `TypeError` with no warning.

### What changed

- `durable` is fully inert below Airflow 3.3: setting it explicitly (`True` or `False`) only emits a `UserWarning` that it has no effect there, and its value is otherwise ignored. `reattach_on_restart` (default `True`, unchanged) is the only lever on those versions, using the same label-search mechanism it always has -- no behavior change for anyone who never touches either flag.
- `reattach_on_restart`'s deprecation warning now fires on **every** supported Airflow version, not just 3.3+. The message itself is version-aware: below 3.3 it points at a future upgrade ("On Airflow 3.3+, use `durable` instead"), since telling that user to switch right now would be bad advice.
- On Airflow 3.3+, `durable` now wins outright when explicitly set -- including `durable=False` beating a conflicting `reattach_on_restart=True` -- rather than `reattach_on_restart` always winning as it did before. `reattach_on_restart` only fills in when `durable` itself was never touched.
- Both messages state the removal is tied to this provider's minimum supported Airflow version reaching 3.3, not to the caller's own version.

### Behavior

See the combination table below. Full test coverage added in `TestKubernetesPodOperatorDurableBelow3_3` (new) and updated in the existing `TestKubernetesPodOperatorDurableExecution` deprecation tests.

---

## Behavior for every combination

`D` = `durable` param as passed, `R` = `reattach_on_restart` param as passed. Both `self.durable` and `self.reattach_on_restart` always end up equal (one mirrors the other).

### Airflow 3.3+

| `D` | `R` | Result | Warnings |
|---|---|---|---|
| not set | not set | `True` (default) | none |
| not set | `True` | `True` | deprecation |
| not set | `False` | `False` | deprecation |
| `True` | not set | `True` | none |
| `True` | `True` | `True` | deprecation |
| `True` | `False` | **`True`** (`D` wins over conflicting `R`) | deprecation |
| `False` | not set | `False` | none |
| `False` | `True` | **`False`** (`D` wins over conflicting `R`) | deprecation |
| `False` | `False` | `False` | deprecation |

### Airflow below 3.3

| `D` | `R` | Result | Warnings |
|---|---|---|---|
| not set | not set | `True` (old default, unchanged) | none |
| not set | `True` | `True` | deprecation |
| not set | `False` | `False` | deprecation |
| `True` | not set | `True` (coincidentally matches) | `durable` inert |
| `True` | `True` | `True` | deprecation + inert |
| `True` | `False` | `False` (`D`'s `True` ignored) | deprecation + inert |
| `False` | not set | **`True`** (`D`'s `False` discarded) | `durable` inert |
| `False` | `True` | `True` | deprecation + inert |
| `False` | `False` | `False` | deprecation + inert |

**Rule of thumb:** on 3.3+, `durable` governs and wins on conflict, defaulting to `True`. Below 3.3, `durable`'s value never matters at all -- the result is always computed purely from `reattach_on_restart` (`True` if untouched, else its value) -- and touching `durable` there always draws a warning that it did nothing.

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
