### PR TITLE
Fix stopped Glue job trigger state

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/glue.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/glue.py
@@ -144,7 +144,7 @@ class GlueJobCompleteTrigger(AwsBaseWaiterTrigger):
                     )
                     return
 
-                if job_run_state in ("FAILED", "TIMEOUT"):
+                if job_run_state in ("FAILED", "STOPPED", "TIMEOUT"):
                     yield TriggerEvent(
                         {
                             "status": "error",
@@ -154,7 +154,7 @@ class GlueJobCompleteTrigger(AwsBaseWaiterTrigger):
                         }
                     )
                     return
-                if job_run_state in ("SUCCEEDED", "STOPPED"):
+                if job_run_state == "SUCCEEDED":
                     self.log.info(
                         "Exiting Job %s Run %s State: %s",
                         self.job_name,

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_glue.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_glue.py
@@ -173,11 +173,12 @@ class TestGlueJobTrigger:
     @pytest.mark.asyncio
     @mock.patch.object(AwsLogsHook, "get_async_conn")
     @mock.patch.object(GlueJobHook, "get_async_conn")
-    async def test_verbose_run_job_failed(self, mock_glue_conn, mock_logs_conn):
+    @pytest.mark.parametrize("job_run_state", ["FAILED", "STOPPED", "TIMEOUT"])
+    async def test_verbose_run_job_failed(self, mock_glue_conn, mock_logs_conn, job_run_state):
         """When verbose=True and the job fails, the trigger yields an error event."""
         glue_client = AsyncMock()
         glue_client.get_job_run = AsyncMock(
-            return_value={"JobRun": {"JobRunState": "FAILED", "LogGroupName": "/aws-glue/python-jobs"}}
+            return_value={"JobRun": {"JobRunState": job_run_state, "LogGroupName": "/aws-glue/python-jobs"}}
         )
         mock_glue_conn.return_value.__aenter__ = AsyncMock(return_value=glue_client)
         mock_glue_conn.return_value.__aexit__ = AsyncMock(return_value=False)
@@ -198,7 +199,7 @@ class TestGlueJobTrigger:
         generator = trigger.run()
         event = await generator.asend(None)
         assert event.payload["status"] == "error"
-        assert "FAILED" in event.payload["message"]
+        assert job_run_state in event.payload["message"]
         assert event.payload["run_id"] == "jr_123"
 
     @pytest.mark.asyncio

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_glue.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_glue.py
@@ -171,9 +171,9 @@ class TestGlueJobTrigger:
         assert logs_client.get_log_events.call_count >= 2
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("job_run_state", ["FAILED", "STOPPED", "TIMEOUT"])
     @mock.patch.object(AwsLogsHook, "get_async_conn")
     @mock.patch.object(GlueJobHook, "get_async_conn")
-    @pytest.mark.parametrize("job_run_state", ["FAILED", "STOPPED", "TIMEOUT"])
     async def test_verbose_run_job_failed(self, mock_glue_conn, mock_logs_conn, job_run_state):
         """When verbose=True and the job fails, the trigger yields an error event."""
         glue_client = AsyncMock()


### PR DESCRIPTION
﻿Makes the verbose `GlueJobCompleteTrigger` agree with both the non-verbose waiter and the synchronous operator by treating a terminal `STOPPED` job run as an error instead of success.

The existing verbose failure regression now covers `FAILED`, `STOPPED`, and `TIMEOUT` states.

closes: #71490

Testing:
- focused source-level regression assertions for terminal-state classification and test coverage
- `uvx ruff check providers/amazon/src/airflow/providers/amazon/aws/triggers/glue.py providers/amazon/tests/unit/amazon/aws/triggers/test_glue.py`
- `uvx ruff format --check providers/amazon/src/airflow/providers/amazon/aws/triggers/glue.py providers/amazon/tests/unit/amazon/aws/triggers/test_glue.py`
- `python -m compileall -q providers/amazon/src/airflow/providers/amazon/aws/triggers/glue.py providers/amazon/tests/unit/amazon/aws/triggers/test_glue.py`
- `git diff --check`

The targeted `uv run pytest ... -k verbose_run_job_failed` command did not start within the 60-second dependency-bootstrap window on this Windows host.