### PR TITLE
Amazon Glue: classify STOPPED job runs as failures consistently

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/glue.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/glue.py
@@ -433,8 +433,11 @@ class GlueJobHook(AwsBaseHook):
         next_log_tokens: GlueJobHook.LogContinuationTokens,
     ) -> dict | None:
         """Process Glue Job state while polling; used by both sync and async methods."""
-        failed_states = ["FAILED", "TIMEOUT"]
-        finished_states = ["SUCCEEDED", "STOPPED"]
+        # STOPPED is treated as a failure (not a successful completion) to stay consistent
+        # with the "job_complete" waiter's acceptors and GlueJobCompleteTrigger's verbose
+        # polling loop, both of which also classify STOPPED as failure.
+        failed_states = ["FAILED", "TIMEOUT", "STOPPED"]
+        finished_states = ["SUCCEEDED"]
 
         if verbose:
             self.print_job_logs(

--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/glue.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/glue.py
@@ -144,7 +144,10 @@ class GlueJobCompleteTrigger(AwsBaseWaiterTrigger):
                     )
                     return
 
-                if job_run_state in ("FAILED", "TIMEOUT"):
+                # STOPPED is treated as a failure, consistent with the "job_complete" waiter's
+                # acceptors and GlueJobHook._handle_state, both of which also classify STOPPED
+                # as failure rather than a successful completion.
+                if job_run_state in ("FAILED", "TIMEOUT", "STOPPED"):
                     yield TriggerEvent(
                         {
                             "status": "error",
@@ -154,7 +157,7 @@ class GlueJobCompleteTrigger(AwsBaseWaiterTrigger):
                         }
                     )
                     return
-                if job_run_state in ("SUCCEEDED", "STOPPED"):
+                if job_run_state == "SUCCEEDED":
                     self.log.info(
                         "Exiting Job %s Run %s State: %s",
                         self.job_name,

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_glue.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_glue.py
@@ -504,13 +504,14 @@ class TestGlueJobHook:
         assert get_state_mock.call_count == 3
         get_state_mock.assert_called_with("job_name", "run_id")
 
+    @pytest.mark.parametrize("final_state", ["FAILED", "TIMEOUT", "STOPPED"])
     @mock.patch.object(GlueJobHook, "get_job_state")
-    def test_job_completion_failure(self, get_state_mock: MagicMock):
+    def test_job_completion_failure(self, get_state_mock: MagicMock, final_state: str):
         hook = GlueJobHook(job_poll_interval=0)
         get_state_mock.side_effect = [
             "RUNNING",
             "RUNNING",
-            "FAILED",
+            final_state,
         ]
 
         with pytest.raises(AirflowException):
@@ -534,13 +535,14 @@ class TestGlueJobHook:
         get_state_mock.assert_called_with("job_name", "run_id")
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("final_state", ["FAILED", "TIMEOUT", "STOPPED"])
     @mock.patch.object(GlueJobHook, "async_get_job_state")
-    async def test_async_job_completion_failure(self, get_state_mock: MagicMock):
+    async def test_async_job_completion_failure(self, get_state_mock: MagicMock, final_state: str):
         hook = GlueJobHook(job_poll_interval=0)
         get_state_mock.side_effect = [
             "RUNNING",
             "RUNNING",
-            "FAILED",
+            final_state,
         ]
 
         with pytest.raises(AirflowException):

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_glue.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_glue.py
@@ -171,13 +171,19 @@ class TestGlueJobTrigger:
         assert logs_client.get_log_events.call_count >= 2
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("final_state", ["FAILED", "TIMEOUT", "STOPPED"])
     @mock.patch.object(AwsLogsHook, "get_async_conn")
     @mock.patch.object(GlueJobHook, "get_async_conn")
-    async def test_verbose_run_job_failed(self, mock_glue_conn, mock_logs_conn):
-        """When verbose=True and the job fails, the trigger yields an error event."""
+    async def test_verbose_run_job_failed(self, mock_glue_conn, mock_logs_conn, final_state: str):
+        """When verbose=True and the job fails or is stopped, the trigger yields an error event.
+
+        STOPPED must be classified as failure here to stay consistent with the "job_complete"
+        waiter's acceptors and GlueJobHook._handle_state, both of which also treat STOPPED as
+        failure rather than a successful completion.
+        """
         glue_client = AsyncMock()
         glue_client.get_job_run = AsyncMock(
-            return_value={"JobRun": {"JobRunState": "FAILED", "LogGroupName": "/aws-glue/python-jobs"}}
+            return_value={"JobRun": {"JobRunState": final_state, "LogGroupName": "/aws-glue/python-jobs"}}
         )
         mock_glue_conn.return_value.__aenter__ = AsyncMock(return_value=glue_client)
         mock_glue_conn.return_value.__aexit__ = AsyncMock(return_value=False)
@@ -198,7 +204,7 @@ class TestGlueJobTrigger:
         generator = trigger.run()
         event = await generator.asend(None)
         assert event.payload["status"] == "error"
-        assert "FAILED" in event.payload["message"]
+        assert final_state in event.payload["message"]
         assert event.payload["run_id"] == "jr_123"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
GlueJobCompleteTrigger's verbose polling loop and GlueJobHook's sync `job_completion` path both treated a Glue job run ending in `STOPPED` (e.g. cancelled via `on_kill` or manually from the AWS console) as a successful completion. Meanwhile, the deferrable non-verbose path's `job_complete` waiter (`providers/amazon/src/airflow/providers/amazon/aws/waiters/glue.json`) and the `GlueJobSensor` family (`sensors/glue.py`, `FAILURE_STATES`) already classify `STOPPED` as a failure.

That meant the same terminal state produced a passing task in some execution modes (sync, or deferred+verbose) and a failing one in others (deferred, non-verbose), depending only on the `verbose` flag or whether the operator was deferred.

This PR aligns all three paths on treating `STOPPED` as a failure, matching the existing waiter acceptors and sensor `FAILURE_STATES` convention:

- `GlueJobHook._handle_state`: moved `STOPPED` from `finished_states` to `failed_states`.
- `GlueJobCompleteTrigger.run()` (verbose branch): `STOPPED` now falls into the same branch as `FAILED`/`TIMEOUT` instead of being treated as `SUCCEEDED`.

Added/extended parametrized tests in both the hook and trigger test suites covering `STOPPED` alongside the existing `FAILED`/`TIMEOUT` cases.

closes: #71490

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)

Generated-by: Claude Code (Sonnet 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)