### PR TITLE
Fetch missing Git bundle tracking refs

### DIFF
--- a/providers/git/src/airflow/providers/git/bundles/git.py
+++ b/providers/git/src/airflow/providers/git/bundles/git.py
@@ -212,9 +212,8 @@ class GitDagBundle(BaseDagBundle):
                 raise RuntimeError("Error cloning repository") from e
             except InvalidGitRepositoryError as e:
                 raise RuntimeError(f"Invalid git repository at {self.repo_path}") from e
-            # If tracking_ref was just repointed to a SHA that predates this working clone's
-            # last fetch, this checkout fails until the clone is fetched or storage is cleared;
-            # tracked at https://github.com/apache/airflow/issues/71388
+            if not self._has_version(self.repo, self.tracking_ref):
+                self.repo.remotes.origin.fetch()
             self.repo.git.checkout(self.tracking_ref)
             self._log.debug("bundle initialize", version=self.version)
             if self.version:

--- a/providers/git/tests/unit/git/bundles/test_git.py
+++ b/providers/git/tests/unit/git/bundles/test_git.py
@@ -734,14 +734,7 @@ class TestGitDagBundle:
         assert {"test_dag.py"} == files_in_repo
 
     @mock.patch("airflow.providers.git.bundles.git.GitHook")
-    def test_tracking_ref_commit_sha_promote_fails_without_clearing_storage(self, mock_githook, git_repo):
-        """A SHA created after the bundle's local storage was first populated can't be
-        promoted to in-place: the working clone never fetches it before checkout.
-
-        This documents a known limitation rather than desired behavior -- it should start
-        passing once the fix tracked at https://github.com/apache/airflow/issues/71388 lands,
-        at which point this test should be updated to assert success instead.
-        """
+    def test_tracking_ref_commit_sha_promote_without_clearing_storage(self, mock_githook, git_repo):
         repo_path, repo = git_repo
         mock_githook.return_value.repo_url = repo_path
         first_commit = repo.head.commit
@@ -758,11 +751,13 @@ class TestGitDagBundle:
         repo.index.add([file_path])
         second_commit = repo.index.commit("Another commit")
 
-        # Promote in-place: config change re-creates the bundle against the same local
-        # storage. The new commit's objects were never fetched into the working clone.
+        # Promote in-place: config change re-creates the bundle against the same local storage.
         bundle = GitDagBundle(name="test", git_conn_id=CONN_HTTPS, tracking_ref=second_commit.hexsha)
-        with pytest.raises(GitCommandError, match="reference is not a tree|unable to read tree"):
-            bundle.initialize()
+        bundle.initialize()
+        assert _version_str(bundle.get_current_version()) == second_commit.hexsha
+        files_in_repo = {f.name for f in bundle.path.iterdir() if f.is_file()}
+        assert {"test_dag.py", "new_test.py"} == files_in_repo
+        assert_repo_is_closed(bundle)
 
     @mock.patch("airflow.providers.git.bundles.git.GitHook")
     def test_tracking_ref_commit_sha_promote_succeeds_with_fresh_storage(self, mock_githook, git_repo):


### PR DESCRIPTION
Promoting a SHA-pinned Git Dag bundle can reuse a working clone whose object database predates the new commit, even though the bundle's local bare mirror has already fetched it. The subsequent checkout then fails with `reference is not a tree` unless local bundle storage is cleared.

Fetch the working clone from its local bare origin only when the configured `tracking_ref` cannot already be resolved, then continue with the existing checkout flow. This keeps the normal branch and tag paths unchanged and avoids an unconditional extra fetch.

The regression test now promotes a second commit into the same local bundle storage and verifies both the resolved version and the newly added file.

closes: #71388

Testing:

- `pytest providers/git/tests/unit/git/bundles/test_git.py::TestGitDagBundle::test_tracking_ref_commit_sha_promote_without_clearing_storage -xvs` (fails on `main`, passes with this change)
- `pytest providers/git/tests/unit/git/bundles/test_git.py -q -s --disable-warnings` (`105 passed`)
- focused test after installing the built provider wheel (`1 passed`)
- `ruff check` and `ruff format --check` for both changed files
- `mypy providers/git/src/airflow/providers/git/bundles/git.py`
- `uv build --project providers/git --wheel`
- `prek run --from-ref b2ee721a2cd30181b2759c00f359d115e2859a8c --stage pre-commit`
- `prek run mypy-providers --from-ref b2ee721a2cd30181b2759c00f359d115e2859a8c --stage manual`

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (OpenAI Codex)

Generated-by: OpenAI Codex following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

Drafted-by: OpenAI Codex (no human review before posting)
