### PR TITLE
Use uv --package instead of --project in codegen prek hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1399,7 +1399,7 @@ repos:
       - id: generate-tasksdk-datamodels
         name: Generate Datamodels for TaskSDK client
         language: python
-        entry: uv run -p 3.12 --no-progress --active --group codegen --project apache-airflow-task-sdk --directory task-sdk -s dev/generate_task_sdk_models.py
+        entry: uv run -p 3.12 --no-progress --active --group codegen --package apache-airflow-task-sdk --directory task-sdk -s dev/generate_task_sdk_models.py
         pass_filenames: false
         files: ^airflow-core/src/airflow/api_fastapi/execution_api/.*\.py$
         require_serial: true
@@ -1408,8 +1408,8 @@ repos:
         language: python
         entry: >
           bash -c '
-          uv run -p 3.12 --no-dev --no-progress --active --group codegen --project apache-airflow-ctl --directory airflow-ctl/ datamodel-codegen &&
-           uv run -p 3.12 --no-dev --no-progress --active --group codegen --project apache-airflow-ctl --directory airflow-ctl/ datamodel-codegen --input="../airflow-core/src/airflow/api_fastapi/auth/managers/simple/openapi/v2-simple-auth-manager-generated.yaml" --output="src/airflowctl/api/datamodels/auth_generated.py"'
+          uv run -p 3.12 --no-dev --no-progress --active --group codegen --package apache-airflow-ctl --directory airflow-ctl/ datamodel-codegen &&
+           uv run -p 3.12 --no-dev --no-progress --active --group codegen --package apache-airflow-ctl --directory airflow-ctl/ datamodel-codegen --input="../airflow-core/src/airflow/api_fastapi/auth/managers/simple/openapi/v2-simple-auth-manager-generated.yaml" --output="src/airflowctl/api/datamodels/auth_generated.py"'
         pass_filenames: false
         files:
           (?x)


### PR DESCRIPTION
The `generate-tasksdk-datamodels` and `generate-airflowctl-datamodels` prek hooks
pass workspace package names (`apache-airflow-task-sdk`, `apache-airflow-ctl`) to
`uv run --project`, which takes a *directory*. uv 0.11 tolerated it; uv 0.12
validates the path and fails with:

```
error: Project directory `apache-airflow-task-sdk` does not exist
```

`--package` is the flag that takes a workspace member name. Verified against both
uv 0.11.29 and uv 0.12.3: both hooks pass and regenerate byte-identical output.

This currently blocks the CI environment upgrade, which bumps uv to 0.12.3.

Note that CI here cannot demonstrate the failure, since `main` still pins uv
0.11.29, where both spellings work. This PR shows no regression; the fix is
exercised by the upgrade PR.

related: #70501

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
