### PR TITLE
[standard, common.sql] Add missing return type annotations to operators, sensors, and hooks

### DIFF
--- a/providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py
@@ -180,7 +180,7 @@ class DbApiHook(BaseHook):
     _dialects: MutableMapping[str, MutableMapping] = resolve_dialects()
     _resolve_target_fields = conf.getboolean("core", "dbapihook_resolve_target_fields", fallback=False)
 
-    def __init__(self, *args, schema: str | None = None, log_sql: bool = True, **kwargs):
+    def __init__(self, *args, schema: str | None = None, log_sql: bool = True, **kwargs) -> None:
         super().__init__()
         if not self.conn_name_attr:
             raise AirflowException("conn_name_attr is not defined")
@@ -1097,7 +1097,7 @@ class DbApiHook(BaseHook):
         """
         raise NotImplementedError()
 
-    def test_connection(self):
+    def test_connection(self) -> tuple[bool, str]:
         """Tests the connection using db-specific query."""
         status, message = False, ""
         try:

--- a/providers/common/sql/src/airflow/providers/common/sql/operators/sql.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/operators/sql.py
@@ -193,7 +193,7 @@ class BaseSQLOperator(BaseOperator):
         hook_params: dict | None = None,
         retry_on_failure: bool = True,
         **kwargs,
-    ):
+    ) -> None:
         super().__init__(**kwargs)
         self.conn_id = conn_id
         self.database = database
@@ -220,7 +220,7 @@ class BaseSQLOperator(BaseOperator):
         return connection.get_hook(hook_params=hook_params)
 
     @cached_property
-    def _hook(self):
+    def _hook(self) -> DbApiHook:
         """Get DB Hook based on connection type."""
         conn_id = getattr(self, self.conn_id_field)
         self.log.debug("Get connection for %s", conn_id)
@@ -552,7 +552,7 @@ class SQLExecuteQueryOperator(BaseSQLOperator):
     def _should_run_output_processing(self) -> bool:
         return self.do_xcom_push
 
-    def execute(self, context):
+    def execute(self, context) -> Any:
         self.log.info("Executing: %s", self.sql)
         hook = self.get_db_hook()
         if self.split_statements is not None:
@@ -683,7 +683,7 @@ class SQLColumnCheckOperator(BaseSQLOperator):
 
         self.sql = f"SELECT col_name, check_type, check_result FROM ({checks_sql}) AS check_columns"
 
-    def execute(self, context: Context):
+    def execute(self, context: Context) -> None:
         hook = self.get_db_hook()
         records = hook.get_records(self.sql)
 

--- a/providers/standard/src/airflow/providers/standard/hooks/filesystem.py
+++ b/providers/standard/src/airflow/providers/standard/hooks/filesystem.py
@@ -59,7 +59,7 @@ class FSHook(BaseHook):
             "placeholders": {},
         }
 
-    def __init__(self, fs_conn_id: str = default_conn_name, **kwargs):
+    def __init__(self, fs_conn_id: str = default_conn_name, **kwargs) -> None:
         super().__init__(**kwargs)
         conn = self.get_connection(fs_conn_id)
         self.basepath = conn.extra_dejson.get("path", "")
@@ -76,7 +76,7 @@ class FSHook(BaseHook):
         """
         return self.basepath
 
-    def test_connection(self):
+    def test_connection(self) -> tuple[bool, str]:
         """Test File connection."""
         try:
             p = self.get_path()

--- a/providers/standard/src/airflow/providers/standard/operators/bash.py
+++ b/providers/standard/src/airflow/providers/standard/operators/bash.py
@@ -181,7 +181,7 @@ class BashOperator(BaseOperator):
         self._is_inline_cmd: bool | None = None
 
     @cached_property
-    def subprocess_hook(self):
+    def subprocess_hook() -> SubprocessHook:
         """Returns hook for running the bash command."""
         return SubprocessHook()
 
@@ -204,7 +204,7 @@ class BashOperator(BaseOperator):
         env.update(airflow_context_vars)
         return env
 
-    def execute(self, context: Context):
+    def execute(self, context: Context) -> Any:
         bash_path: str = shutil.which("bash") or "bash"
         if self.cwd is not None:
             if not os.path.exists(self.cwd):

--- a/providers/standard/src/airflow/providers/standard/operators/empty.py
+++ b/providers/standard/src/airflow/providers/standard/operators/empty.py
@@ -35,5 +35,5 @@ class EmptyOperator(BaseOperator):
     ui_color = "#e8f7e4"
     inherits_from_empty_operator = True
 
-    def execute(self, context: Context):
+    def execute(self, context: Context) -> None:
         pass

--- a/providers/standard/src/airflow/providers/standard/operators/smooth.py
+++ b/providers/standard/src/airflow/providers/standard/operators/smooth.py
@@ -34,5 +34,5 @@ class SmoothOperator(BaseOperator):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
 
-    def execute(self, context: Context):
+    def execute(self, context: Context) -> None:
         self.log.info("Enjoy Sade - Smooth Operator: %s", self.yt_link)

--- a/providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py
+++ b/providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py
@@ -230,7 +230,7 @@ class TriggerDagRunOperator(BaseOperator):
                 "(it relies on the task-SDK DAG state endpoint added in 3.2.0)."
             )
 
-    def execute(self, context: Context):
+    def execute(self, context: Context) -> Any:
         _validate_datetime_param("logical_date", self.logical_date)
         if self.logical_date is NOTSET:
             if self.run_after is not NOTSET:
@@ -301,7 +301,7 @@ class TriggerDagRunOperator(BaseOperator):
                 context=context, run_id=self.trigger_run_id, parsed_logical_date=parsed_logical_date
             )
 
-    def _trigger_dag_af_3(self, context, run_id, parsed_logical_date, parsed_run_after=None):
+    def _trigger_dag_af_3(self, context, run_id, parsed_logical_date, parsed_run_after=None) -> None:
         from airflow.providers.common.compat.sdk import DagRunTriggerException
 
         kwargs_accepted = dict(
@@ -344,7 +344,7 @@ class TriggerDagRunOperator(BaseOperator):
 
         raise DagRunTriggerException(**kwargs_accepted)
 
-    def _trigger_dag_af_2(self, context, run_id, parsed_logical_date):
+    def _trigger_dag_af_2(self, context, run_id, parsed_logical_date) -> None:
         try:
             unsupported_parameters = []
             for attr, default_value in self.attributes_not_supported_in_airflow_2.items():
@@ -423,7 +423,7 @@ class TriggerDagRunOperator(BaseOperator):
                     self.log.info("%s finished with allowed state %s", self.trigger_dag_id, state)
                     return
 
-    def execute_complete(self, context: Context, event: tuple[str, dict[str, Any]]):
+    def execute_complete(self, context: Context, event: tuple[str, dict[str, Any]]) -> Any:
         """
         Handle task completion after returning from a deferral.
 

--- a/providers/standard/src/airflow/providers/standard/sensors/bash.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/bash.py
@@ -57,15 +57,21 @@ class BashSensor(BaseSensorOperator):
     template_fields: Sequence[str] = ("bash_command", "env")
 
     def __init__(
-        self, *, bash_command, env=None, output_encoding="utf-8", retry_exit_code: int | None = None, **kwargs
-    ):
+        self,
+        *,
+        bash_command: str,
+        env: dict[str, str] | None = None,
+        output_encoding: str = "utf-8",
+        retry_exit_code: int | None = None,
+        **kwargs,
+    ) -> None:
         super().__init__(**kwargs)
         self.bash_command = bash_command
         self.env = env
         self.output_encoding = output_encoding
         self.retry_exit_code = retry_exit_code
 
-    def poke(self, context: Context):
+    def poke(self, context: Context) -> bool:
         """Execute the bash command in a temporary directory."""
         bash_command = self.bash_command
         self.log.info("Tmp dir root location: %s", gettempdir())

--- a/providers/standard/src/airflow/providers/standard/sensors/filesystem.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/filesystem.py
@@ -74,14 +74,14 @@ class FileSensor(BaseSensorOperator):
     def __init__(
         self,
         *,
-        filepath,
-        fs_conn_id="fs_default",
-        recursive=False,
+        filepath: str,
+        fs_conn_id: str = "fs_default",
+        recursive: bool = False,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
         start_from_trigger: bool = False,
         trigger_kwargs: dict[str, Any] | None = None,
         **kwargs,
-    ):
+    ) -> None:
         super().__init__(**kwargs)
         self.filepath = filepath
         self.fs_conn_id = fs_conn_id

--- a/providers/standard/src/airflow/providers/standard/sensors/time_delta.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/time_delta.py
@@ -64,7 +64,7 @@ class TimeDeltaSensor(BaseSensorOperator):
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
         end_from_trigger: bool = False,
         **kwargs,
-    ):
+    ) -> None:
         super().__init__(**kwargs)
         self.delta = delta
         self.deferrable = deferrable


### PR DESCRIPTION
### Description
Adds missing return type annotations (`-> None`, `-> Any`, `-> tuple[bool, str]`, `-> bool`) and parameter type hints to operators, sensors, and hooks in `providers/standard` and `providers/common/sql`.

Key updates:
- Added explicit return type hints to `EmptyOperator.execute`, `SmoothOperator.execute`, `BashOperator.execute`, `TriggerDagRunOperator.execute`, `SQLColumnCheckOperator.execute`, and `SQLExecuteQueryOperator.execute`.
- Added return types to `test_connection()` in `FSHook` and `DbApiHook`.
- Added explicit parameter type annotations for `BashSensor.__init__` and `FileSensor.__init__`.

### Tests
- Validated static analysis with `ruff check` (all checks passed).