### PR TITLE
Walk each Dag once in DBDagBag.iter_all_latest_version_dags

### DIFF
--- a/airflow-core/src/airflow/models/dagbag.py
+++ b/airflow-core/src/airflow/models/dagbag.py
@@ -229,7 +229,7 @@ class DBDagBag:
         """
         from airflow.models.serialized_dag import SerializedDagModel
 
-        for sdm in session.scalars(select(SerializedDagModel)):
+        for sdm in session.scalars(SerializedDagModel.latest_by_version_select()):
             sdm.load_op_links = self.load_op_links
             if dag := sdm.dag:
                 yield dag

--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -817,7 +817,7 @@ class SerializedDagModel(Base):
         )
 
     @classmethod
-    def _latest_by_version_select(cls, dag_ids: list[str] | None = None) -> Select:
+    def latest_by_version_select(cls, dag_ids: list[str] | None = None) -> Select:
         """
         Select the serialized DAG with the highest ``version_number`` per dag_id.
 
@@ -856,7 +856,7 @@ class SerializedDagModel(Base):
         :param session: The database session.
         :return: The latest serialized dag of the DAGs.
         """
-        latest_serdags = session.scalars(cls._latest_by_version_select(dag_ids)).all()
+        latest_serdags = session.scalars(cls.latest_by_version_select(dag_ids)).all()
         return latest_serdags or []
 
     @classmethod
@@ -868,7 +868,7 @@ class SerializedDagModel(Base):
         :param session: ORM Session
         :returns: a dict of DAGs read from database
         """
-        serialized_dags = session.scalars(cls._latest_by_version_select())
+        serialized_dags = session.scalars(cls.latest_by_version_select())
 
         dags = {}
         for row in serialized_dags:

--- a/airflow-core/tests/unit/models/test_dagbag.py
+++ b/airflow-core/tests/unit/models/test_dagbag.py
@@ -35,6 +35,7 @@ from airflow.serialization.serialized_objects import LazyDeserializedDAG, Serial
 from airflow.utils.session import create_session
 
 from tests_common.test_utils import db
+from tests_common.test_utils.dag import sync_dag_to_db
 
 pytestmark = pytest.mark.db_test
 
@@ -241,6 +242,31 @@ class TestDBDagBag:
         db.clear_db_dags()
         db.clear_db_serialized_dags()
         db.clear_db_dag_bundles()
+
+    def test_iter_all_latest_version_dags_yields_each_dag_once(self, dag_maker, session):
+        """A Dag with several versions must be walked once, at its latest version."""
+        dag_id = "multi_version_dag"
+        db.clear_db_dags()
+        db.clear_db_serialized_dags()
+
+        with dag_maker(dag_id, schedule=None):
+            EmptyOperator(task_id="task1")
+        # A version with task instances is kept rather than updated in place, so the next sync
+        # adds a second row for the same dag_id.
+        dag_maker.create_dagrun()
+
+        with DAG(dag_id, schedule=None) as dag:
+            EmptyOperator(task_id="task1")
+            EmptyOperator(task_id="task2")
+        sync_dag_to_db(dag)
+
+        dags = list(DBDagBag().iter_all_latest_version_dags(session=session))
+
+        assert [walked.dag_id for walked in dags] == [dag_id]
+        assert set(dags[0].task_ids) == {"task1", "task2"}
+
+        db.clear_db_dags()
+        db.clear_db_serialized_dags()
 
 
 class TestDBDagBagCache:


### PR DESCRIPTION
`DBDagBag.iter_all_latest_version_dags()` promises the latest version, but the
query returned every `serialized_dag` row, so a Dag was walked once per version
it had. Its one production caller is the FAB auth manager's Dag permission sync,
which therefore re-synced the same dag_id once per version.

Same origin and same fix as #70934: reuse the select that picks the highest
`version_number` per dag_id. That select is now used from a second module, so it
loses its leading underscore.

`SerializedDagModel.read_all_dags()` is not used here on purpose — it materialises
every Dag into a dict and ignores `load_op_links`, while this method is
deliberately a non-caching generator.

related: #70934

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.