### PR TITLE
Fix HttpAsyncHook crash on stream/cert/trust_env connection extras

### DIFF
--- a/providers/http/src/airflow/providers/http/hooks/http.py
+++ b/providers/http/src/airflow/providers/http/hooks/http.py
@@ -44,6 +44,10 @@ if TYPE_CHECKING:
 
     from airflow.models import Connection
 
+# requests-only extra options with no aiohttp equivalent; aiohttp's request methods raise
+# TypeError on unexpected kwargs, so HttpAsyncHook must strip these before the request call.
+_AIOHTTP_UNSUPPORTED_EXTRA_OPTIONS = {"stream", "cert", "trust_env"}
+
 
 def _url_from_endpoint(base_url: str | None, endpoint: str | None) -> str:
     """Combine base url with endpoint."""
@@ -513,6 +517,16 @@ class AsyncHttpSession(LoggingMixin):
         merged_headers = {**(self.headers or {}), **(headers or {})}
         extra_options = {**(self.extra_options or {}), **(extra_options or {})}
 
+        check_response = extra_options.pop("check_response", True)
+        unsupported_options = _AIOHTTP_UNSUPPORTED_EXTRA_OPTIONS & extra_options.keys()
+        if unsupported_options:
+            self.log.warning(
+                "Ignoring connection extra option(s) %s: not supported by HttpAsyncHook.",
+                ", ".join(sorted(unsupported_options)),
+            )
+            for option in unsupported_options:
+                extra_options.pop(option)
+
         async def request_func() -> ClientResponse:
             response = await self._request(
                 url,
@@ -523,7 +537,8 @@ class AsyncHttpSession(LoggingMixin):
                 auth=self.auth,
                 **extra_options,
             )
-            response.raise_for_status()
+            if check_response:
+                response.raise_for_status()
             return response
 
         async for attempt in AsyncRetrying(

--- a/providers/http/tests/unit/http/hooks/test_http.py
+++ b/providers/http/tests/unit/http/hooks/test_http.py
@@ -833,7 +833,6 @@ class TestHttpAsyncHook:
                 "verify": False,
                 "allow_redirects": False,
                 "max_redirects": 3,
-                "trust_env": False,
             }
         ],
         indirect=True,
@@ -865,7 +864,60 @@ class TestHttpAsyncHook:
                 assert mocked_function.call_args.kwargs.get("verify_ssl") is False
                 assert mocked_function.call_args.kwargs.get("allow_redirects") is False
                 assert mocked_function.call_args.kwargs.get("max_redirects") == 3
-                assert mocked_function.call_args.kwargs.get("trust_env") is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "setup_connections_with_extras",
+        [{"stream": True, "cert": "client.pem", "trust_env": True}],
+        indirect=True,
+    )
+    async def test_async_request_ignores_unsupported_extra_options(
+        self, setup_connections_with_extras, caplog
+    ):
+        """stream/cert/trust_env have no aiohttp equivalent and must not reach the request call."""
+        hook = HttpAsyncHook(http_conn_id="http_conn_with_extras")
+
+        with mock.patch("aiohttp.ClientSession.post", new_callable=mock.AsyncMock) as mocked_function:
+            mocked_function.return_value = MockAiohttpClientResponse(
+                status=200,
+                payload={"status": {"status": 200}},
+                method="POST",
+                url="http://test:8080/v1/test",
+            )
+            async with aiohttp.ClientSession() as session:
+                await hook.run(session=session, endpoint="v1/test")
+
+        kwargs = mocked_function.call_args.kwargs
+        assert "stream" not in kwargs
+        assert "cert" not in kwargs
+        assert "trust_env" not in kwargs
+        assert (
+            "Ignoring connection extra option(s) cert, stream, trust_env: not supported by HttpAsyncHook."
+            in caplog.messages
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "setup_connections_with_extras",
+        [{"check_response": False}],
+        indirect=True,
+    )
+    async def test_async_request_does_not_raise_for_status_if_check_response_is_false(
+        self, setup_connections_with_extras
+    ):
+        hook = HttpAsyncHook(http_conn_id="http_conn_with_extras", method="GET")
+
+        with mock.patch("aiohttp.ClientSession.get", new_callable=mock.AsyncMock) as mocked_get:
+            mocked_get.return_value = MockAiohttpClientResponse(
+                status=500,
+                reason="Internal Server Error",
+                method="GET",
+                url="http://test:8080/v1/test",
+            )
+            async with aiohttp.ClientSession() as session:
+                resp = await hook.run(session=session, endpoint="v1/test")
+
+        assert resp.status == 500
 
     @pytest.mark.asyncio
     async def test_build_request_url_from_connection(self):


### PR DESCRIPTION
`HttpAsyncHook`/`AsyncHttpSession.run()` shares `_process_extra_options_from_connection()` with the sync `HttpHook`, but that function's output uses `requests`-flavored option names, and the async path blindly forwards all of them as kwargs into `aiohttp.ClientSession`'s request call. `aiohttp` doesn't accept `stream`, `cert`, or `trust_env` as request kwargs at all, so any HTTP connection with one of those three keys set in its `Extra` field — or passed via `extra_options=` at call time — crashed every single request with `TypeError: request() got an unexpected keyword argument '...'`. This affects both direct HttpAsyncHook usage and Airflow's deferred/async HTTP triggers, since they route through the same code path.

Separately, `check_response` (meant to suppress `raise_for_status()` on non-2xx responses, matching sync's `run_and_check()`) was accepted into the same shared dict but never actually consumed on the async side — `AsyncHttpSession.run()` always `called raise_for_status()` unconditionally, so setting `check_response: false` had no effect on async requests.

## Fix:

* `AsyncHttpSession.run()` now pops `check_response` and honors it before calling `raise_for_status()`, bringing async to parity with sync's existing behavior.
* `stream`, `cert`, and `trust_env` are filtered out before the aiohttp call, with a warning logged listing which were dropped. These three have no aiohttp equivalent worth implementing here: aiohttp streams responses by default (no `stream` flag needed), and `cert`/`trust_env` would require real work (building an `ssl.SSLContext`, restructuring session construction) that's out of scope for a crash fix.
* Corrected an existing test that had been asserting `trust_env` gets passed through to the aiohttp mock — it only passed because the plain `AsyncMock` doesn't validate kwargs against aiohttp's real method signature, which is exactly how this bug went undetected.

## Test plan:
* Added regression tests confirming `stream`/`cert`/`trust_env` never reach the aiohttp call (with the warning logged) and that `check_response: false` suppresses `raise_for_status()` on async requests.
* Full `providers-tests --test-type "Providers[http]"` suite, mypy, and ruff all pass.

Drafted-by: Claude Code (Sonnet 5) Reviewed-by: @gtxu before submission
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes Claude Code (Sonnet 5)

Generated-by: Claude Code (Sonnet 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---
<!--
* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
-->