### PR TITLE
Stop presenting multi-team tagged metrics as an exhaustive list

### DIFF
--- a/airflow-core/docs/core-concepts/multi-team.rst
+++ b/airflow-core/docs/core-concepts/multi-team.rst
@@ -1063,26 +1063,24 @@ Dags, and global components emit the same metrics without a ``team_name`` tag.
     When Multi-Team mode is disabled, metrics are emitted with no ``team_name`` tag whatsoever, exactly
     as they have always been emitted for a single-team Airflow environment.
 
-The ``team_name`` tag is applied to metrics across the following components:
+The ``team_name`` tag is applied to metrics across the following components. The metrics named are
+examples only, not a complete list:
 
-- **Triggerer**: heartbeat, capacity, blocked-main-thread, trigger-queue delay, and trigger-outcome metrics
-  (for example, ``triggerer_heartbeat``, ``triggers.running``, ``triggers.succeeded``,
-  ``triggers.blocked_main_thread``, ``triggerer.trigger_queue_delay``).
-- **Executors**: executor slot gauges and scheduler-observed executor heartbeat timing (for example,
-  ``executor.open_slots``, ``executor.queued_tasks``, ``scheduler.executor_heartbeat_duration``).
-- **Scheduler**: pool slot gauges for team-scoped pools plus task- and asset-scheduling counters (for
-  example, ``pool.open_slots``, ``scheduler.tasks.killed_externally``, ``asset.triggered_dagruns``).
-- **Dag runs**: dag run timing and lifecycle metrics (for example, ``dagrun.duration.<state>``,
-  ``dagrun.first_task_scheduling_delay``, ``dag.callback_exceptions``).
-- **Task instances**: task start, finish, and outcome counters (for example, ``ti.start``, ``ti.finish``,
-  ``ti_successes``, ``ti_failures``).
-- **Dag processing**: per-file parsing and callback metrics (for example, ``dag_processing.processes``,
-  ``dag_processing.processor_timeouts``, ``dag_processing.callback_only_count``).
-- **Callbacks**: callback execution counters (``callback_success`` / ``callback_failure``, optionally
-  prefixed).
-- **Connection tests**: per-request worker and reaper metrics for team-owned connection tests (for
-  example, ``connection_test.success``, ``connection_test.failed``, ``connection_test.hook_duration``,
-  ``connection_test.reaped``). Instance-wide connection-test queue gauges remain untagged.
+- **Triggerer**: heartbeat, capacity, blocked-main-thread, trigger-queue delay, and trigger-outcome
+  metrics (``triggerer_heartbeat``, ``triggers.running``, etc.).
+- **Executors**: executor slot gauges and scheduler-observed executor heartbeat timing
+  (``executor.open_slots``, ``executor.queued_tasks``, etc.).
+- **Scheduler**: pool slot gauges for team-scoped pools plus task- and asset-scheduling counters
+  (``pool.open_slots``, ``scheduler.tasks.killed_externally``, etc.).
+- **Dag runs**: dag run timing and lifecycle metrics (``dagrun.duration.<state>``,
+  ``dagrun.first_task_scheduling_delay``, etc.).
+- **Task instances**: task start, finish, and outcome counters (``ti.start``, ``ti.finish``, etc.).
+- **Dag processing**: per-file parsing and callback metrics (``dag_processing.processes``,
+  ``dag_processing.processor_timeouts``, etc.).
+- **Callbacks**: callback execution counters (``callback_<state>``, optionally prefixed).
+- **Connection tests**: per-request worker and reaper metrics for team-owned connection tests
+  (``connection_test.success``, ``connection_test.failed``, etc.). Instance-wide connection-test queue
+  gauges remain untagged.
 
 .. note::
 
@@ -1090,6 +1088,12 @@ The ``team_name`` tag is applied to metrics across the following components:
     team-scoped executor and worker metrics). Provider executors additionally inherit core
     ``executor.*`` slot gauges from the base executor. Check individual provider change logs for the
     minimum Airflow version that includes ``team_name`` tagging.
+
+.. note::
+
+    This list is not exhaustive and may lag behind the code. Use it to see which areas of Airflow
+    carry the ``team_name`` tag; the metric emission sites in the Airflow source are the
+    authoritative reference for individual metric names.
 
 Important Considerations
 ------------------------


### PR DESCRIPTION
The list read as an authoritative enumeration of every metric carrying a team_name tag, so it drifts out of date as metrics change and misleads anyone building dashboards or alerts from it. A stale entry naming a callback failure counter that is never emitted is the symptom that surfaced the problem.

Readers need to know which areas of Airflow carry the tag; the emission sites in the source are the right authority for individual metric names.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (Claude Opus 5)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
