### PR TITLE
Fix login loop when the login callback carries an expired Airflow JWT in KeycloakAuthManager

### DIFF
--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/middleware.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/middleware.py
@@ -95,6 +95,9 @@ class KeycloakJWTMiddleware(BaseHTTPMiddleware):
 
             response = await call_next(request)
 
+            if new_token == "" and getattr(request.state, "jwt_token_issued", False):
+                new_token = None
+
             if new_user or new_token is not None:
                 secure = request.base_url.scheme == "https" or bool(conf.get("api", "ssl_cert", fallback=""))
                 cookie_path = get_cookie_path()

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/login.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/login.py
@@ -126,6 +126,7 @@ def login_callback(request: Request):
         refresh_token=tokens["refresh_token"],
     )
     token = get_auth_manager().generate_jwt(user)
+    request.state.jwt_token_issued = True
 
     response = RedirectResponse(url=conf.get("api", "base_url", fallback="/"), status_code=303)
     secure = request.base_url.scheme == "https" or bool(conf.get("api", "ssl_cert", fallback=""))

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/test_middleware.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/test_middleware.py
@@ -340,6 +340,40 @@ class TestKeycloakJWTMiddleware:
             )
         auth_manager.generate_jwt.assert_not_called()
 
+    @patch("airflow.providers.keycloak.auth_manager.middleware.get_auth_manager")
+    async def test_dispatch_does_not_clear_fresh_token_set_by_endpoint(
+        self,
+        mock_get_auth_manager,
+        auth_manager,
+        call_next,
+        middleware,
+        mock_request,
+        mock_user,
+    ):
+        """
+        An expired token on the request must not clear the cookie when the endpoint
+        set a fresh one on the response (e.g. the login callback exchanging the
+        authorization code while an expired token is still in the cookie jar).
+        """
+        mock_get_auth_manager.return_value = auth_manager
+        mock_request.cookies = {
+            COOKIE_NAME_JWT_TOKEN: "expired",
+            COOKIE_NAME_ACCESS_TOKEN: "expired_token",
+            COOKIE_NAME_REFRESH_TOKEN: "refresh_token",
+        }
+        auth_manager.get_user_from_token = AsyncMock(side_effect=InvalidTokenError())
+
+        async def call_endpoint(request):
+            # The endpoint (login callback) mints a fresh JWT and signals it
+            request.state.jwt_token_issued = True
+            return Mock(name="response")
+
+        call_next.side_effect = call_endpoint
+
+        response = await middleware.dispatch(mock_request, call_next)
+
+        response.set_cookie.assert_not_called()
+
     @patch("airflow.providers.keycloak.auth_manager.middleware.get_cookie_path")
     @patch("airflow.providers.keycloak.auth_manager.middleware.get_auth_manager")
     @pytest.mark.asyncio


### PR DESCRIPTION
related: #71077, #70800

#71077 fixed the `_token` cookie getting cleared in `/login_callback` when the request carries no token. The same bug still happens when the request carries an expired token: a user re-logging in after their Airflow JWT expired (default 24h) still has the stale cookie in the browser. `KeycloakJWTMiddleware` fails to validate it, marks the cookie for clearing, and appends `Set-Cookie: _token=""` after the fresh token the callback just set. The browser applies the deletion last, so every login dies in the response that created it and the user loops back to the login page indefinitely.

Fix: the login callback signals via `request.state.jwt_token_issued` that the response carries a freshly issued JWT, and the middleware skips the cookie clear in that case. This is the same request-scoped signaling the middleware already uses for `request.state.user`. The flag needs no reset: `request.state` is per-request scratch space, born absent (read as `False`) and discarded with the request.

Added a regression test: an invalid token on the request plus an endpoint that issues a fresh JWT must not produce a clearing cookie.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code)
- [ ] No