### PR TITLE
Initialize the default state of SalesforceToGcsOperator in the Google provider

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/transfers/salesforce_to_gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/salesforce_to_gcs.py
@@ -103,7 +103,7 @@ class SalesforceToGcsOperator(BaseOperator):
                 FutureWarning,
                 stacklevel=2,
             )
-            unwrap_single = True
+            self.unwrap_single = True
         else:
             self.unwrap_single = unwrap_single
 

--- a/providers/google/tests/unit/google/cloud/transfers/test_salesforce_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_salesforce_to_gcs.py
@@ -53,6 +53,7 @@ pytestmark = pytest.mark.filterwarnings("ignore::FutureWarning")
     [
         (True, EXPECTED_GCS_URI),
         (False, [EXPECTED_GCS_URI]),
+        (None, EXPECTED_GCS_URI),
     ],
 )
 class TestSalesforceToGcsOperator:


### PR DESCRIPTION
## Summary

- initialize `self.unwrap_single` on the omitted-argument compatibility path
- extend the existing parameterized unit test to cover the default path

`SalesforceToGcsOperator` added an `unwrap_single=None` compatibility path in #61659, but that branch only assigned the local variable. `execute()` later reads `self.unwrap_single`, so the official system example, which omits the argument, can upload to GCS and then fail with `AttributeError`.

## Verification

- `uv run --no-sync --project providers/google python -m compileall -q providers/google/src/airflow/providers/google/cloud/transfers/salesforce_to_gcs.py providers/google/tests/unit/google/cloud/transfers/test_salesforce_to_gcs.py`
- `git diff --check`

The focused pytest command was attempted with the repository's `uv` path but collection was blocked by missing test dependencies (`tests_common` initially, then `time_machine` after adding `devel-common/src` to `PYTHONPATH`).
