### PR TITLE
Fix GKEStartPodOperator ignoring execution_timeout when deferrable

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -801,20 +801,14 @@ class GKEStartPodOperator(GKEOperatorMixin, KubernetesPodOperator):
         if type(on_finish_action) is str and self.on_finish_action not in [i.value for i in OnFinishAction]:
             on_finish_action = self.on_finish_action.split(".")[-1].lower()  # type: ignore[assignment]
 
-        # Translate ``execution_timeout`` into an absolute deadline plumbed to
-        # the trigger via ``trigger_kwargs["_execution_deadline"]``. Anchoring
-        # on ``ti.start_date`` keeps the deadline stable across re-deferrals
-        # (``logging_interval`` re-entries), since Airflow preserves the
-        # original ``start_date`` when a task resumes from defer.
+        # Anchor on ti.start_date so the deadline survives re-deferrals.
         trigger_kwargs = dict(self.trigger_kwargs or {})
         defer_timeout: datetime.timedelta | None = None
         if self.execution_timeout is not None and context is not None:
             ti_start_date = context["ti"].start_date
             execution_deadline = int(ti_start_date.timestamp() + self.execution_timeout.total_seconds())
             trigger_kwargs["_execution_deadline"] = execution_deadline
-            # Pad ``defer.timeout`` past the deadline so the framework
-            # backstop doesn't preempt the trigger's ``status="timeout"``
-            # emission and orphan the pod via the ``__fail__`` path.
+            # Allow the trigger to emit its timeout event before the framework backstop fires.
             remaining = execution_deadline - time.time()
             poll_buffer = max(60, int(self.poll_interval * 2))
             defer_timeout = datetime.timedelta(seconds=max(remaining, 0) + poll_buffer)

--- a/providers/google/src/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 
+import datetime
 import time
 import warnings
 from collections.abc import Sequence
@@ -799,6 +800,25 @@ class GKEStartPodOperator(GKEOperatorMixin, KubernetesPodOperator):
         on_finish_action = self.on_finish_action
         if type(on_finish_action) is str and self.on_finish_action not in [i.value for i in OnFinishAction]:
             on_finish_action = self.on_finish_action.split(".")[-1].lower()  # type: ignore[assignment]
+
+        # Translate ``execution_timeout`` into an absolute deadline plumbed to
+        # the trigger via ``trigger_kwargs["_execution_deadline"]``. Anchoring
+        # on ``ti.start_date`` keeps the deadline stable across re-deferrals
+        # (``logging_interval`` re-entries), since Airflow preserves the
+        # original ``start_date`` when a task resumes from defer.
+        trigger_kwargs = dict(self.trigger_kwargs or {})
+        defer_timeout: datetime.timedelta | None = None
+        if self.execution_timeout is not None and context is not None:
+            ti_start_date = context["ti"].start_date
+            execution_deadline = int(ti_start_date.timestamp() + self.execution_timeout.total_seconds())
+            trigger_kwargs["_execution_deadline"] = execution_deadline
+            # Pad ``defer.timeout`` past the deadline so the framework
+            # backstop doesn't preempt the trigger's ``status="timeout"``
+            # emission and orphan the pod via the ``__fail__`` path.
+            remaining = execution_deadline - time.time()
+            poll_buffer = max(60, int(self.poll_interval * 2))
+            defer_timeout = datetime.timedelta(seconds=max(remaining, 0) + poll_buffer)
+
         self.defer(
             trigger=GKEStartPodTrigger(
                 pod_name=self.pod.metadata.name,  # type: ignore[union-attr]
@@ -819,8 +839,10 @@ class GKEStartPodOperator(GKEOperatorMixin, KubernetesPodOperator):
                 logging_interval=self.logging_interval,
                 last_log_time=last_log_time,
                 use_dns_endpoint=self.use_dns_endpoint,
+                trigger_kwargs=trigger_kwargs,
             ),
             method_name="trigger_reentry",
+            timeout=defer_timeout,
         )
 
 

--- a/providers/google/src/airflow/providers/google/cloud/triggers/kubernetes_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/kubernetes_engine.py
@@ -157,6 +157,7 @@ class GKEStartPodTrigger(KubernetesPodTrigger):
                 "impersonation_chain": self.impersonation_chain,
                 "logging_interval": self.logging_interval,
                 "last_log_time": self.last_log_time,
+                "trigger_kwargs": self.trigger_kwargs,
             },
         )
 

--- a/providers/google/tests/unit/google/cloud/operators/test_kubernetes_engine.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_kubernetes_engine.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import datetime
 from copy import deepcopy
 from unittest import mock
 from unittest.mock import PropertyMock, call
@@ -1060,11 +1061,144 @@ class TestGKEStartPodOperator:
             logging_interval=None,
             last_log_time=mock_last_log_time,
             use_dns_endpoint=False,
+            trigger_kwargs={},
         )
         mock_defer.assert_called_once_with(
             trigger=mock_trigger.return_value,
             method_name="trigger_reentry",
+            timeout=None,
         )
+
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodOperator.defer"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEClusterAuthDetails.fetch_cluster_info"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEHook"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodTrigger"))
+    @mock.patch(GKE_OPERATORS_PATH.format("timezone.utcnow"))
+    def test_invoke_defer_method_passes_execution_deadline_when_execution_timeout_set(
+        self, mock_utcnow, mock_trigger, mock_cluster_hook, mock_fetch_cluster_info, mock_defer
+    ):
+        """
+        ``execution_timeout`` is converted into an absolute ``_execution_deadline``
+        anchored on ``ti.start_date`` and propagated to the trigger via
+        ``trigger_kwargs``.
+        """
+        import time_machine
+
+        execution_timeout = datetime.timedelta(seconds=300)
+        operator = GKEStartPodOperator(
+            project_id=TEST_PROJECT_ID,
+            location=TEST_LOCATION,
+            cluster_name=GKE_CLUSTER_NAME,
+            task_id=TEST_TASK_ID,
+            name=K8S_POD_NAME,
+            namespace=K8S_NAMESPACE,
+            image=TEST_IMAGE,
+            on_finish_action=OnFinishAction.KEEP_POD,
+            gcp_conn_id=TEST_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+            deferrable=True,
+            execution_timeout=execution_timeout,
+        )
+        operator.pod = make_pod()
+        mock_fetch_cluster_info.return_value = GKE_CLUSTER_URL, GKE_SSL_CA_CERT
+
+        ti_mock = mock.MagicMock()
+        ti_start = datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        ti_mock.start_date = ti_start
+        context = {"ti": ti_mock}
+
+        # Freeze at ``ti_start + 30s`` → remaining=270s. ``defer.timeout`` =
+        # remaining + max(60, poll_interval * 2) = 270 + 60 = 330s for default
+        # poll_interval=2.
+        elapsed = datetime.timedelta(seconds=30)
+        with time_machine.travel(ti_start + elapsed, tick=False):
+            operator.invoke_defer_method(context=context)
+
+        expected_deadline = int((ti_start + execution_timeout).timestamp())
+        trigger_call_kwargs = mock_trigger.call_args[1]
+        assert trigger_call_kwargs["trigger_kwargs"]["_execution_deadline"] == expected_deadline
+        assert mock_defer.call_args[1]["timeout"] == datetime.timedelta(seconds=270 + 60)
+
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodOperator.defer"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEClusterAuthDetails.fetch_cluster_info"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEHook"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodTrigger"))
+    @mock.patch(GKE_OPERATORS_PATH.format("timezone.utcnow"))
+    def test_invoke_defer_method_no_deadline_when_execution_timeout_not_set(
+        self, mock_utcnow, mock_trigger, mock_cluster_hook, mock_fetch_cluster_info, mock_defer
+    ):
+        """
+        Without ``execution_timeout``, ``_execution_deadline`` is absent from
+        ``trigger_kwargs`` and no backstop timeout is set on defer.
+        """
+        operator = GKEStartPodOperator(
+            project_id=TEST_PROJECT_ID,
+            location=TEST_LOCATION,
+            cluster_name=GKE_CLUSTER_NAME,
+            task_id=TEST_TASK_ID,
+            name=K8S_POD_NAME,
+            namespace=K8S_NAMESPACE,
+            image=TEST_IMAGE,
+            on_finish_action=OnFinishAction.KEEP_POD,
+            gcp_conn_id=TEST_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+            deferrable=True,
+        )
+        operator.pod = make_pod()
+        mock_fetch_cluster_info.return_value = GKE_CLUSTER_URL, GKE_SSL_CA_CERT
+
+        context = {"ti": mock.MagicMock()}
+
+        operator.invoke_defer_method(context=context)
+
+        trigger_call_kwargs = mock_trigger.call_args[1]
+        assert "_execution_deadline" not in trigger_call_kwargs["trigger_kwargs"]
+        assert mock_defer.call_args[1]["timeout"] is None
+
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodOperator.defer"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEClusterAuthDetails.fetch_cluster_info"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEHook"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodTrigger"))
+    @mock.patch(GKE_OPERATORS_PATH.format("timezone.utcnow"))
+    def test_invoke_defer_method_preserves_existing_trigger_kwargs(
+        self, mock_utcnow, mock_trigger, mock_cluster_hook, mock_fetch_cluster_info, mock_defer
+    ):
+        """
+        User-provided ``trigger_kwargs`` values must not be discarded when
+        ``_execution_deadline`` is injected.
+        """
+        import time_machine
+
+        execution_timeout = datetime.timedelta(seconds=120)
+        operator = GKEStartPodOperator(
+            project_id=TEST_PROJECT_ID,
+            location=TEST_LOCATION,
+            cluster_name=GKE_CLUSTER_NAME,
+            task_id=TEST_TASK_ID,
+            name=K8S_POD_NAME,
+            namespace=K8S_NAMESPACE,
+            image=TEST_IMAGE,
+            on_finish_action=OnFinishAction.KEEP_POD,
+            gcp_conn_id=TEST_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+            deferrable=True,
+            execution_timeout=execution_timeout,
+        )
+        operator.trigger_kwargs = {"_redefer_count": 1}
+        operator.pod = make_pod()
+        mock_fetch_cluster_info.return_value = GKE_CLUSTER_URL, GKE_SSL_CA_CERT
+
+        ti_mock = mock.MagicMock()
+        ti_start = datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        ti_mock.start_date = ti_start
+        context = {"ti": ti_mock}
+
+        with time_machine.travel(ti_start, tick=False):
+            operator.invoke_defer_method(context=context)
+
+        trigger_call_kwargs = mock_trigger.call_args[1]
+        assert trigger_call_kwargs["trigger_kwargs"]["_redefer_count"] == 1
+        assert "_execution_deadline" in trigger_call_kwargs["trigger_kwargs"]
 
 
 class TestGKEStartJobOperator:

--- a/providers/google/tests/unit/google/cloud/triggers/test_kubernetes_engine.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_kubernetes_engine.py
@@ -145,6 +145,7 @@ class TestGKEStartPodTrigger:
             "last_log_time": None,
             "logging_interval": None,
             "use_dns_endpoint": False,
+            "trigger_kwargs": {},
         }
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #71514.

`GKEStartPodOperator` did not respect `execution_timeout` when
`deferrable=True` because its custom `invoke_defer_method` did not
propagate the execution deadline to `GKEStartPodTrigger`.

### What changed

- Translate `execution_timeout` into an absolute `_execution_deadline`
  anchored to the task instance `start_date`.
- Pass the deadline through `trigger_kwargs` to `GKEStartPodTrigger`.
- Add a buffered `defer.timeout` backstop so the trigger can emit its
  timeout event before the framework timeout fires.
- Preserve `trigger_kwargs` in `GKEStartPodTrigger.serialize()` so the
  deadline survives trigger serialization/restarts.
- Add regression tests covering deadline propagation, no-timeout
  behavior, existing `trigger_kwargs`, and trigger serialization.

### Testing

- `TestGKEStartPodOperator`: 16 passed
- `GKEStartPodTrigger` serialization test: passed
- Ruff format/check: passed

One broader trigger test run encountered an unrelated local
`ModuleNotFoundError: airflow_shared` in the test infrastructure.
The affected serialization test and all operator tests for this change
passed successfully.