### PR TITLE
Fail Glue job tasks stopped mid-run in deferrable verbose mode

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/glue.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/glue.py
@@ -144,7 +144,8 @@ class GlueJobCompleteTrigger(AwsBaseWaiterTrigger):
                     )
                     return
 
-                if job_run_state in ("FAILED", "TIMEOUT"):
+                # STOPPED means the run was cancelled before it produced its output, not that it succeeded.
+                if job_run_state in ("FAILED", "TIMEOUT", "STOPPED"):
                     yield TriggerEvent(
                         {
                             "status": "error",
@@ -154,7 +155,7 @@ class GlueJobCompleteTrigger(AwsBaseWaiterTrigger):
                         }
                     )
                     return
-                if job_run_state in ("SUCCEEDED", "STOPPED"):
+                if job_run_state == "SUCCEEDED":
                     self.log.info(
                         "Exiting Job %s Run %s State: %s",
                         self.job_name,

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_glue.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_glue.py
@@ -174,7 +174,7 @@ class TestGlueJobTrigger:
     @pytest.mark.parametrize("job_run_state", ["FAILED", "TIMEOUT", "STOPPED"])
     @mock.patch.object(AwsLogsHook, "get_async_conn")
     @mock.patch.object(GlueJobHook, "get_async_conn")
-    async def test_verbose_run_job_failed(self, mock_glue_conn, mock_logs_conn, job_run_state):
+    async def test_verbose_run_failure_states(self, mock_glue_conn, mock_logs_conn, job_run_state):
         """When verbose=True and the run ends in a failure state, the trigger yields an error event."""
         glue_client = AsyncMock()
         glue_client.get_job_run = AsyncMock(

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_glue.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_glue.py
@@ -171,13 +171,14 @@ class TestGlueJobTrigger:
         assert logs_client.get_log_events.call_count >= 2
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("job_run_state", ["FAILED", "TIMEOUT", "STOPPED"])
     @mock.patch.object(AwsLogsHook, "get_async_conn")
     @mock.patch.object(GlueJobHook, "get_async_conn")
-    async def test_verbose_run_job_failed(self, mock_glue_conn, mock_logs_conn):
-        """When verbose=True and the job fails, the trigger yields an error event."""
+    async def test_verbose_run_job_failed(self, mock_glue_conn, mock_logs_conn, job_run_state):
+        """When verbose=True and the run ends in a failure state, the trigger yields an error event."""
         glue_client = AsyncMock()
         glue_client.get_job_run = AsyncMock(
-            return_value={"JobRun": {"JobRunState": "FAILED", "LogGroupName": "/aws-glue/python-jobs"}}
+            return_value={"JobRun": {"JobRunState": job_run_state, "LogGroupName": "/aws-glue/python-jobs"}}
         )
         mock_glue_conn.return_value.__aenter__ = AsyncMock(return_value=glue_client)
         mock_glue_conn.return_value.__aexit__ = AsyncMock(return_value=False)
@@ -198,7 +199,7 @@ class TestGlueJobTrigger:
         generator = trigger.run()
         event = await generator.asend(None)
         assert event.payload["status"] == "error"
-        assert "FAILED" in event.payload["message"]
+        assert job_run_state in event.payload["message"]
         assert event.payload["run_id"] == "jr_123"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

A Glue job run ending in `STOPPED` — cancelled from the AWS console, or by the operator's own `on_kill` — fails the task on every path but this one, where the verbose polling loop buckets it with `SUCCEEDED` and lets downstream work run on output the run never produced. The operator docs already state the intended behaviour without qualification: a run that ends in `STOPPED` is treated as a failure, not a success.

## Scope

`GlueJobHook._handle_state` still counts `STOPPED` as finished and is left alone, since #71211 moved the operator's success decision out of the hook. `GlueJobSensor` defers to the same trigger, so its verbose deferrable mode changes too, toward its own `FAILURE_STATES`.

closes: #71490

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)