### PR TITLE
Drop extraneous "common" tag in i18n

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/AdvancedSearchToggle.tsx
+++ b/airflow-core/src/airflow/ui/src/components/AdvancedSearchToggle.tsx
@@ -37,7 +37,7 @@ export const AdvancedSearchToggle = ({
   size = "sm",
   variant = "standalone",
 }: AdvancedSearchToggleProps) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
 
   return (
     <Tooltip

--- a/airflow-core/src/airflow/ui/src/components/AssetExpression/AndGateNode.tsx
+++ b/airflow-core/src/airflow/ui/src/components/AssetExpression/AndGateNode.tsx
@@ -22,7 +22,7 @@ import { useTranslation } from "react-i18next";
 import { TbLogicAnd } from "react-icons/tb";
 
 export const AndGateNode = ({ children }: PropsWithChildren) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
 
   return (
     <Box

--- a/airflow-core/src/airflow/ui/src/components/AssetExpression/AssetExpression.tsx
+++ b/airflow-core/src/airflow/ui/src/components/AssetExpression/AssetExpression.tsx
@@ -35,7 +35,7 @@ export const AssetExpression = ({
   readonly events?: Array<NextRunAssetEventResponse>;
   readonly expression: ExpressionType | undefined;
 }) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
 
   if (expression === undefined) {
     return undefined;

--- a/airflow-core/src/airflow/ui/src/components/Assets/TriggeredRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Assets/TriggeredRuns.tsx
@@ -35,7 +35,7 @@ const DagRunGroup = ({
   readonly dagRuns: Array<DagRunAssetReference>;
   readonly prefix: string;
 }) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
 
   return dagRuns.length === 1 ? (
     <Flex flexWrap="wrap" gap={1}>

--- a/airflow-core/src/airflow/ui/src/components/ConfirmationModal.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ConfirmationModal.tsx
@@ -30,7 +30,7 @@ type Props = {
 };
 
 export const ConfirmationModal = ({ children, header, onConfirm, onOpenChange, open }: Props) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
 
   return (
     <Modal

--- a/airflow-core/src/airflow/ui/src/components/DagRunInfo.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagRunInfo.tsx
@@ -35,7 +35,7 @@ type Props = {
 };
 
 const DagRunInfo = ({ endDate, logicalDate, runAfter, startDate, state }: Props) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
 
   return (
     <Tooltip

--- a/airflow-core/src/airflow/ui/src/components/DataTable/FilterMenuButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/FilterMenuButton.tsx
@@ -30,7 +30,7 @@ type Props<TData> = {
 export const FilterMenuButton = <TData,>({ table }: Props<TData>) => {
   "use no memo"; // remove if https://github.com/TanStack/table/issues/5567 is resolved
 
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
 
   return (
     <Menu.Root closeOnSelect={false} tooltipLabel={translate("table.filterColumns")}>

--- a/airflow-core/src/airflow/ui/src/components/DeleteDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DeleteDialog.tsx
@@ -43,7 +43,7 @@ const DeleteDialog = ({
   title,
   warningText,
 }: DeleteDialogProps) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
 
   return (
     <Modal

--- a/airflow-core/src/airflow/ui/src/components/EditableMarkdownButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/EditableMarkdownButton.tsx
@@ -41,7 +41,7 @@ const EditableMarkdownButton = ({
   readonly placeholder: string;
   readonly setMdContent: (value: string) => void;
 }) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
 
   const hasContent = Boolean(mdContent?.trim());

--- a/airflow-core/src/airflow/ui/src/components/Graph/AssetConditionNode.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Graph/AssetConditionNode.tsx
@@ -25,7 +25,7 @@ import { NodeWrapper } from "./NodeWrapper";
 import type { CustomNodeProps } from "./reactflowUtils";
 
 export const AssetConditionNode = ({ data }: NodeProps<NodeType<CustomNodeProps, "asset-condition">>) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
 
   return (
     <NodeWrapper>

--- a/airflow-core/src/airflow/ui/src/components/KeyboardShortcuts/KeyboardShortcutsModal.tsx
+++ b/airflow-core/src/airflow/ui/src/components/KeyboardShortcuts/KeyboardShortcutsModal.tsx
@@ -52,7 +52,7 @@ const buildGroups = (shortcuts: ReadonlyArray<ShortcutEntry>) =>
   }).filter((group) => group.items.length > 0);
 
 export const KeyboardShortcutsModal = () => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
   const { shortcuts } = useShortcutRegistry();
   const [open, setOpen] = useState(false);
   const metaKey = getMetaKey();

--- a/airflow-core/src/airflow/ui/src/components/MarkdownModal.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkdownModal.tsx
@@ -48,7 +48,7 @@ const MarkdownModal = ({
   readonly placeholder: string;
   readonly setMdContent: (value: string) => void;
 }) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
 
   const hasContent = Boolean(mdContent?.trim());
   // Open straight into editing when there's nothing to read; otherwise show the

--- a/airflow-core/src/airflow/ui/src/components/PoolBar.tsx
+++ b/airflow-core/src/airflow/ui/src/components/PoolBar.tsx
@@ -37,7 +37,7 @@ export const PoolBar = ({
   readonly poolsWithSlotType?: Slots;
   readonly totalSlots: number;
 }) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
 
   const isUnlimited = totalSlots === UNLIMITED_SLOTS;
   const isDashboard = Boolean(poolsWithSlotType);

--- a/airflow-core/src/airflow/ui/src/components/PresetFiltersMenu.tsx
+++ b/airflow-core/src/airflow/ui/src/components/PresetFiltersMenu.tsx
@@ -45,7 +45,7 @@ const normalizeSearch = (value: string) => {
 };
 
 export const PresetFiltersMenu = () => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
   const { pathname } = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
   const [, setSorting] = useLocalStorage<SortingState>(tableSortKey(pathname), []);

--- a/airflow-core/src/airflow/ui/src/components/TaskInstanceTooltip.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TaskInstanceTooltip.tsx
@@ -42,7 +42,7 @@ type Props = {
 } & Omit<TooltipProps, "content">;
 
 const TaskInstanceTooltip = ({ children, positioning, runId, taskInstance, tooltip, ...rest }: Props) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
 
   const hasTooltip = tooltip !== undefined && tooltip !== null;
 

--- a/airflow-core/src/airflow/ui/src/components/ui/ResetButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ui/ResetButton.tsx
@@ -26,7 +26,7 @@ type Props = {
 };
 
 export const ResetButton = ({ filterCount, onClearFilters }: Props) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
 
   if (filterCount === 0) {
     return undefined;

--- a/airflow-core/src/airflow/ui/src/hooks/useShortcut.ts
+++ b/airflow-core/src/airflow/ui/src/hooks/useShortcut.ts
@@ -47,7 +47,7 @@ export const useShortcut = ({
   options,
 }: UseShortcutParams) => {
   const id = useId();
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
   const { register, unregister } = useShortcutRegistry();
 
   const ref = useHotkeys(keys, callback, options, dependencies);

--- a/airflow-core/src/airflow/ui/src/layouts/DagsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/DagsLayout.tsx
@@ -23,7 +23,7 @@ import { useTranslation } from "react-i18next";
 import { NavTabs } from "./Details/NavTabs";
 
 export const DagsLayout = ({ children }: PropsWithChildren) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
 
   const tabs = [
     { label: translate("nav.dags"), value: "/dags" },

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/AdminButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/AdminButton.tsx
@@ -61,7 +61,7 @@ export const AdminButton = ({
   readonly authorizedMenuItems: Array<MenuItem>;
   readonly externalViews: Array<NavItemResponse>;
 }) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
   const authorizedLinks = links.filter(({ title }) => authorizedMenuItems.includes(title as MenuItem));
   const menuItems = authorizedLinks.map((link) => (
     <Menu.Item asChild key={link.title} value={link.title}>

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/BrowseButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/BrowseButton.tsx
@@ -62,7 +62,7 @@ export const BrowseButton = ({
   readonly authorizedMenuItems: Array<MenuItem>;
   readonly externalViews: Array<NavItemResponse>;
 }) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
   const authorizedLinks = links.filter(({ title }) => authorizedMenuItems.includes(title as MenuItem));
   const menuItems = authorizedLinks.map((link) => (
     <Menu.Item asChild key={link.key} value={translate(`browse.${link.key}`)}>

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/DocsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/DocsButton.tsx
@@ -53,7 +53,7 @@ export const DocsButton = ({
   readonly showAPI?: boolean;
   readonly version?: string;
 }) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
   const showAPIDocs = Boolean(useConfig("enable_swagger_ui")) && showAPI;
 
   const versionLink = `https://airflow.apache.org/docs/apache-airflow/${version}/index.html`;

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/LogoutModal.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/LogoutModal.tsx
@@ -28,7 +28,7 @@ type LogoutModalProps = {
 };
 
 const LogoutModal = ({ isOpen, onClose }: LogoutModalProps) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
 
   return (
     <ConfirmationModal

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -96,7 +96,7 @@ export const Nav = () => {
   const { data } = useVersionServiceGetVersion();
   const { data: authLinks } = useAuthLinksServiceGetAuthMenus();
   const { data: pluginData } = usePluginServiceGetPlugins();
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
   const { onClose: onCloseTimezone, onOpen: onOpenTimezone, open: isOpenTimezone } = useDisclosure();
   const { selectedTimezone } = useTimezone();
   const offset = getTimezoneOffsetString(selectedTimezone);

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/PluginMenus.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/PluginMenus.tsx
@@ -28,7 +28,7 @@ import { NavButton } from "./NavButton";
 import { PluginMenuItem } from "./PluginMenuItem";
 
 export const PluginMenus = ({ navItems }: { readonly navItems: Array<NavItemResponse> }) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
 
   if (navItems.length === 0) {
     return undefined;

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/SecurityButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/SecurityButton.tsx
@@ -27,7 +27,7 @@ import { NavButton } from "./NavButton";
 
 export const SecurityButton = () => {
   const { data: authLinks } = useAuthLinksServiceGetAuthMenus();
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
 
   if (authLinks?.extra_menu_items === undefined || authLinks.extra_menu_items.length < 1) {
     return undefined;

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/TimezoneModal.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/TimezoneModal.tsx
@@ -28,7 +28,7 @@ type TimezoneModalProps = {
 };
 
 const TimezoneModal = ({ isOpen, onClose }: TimezoneModalProps) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
 
   return (
     <Modal lazyMount onOpenChange={onClose} open={isOpen} title={translate("timezoneModal.title")}>

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/TimezoneSelector.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/TimezoneSelector.tsx
@@ -33,7 +33,7 @@ dayjs.extend(timezone);
 
 const TimezoneSelector = () => {
   const { selectedTimezone, setSelectedTimezone } = useTimezone();
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
   const [currentTime, setCurrentTime] = useState<string>("");
 
   const tzList = Intl.supportedValuesOf("timeZone");

--- a/airflow-core/src/airflow/ui/src/pages/AssetsList/DependencyPopover.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/AssetsList/DependencyPopover.tsx
@@ -57,7 +57,7 @@ const IconTeamName = ({ teamName }: { readonly teamName?: string | null }) => {
 };
 
 export const DependencyPopover = ({ dependencies, type }: Props) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
   const dependencyKey = type.toLowerCase() as "dag" | "task";
 
   return (

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/AssetSchedule.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/AssetSchedule.tsx
@@ -47,7 +47,7 @@ type PartitionScheduleProps = {
 };
 
 const PartitionSchedule = ({ dagId, hasInactiveAsset, isLoading, pendingCount }: PartitionScheduleProps) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
   const [open, setOpen] = useState(false);
 
   return (

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/PartitionScheduleModal.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/PartitionScheduleModal.tsx
@@ -73,7 +73,7 @@ const getColumns = (
 ];
 
 export const PartitionScheduleModal = ({ dagId, onClose, open }: PartitionScheduleModalProps) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
   const pageSize = (useConfig("fallback_page_limit") as number | undefined) ?? 100;
   const [pageIndex, setPageIndex] = useState(0);
   const tableState = {

--- a/airflow-core/src/airflow/ui/src/pages/MappedTaskInstance/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/MappedTaskInstance/Details.tsx
@@ -28,7 +28,7 @@ import { getDuration } from "src/utils";
 
 export const Details = () => {
   const { dagId = "", taskId = "" } = useParams();
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
 
   // The aggregate summary (per-state counts, dates) is streamed once by the parent page and
   // shared through the router outlet, so this tab does not re-open the TI summaries stream.

--- a/airflow-core/src/airflow/ui/src/pages/Security.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Security.tsx
@@ -35,7 +35,7 @@ const SANDBOX = "allow-scripts allow-same-origin allow-forms";
 
 export const Security = () => {
   const { page } = useParams();
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
 
   useDocumentTitle(translate("nav.security"));
 

--- a/airflow-core/src/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow-core/src/airflow/ui/src/queries/useLogs.tsx
@@ -299,7 +299,7 @@ export const useLogs = (
   }: Props,
   options?: Omit<UseQueryOptions<TaskInstancesLogResponse>, "queryFn" | "queryKey">,
 ) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
   const refetchInterval = useAutoRefresh({ dagId });
 
   const { data, ...rest } = useTaskInstanceServiceGetLog(

--- a/airflow-core/src/airflow/ui/src/queries/useStoreMutation.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useStoreMutation.ts
@@ -39,7 +39,7 @@ export const useStoreMutation = ({
   resourceName,
 }: UseStoreMutationOptions) => {
   const queryClient = useQueryClient();
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
 
   const onError = (error: unknown) => {
     createErrorToaster(

--- a/airflow-core/src/airflow/ui/src/queries/useTogglePause.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useTogglePause.ts
@@ -45,7 +45,7 @@ type TogglePauseContext = {
 
 export const useTogglePause = ({ dagId }: { dagId: string }) => {
   const queryClient = useQueryClient();
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation();
 
   const dagKey = UseDagServiceGetDagKeyFn({ dagId }, [{ dagId }]);
   const dagDetailsKey = UseDagServiceGetDagDetailsKeyFn({ dagId }, [{ dagId }]);


### PR DESCRIPTION
`"common"` is already our default i18n namespace. Anytime we declared `useTranslation("common");` was extraneous. We should just use `useTranslation();`

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
