### PR TITLE
Operator extra links per attempt (draft B): the link opts in

### DIFF
--- a/airflow-core/newsfragments/71471.bugfix.rst
+++ b/airflow-core/newsfragments/71471.bugfix.rst
@@ -1,0 +1,1 @@
+Return each attempt's own URL from operator extra links, for links that opt in.

--- a/airflow-core/newsfragments/71471.bugfix.rst
+++ b/airflow-core/newsfragments/71471.bugfix.rst
@@ -1,1 +1,0 @@
-Return each attempt's own URL from operator extra links, for links that opt in.

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -94,6 +94,7 @@ from airflow.models.taskinstancehistory import TaskInstanceHistory as TIH
 from airflow.models.taskreschedule import TaskReschedule
 from airflow.models.trigger import Trigger, handle_event_submit
 from airflow.models.xcom import XComModel
+from airflow.sdk.bases.operatorlink import ATTEMPT_LINK_XCOM_KEY_PREFIX
 from airflow.serialization.definitions.assets import SerializedAsset, SerializedAssetUniqueKey
 from airflow.state import get_state_backend
 from airflow.triggers.base import TriggerEvent
@@ -295,6 +296,13 @@ def ti_run(
             )
             if map_index is not None:
                 xcom_query = xcom_query.where(XComModel.map_index == map_index)
+
+            # A link that keeps one row per attempt describes an attempt that already ran,
+            # so those rows outlive the clear. The underscores are LIKE single-character
+            # wildcards and must be escaped, or unrelated keys are spared too.
+            xcom_query = xcom_query.where(
+                ~XComModel.key.like(ATTEMPT_LINK_XCOM_KEY_PREFIX.replace("_", r"\_") + "%", escape="\\")
+            )
 
             xcom_keys = list(session.scalars(xcom_query))
         task_reschedule_count = (

--- a/airflow-core/src/airflow/serialization/definitions/operatorlink.py
+++ b/airflow-core/src/airflow/serialization/definitions/operatorlink.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING
 import attrs
 
 from airflow.models.xcom import XComModel
+from airflow.sdk.bases.operatorlink import attempt_link_xcom_key
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import create_session
 
@@ -42,6 +43,12 @@ class XComOperatorLink(LoggingMixin):
 
     name: str
     xcom_key: str
+    per_attempt: bool = False
+
+    def xcom_key_for_try(self, try_number: int) -> str:
+        if not self.per_attempt:
+            return self.xcom_key
+        return attempt_link_xcom_key(self.xcom_key, try_number)
 
     def get_link(self, operator: Operator, *, ti_key: TaskInstanceKey) -> str:
         """
@@ -57,7 +64,7 @@ class XComOperatorLink(LoggingMixin):
         with create_session() as session:
             result = session.execute(
                 XComModel.get_many(
-                    key=self.xcom_key,
+                    key=self.xcom_key_for_try(ti_key.try_number),
                     run_id=ti_key.run_id,
                     dag_ids=ti_key.dag_id,
                     task_ids=ti_key.task_id,

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -1512,7 +1512,7 @@ class OperatorSerialization(DAGNode, BaseSerialization):
 
     @classmethod
     def _deserialize_operator_extra_links(
-        cls, encoded_op_links: dict[str, str]
+        cls, encoded_op_links: dict[str, str | dict[str, Any]]
     ) -> dict[str, XComOperatorLink]:
         """
         Deserialize Operator Links if the Classes are registered in Airflow Plugins.
@@ -1540,7 +1540,14 @@ class OperatorSerialization(DAGNode, BaseSerialization):
             #     'raise_error': 'key'
             # }
 
-            op_predefined_extra_link = XComOperatorLink(name=name, xcom_key=xcom_key)
+            # A link that keeps one row per attempt serializes as a mapping; everything
+            # else stays the bare key string it has always been.
+            if isinstance(xcom_key, dict):
+                op_predefined_extra_link = XComOperatorLink(
+                    name=name, xcom_key=xcom_key["key"], per_attempt=xcom_key.get("per_attempt", False)
+                )
+            else:
+                op_predefined_extra_link = XComOperatorLink(name=name, xcom_key=xcom_key)
             op_predefined_extra_links.update({op_predefined_extra_link.name: op_predefined_extra_link})
 
         return op_predefined_extra_links
@@ -1560,7 +1567,12 @@ class OperatorSerialization(DAGNode, BaseSerialization):
         :param operator_extra_links: Operator Link
         :return: Serialized Operator Link
         """
-        return {link.name: link.xcom_key for link in operator_extra_links}
+        return {
+            link.name: {"key": link.xcom_key, "per_attempt": link.keeps_a_link_per_attempt}
+            if link.keeps_a_link_per_attempt
+            else link.xcom_key
+            for link in operator_extra_links
+        }
 
     @classmethod
     def serialize(cls, var: Any, *, strict: bool = False) -> Any:

--- a/task-sdk/src/airflow/sdk/bases/operatorlink.py
+++ b/task-sdk/src/airflow/sdk/bases/operatorlink.py
@@ -27,6 +27,15 @@ if TYPE_CHECKING:
     from airflow.sdk.types import TaskInstanceKey
 
 
+ATTEMPT_LINK_XCOM_KEY_PREFIX = "_link_attempt_"
+"""Prefix marking the XCom rows that hold one attempt's rendered operator link."""
+
+
+def attempt_link_xcom_key(xcom_key: str, try_number: int) -> str:
+    """Return the XCom key holding ``xcom_key``'s link as rendered for ``try_number``."""
+    return f"{ATTEMPT_LINK_XCOM_KEY_PREFIX}{try_number}_{xcom_key}"
+
+
 @attrs.define()
 class BaseOperatorLink(metaclass=ABCMeta):
     """Abstract base class that defines how we get an operator link."""
@@ -54,6 +63,21 @@ class BaseOperatorLink(metaclass=ABCMeta):
         Defaults to `_link_<class name>` if not provided.
         """
         return f"_link_{self.__class__.__name__}"
+
+    keeps_a_link_per_attempt: ClassVar[bool] = False
+    """
+    Keep one row per attempt rather than a single row holding whichever ran last.
+
+    Set on links whose URL cannot be recomputed, such as one carrying a job id the remote
+    service mints per submission. A task's XComs are cleared before each attempt; the rows
+    behind a link that sets this are kept.
+    """
+
+    def xcom_key_for_try(self, try_number: int) -> str:
+        """Return the XCom key holding this link as rendered for ``try_number``."""
+        if not self.keeps_a_link_per_attempt:
+            return self.xcom_key
+        return attempt_link_xcom_key(self.xcom_key, try_number)
 
     @abstractmethod
     def get_link(self, operator: BaseOperator, *, ti_key: TaskInstanceKey) -> str:

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -2326,7 +2326,8 @@ def finalize(
     # Pushing xcom for each operator extra links defined on the operator only.
     for oe in task.operator_extra_links:
         try:
-            link, xcom_key = oe.get_link(operator=task, ti_key=ti), oe.xcom_key  # type: ignore[arg-type]
+            link = oe.get_link(operator=task, ti_key=ti)  # type: ignore[arg-type]
+            xcom_key = oe.xcom_key_for_try(ti.try_number)
             log.debug("Setting xcom for operator extra link", link=link, xcom_key=xcom_key)
             _xcom_push_to_db(ti, key=xcom_key, value=link)
         except Exception:


### PR DESCRIPTION
**TL;DR — operator extra links don't work per attempt** (#71471). After a retry the button
under attempt 1 opens attempt 2's logs. It hits every bundled provider linking to per-attempt
logs: EMR, Glue, Databricks, Dataproc, Livy.

Draft **B of three** for the same bug — pick a shape and I'll finish it and close the others.
**Recommended: C** (#71522). See the issue for why; A is the fallback if this needs to ship on the 3.2 line.


| | Approach | Trade |
|---|---|---|
| A | #71518 — a row per attempt in XCom | smallest; core owns a key convention for every link |
| **B** | **this PR — the link opts in** | **no extra rows when unneeded; changes the serialized DAG format** |
| C | #71522 — the task state store | nothing about the clear moves; 3.3+ only |

## How

`BaseOperatorLink` gains `keeps_a_link_per_attempt` and `xcom_key_for_try`. A link that sets
the flag gets a row per attempt, exempt from the retry clear; everything else behaves as it
does today.

The flag has to survive DAG serialization, and that is the cost. The api-server never sees a
provider's link class — it rebuilds every link as `XComOperatorLink` from a `{name: xcom_key}`
mapping carrying a string and nothing else. That mapping now carries
`{"key": ..., "per_attempt": true}` for opted-in links and stays a bare string otherwise, so
existing serialized DAGs read back unchanged.

## Testing

Read path against a real metastore on 3.2.2, rows present for both attempts, asking an
opted-in link and a plain one.

<details><summary>Raw output</summary>

```
$ AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=sqlite:///af.db python b_test.py
opted-in  try 1 -> https://logs/attempt-1
opted-in  try 2 -> https://logs/attempt-2
not opted try 1 -> https://logs/attempt-2
```

Line 3 is the before state on the same path: without the flag, attempt 1 still returns the
latest attempt's URL. Lines 1 and 2 are the same read with it set.

Key derivation:

```
$ python -c "from airflow.serialization.definitions.operatorlink import XComOperatorLink; ..."
default  try1 -> _link_X                 | try2 -> _link_X
opted-in try1 -> _link_attempt_1__link_X | try2 -> _link_attempt_2__link_X
```

Serialization round-trip, the risky part:

```
encoded: {'plain': '_link_P', 'opted': {'key': '_link_O', 'per_attempt': True}}
  plain: key=_link_P per_attempt=False  (legacy string, unchanged)
  opted: key=_link_O per_attempt=True
```

</details>
