### PR TITLE
Show the teams of the signed-in user in multi-team mode

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/auth.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/auth.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 from enum import Enum
 
+from pydantic import Field
+
 from airflow.api_fastapi.common.types import ExtraMenuItem, MenuItem
 from airflow.api_fastapi.core_api.base import BaseModel
 
@@ -35,6 +37,10 @@ class AuthenticatedMeResponse(BaseModel):
 
     id: str
     username: str
+    teams: list[str] | None = Field(
+        default=None,
+        description="Teams the user has access to. Null when the environment does not run in multi-team mode.",
+    )
 
 
 class TokenType(str, Enum):

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -2377,6 +2377,15 @@ components:
         username:
           type: string
           title: Username
+        teams:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Teams
+          description: Teams the user has access to. Null when the environment does
+            not run in multi-team mode.
       type: object
       required:
       - id

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/auth.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/auth.py
@@ -22,6 +22,7 @@ import logging
 from fastapi import Depends
 
 from airflow.api_fastapi.app import get_auth_manager
+from airflow.api_fastapi.common.db.common import SessionDep
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.datamodels.ui.auth import (
     AuthenticatedMeResponse,
@@ -55,11 +56,17 @@ def get_auth_menus(
 @auth_router.get("/auth/me")
 def get_current_user_info(
     user: GetUserDep,
+    session: SessionDep,
 ) -> AuthenticatedMeResponse:
     """Convienently get the current authenticated user information."""
+    teams = None
+    if conf.getboolean("core", "multi_team"):
+        teams = sorted(get_auth_manager().get_authorized_teams(user=user, session=session))
+
     return AuthenticatedMeResponse(
         id=user.get_id(),
         username=user.get_name(),
+        teams=teams,
     )
 
 

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -8681,6 +8681,21 @@ export const $AuthenticatedMeResponse = {
         username: {
             type: 'string',
             title: 'Username'
+        },
+        teams: {
+            anyOf: [
+                {
+                    items: {
+                        type: 'string'
+                    },
+                    type: 'array'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Teams',
+            description: 'Teams the user has access to. Null when the environment does not run in multi-team mode.'
         }
     },
     type: 'object',

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -2182,6 +2182,10 @@ export type XComUpdateBody = {
 export type AuthenticatedMeResponse = {
     id: string;
     username: string;
+    /**
+     * Teams the user has access to. Null when the environment does not run in multi-team mode.
+     */
+    teams?: Array<(string)> | null;
 };
 
 /**

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -417,6 +417,12 @@
   },
   "taskInstance_one": "Task Instance",
   "taskInstance_other": "Task Instances",
+  "teams": {
+    "more_one": "and {{count}} more",
+    "more_other": "and {{count}} more",
+    "none": "No team",
+    "title": "Teams"
+  },
   "timeRange": {
     "last12Hours": "Last 12 Hours",
     "last24Hours": "Last 24 Hours",

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/UserSettingsButton.test.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/UserSettingsButton.test.tsx
@@ -18,20 +18,97 @@
  */
 import "@testing-library/jest-dom";
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
+import type * as OpenapiQueries from "openapi/queries";
 import { Wrapper } from "src/utils/Wrapper";
 
 import { UserSettingsButton } from "./UserSettingsButton";
 
+const mockCurrentUser: { data: { id: string; teams?: Array<string> | null; username: string } } = {
+  data: { id: "test", teams: null, username: "test" },
+};
+
+vi.mock("openapi/queries", async (importOriginal) => ({
+  ...(await importOriginal<typeof OpenapiQueries>()),
+  useAuthLinksServiceGetCurrentUserInfo: () => mockCurrentUser,
+}));
+
+const openUserMenu = () => fireEvent.click(screen.getByRole("button", { name: /user/iu }));
+
 describe("UserSettingsButton", () => {
+  afterEach(() => {
+    mockCurrentUser.data = { id: "test", teams: null, username: "test" };
+  });
+
   it("links to the settings page from the user menu", async () => {
     render(<UserSettingsButton externalViews={[]} />, { wrapper: Wrapper });
 
-    fireEvent.click(screen.getByRole("button", { name: /user/iu }));
+    openUserMenu();
 
     const settingsLink = await screen.findByRole("menuitem", { name: /settings.title/iu });
 
     expect(settingsLink).toHaveAttribute("href", "/settings");
+  });
+
+  it("lists each team the user belongs to when multi-team is enabled", async () => {
+    mockCurrentUser.data = { id: "test", teams: ["team-a", "team-b"], username: "test" };
+    render(<UserSettingsButton externalViews={[]} />, { wrapper: Wrapper });
+
+    openUserMenu();
+
+    expect(await screen.findByText("team-a")).toBeInTheDocument();
+    expect(screen.getByText("team-b")).toBeInTheDocument();
+  });
+
+  it("counts the teams it does not list when the user belongs to many", async () => {
+    mockCurrentUser.data = {
+      id: "test",
+      teams: Array.from({ length: 8 }, (_, index) => `team-${index}`),
+      username: "test",
+    };
+    render(<UserSettingsButton externalViews={[]} />, { wrapper: Wrapper });
+
+    openUserMenu();
+
+    expect(await screen.findByText("team-4")).toBeInTheDocument();
+    expect(screen.queryByText("team-5")).not.toBeInTheDocument();
+    expect(screen.getByText("teams.more")).toBeInTheDocument();
+  });
+
+  it("reveals the teams it does not list when hovering the overflow count", async () => {
+    mockCurrentUser.data = {
+      id: "test",
+      teams: Array.from({ length: 8 }, (_, index) => `team-${index}`),
+      username: "test",
+    };
+    render(<UserSettingsButton externalViews={[]} />, { wrapper: Wrapper });
+
+    openUserMenu();
+
+    fireEvent.pointerMove(await screen.findByText("teams.more"), { pointerType: "mouse" });
+
+    expect(await screen.findByText("team-5")).toBeInTheDocument();
+    expect(screen.getByText("team-6")).toBeInTheDocument();
+    expect(screen.getByText("team-7")).toBeInTheDocument();
+  });
+
+  it("tells the user they belong to no team when multi-team is enabled", async () => {
+    mockCurrentUser.data = { id: "test", teams: [], username: "test" };
+    render(<UserSettingsButton externalViews={[]} />, { wrapper: Wrapper });
+
+    openUserMenu();
+
+    expect(await screen.findByText("teams.none")).toBeInTheDocument();
+  });
+
+  it("hides teams when the deployment does not run in multi-team mode", async () => {
+    render(<UserSettingsButton externalViews={[]} />, { wrapper: Wrapper });
+
+    openUserMenu();
+
+    await screen.findByRole("menuitem", { name: /settings.title/iu });
+
+    expect(screen.queryByText("teams.title")).not.toBeInTheDocument();
   });
 });

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/UserSettingsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/UserSettingsButton.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Icon, useDisclosure } from "@chakra-ui/react";
+import { Box, HStack, Icon, useDisclosure, VStack } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 import {
   FiKey,
@@ -33,7 +33,7 @@ import {
 } from "react-icons/fi";
 
 import { useAuthLinksServiceGetCurrentUserInfo } from "openapi/queries";
-import { Menu } from "src/components/ui";
+import { Menu, Tooltip } from "src/components/ui";
 import { RouterLink } from "src/components/ui/RouterLink";
 import { useColorMode } from "src/context/colorMode/useColorMode";
 import type { NavItemResponse } from "src/utils/types";
@@ -43,6 +43,9 @@ import LogoutModal from "./LogoutModal";
 import { NavButton } from "./NavButton";
 import { PluginMenuItem } from "./PluginMenuItem";
 import TokenGenerationModal from "./TokenGenerationModal";
+
+// Beyond a handful of teams the list would push the menu items below the fold.
+const MAX_VISIBLE_TEAMS = 5;
 
 const COLOR_MODES = {
   DARK: "dark",
@@ -97,6 +100,44 @@ export const UserSettingsButton = ({ externalViews }: { readonly externalViews: 
                 <Box fontSize="md" fontWeight="semibold">
                   {`${currentUser.username} (id: ${currentUser.id})`}
                 </Box>
+                {Array.isArray(currentUser.teams) ? (
+                  <>
+                    <Box color="fg.muted" fontSize="sm" mt={2}>
+                      {translate("teams.title")}
+                    </Box>
+                    {currentUser.teams.length ? (
+                      <HStack fontSize="sm" gap={2} wrap="wrap">
+                        {currentUser.teams.slice(0, MAX_VISIBLE_TEAMS).map((team) => (
+                          <Box key={team}>{team}</Box>
+                        ))}
+                        {currentUser.teams.length > MAX_VISIBLE_TEAMS ? (
+                          <Tooltip
+                            closeDelay={0}
+                            content={
+                              <VStack align="start" gap={0}>
+                                {currentUser.teams.slice(MAX_VISIBLE_TEAMS).map((team) => (
+                                  <Box key={team}>{team}</Box>
+                                ))}
+                              </VStack>
+                            }
+                            openDelay={0}
+                            portalled
+                          >
+                            <Box color="fg.muted" textDecoration="underline dotted">
+                              {translate("teams.more", {
+                                count: currentUser.teams.length - MAX_VISIBLE_TEAMS,
+                              })}
+                            </Box>
+                          </Tooltip>
+                        ) : undefined}
+                      </HStack>
+                    ) : (
+                      <Box color="fg.muted" fontSize="sm">
+                        {translate("teams.none")}
+                      </Box>
+                    )}
+                  </>
+                ) : undefined}
               </Box>
               <Menu.Separator />
             </>

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_auth.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_auth.py
@@ -22,6 +22,10 @@ import pytest
 
 from airflow.api_fastapi.auth.managers.simple.simple_auth_manager import SimpleAuthManager
 from airflow.api_fastapi.common.types import ExtraMenuItem, MenuItem
+from airflow.models.team import Team
+
+from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.db import clear_db_teams
 
 pytestmark = pytest.mark.db_test
 
@@ -61,6 +65,12 @@ class TestGetAuthLinks:
 
 
 class TestGetMeResponse:
+    @pytest.fixture(autouse=True)
+    def clean_teams(self):
+        clear_db_teams()
+        yield
+        clear_db_teams()
+
     def test_should_response_200_with_authenticated_user(self, test_client):
         """Test /auth/me endpoint with SimpleAuthManager authenticated user."""
         response = test_client.get("/auth/me")
@@ -69,7 +79,41 @@ class TestGetMeResponse:
         assert response.json() == {
             "username": "test",
             "id": "test",
+            "teams": None,
         }
+
+    @conf_vars({("core", "multi_team"): "true"})
+    def test_teams_of_user_authorized_on_all_teams(self, test_client, session):
+        session.add_all([Team(name="team2"), Team(name="team1")])
+        session.commit()
+
+        response = test_client.get("/auth/me")
+
+        assert response.status_code == 200
+        assert response.json()["teams"] == ["team1", "team2"]
+
+    @conf_vars({("core", "multi_team"): "true"})
+    @mock.patch.object(SimpleAuthManager, "_is_admin", return_value=False)
+    def test_teams_limited_to_the_teams_the_user_belongs_to(self, _, test_client, session):
+        session.add_all([Team(name="team1"), Team(name="team2")])
+        session.commit()
+
+        response = test_client.get("/auth/me")
+
+        assert response.status_code == 200
+        # The authenticated test user belongs to ``team1`` only.
+        assert response.json()["teams"] == ["team1"]
+
+    @conf_vars({("core", "multi_team"): "true"})
+    @mock.patch.object(SimpleAuthManager, "_is_admin", return_value=False)
+    def test_teams_empty_when_user_belongs_to_no_team(self, _, test_client, session):
+        session.add(Team(name="team2"))
+        session.commit()
+
+        response = test_client.get("/auth/me")
+
+        assert response.status_code == 200
+        assert response.json()["teams"] == []
 
     def test_with_unauthenticated_user(self, unauthenticated_test_client):
         """Test /auth/me endpoint with no authentication."""


### PR DESCRIPTION
When an Airflow environment runs in multi-team mode, users had no way to see which teams they belong to.

`GET /ui/auth/me` now returns a `teams` field, and the UI lists those teams in the user menu below the user name. The field is `null`, and the UI section hidden, when the environment is not in multi-team mode, so nothing changes for single-team deployments and auth managers that don't support teams are never queried.

## Screenshot

<img width="182" height="317" alt="Screenshot 2026-08-12 at 11 01 06 AM" src="https://github.com/user-attachments/assets/67d9ae8e-1fec-48ef-93d2-9a15db48583d" />

### Long name

<img width="581" height="319" alt="Screenshot 2026-08-12 at 11 39 45 AM" src="https://github.com/user-attachments/assets/9abf30db-d580-483f-8868-4b74266142ef" />

### More than 5 teams

<img width="478" height="321" alt="Screenshot 2026-08-12 at 11 51 46 AM" src="https://github.com/user-attachments/assets/7bc8ae3a-deeb-43d2-bbe5-45ed5203bc0d" />


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
