### PR TITLE
Fix DAG parsing crash for DateTimeSensorAsync with templated target_time

### DIFF
--- a/providers/standard/src/airflow/providers/standard/sensors/date_time.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/date_time.py
@@ -116,16 +116,25 @@ class DateTimeSensorAsync(DateTimeSensor):
 
         self.start_from_trigger = start_from_trigger
         if self.start_from_trigger:
-            # Replaced rather than mutated: ``start_trigger_args`` is a class attribute, so
-            # assigning through it would overwrite the arguments of every other task built
-            # from this operator.
-            self.start_trigger_args = dataclasses.replace(
-                self.start_trigger_args,
-                trigger_kwargs=dict(
-                    moment=self._moment,
-                    end_from_trigger=self.end_from_trigger,
-                ),
-            )
+            try:
+                moment = self._moment
+            except (ValueError, TypeError):
+                # target_time is likely a templated string that cannot be parsed as a datetime
+                # during DAG parsing. Fall back to start_from_trigger=False.
+                self.start_from_trigger = False
+                moment = None
+
+            if self.start_from_trigger:
+                # Replaced rather than mutated: ``start_trigger_args`` is a class attribute, so
+                # assigning through it would overwrite the arguments of every other task built
+                # from this operator.
+                self.start_trigger_args = dataclasses.replace(
+                    self.start_trigger_args,
+                    trigger_kwargs=dict(
+                        moment=moment,
+                        end_from_trigger=self.end_from_trigger,
+                    ),
+                )
 
     def execute(self, context: Context) -> NoReturn:
         self.defer(

--- a/providers/standard/tests/unit/standard/sensors/test_date_time.py
+++ b/providers/standard/tests/unit/standard/sensors/test_date_time.py
@@ -184,8 +184,21 @@ class TestDateTimeSensor:
         assert second.start_trigger_args.trigger_kwargs["moment"] == pendulum.parse(
             "2040-06-06T00:00:00+00:00"
         )
-        # the class level template must survive untouched for the next task built from it
         assert DateTimeSensorAsync.start_trigger_args.trigger_kwargs == {
             "moment": "",
             "end_from_trigger": False,
         }
+
+    def test_start_from_trigger_with_templated_target_time(self):
+        """
+        Test that DateTimeSensorAsync correctly disables start_from_trigger when
+        target_time is a template string that cannot be parsed as a datetime.
+        """
+        op = DateTimeSensorAsync(
+            task_id="templated_async",
+            target_time="{{ data_interval_end }}",
+            start_from_trigger=True,
+            dag=self.dag,
+        )
+        assert op.start_from_trigger is False
+        assert op.start_trigger_args == DateTimeSensorAsync.start_trigger_args


### PR DESCRIPTION
Resolves #70284. When start_from_trigger=True is provided to DateTimeSensorAsync with a templated target_time, it attempts to evaluate the template during DAG parsing, leading to a parser crash. This fallback gracefully disables start_from_trigger when target_time is unparsable as a datetime, delaying evaluation until task execution and avoiding the DAG parsing crash.