### PR TITLE
Treat stopped Glue jobs as failures in verbose trigger

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/glue.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/glue.py
@@ -144,7 +144,7 @@ class GlueJobCompleteTrigger(AwsBaseWaiterTrigger):
                     )
                     return
 
-                if job_run_state in ("FAILED", "TIMEOUT"):
+                if job_run_state in ("FAILED", "STOPPED", "TIMEOUT"):
                     yield TriggerEvent(
                         {
                             "status": "error",
@@ -154,7 +154,7 @@ class GlueJobCompleteTrigger(AwsBaseWaiterTrigger):
                         }
                     )
                     return
-                if job_run_state in ("SUCCEEDED", "STOPPED"):
+                if job_run_state == "SUCCEEDED":
                     self.log.info(
                         "Exiting Job %s Run %s State: %s",
                         self.job_name,

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_glue.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_glue.py
@@ -171,13 +171,14 @@ class TestGlueJobTrigger:
         assert logs_client.get_log_events.call_count >= 2
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("job_run_state", ["FAILED", "STOPPED", "TIMEOUT"])
     @mock.patch.object(AwsLogsHook, "get_async_conn")
     @mock.patch.object(GlueJobHook, "get_async_conn")
-    async def test_verbose_run_job_failed(self, mock_glue_conn, mock_logs_conn):
+    async def test_verbose_run_job_failed(self, mock_glue_conn, mock_logs_conn, job_run_state):
         """When verbose=True and the job fails, the trigger yields an error event."""
         glue_client = AsyncMock()
         glue_client.get_job_run = AsyncMock(
-            return_value={"JobRun": {"JobRunState": "FAILED", "LogGroupName": "/aws-glue/python-jobs"}}
+            return_value={"JobRun": {"JobRunState": job_run_state, "LogGroupName": "/aws-glue/python-jobs"}}
         )
         mock_glue_conn.return_value.__aenter__ = AsyncMock(return_value=glue_client)
         mock_glue_conn.return_value.__aexit__ = AsyncMock(return_value=False)
@@ -198,7 +199,7 @@ class TestGlueJobTrigger:
         generator = trigger.run()
         event = await generator.asend(None)
         assert event.payload["status"] == "error"
-        assert "FAILED" in event.payload["message"]
+        assert job_run_state in event.payload["message"]
         assert event.payload["run_id"] == "jr_123"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Treat AWS Glue `STOPPED` job runs as failures in the verbose trigger path.
- Keep the success path limited to `SUCCEEDED`.
- Extend the existing regression test to cover `FAILED`, `STOPPED`, and `TIMEOUT`.

Fixes #71490

## Validation

- Python syntax validation passed for both changed files.
- Full Airflow provider tests were not run because the Breeze environment was unavailable locally.
- No GitHub Actions workflow was added or changed.

##### Was generative AI tooling used to co-author this PR?

- [x] Yes — OpenAI Codex

Generated-by: OpenAI Codex following the [Airflow generative AI contribution guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)