### PR TITLE
Keep the MeterProvider configured via OTEL_CONFIG_FILE

### DIFF
--- a/shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import atexit
 import datetime
 import logging
+import os
 import random
 import warnings
 from collections.abc import Callable
@@ -75,6 +76,11 @@ UP_DOWN_COUNTERS = {"airflow.dag_processing.processes"}
 DEFAULT_METRIC_NAME_PREFIX = "airflow"
 # Delimiter is placed between the universal metric prefix and the unique metric name.
 DEFAULT_METRIC_NAME_DELIMITER = "."
+
+# Not imported from ``opentelemetry.sdk.environment_variables``: the constant postdates the
+# ``opentelemetry-api>=1.27.0`` floor this distribution declares, while the name is spec-fixed.
+# https://opentelemetry.io/docs/specs/otel/configuration/sdk/#declarative-configuration
+OTEL_CONFIG_FILE = "OTEL_CONFIG_FILE"
 
 
 def full_name(name: str, *, prefix: str = DEFAULT_METRIC_NAME_PREFIX) -> str:
@@ -457,11 +463,24 @@ def get_otel_logger(
     so that bucket boundaries adapt automatically to the observed data range.  This avoids
     the need to hand-tune explicit bucket boundaries for metrics that span very different
     scales (milliseconds to hours).
+
+    A ``MeterProvider`` already built from ``OTEL_CONFIG_FILE`` is used as-is: the declarative
+    configuration spec makes that file the sole source of SDK construction.
     """
+    effective_prefix: str = prefix or DEFAULT_METRIC_NAME_PREFIX
+    validator = get_validator(metrics_allow_list, metrics_block_list)
+
+    configured_provider = metrics.get_meter_provider()
+    if os.environ.get(OTEL_CONFIG_FILE) and isinstance(configured_provider, MeterProvider):
+        log.info("%s is set; using the MeterProvider it built.", OTEL_CONFIG_FILE)
+        atexit_register_metrics_flush()
+        return SafeOtelLogger(
+            configured_provider, effective_prefix, validator, stat_name_handler, statsd_influxdb_enabled
+        )
+
     otel_env_config = load_metrics_env_config()
 
     effective_service_name: str = otel_env_config.service_name or service_name or "airflow"
-    effective_prefix: str = prefix or DEFAULT_METRIC_NAME_PREFIX
     resource = Resource.create(attributes={SERVICE_NAME: effective_service_name})
 
     # https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#periodic-exporting-metricreader
@@ -523,8 +542,6 @@ def get_otel_logger(
 
     # Register a hook that flushes any in-memory metrics at shutdown.
     atexit_register_metrics_flush()
-
-    validator = get_validator(metrics_allow_list, metrics_block_list)
 
     return SafeOtelLogger(
         metrics.get_meter_provider(), effective_prefix, validator, stat_name_handler, statsd_influxdb_enabled

--- a/shared/observability/tests/observability/metrics/test_otel_logger.py
+++ b/shared/observability/tests/observability/metrics/test_otel_logger.py
@@ -24,8 +24,14 @@ import time
 from unittest import mock
 
 import pytest
+from opentelemetry import metrics
 from opentelemetry.metrics import MeterProvider
-from opentelemetry.sdk.metrics.view import ExponentialBucketHistogramAggregation, View
+from opentelemetry.sdk.metrics import MeterProvider as SDKMeterProvider
+from opentelemetry.sdk.metrics.view import (
+    ExplicitBucketHistogramAggregation,
+    ExponentialBucketHistogramAggregation,
+    View,
+)
 
 from airflow_shared.observability.common import get_otel_data_exporter
 from airflow_shared.observability.metrics.otel_logger import (
@@ -59,6 +65,26 @@ RATE_MUST_BE_POSITIVE_MSG = "rate must be a positive value"
 @pytest.fixture
 def name():
     return "test_stats_run"
+
+
+@pytest.fixture
+def reset_meter_provider():
+    """Let a test install its own global MeterProvider, then restore the previous one.
+
+    ``set_meter_provider`` is guarded by a process-wide ``Once``, so tests that install a
+    provider have to clear it the same way ``get_otel_logger`` does after a fork.
+    """
+    import opentelemetry.metrics._internal as metrics_internal
+
+    def clear() -> None:
+        metrics_internal._METER_PROVIDER_SET_ONCE._done = False
+        metrics_internal._METER_PROVIDER = None
+
+    previous = metrics_internal._METER_PROVIDER
+    clear()
+    yield
+    clear()
+    metrics_internal._METER_PROVIDER = previous
 
 
 class TestOtelMetrics:
@@ -501,6 +527,37 @@ class TestOtelMetrics:
         view = views[0]
         assert isinstance(view, View)
         assert isinstance(view._aggregation, ExponentialBucketHistogramAggregation)
+
+    def test_declaratively_configured_provider_is_not_replaced(self, reset_meter_provider):
+        """A MeterProvider built from OTEL_CONFIG_FILE must survive get_otel_logger().
+
+        The declarative configuration spec makes that file the sole source of SDK
+        construction, so replacing its provider silently drops the deployment's views.
+        See https://github.com/apache/airflow/issues/64690 for why the provider is
+        otherwise force-replaced.
+        """
+        declarative_view = View(
+            instrument_name="*_duration",
+            aggregation=ExplicitBucketHistogramAggregation(boundaries=(0.5, 1, 2, 4, 8)),
+        )
+        configured_provider = SDKMeterProvider(views=[declarative_view], shutdown_on_exit=False)
+        metrics.set_meter_provider(configured_provider)
+
+        with env_vars({"OTEL_CONFIG_FILE": "/tmp/otel-config.yaml"}):
+            logger = get_otel_logger(host="localhost", port=4318)
+
+        assert logger.otel is configured_provider
+        assert metrics.get_meter_provider() is configured_provider
+        assert list(configured_provider._sdk_config.views) == [declarative_view]
+
+    def test_provider_is_replaced_without_declarative_config(self, reset_meter_provider):
+        """Without OTEL_CONFIG_FILE, Airflow still installs its own provider."""
+        pre_existing = SDKMeterProvider(shutdown_on_exit=False)
+        metrics.set_meter_provider(pre_existing)
+
+        logger = get_otel_logger(host="localhost", port=4318)
+
+        assert logger.otel is not pre_existing
 
     def test_atexit_flush_on_process_exit(self):
         """


### PR DESCRIPTION
Running Airflow under `opentelemetry-instrument` with `OTEL_CONFIG_FILE` set silently discards the whole file. Every view, reader and exporter it declares is thrown away and the deployment gets Airflow's defaults instead, with nothing in the logs.

`get_otel_logger()` resets the SDK's `Once` guard and calls `set_meter_provider()` unconditionally, so whatever the agent bootstrap installed is replaced. The [declarative configuration spec](https://opentelemetry.io/docs/specs/otel/configuration/sdk/#declarative-configuration) makes that file the sole source of SDK construction, so this is a spec violation rather than a matter of precedence.

The fix declines to replace a provider that came from `OTEL_CONFIG_FILE`. The guard reset stays on every path where Airflow owns the provider, so the post-fork case in #64690 is unaffected.

Scoped to `OTEL_CONFIG_FILE` on purpose: the env-var bootstrap path carries no equivalent "sole source" rule, and Airflow's `[metrics] otel_*` settings legitimately compete with it there.

related: #64690

Overlaps textually with https://github.com/apache/airflow/pull/68393, which restructures this module but leaves the clobber in place. Happy to rebase on it if that lands first.

### Testing Done

A script mirroring what `opentelemetry-instrument airflow scheduler` does: run `_OTelSDKConfigurator()._configure()` with `OTEL_CONFIG_FILE` pointing at a config that declares a `*_duration` view, then call `get_otel_logger()` and inspect the installed provider.

```yaml
# otel-config.yaml
file_format: "1.0-rc.1"
meter_provider:
  readers:
    - periodic:
        interval: 60000
        exporter:
          console: {}
  views:
    - selector:
        instrument_name: "*_duration"
      stream:
        aggregation:
          explicit_bucket_histogram:
            boundaries: [0.5, 1, 2, 4, 8]
```

```python
# repro.py
import os
os.environ["OTEL_CONFIG_FILE"] = "otel-config.yaml"

from opentelemetry import metrics
from opentelemetry.sdk._configuration import _OTelSDKConfigurator

def views_of(provider):
    sdk_config = getattr(provider, "_sdk_config", None)
    return [] if sdk_config is None else [str(v._instrument_name) for v in sdk_config.views]

_OTelSDKConfigurator()._configure()          # what opentelemetry-instrument runs
before = metrics.get_meter_provider()
print("bootstrap views:", views_of(before))

from airflow_shared.observability.metrics.otel_logger import get_otel_logger
get_otel_logger(host="localhost", port=4318)
after = metrics.get_meter_provider()
print("after get_otel_logger:", views_of(after))
print("same provider object?", before is after)
```

On `main`, the declarative view is gone and the provider has been swapped for Airflow's, whose only view is the instrument-type baseline:

<details><summary>Raw output</summary>

```
$ pip install opentelemetry-configuration
$ python repro.py
after opentelemetry-instrument bootstrap: MeterProvider
  declarative views: ['*_duration']
after get_otel_logger():                   MeterProvider
  declarative views: ['None']

same provider object? False
RESULT: declarative view was DISCARDED
```

</details>

With this change, the provider and its view survive:

<details><summary>Raw output</summary>

```
$ python repro.py
after opentelemetry-instrument bootstrap: MeterProvider
  declarative views: ['*_duration']
after get_otel_logger():                   MeterProvider
  declarative views: ['*_duration']

same provider object? True
RESULT: declarative view survived
```

</details>

`test_declaratively_configured_provider_is_not_replaced` covers this through the real `get_otel_logger()` against a real SDK `MeterProvider`, and fails on unpatched sources:

<details><summary>Raw output</summary>

```
# revert just the fixed file to the released behaviour
$ git checkout origin/main -- shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
$ uv run --project shared/observability pytest \
    shared/observability/tests/observability/metrics/test_otel_logger.py -q -k declarative
FAILED ...::test_declaratively_configured_provider_is_not_replaced
    assert logger.otel is configured_provider
E   assert <...MeterProvider object at 0x10a252ec0> is <...MeterProvider object at 0x109fb0190>
1 failed, 1 passed, 51 deselected

# restore the fix
$ git checkout HEAD -- shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
$ uv run --project shared/observability pytest \
    shared/observability/tests/observability/metrics/test_otel_logger.py -q -k declarative
2 passed, 51 deselected
```

</details>

`test_provider_is_replaced_without_declarative_config` pins the other side, so the fix can't quietly widen into "never replace any provider".

The #64690 re-init path still exports after a second `get_otel_logger()` call:

<details><summary>Raw output</summary>

```
$ python -c "
from airflow_shared.observability.metrics.otel_logger import get_otel_logger, flush_otel_metrics
get_otel_logger(debug=True)
logger = get_otel_logger(debug=True)
logger.incr('post_fork_stat')
flush_otel_metrics()" | grep -c post_fork_stat
3
```

</details>