### PR TITLE
Make `durable` reach `default_args` and warn when set below Airflow 3.3

### DIFF
--- a/providers/amazon/docs/operators/redshift/redshift_data.rst
+++ b/providers/amazon/docs/operators/redshift/redshift_data.rst
@@ -125,6 +125,10 @@ Durable execution applies to the synchronous path. When ``deferrable=True`` is s
 already tracks the statement across the wait, so deferrable mode takes precedence and ``durable``
 has no effect.
 
+Durable execution requires Airflow 3.3 or newer, since it relies on the task state store. Below
+3.3, ``durable`` has no effect either way: setting it explicitly only emits a warning, and the
+operator always submits fresh SQL on retry, exactly as before this feature existed.
+
 Reference
 ---------
 

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/redshift_data.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/redshift_data.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Any, cast
 
 import botocore.exceptions
@@ -28,6 +29,20 @@ from airflow.providers.amazon.aws.utils import validate_execute_complete_event
 from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException, conf
 
+_DURABLE_UNSET = object()
+
+
+def _warn_and_disable_durable_pre_3_3(durable: Any) -> bool:
+    """Shared by the <3.3 compat stub: durable has no effect below 3.3, warn if it was set."""
+    if durable is not _DURABLE_UNSET:
+        warnings.warn(
+            "`durable` has no effect on Airflow versions below 3.3.",
+            UserWarning,
+            stacklevel=3,
+        )
+    return False
+
+
 try:
     from airflow.sdk import ResumableJobMixin
 except ImportError:
@@ -37,9 +52,9 @@ except ImportError:
 
         external_id_key: str = "redshift_statement_id"
 
-        def __init__(self, *, durable: bool = True, **kwargs: Any) -> None:
+        def __init__(self, *, durable: Any = _DURABLE_UNSET, **kwargs: Any) -> None:
             super().__init__(**kwargs)
-            self.durable = durable
+            self.durable = _warn_and_disable_durable_pre_3_3(durable)
 
         def execute_resumable(self, context):
             external_id = self.submit_job(context)
@@ -135,8 +150,13 @@ class RedshiftDataOperator(ResumableJobMixin, AwsBaseOperator[RedshiftDataHook])
         session_id: str | None = None,
         session_keep_alive_seconds: int | None = None,
         cancel_on_kill: bool = True,
+        durable: bool | None = None,
         **kwargs,
     ) -> None:
+        # Named here (not left to **kwargs) so default_args reaches it on every
+        # supported Airflow version.
+        if durable is not None:
+            kwargs["durable"] = durable
         super().__init__(**kwargs)
         self.database = database
         self.sql = sql

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_redshift_data.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_redshift_data.py
@@ -17,13 +17,20 @@
 # under the License.
 from __future__ import annotations
 
+import warnings
+from datetime import datetime
 from unittest import mock
 
 import botocore.exceptions
 import pytest
 
+from airflow.models.dag import DAG
 from airflow.providers.amazon.aws.hooks.redshift_data import QueryExecutionOutput
-from airflow.providers.amazon.aws.operators.redshift_data import RedshiftDataOperator
+from airflow.providers.amazon.aws.operators.redshift_data import (
+    _DURABLE_UNSET,
+    RedshiftDataOperator,
+    _warn_and_disable_durable_pre_3_3,
+)
 from airflow.providers.amazon.aws.triggers.redshift_data import RedshiftDataTrigger
 from airflow.providers.common.compat.sdk import AirflowException, TaskDeferred
 
@@ -721,3 +728,28 @@ class TestRedshiftDataOperatorDurable:
 
         assert operator.is_job_succeeded("FINISHED") is True
         assert operator.is_job_succeeded("STARTED") is False
+
+    def test_default_args_durable_reaches_operator(self):
+        with DAG(
+            dag_id="test_redshift_data_durable_default_args",
+            schedule=None,
+            start_date=datetime(2024, 1, 1),
+            default_args={"durable": False},
+        ):
+            operator = self._make_operator()
+        assert operator.durable is False
+
+
+class TestWarnAndDisableDurableAirflowPre3_3:
+    def test_no_warning_when_unset(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = _warn_and_disable_durable_pre_3_3(_DURABLE_UNSET)
+        assert result is False
+        assert caught == []
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_warns_and_disables_when_explicitly_set(self, value):
+        with pytest.warns(UserWarning, match="durable.*no effect"):
+            result = _warn_and_disable_durable_pre_3_3(value)
+        assert result is False

--- a/providers/apache/livy/src/airflow/providers/apache/livy/operators/livy.py
+++ b/providers/apache/livy/src/airflow/providers/apache/livy/operators/livy.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import time
+import warnings
 from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, cast
@@ -28,6 +29,20 @@ from airflow.providers.common.compat.openlineage.utils.spark import (
     inject_transport_information_into_spark_properties,
 )
 from airflow.providers.common.compat.sdk import AirflowException, BaseOperator, conf
+
+_DURABLE_UNSET = object()
+
+
+def _warn_and_disable_durable_pre_3_3(durable: Any) -> bool:
+    """Shared by the <3.3 compat stub: durable has no effect below 3.3, warn if it was set."""
+    if durable is not _DURABLE_UNSET:
+        warnings.warn(
+            "`durable` has no effect on Airflow versions below 3.3.",
+            UserWarning,
+            stacklevel=3,
+        )
+    return False
+
 
 # ResumableJobMixin ships in airflow.sdk, which only exists on Airflow 3, while this provider
 # still targets apache-airflow>=2.11. Guard the import and fall back to a stub on Airflow 2;
@@ -41,10 +56,10 @@ except ImportError:
 
         external_id_key: str = "livy_batch_id"
 
-        def __init__(self, *, durable: bool = True, **kwargs: Any) -> None:
+        def __init__(self, *, durable: Any = _DURABLE_UNSET, **kwargs: Any) -> None:
             # Swallow ``durable`` so it doesn't reach BaseOperator; crash recovery is a no-op here.
             super().__init__(**kwargs)
-            self.durable = durable
+            self.durable = _warn_and_disable_durable_pre_3_3(durable)
 
         def execute_resumable(self, context):
             external_id = self.submit_job(context)
@@ -130,8 +145,13 @@ class LivyOperator(ResumableJobMixin, BaseOperator):
         openlineage_inject_transport_info: bool = conf.getboolean(
             "openlineage", "spark_inject_transport_info", fallback=False
         ),
+        durable: bool | None = None,
         **kwargs: Any,
     ) -> None:
+        # Named here (not left to **kwargs) so default_args reaches it on every
+        # supported Airflow version.
+        if durable is not None:
+            kwargs["durable"] = durable
         super().__init__(**kwargs)
 
         if conf is None:

--- a/providers/apache/livy/tests/unit/apache/livy/operators/test_livy.py
+++ b/providers/apache/livy/tests/unit/apache/livy/operators/test_livy.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -25,7 +26,11 @@ import pytest
 from airflow.models import Connection
 from airflow.models.dag import DAG
 from airflow.providers.apache.livy.hooks.livy import BatchState, LivyHook
-from airflow.providers.apache.livy.operators.livy import LivyOperator
+from airflow.providers.apache.livy.operators.livy import (
+    _DURABLE_UNSET,
+    LivyOperator,
+    _warn_and_disable_durable_pre_3_3,
+)
 from airflow.providers.common.compat.sdk import AirflowException, timezone
 
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_3_PLUS
@@ -714,6 +719,12 @@ class TestLivyOperatorResumable:
         assert operator.is_job_succeeded("success") is True
         assert operator.is_job_succeeded("dead") is False
 
+    def test_default_args_durable_reaches_operator():
+        operator = LivyOperator(
+            task_id="livy_default_args", file="sparkapp.jar", default_args={"durable": False}
+        )
+        assert operator.durable is False
+
     def test_get_job_status_reads_batch_state_value(self):
         operator = self._make_operator()
         hook = self._make_hook()
@@ -731,3 +742,18 @@ class TestLivyOperatorResumable:
         operator.poll_until_complete(55, {})
 
         assert operator._batch_id == 55
+
+
+class TestWarnAndDisableDurableAirflowPre3_3:
+    def test_no_warning_when_unset(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = _warn_and_disable_durable_pre_3_3(_DURABLE_UNSET)
+        assert result is False
+        assert caught == []
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_warns_and_disables_when_explicitly_set(self, value):
+        with pytest.warns(UserWarning, match="durable.*no effect"):
+            result = _warn_and_disable_durable_pre_3_3(value)
+        assert result is False

--- a/providers/apache/livy/tests/unit/apache/livy/operators/test_livy.py
+++ b/providers/apache/livy/tests/unit/apache/livy/operators/test_livy.py
@@ -719,7 +719,7 @@ class TestLivyOperatorResumable:
         assert operator.is_job_succeeded("success") is True
         assert operator.is_job_succeeded("dead") is False
 
-    def test_default_args_durable_reaches_operator():
+    def test_default_args_durable_reaches_operator(self):
         operator = LivyOperator(
             task_id="livy_default_args", file="sparkapp.jar", default_args={"durable": False}
         )

--- a/providers/apache/spark/src/airflow/providers/apache/spark/operators/spark_submit.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/operators/spark_submit.py
@@ -400,6 +400,7 @@ class SparkSubmitOperator(ResumableJobMixin, BaseOperator):
             "openlineage", "spark_inject_transport_info", fallback=False
         ),
         reconnect_on_retry: bool | None = None,
+        durable: bool | None = None,
         **kwargs: Any,
     ) -> None:
         if reconnect_on_retry is not None:
@@ -409,6 +410,10 @@ class SparkSubmitOperator(ResumableJobMixin, BaseOperator):
                 stacklevel=2,
             )
             kwargs.setdefault("durable", reconnect_on_retry)
+        # Named here (not left to **kwargs) so default_args={"durable": ...} reaches it on every
+        # supported Airflow version; applied after reconnect_on_retry so an explicit durable wins.
+        if durable is not None:
+            kwargs["durable"] = durable
         super().__init__(**kwargs)
         self.application = application
         self.conf = conf

--- a/providers/apache/spark/tests/unit/apache/spark/operators/test_spark_submit.py
+++ b/providers/apache/spark/tests/unit/apache/spark/operators/test_spark_submit.py
@@ -601,6 +601,10 @@ class TestSparkSubmitOperatorResumable:
         assert "reconnect_on_retry" in str(w[0].message)
         assert operator.durable is False
 
+    def test_default_args_durable_reaches_operator(self):
+        operator = self._make_operator(default_args={"durable": False})
+        assert operator.durable is False
+
     def test_durable_false_submits_fresh_and_polls(self):
         operator = self._make_operator(durable=False)
         operator._hook = self._make_hook(should_track=True)

--- a/providers/databricks/docs/operators/run_now.rst
+++ b/providers/databricks/docs/operators/run_now.rst
@@ -136,6 +136,10 @@ Durable execution applies to the synchronous path. When ``deferrable=True`` is s
 already tracks the run across the wait, so deferrable mode takes precedence and ``durable`` has no
 effect.
 
+Durable execution requires Airflow 3.3 or newer, since it relies on the task state store. Below
+3.3, ``durable`` has no effect either way: setting it explicitly only emits a warning, and the
+operator always triggers a fresh run on retry, exactly as before this feature existed.
+
 
 DatabricksRunNowDeferrableOperator
 ==================================

--- a/providers/databricks/docs/operators/submit_run.rst
+++ b/providers/databricks/docs/operators/submit_run.rst
@@ -215,6 +215,10 @@ Durable execution applies to the synchronous path. When ``deferrable=True`` is s
 Triggerer already tracks the run across the wait, so deferrable mode takes precedence and
 ``durable`` has no effect.
 
+Durable execution requires Airflow 3.3 or newer, since it relies on the task state store. Below
+3.3, ``durable`` has no effect either way: setting it explicitly only emits a warning, and the
+operator always submits a fresh run on retry, exactly as before this feature existed.
+
 
 DatabricksSubmitRunDeferrableOperator
 =====================================

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
@@ -24,6 +24,7 @@ import copy
 import hashlib
 import json as json_utils
 import time
+import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from functools import cached_property
@@ -68,6 +69,20 @@ if TYPE_CHECKING:
     from airflow.sdk import TaskGroup
     from airflow.sdk.types import Context, Logger
 
+_DURABLE_UNSET = object()
+
+
+def _warn_and_disable_durable_pre_3_3(durable: Any) -> bool:
+    """Shared by the <3.3 compat stub: durable has no effect below 3.3, warn if it was set."""
+    if durable is not _DURABLE_UNSET:
+        warnings.warn(
+            "`durable` has no effect on Airflow versions below 3.3.",
+            UserWarning,
+            stacklevel=3,
+        )
+    return False
+
+
 try:
     from airflow.sdk import ResumableJobMixin
 except ImportError:
@@ -77,9 +92,9 @@ except ImportError:
 
         external_id_key: str = "databricks_run_id"
 
-        def __init__(self, *, durable: bool = True, **kwargs: Any) -> None:
+        def __init__(self, *, durable: Any = _DURABLE_UNSET, **kwargs: Any) -> None:
             super().__init__(**kwargs)
-            self.durable = durable
+            self.durable = _warn_and_disable_durable_pre_3_3(durable)
 
         def execute_resumable(self, context):
             external_id = self.submit_job(context)
@@ -776,9 +791,14 @@ class DatabricksSubmitRunOperator(ResumableJobMixin, BaseOperator):
         openlineage_inject_transport_info: bool = conf.getboolean(
             "openlineage", "spark_inject_transport_info", fallback=False
         ),
+        durable: bool | None = None,
         **kwargs,
     ) -> None:
         """Create a new ``DatabricksSubmitRunOperator``."""
+        # Named here (not left to **kwargs) so default_args reaches it on every
+        # supported Airflow version.
+        if durable is not None:
+            kwargs["durable"] = durable
         super().__init__(**kwargs)
         self.json = json
         self.tasks = tasks
@@ -1246,9 +1266,14 @@ class DatabricksRunNowOperator(ResumableJobMixin, BaseOperator):
         databricks_repair_reason_new_settings: dict[str, Any] | None = None,
         cancel_previous_runs: bool = False,
         forward_dag_params: bool = True,
+        durable: bool | None = None,
         **kwargs,
     ) -> None:
         """Create a new ``DatabricksRunNowOperator``."""
+        # Named here (not left to **kwargs) so default_args reaches it on every
+        # supported Airflow version.
+        if durable is not None:
+            kwargs["durable"] = durable
         super().__init__(**kwargs)
         self.json = json
         self.job_id = job_id

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import copy
 import hashlib
+import warnings
 from datetime import datetime, timedelta
 from typing import Any
 from unittest import mock
@@ -40,6 +41,7 @@ from airflow.providers.common.compat.sdk import AirflowException, BaseOperator, 
 from airflow.providers.databricks.exceptions import DatabricksApiError
 from airflow.providers.databricks.hooks.databricks import RunState, SQLStatementState
 from airflow.providers.databricks.operators.databricks import (
+    _DURABLE_UNSET,
     DatabricksCreateJobsOperator,
     DatabricksNotebookOperator,
     DatabricksRunNowOperator,
@@ -47,6 +49,7 @@ from airflow.providers.databricks.operators.databricks import (
     DatabricksSubmitRunOperator,
     DatabricksTaskBaseOperator,
     DatabricksTaskOperator,
+    _warn_and_disable_durable_pre_3_3,
 )
 from airflow.providers.databricks.triggers.databricks import (
     DatabricksExecutionTrigger,
@@ -1889,6 +1892,12 @@ class TestDatabricksSubmitRunOperatorDurable:
         op = DatabricksSubmitRunOperator(task_id=TASK_ID, json={"notebook_task": NOTEBOOK_TASK})
         assert op.is_job_succeeded(status) is expected
 
+    def test_default_args_durable_reaches_operator(self):
+        op = DatabricksSubmitRunOperator(
+            task_id=TASK_ID, json={"notebook_task": NOTEBOOK_TASK}, default_args={"durable": False}
+        )
+        assert op.durable is False
+
 
 class TestDatabricksRunNowOperator:
     def test_init_with_named_parameters(self):
@@ -3201,6 +3210,10 @@ class TestDatabricksRunNowOperatorDurable:
     def test_is_job_succeeded(self, status, expected):
         op = DatabricksRunNowOperator(task_id=TASK_ID, job_id=JOB_ID)
         assert op.is_job_succeeded(status) is expected
+
+    def test_default_args_durable_reaches_operator(self):
+        op = DatabricksRunNowOperator(task_id=TASK_ID, job_id=JOB_ID, default_args={"durable": False})
+        assert op.durable is False
 
 
 class TestDatabricksSQLStatementsOperator:
@@ -4800,3 +4813,18 @@ class TestDatabricksTaskOperator:
 
         operator.monitor_databricks_job()
         assert mock_databricks_hook.return_value.get_run.call_count == 3
+
+
+class TestWarnAndDisableDurableAirflowPre3_3:
+    def test_no_warning_when_unset(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = _warn_and_disable_durable_pre_3_3(_DURABLE_UNSET)
+        assert result is False
+        assert caught == []
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_warns_and_disables_when_explicitly_set(self, value):
+        with pytest.warns(UserWarning, match="durable.*no effect"):
+            result = _warn_and_disable_durable_pre_3_3(value)
+        assert result is False

--- a/providers/google/docs/operators/cloud/bigquery.rst
+++ b/providers/google/docs/operators/cloud/bigquery.rst
@@ -403,10 +403,10 @@ the same logical run doesn't submit a second job, that guarantee is unrelated to
 and keeping ``force_rerun=False`` is still the right choice for it.
 
 Durable execution requires Airflow 3.3 or newer, since it relies on the task state store. On
-earlier Airflow versions the flag is a no-op and the operator always submits a fresh job on retry,
-exactly as before -- including the pre-existing ``reattach_states``/``Conflict`` behavior, which is
-unchanged. If the task state store is unavailable at runtime, the operator logs that crash
-recovery is disabled and behaves the same way.
+earlier Airflow versions the flag is a no-op -- setting it explicitly only emits a warning -- and
+the operator always submits a fresh job on retry, exactly as before -- including the pre-existing
+``reattach_states``/``Conflict`` behavior, which is unchanged. If the task state store is
+unavailable at runtime, the operator logs that crash recovery is disabled and behaves the same way.
 
 Like the persisted state itself, the stored job id isn't deleted automatically, that only happens
 when someone runs ``airflow state-store clean``. If a task's ``retry_delay`` is longer than

--- a/providers/google/src/airflow/providers/google/cloud/operators/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/bigquery.py
@@ -73,6 +73,20 @@ except ImportError:
         return value is not NOTSET
 
 
+_DURABLE_UNSET = object()
+
+
+def _warn_and_disable_durable_pre_3_3(durable: Any) -> bool:
+    """Shared by the <3.3 compat stub: durable has no effect below 3.3, warn if it was set."""
+    if durable is not _DURABLE_UNSET:
+        warnings.warn(
+            "`durable` has no effect on Airflow versions below 3.3.",
+            UserWarning,
+            stacklevel=3,
+        )
+    return False
+
+
 try:
     from airflow.sdk import ResumableJobMixin
 except ImportError:
@@ -82,9 +96,9 @@ except ImportError:
 
         external_id_key: str = "bigquery_job_id"
 
-        def __init__(self, *, durable: bool = True, **kwargs: Any) -> None:
+        def __init__(self, *, durable: Any = _DURABLE_UNSET, **kwargs: Any) -> None:
             super().__init__(**kwargs)
-            self.durable = durable
+            self.durable = _warn_and_disable_durable_pre_3_3(durable)
 
         def execute_resumable(self, context):
             external_id = self.submit_job(context)
@@ -2373,8 +2387,13 @@ class BigQueryInsertJobOperator(
         result_timeout: float | None = None,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
         poll_interval: float = 4.0,
+        durable: bool | None = None,
         **kwargs,
     ) -> None:
+        # Named here (not left to **kwargs) so default_args reaches it on every
+        # supported Airflow version.
+        if durable is not None:
+            kwargs["durable"] = durable
         super().__init__(**kwargs)
         self.configuration = configuration
         self.location = location

--- a/providers/google/tests/unit/google/cloud/operators/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_bigquery.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import warnings
 from contextlib import suppress
 from unittest import mock
 from unittest.mock import ANY, MagicMock
@@ -51,6 +52,7 @@ from airflow.providers.common.compat.sdk import (
 )
 from airflow.providers.google.cloud.openlineage.utils import BIGQUERY_NAMESPACE
 from airflow.providers.google.cloud.operators.bigquery import (
+    _DURABLE_UNSET,
     BigQueryCheckOperator,
     BigQueryColumnCheckOperator,
     BigQueryCreateEmptyDatasetOperator,
@@ -73,6 +75,7 @@ from airflow.providers.google.cloud.operators.bigquery import (
     BigQueryUpdateTableSchemaOperator,
     BigQueryUpsertTableOperator,
     BigQueryValueCheckOperator,
+    _warn_and_disable_durable_pre_3_3,
 )
 from airflow.providers.google.cloud.triggers.bigquery import (
     BigQueryCheckTrigger,
@@ -2560,6 +2563,10 @@ class TestBigQueryInsertJobOperatorDurable:
         assert op.is_job_succeeded("success") is True
         assert op.is_job_succeeded("RUNNING") is False
 
+    def test_default_args_durable_reaches_operator(self):
+        op = self._make_operator(default_args={"durable": False})
+        assert op.durable is False
+
 
 class TestBigQueryIntervalCheckOperator:
     def test_bigquery_interval_check_operator_execute_complete(self):
@@ -3439,3 +3446,18 @@ class TestBigQueryListRoutinesOperator:
         call_kwargs = mock_hook.return_value.list_routines.call_args.kwargs
         assert call_kwargs["dataset_id"] == TEST_DATASET
         assert call_kwargs["max_results"] == 10
+
+
+class TestWarnAndDisableDurableAirflowPre3_3:
+    def test_no_warning_when_unset(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = _warn_and_disable_durable_pre_3_3(_DURABLE_UNSET)
+        assert result is False
+        assert caught == []
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_warns_and_disables_when_explicitly_set(self, value):
+        with pytest.warns(UserWarning, match="durable.*no effect"):
+            result = _warn_and_disable_durable_pre_3_3(value)
+        assert result is False

--- a/providers/snowflake/docs/operators/snowflake.rst
+++ b/providers/snowflake/docs/operators/snowflake.rst
@@ -214,3 +214,7 @@ To opt out and always submit fresh SQL on retry, set ``durable=False``:
 Durable execution applies to the synchronous path. When ``deferrable=True`` is set, the Triggerer
 already tracks the statement handles across the wait, so deferrable mode takes precedence and
 ``durable`` has no effect.
+
+Durable execution requires Airflow 3.3 or newer, since it relies on the task state store. Below
+3.3, ``durable`` has no effect either way: setting it explicitly only emits a warning, and the
+operator always submits fresh SQL on retry, exactly as before this feature existed.

--- a/providers/snowflake/src/airflow/providers/snowflake/operators/snowflake.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/operators/snowflake.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import time
+import warnings
 from collections.abc import Iterable, Mapping, Sequence
 from datetime import timedelta
 from functools import cached_property
@@ -35,6 +36,20 @@ from airflow.providers.common.sql.operators.sql import (
 from airflow.providers.snowflake.hooks.snowflake_sql_api import SnowflakeSqlApiHook
 from airflow.providers.snowflake.triggers.snowflake_trigger import SnowflakeSqlApiTrigger
 
+_DURABLE_UNSET = object()
+
+
+def _warn_and_disable_durable_pre_3_3(durable: Any) -> bool:
+    """Shared by the <3.3 compat stub: durable has no effect below 3.3, warn if it was set."""
+    if durable is not _DURABLE_UNSET:
+        warnings.warn(
+            "`durable` has no effect on Airflow versions below 3.3.",
+            UserWarning,
+            stacklevel=3,
+        )
+    return False
+
+
 try:
     from airflow.sdk import ResumableJobMixin
 except ImportError:
@@ -44,9 +59,9 @@ except ImportError:
 
         external_id_key: str = "snowflake_query_ids"
 
-        def __init__(self, *, durable: bool = True, **kwargs: Any) -> None:
+        def __init__(self, *, durable: Any = _DURABLE_UNSET, **kwargs: Any) -> None:
             super().__init__(**kwargs)
-            self.durable = durable
+            self.durable = _warn_and_disable_durable_pre_3_3(durable)
 
         def execute_resumable(self, context):
             external_id = self.submit_job(context)
@@ -413,8 +428,13 @@ class SnowflakeSqlApiOperator(ResumableJobMixin, SQLExecuteQueryOperator):
         timeout: int | None = None,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
         snowflake_api_retry_args: dict[str, Any] | None = None,
+        durable: bool | None = None,
         **kwargs: Any,
     ) -> None:
+        # Named here (not left to **kwargs) so default_args reaches it on every
+        # supported Airflow version.
+        if durable is not None:
+            kwargs["durable"] = durable
         self.snowflake_conn_id = snowflake_conn_id
         self.poll_interval = poll_interval
         self.statement_count = statement_count

--- a/providers/snowflake/tests/unit/snowflake/operators/test_snowflake.py
+++ b/providers/snowflake/tests/unit/snowflake/operators/test_snowflake.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import warnings
 from unittest import mock
 from unittest.mock import MagicMock, call
 
@@ -31,10 +32,12 @@ from airflow.models.taskinstance import TaskInstance
 from airflow.providers.common.compat.sdk import TaskDeferred
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.providers.snowflake.operators.snowflake import (
+    _DURABLE_UNSET,
     SnowflakeCheckOperator,
     SnowflakeIntervalCheckOperator,
     SnowflakeSqlApiOperator,
     SnowflakeValueCheckOperator,
+    _warn_and_disable_durable_pre_3_3,
 )
 from airflow.providers.snowflake.triggers.snowflake_trigger import SnowflakeSqlApiTrigger
 from airflow.utils.types import DagRunType
@@ -967,3 +970,22 @@ class TestSnowflakeSqlApiOperatorDurable:
         assert operator.is_job_active("success") is False
         assert operator.is_job_succeeded("success") is True
         assert operator.is_job_succeeded("running") is False
+
+    def test_default_args_durable_reaches_operator(self):
+        operator = self._make_operator(default_args={"durable": False})
+        assert operator.durable is False
+
+
+class TestWarnAndDisableDurableAirflowPre3_3:
+    def test_no_warning_when_unset(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = _warn_and_disable_durable_pre_3_3(_DURABLE_UNSET)
+        assert result is False
+        assert caught == []
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_warns_and_disables_when_explicitly_set(self, value):
+        with pytest.warns(UserWarning, match="durable.*no effect"):
+            result = _warn_and_disable_durable_pre_3_3(value)
+        assert result is False


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

`durable` was left in `**kwargs` instead of being a named parameter on `RedshiftDataOperator`, `LivyOperator`, `DatabricksSubmitRunOperator`, `DatabricksRunNowOperator`, `BigQueryInsertJobOperator`, and `SnowflakeSqlApiOperator`. 

`_apply_defaults` only fills parameters that are literally named in a decorated `__init__`, so `default_args={"durable": False}` silently left `durable` at its mixin-owned default of `True` on every one of these operators.

Separately, none of these six operators ever read `self.durable` outside their own compat stub's `__init__`, so the value has always been a genuine no-op below Airflow 3.3 because there's no task state store for it to control. But the stub accepted any value silently, with no signal that it did nothing. Now it warns, below 3.3 emits `UserWarning: durable has no effect on Airflow versions below 3.3.`, so nobody mistakes silence for effect.

None of these operators have a legacy flag to fall back on (unlike
Glue's `resume_glue_job_on_retry` or KPO's `reattach_on_restart`), so
there's nothing else to resolve -- the warning is the whole fix.

---

## Before / after: `durable` on Airflow below 3.3

Applies identically to all six operators (`RedshiftDataOperator`, `LivyOperator`, `DatabricksSubmitRunOperator`, `DatabricksRunNowOperator`, `BigQueryInsertJobOperator`, `SnowflakeSqlApiOperator`) — none of them have a legacy flag, and none of them ever read `self.durable` outside their compat stub, so **behavior never changes** here. Only the warning is new.

| `durable` passed | Behavior (before and after, unchanged) | Warning — before | Warning — after |
|---|---|---|---|
| not set | operator always submits fresh, no task-state-store lookup (below 3.3 doesn't have one) | none | none |
| `True` | same — no effect | none | `UserWarning`: "`durable` has no effect on Airflow versions below 3.3." |
| `False` | same — no effect | none | `UserWarning`: "`durable` has no effect on Airflow versions below 3.3." |


| `default_args` | Before | After |
|---|---|---|
| `default_args={"durable": False}`, no explicit `durable` kwarg | ignored — `durable` stayed at the mixin's default of `True` | reaches the operator correctly — `durable` is `False` |

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
