### PR TITLE
Pass native datetime and UUID literals to stub tasks

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/task_arg_binding.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/task_arg_binding.py
@@ -43,18 +43,28 @@ by pydantic from the stub annotation, carried verbatim, unknown keywords ignored
 lang SDK should decode the value into. Every SDK is expected to follow the same table,
 so a Dag author sees one behaviour regardless of the task's language:
 
-===================  ==========  ====================================  =========================
-Python annotation    ``type``    ``format`` / wire spelling            Native target
-===================  ==========  ====================================  =========================
-``datetime``         string      ``date-time`` ``2024-01-02T03:04:05Z``  timestamp
-``date``             string      ``date`` ``2024-01-02``                 date
-``time``             string      ``time`` ``03:04:05``                    time of day
-``timedelta``        string      ``duration`` ``P1DT2H3M4S`` ``-PT1M30S`` duration
-``UUID``             string      ``uuid`` ``6ba7b810-9dad-...-...``       UUID
-``bytes``            string      ``binary`` (raw text, **not** base64)   byte string
-``int``              integer     ``int64``                                64-bit integer
-``float``            number      ``double``                               64-bit float
-===================  ==========  ====================================  =========================
+=========================  ========================  ====================================  ==================  =================================
+Python annotation          JSON-schema signal        Wire spelling                         Native target       Inline literal handling
+=========================  ========================  ====================================  ==================  =================================
+``datetime``               string + ``date-time``    ``2024-01-02T03:04:05Z``              timestamp           converted
+``date``                   string + ``date``         ``2024-01-02``                         date                converted
+``time``                   string + ``time``         ``03:04:05``                           time of day         converted
+``timedelta``              string + ``duration``     ``P1DT2H3M4S`` or ``-PT1M30S``         duration            converted
+``UUID``                   string + ``uuid``         ``6ba7b810-9dad-...-...``              UUID                converted
+``int``                    integer + ``int64``       ``42``                                 64-bit integer      JSON-native
+``float``                  number + ``double``       ``1.5``                                64-bit float        JSON-native
+``Enum`` (string value)    string + ``enum``         ``"value"``                            enum                member rejected; pass ``.value``
+``str``-backed ``Enum``    string + ``enum``         ``"value"``                            enum                JSON-native
+``int``-backed ``Enum``    integer + ``enum``        ``1``                                  enum                JSON-native
+``Decimal``                number or string          ``1.2`` or ``"1.20"``                   decimal             rejected; pass number/string
+``Path``                   string + ``path``         ``"/tmp/example"``                     path or string      rejected; pass string
+``set[datetime]``          array + ``uniqueItems``   ``["2024-01-02T03:04:05Z"]``           set of timestamps   converted in stable order
+=========================  ========================  ====================================  ==================  =================================
+
+``Inline literal handling`` describes a value captured directly from the Python Dag. The
+schema also accompanies XCom bindings, where the value is produced later. Schema generation
+does not itself serialize a literal: unsupported Python objects are rejected before a binding
+is emitted even when pydantic can describe their eventual JSON representation.
 
 Timestamps always carry an explicit offset -- a naive ``datetime`` is pinned to Airflow's
 default timezone at serialization time -- because an offset-less timestamp means different

--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/task_arg_binding.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/task_arg_binding.py
@@ -37,7 +37,33 @@ ArgValueSchema = TypeAliasType(
     "ArgValueSchema", Annotated[dict[str, JsonValue], Field(title="ArgValueSchema")]
 )
 """JSON-schema fragment constraining the value a stub-task argument binds to; generated
-by pydantic from the stub annotation, carried verbatim, unknown keywords ignored."""
+by pydantic from the stub annotation, carried verbatim, unknown keywords ignored.
+
+``format`` carries the part of the contract ``type`` alone cannot: which native type a
+lang SDK should decode the value into. Every SDK is expected to follow the same table,
+so a Dag author sees one behaviour regardless of the task's language:
+
+===================  ==========  ====================================  =========================
+Python annotation    ``type``    ``format`` / wire spelling            Native target
+===================  ==========  ====================================  =========================
+``datetime``         string      ``date-time`` ``2024-01-02T03:04:05Z``  timestamp
+``date``             string      ``date`` ``2024-01-02``                 date
+``time``             string      ``time`` ``03:04:05``                    time of day
+``timedelta``        string      ``duration`` ``P1DT2H3M4S`` ``-PT1M30S`` duration
+``UUID``             string      ``uuid`` ``6ba7b810-9dad-...-...``       UUID
+``bytes``            string      ``binary`` (raw text, **not** base64)   byte string
+``int``              integer     ``int64``                                64-bit integer
+``float``            number      ``double``                               64-bit float
+===================  ==========  ====================================  =========================
+
+Timestamps always carry an explicit offset -- a naive ``datetime`` is pinned to Airflow's
+default timezone at serialization time -- because an offset-less timestamp means different
+instants to different runtimes (UTC in Go, worker-local in JavaScript, unparsable in Java).
+
+A ``string`` target is always acceptable for any of the string formats: an SDK that does
+not model a format hands the raw text to the task and lets it parse. Unions serialize as
+``anyOf``, and a ``null`` branch means the argument may arrive absent, so the native
+parameter has to be nullable."""
 
 
 class _ArgBindingBase(BaseModel):

--- a/airflow-core/src/airflow/serialization/stub_arg_bindings.py
+++ b/airflow-core/src/airflow/serialization/stub_arg_bindings.py
@@ -31,6 +31,8 @@ import datetime
 import json
 import types
 import typing
+import uuid
+from collections.abc import Mapping, Sequence
 from functools import cache
 from inspect import Parameter, Signature, signature
 from typing import TYPE_CHECKING, Any, NamedTuple
@@ -67,6 +69,7 @@ class _ValueSchemaGenerator(GenerateJsonSchema):
 
 # Most-derived first: datetime subclasses date, so it must be matched before date.
 _TEMPORAL_BASES = (datetime.datetime, datetime.date, datetime.time, datetime.timedelta)
+_NATIVE_VALUE_BASES = (*_TEMPORAL_BASES, uuid.UUID)
 
 
 def _normalize_temporal_annotation(annotation: Any) -> Any:
@@ -138,9 +141,9 @@ def _build_wire_form(annotation: Any) -> _ValueWireForm | None:
     TypeAdapter construction is one of pydantic's most expensive operations and
     annotations are static, so re-serializations of the same Dag must not re-pay it.
 
-    Pairing them is what keeps a literal from being rendered in a spelling its own
-    ``value_schema`` does not describe: both come from the same adapter, including when
-    the temporal-normalization retry below settles on a different annotation.
+    Pairing them keeps an explicitly supported native value from being rendered in a
+    spelling its own ``value_schema`` does not describe, including when the
+    temporal-normalization retry below settles on a different annotation.
     """
     # PydanticUserError/TypeError cover annotations pydantic can't schema; either way,
     # that degrades to no schema rather than failing Dag serialization.
@@ -153,32 +156,145 @@ def _build_wire_form(annotation: Any) -> _ValueWireForm | None:
     return None
 
 
+def _unwrap_annotated(annotation: Any) -> Any:
+    while typing.get_origin(annotation) is typing.Annotated:
+        annotation = typing.get_args(annotation)[0]
+    return annotation
+
+
+def _get_annotation_native_base(annotation: Any) -> type[Any] | None:
+    annotation = _unwrap_annotated(annotation)
+    if not isinstance(annotation, type):
+        return None
+    return next((base for base in _NATIVE_VALUE_BASES if issubclass(annotation, base)), None)
+
+
+def _get_value_native_base(value: Any) -> type[Any] | None:
+    return next((base for base in _NATIVE_VALUE_BASES if isinstance(value, base)), None)
+
+
+def _has_native_value_annotation(annotation: Any) -> bool:
+    annotation = _unwrap_annotated(annotation)
+    if _get_annotation_native_base(annotation) is not None:
+        return True
+    return any(
+        arg is not Ellipsis and _has_native_value_annotation(arg) for arg in typing.get_args(annotation)
+    )
+
+
+def _annotation_accepts_value(annotation: Any, value: Any) -> bool:
+    annotation = _unwrap_annotated(annotation)
+    if annotation is Any:
+        return False
+
+    annotation_native_base = _get_annotation_native_base(annotation)
+    if annotation_native_base is not None:
+        return annotation_native_base is _get_value_native_base(value)
+
+    origin = typing.get_origin(annotation)
+    if origin in (typing.Union, types.UnionType):
+        return any(_annotation_accepts_value(member, value) for member in typing.get_args(annotation))
+    if origin is typing.Literal:
+        return value in typing.get_args(annotation)
+
+    runtime_type = origin or annotation
+    try:
+        return isinstance(value, runtime_type)
+    except TypeError:
+        return False
+
+
+def _select_union_member(annotation: Any, value: Any) -> Any:
+    unwrapped = _unwrap_annotated(annotation)
+    if typing.get_origin(unwrapped) not in (typing.Union, types.UnionType):
+        return annotation
+    return next(
+        (member for member in typing.get_args(unwrapped) if _annotation_accepts_value(member, value)),
+        annotation,
+    )
+
+
+def _origin_accepts_value(origin: Any, value: Any) -> bool:
+    try:
+        return isinstance(value, origin)
+    except TypeError:
+        return False
+
+
+def _get_json_sort_key(value: Any) -> str:
+    return json.dumps(value, allow_nan=False, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
 def _to_json_value(value: Any, annotation: Any) -> Any:
     """
-    Render a native value in the JSON form its ``value_schema`` advertises.
+    Render supported native values in the JSON form their ``value_schema`` advertises.
 
-    A ``datetime``/``timedelta``/``UUID`` is not JSON-serializable, so without this it
-    could not cross the language boundary at all. Dumping it through the same adapter
-    that produced the schema gives every lang SDK exactly one spelling per format --
-    RFC 3339 timestamps, ISO-8601 durations, canonical UUIDs -- instead of each Dag
-    author picking their own.
+    Temporal and UUID values are converted directly or recursively inside lists, tuples,
+    mapping values, and sets. Each native leaf uses the same adapter that produced its schema,
+    giving every lang SDK one spelling per format without opting unrelated pydantic-supported
+    types into serialization. Sets containing supported leaves become deterministically ordered
+    JSON arrays so repeated Dag serialization remains stable.
 
-    Values pydantic cannot render for this annotation pass through untouched, leaving
-    the JSON-serializability check to reject them.
+    Unsupported values and containers pass through untouched, leaving the
+    JSON-serializability check to reject them.
     """
     if annotation is Parameter.empty or annotation is None or annotation is Any:
         return value
-    if isinstance(value, datetime.datetime):
-        # A naive timestamp is ambiguous once it leaves Python: Go would read it as UTC,
-        # JavaScript as the worker's local time, and Java would refuse to parse it. Pin
-        # the offset here, using the same default timezone the rest of Airflow applies.
-        value = coerce_datetime(value)
-    wire_form = _get_wire_form(annotation)
-    if wire_form is None:
+
+    annotation = _select_union_member(annotation, value)
+    annotation_native_base = _get_annotation_native_base(annotation)
+    value_native_base = _get_value_native_base(value)
+    if annotation_native_base is not None:
+        if annotation_native_base is not value_native_base:
+            return value
+        if value_native_base is datetime.datetime:
+            # A naive timestamp is ambiguous once it leaves Python: Go would read it as UTC,
+            # JavaScript as the worker's local time, and Java would refuse to parse it. Pin
+            # the offset here, using the same default timezone the rest of Airflow applies.
+            value = coerce_datetime(value)
+        wire_form = _get_wire_form(annotation)
+        if wire_form is None:
+            return value
+        # warnings=False: a value that does not match its annotation is the JSON-literal
+        # check's business, not a serializer warning's.
+        return wire_form.adapter.dump_python(value, mode="json", warnings=False)
+
+    unwrapped = _unwrap_annotated(annotation)
+    origin = typing.get_origin(unwrapped)
+    args = typing.get_args(unwrapped)
+    if not args or not _origin_accepts_value(origin, value):
         return value
-    # warnings=False: a value that does not match its annotation is the JSON-literal
-    # check's business, not a serializer warning's.
-    return wire_form.adapter.dump_python(value, mode="json", warnings=False)
+
+    if isinstance(value, dict) and isinstance(origin, type) and issubclass(origin, Mapping):
+        value_annotation = args[1]
+        return {key: _to_json_value(item, value_annotation) for key, item in value.items()}
+
+    if origin is set and isinstance(value, set):
+        item_annotation = args[0]
+        if not _has_native_value_annotation(item_annotation):
+            return value
+        rendered = [_to_json_value(item, item_annotation) for item in value]
+        try:
+            return sorted(rendered, key=_get_json_sort_key)
+        except (TypeError, ValueError):
+            return value
+
+    if not isinstance(origin, type) or not issubclass(origin, Sequence):
+        return value
+    if isinstance(value, list):
+        item_annotation = args[0]
+        return [_to_json_value(item, item_annotation) for item in value]
+    if not isinstance(value, tuple):
+        return value
+    if origin is tuple:
+        if len(args) == 2 and args[1] is Ellipsis:
+            return tuple(_to_json_value(item, args[0]) for item in value)
+        if len(args) != len(value):
+            return value
+        return tuple(
+            _to_json_value(item, item_annotation) for item, item_annotation in zip(value, args, strict=True)
+        )
+    return tuple(_to_json_value(item, args[0]) for item in value)
 
 
 def _validate_stub_signature(sig: Signature, task_id: str) -> None:

--- a/airflow-core/src/airflow/serialization/stub_arg_bindings.py
+++ b/airflow-core/src/airflow/serialization/stub_arg_bindings.py
@@ -33,11 +33,12 @@ import types
 import typing
 from functools import cache
 from inspect import Parameter, Signature, signature
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from pydantic import PydanticUserError, TypeAdapter
 from pydantic.json_schema import GenerateJsonSchema
 
+from airflow._shared.timezones.timezone import coerce_datetime
 from airflow.models.xcom import XCOM_RETURN_KEY
 from airflow.sdk import XComArg
 from airflow.sdk.definitions.context import KNOWN_CONTEXT_KEYS
@@ -108,36 +109,76 @@ def _infer_value_schema(annotation: Any) -> dict[str, Any] | None:
         # get_type_hints normalizes a bare ``None`` annotation to NoneType; a parameter
         # that can only ever be None constrains nothing worth shipping.
         return None
-    try:
-        schema = _generate_value_schema(annotation)
-    except TypeError:
-        # Unhashable annotations cannot key the cache; generate directly. Any pydantic
-        # failure inside the body degrades to None there, so this retry never re-raises.
-        schema = _generate_value_schema.__wrapped__(annotation)
+    wire_form = _get_wire_form(annotation)
     # Deep-copy so callers embedding the fragment never alias the cached dict.
-    return copy.deepcopy(schema) if schema else None
+    return copy.deepcopy(wire_form.schema) if wire_form else None
+
+
+class _ValueWireForm(NamedTuple):
+    """The schema describing an annotation's JSON form, and the adapter that renders values into it."""
+
+    adapter: TypeAdapter
+    schema: dict[str, Any]
+
+
+def _get_wire_form(annotation: Any) -> _ValueWireForm | None:
+    try:
+        return _build_wire_form(annotation)
+    except TypeError:
+        # Unhashable annotations cannot key the cache; build directly. Any pydantic
+        # failure inside the body degrades to None there, so this retry never re-raises.
+        return _build_wire_form.__wrapped__(annotation)
 
 
 @cache
-def _generate_value_schema(annotation: Any) -> dict[str, Any] | None:
+def _build_wire_form(annotation: Any) -> _ValueWireForm | None:
     """
-    Generate the schema for one annotation, cached for the process lifetime.
+    Build the adapter and schema for one annotation together, cached for the process lifetime.
 
     TypeAdapter construction is one of pydantic's most expensive operations and
     annotations are static, so re-serializations of the same Dag must not re-pay it.
+
+    Pairing them is what keeps a literal from being rendered in a spelling its own
+    ``value_schema`` does not describe: both come from the same adapter, including when
+    the temporal-normalization retry below settles on a different annotation.
     """
     # PydanticUserError/TypeError cover annotations pydantic can't schema; either way,
     # that degrades to no schema rather than failing Dag serialization.
-    try:
-        return TypeAdapter(annotation).json_schema(schema_generator=_ValueSchemaGenerator)
-    except (PydanticUserError, TypeError):
-        normalized = _normalize_temporal_annotation(annotation)
-        if normalized is annotation:
-            return None
+    for candidate in (annotation, _normalize_temporal_annotation(annotation)):
         try:
-            return TypeAdapter(normalized).json_schema(schema_generator=_ValueSchemaGenerator)
+            adapter = TypeAdapter(candidate)
+            return _ValueWireForm(adapter, adapter.json_schema(schema_generator=_ValueSchemaGenerator))
         except (PydanticUserError, TypeError):
-            return None
+            continue
+    return None
+
+
+def _to_json_value(value: Any, annotation: Any) -> Any:
+    """
+    Render a native value in the JSON form its ``value_schema`` advertises.
+
+    A ``datetime``/``timedelta``/``UUID`` is not JSON-serializable, so without this it
+    could not cross the language boundary at all. Dumping it through the same adapter
+    that produced the schema gives every lang SDK exactly one spelling per format --
+    RFC 3339 timestamps, ISO-8601 durations, canonical UUIDs -- instead of each Dag
+    author picking their own.
+
+    Values pydantic cannot render for this annotation pass through untouched, leaving
+    the JSON-serializability check to reject them.
+    """
+    if annotation is Parameter.empty or annotation is None or annotation is Any:
+        return value
+    if isinstance(value, datetime.datetime):
+        # A naive timestamp is ambiguous once it leaves Python: Go would read it as UTC,
+        # JavaScript as the worker's local time, and Java would refuse to parse it. Pin
+        # the offset here, using the same default timezone the rest of Airflow applies.
+        value = coerce_datetime(value)
+    wire_form = _get_wire_form(annotation)
+    if wire_form is None:
+        return value
+    # warnings=False: a value that does not match its annotation is the JSON-literal
+    # check's business, not a serializer warning's.
+    return wire_form.adapter.dump_python(value, mode="json", warnings=False)
 
 
 def _validate_stub_signature(sig: Signature, task_id: str) -> None:
@@ -174,20 +215,24 @@ def _resolve_param_annotations(python_callable: Any, sig: Signature) -> dict[str
     return {name: _resolve(name, param) for name, param in sig.parameters.items()}
 
 
-def _ensure_json_literal(value: Any, task_id: str, name: str) -> None:
+def _reject_nested_xcom(value: Any, task_id: str, name: str) -> None:
     if next(XComArg.iter_xcom_references(value), None) is not None:
         raise ValueError(
             f"@task.stub task {task_id!r} parameter {name!r} received a collection with an "
             "upstream task output nested inside it; only a direct XComArg argument can cross "
             "the language boundary -- pass the upstream output as its own argument"
         )
+
+
+def _ensure_json_literal(value: Any, task_id: str, name: str) -> None:
     try:
         json.dumps(value, allow_nan=False)
     except (TypeError, ValueError):
         raise ValueError(
             f"@task.stub task {task_id!r} parameter {name!r} received a literal of type "
             f"{type(value).__name__} that is not JSON-serializable, so it cannot be passed "
-            "to the foreign runtime; pass it in its JSON form instead"
+            "to the foreign runtime; annotate the stub parameter with the value's type so it "
+            "can be serialized, or pass it in its JSON form instead"
         )
 
 
@@ -274,6 +319,8 @@ def build_arg_bindings(op: DecoratedOperator) -> list[dict[str, Any]] | None:
                 xcom_entry["value_schema"] = value_schema
             spec.append(xcom_entry)
             continue
+        _reject_nested_xcom(value, task_id, name)
+        value = _to_json_value(value, annotations[name])
         _ensure_json_literal(value, task_id, name)
         entry: dict[str, Any] = {"name": name, "kind": "literal", "value": value}
         if value_schema is not None:

--- a/airflow-core/tests/unit/serialization/test_dag_serialization.py
+++ b/airflow-core/tests/unit/serialization/test_dag_serialization.py
@@ -31,9 +31,10 @@ import os
 import pickle
 import re
 import sys
+import uuid
 import warnings
 from collections.abc import Generator
-from datetime import datetime, timedelta, timezone as dt_timezone
+from datetime import date, datetime, timedelta, timezone as dt_timezone
 from glob import glob
 from pathlib import Path
 from textwrap import dedent
@@ -3627,6 +3628,77 @@ def test_stub_task_args_round_trip():
 
     for task_id in ("transform", "aggregate"):
         get_arg_bindings_adapter().validate_python(round_tripped.task_dict[task_id].arg_bindings)
+
+
+def test_stub_task_native_literals_serialize_to_their_wire_form():
+    """A native temporal/UUID literal reaches the lang SDK as the JSON spelling its
+    ``value_schema`` advertises, rather than being rejected as unserializable."""
+    from airflow.sdk import task
+
+    with DAG(dag_id="native_arg_bindings_dag", schedule=None) as dag:
+
+        @task.stub
+        def schedule_window(starts_at: datetime, on_day: date, every: timedelta, trace_id: uuid.UUID): ...
+
+        schedule_window(
+            # Naive on purpose: the offset must be pinned at serialization time, because an
+            # offset-less timestamp means a different instant to each lang SDK.
+            datetime(2024, 1, 2, 3, 4, 5),
+            date(2024, 1, 2),
+            timedelta(days=1, hours=2),
+            uuid.UUID("6BA7B810-9DAD-11D1-80B4-00C04FD430C8"),
+        )
+
+    ser_dag = DagSerialization.to_dict(dag)
+    DagSerialization.validate_schema(ser_dag)
+    round_tripped = DagSerialization.from_dict(ser_dag)
+
+    assert round_tripped.task_dict["schedule_window"].arg_bindings == [
+        {
+            "name": "starts_at",
+            "kind": "literal",
+            "value_schema": {"type": "string", "format": "date-time"},
+            "value": "2024-01-02T03:04:05Z",
+        },
+        {
+            "name": "on_day",
+            "kind": "literal",
+            "value_schema": {"type": "string", "format": "date"},
+            "value": "2024-01-02",
+        },
+        {
+            "name": "every",
+            "kind": "literal",
+            "value_schema": {"type": "string", "format": "duration"},
+            "value": "P1DT2H",
+        },
+        {
+            "name": "trace_id",
+            "kind": "literal",
+            "value_schema": {"type": "string", "format": "uuid"},
+            "value": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+        },
+    ]
+
+    from airflow.api_fastapi.execution_api.datamodels.task_arg_binding import get_arg_bindings_adapter
+
+    get_arg_bindings_adapter().validate_python(round_tripped.task_dict["schedule_window"].arg_bindings)
+
+
+def test_stub_task_unannotated_native_literal_still_rejected():
+    """Without an annotation there is no value_schema, so no lang SDK could interpret the
+    value -- the existing "not JSON-serializable" error is still the right answer."""
+    from airflow.sdk import task
+
+    with DAG(dag_id="unannotated_native_dag", schedule=None) as dag:
+
+        @task.stub
+        def starts_at(when): ...
+
+        starts_at(datetime(2024, 1, 2, 3, 4, 5))
+
+    with pytest.raises(SerializationError, match="not JSON-serializable"):
+        DagSerialization.to_dict(dag)
 
 
 @pytest.mark.parametrize("raw", ["false", "true", 0, 1, None, [], {"a": 1}])

--- a/airflow-core/tests/unit/serialization/test_dag_serialization.py
+++ b/airflow-core/tests/unit/serialization/test_dag_serialization.py
@@ -3638,7 +3638,14 @@ def test_stub_task_native_literals_serialize_to_their_wire_form():
     with DAG(dag_id="native_arg_bindings_dag", schedule=None) as dag:
 
         @task.stub
-        def schedule_window(starts_at: datetime, on_day: date, every: timedelta, trace_id: uuid.UUID): ...
+        def schedule_window(
+            starts_at: datetime,
+            on_day: date,
+            every: timedelta,
+            trace_id: uuid.UUID,
+            checkpoints: list[dict[str, datetime | None]],
+            observed_at: set[datetime],
+        ): ...
 
         schedule_window(
             # Naive on purpose: the offset must be pinned at serialization time, because an
@@ -3647,6 +3654,8 @@ def test_stub_task_native_literals_serialize_to_their_wire_form():
             date(2024, 1, 2),
             timedelta(days=1, hours=2),
             uuid.UUID("6BA7B810-9DAD-11D1-80B4-00C04FD430C8"),
+            [{"started_at": datetime(2024, 1, 3, 4, 5, 6), "finished_at": None}],
+            {datetime(2024, 1, 5, 4, 5, 6), datetime(2024, 1, 4, 4, 5, 6)},
         )
 
     ser_dag = DagSerialization.to_dict(dag)
@@ -3677,6 +3686,33 @@ def test_stub_task_native_literals_serialize_to_their_wire_form():
             "kind": "literal",
             "value_schema": {"type": "string", "format": "uuid"},
             "value": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+        },
+        {
+            "name": "checkpoints",
+            "kind": "literal",
+            "value_schema": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "anyOf": [
+                            {"type": "string", "format": "date-time"},
+                            {"type": "null"},
+                        ]
+                    },
+                },
+            },
+            "value": [{"started_at": "2024-01-03T04:05:06Z", "finished_at": None}],
+        },
+        {
+            "name": "observed_at",
+            "kind": "literal",
+            "value_schema": {
+                "type": "array",
+                "items": {"type": "string", "format": "date-time"},
+                "uniqueItems": True,
+            },
+            "value": ["2024-01-04T04:05:06Z", "2024-01-05T04:05:06Z"],
         },
     ]
 

--- a/airflow-core/tests/unit/serialization/test_stub_arg_bindings.py
+++ b/airflow-core/tests/unit/serialization/test_stub_arg_bindings.py
@@ -18,14 +18,29 @@ from __future__ import annotations
 
 import contextlib
 import datetime
+import enum
 import typing
 import uuid
+from decimal import Decimal
+from pathlib import Path
 from typing import Any
 
 import pendulum
 import pytest
 
 from airflow.serialization.stub_arg_bindings import _infer_value_schema, _to_json_value
+
+
+class _PlainEnum(enum.Enum):
+    VALUE = "value"
+
+
+class _StringEnum(str, enum.Enum):
+    VALUE = "value"
+
+
+class _IntegerEnum(int, enum.Enum):
+    VALUE = 1
 
 
 @pytest.mark.parametrize(
@@ -63,7 +78,6 @@ from airflow.serialization.stub_arg_bindings import _infer_value_schema, _to_jso
         pytest.param(datetime.date, {"type": "string", "format": "date"}, id="date"),
         pytest.param(datetime.time, {"type": "string", "format": "time"}, id="time"),
         pytest.param(datetime.timedelta, {"type": "string", "format": "duration"}, id="timedelta"),
-        pytest.param(bytes, {"type": "string", "format": "binary"}, id="bytes"),
         pytest.param(
             typing.Literal["a", "b"],
             {"type": "string", "enum": ["a", "b"]},
@@ -159,59 +173,185 @@ def test_infer_value_schema_unhashable_annotation_generates_uncached():
 
 
 @pytest.mark.parametrize(
-    ("annotation", "value", "expected"),
+    ("annotation", "value", "expected_value", "expected_schema"),
     [
         pytest.param(
             datetime.datetime,
             datetime.datetime(2024, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc),
             "2024-01-02T03:04:05Z",
+            {"type": "string", "format": "date-time"},
             id="aware-datetime",
         ),
-        pytest.param(datetime.date, datetime.date(2024, 1, 2), "2024-01-02", id="date"),
-        pytest.param(datetime.time, datetime.time(3, 4, 5), "03:04:05", id="time"),
-        pytest.param(datetime.timedelta, datetime.timedelta(minutes=5), "PT5M", id="timedelta"),
+        pytest.param(
+            datetime.date,
+            datetime.date(2024, 1, 2),
+            "2024-01-02",
+            {"type": "string", "format": "date"},
+            id="date",
+        ),
+        pytest.param(
+            datetime.time,
+            datetime.time(3, 4, 5),
+            "03:04:05",
+            {"type": "string", "format": "time"},
+            id="time",
+        ),
+        pytest.param(
+            datetime.timedelta,
+            datetime.timedelta(minutes=5),
+            "PT5M",
+            {"type": "string", "format": "duration"},
+            id="timedelta",
+        ),
         pytest.param(
             datetime.timedelta,
             datetime.timedelta(days=1, hours=2, minutes=3, seconds=4),
             "P1DT2H3M4S",
+            {"type": "string", "format": "duration"},
             id="timedelta-compound",
         ),
         pytest.param(
-            datetime.timedelta, datetime.timedelta(seconds=-90), "-PT1M30S", id="timedelta-negative"
+            datetime.timedelta,
+            datetime.timedelta(seconds=-90),
+            "-PT1M30S",
+            {"type": "string", "format": "duration"},
+            id="timedelta-negative",
         ),
         pytest.param(
             datetime.timedelta,
             datetime.timedelta(milliseconds=1500),
             "PT1.5S",
+            {"type": "string", "format": "duration"},
             id="timedelta-fractional",
         ),
         pytest.param(
             uuid.UUID,
             uuid.UUID("6BA7B810-9DAD-11D1-80B4-00C04FD430C8"),
             "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+            {"type": "string", "format": "uuid"},
             id="uuid-normalized-to-lowercase",
         ),
         pytest.param(
             pendulum.DateTime,
             pendulum.datetime(2024, 1, 2, 3, 4, 5),
             "2024-01-02T03:04:05Z",
+            {"type": "string", "format": "date-time"},
             id="pendulum-datetime-via-normalized-annotation",
         ),
         # Values that are already JSON pass through unchanged.
-        pytest.param(str, "plain", "plain", id="str-untouched"),
-        pytest.param(int, 3, 3, id="int-untouched"),
-        pytest.param(dict, {"k": "v"}, {"k": "v"}, id="dict-untouched"),
+        pytest.param(str, "plain", "plain", {"type": "string"}, id="str-untouched"),
+        pytest.param(int, 3, 3, {"type": "integer", "format": "int64"}, id="int-untouched"),
+        pytest.param(
+            dict,
+            {"k": "v"},
+            {"k": "v"},
+            {"type": "object", "additionalProperties": True},
+            id="dict-untouched",
+        ),
         pytest.param(
             list[datetime.datetime],
-            [datetime.datetime(2024, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc)],
+            [datetime.datetime(2024, 1, 2, 3, 4, 5)],
             ["2024-01-02T03:04:05Z"],
-            id="list-of-datetimes",
+            {"type": "array", "items": {"type": "string", "format": "date-time"}},
+            id="list",
+        ),
+        pytest.param(
+            typing.Sequence[datetime.datetime],
+            [datetime.datetime(2024, 1, 2, 3, 4, 5)],
+            ["2024-01-02T03:04:05Z"],
+            {"type": "array", "items": {"type": "string", "format": "date-time"}},
+            id="sequence",
+        ),
+        pytest.param(
+            set[datetime.datetime],
+            {
+                datetime.datetime(2024, 1, 3, 3, 4, 5),
+                datetime.datetime(2024, 1, 2, 3, 4, 5),
+            },
+            ["2024-01-02T03:04:05Z", "2024-01-03T03:04:05Z"],
+            {
+                "type": "array",
+                "items": {"type": "string", "format": "date-time"},
+                "uniqueItems": True,
+            },
+            id="set-deterministic-order",
+        ),
+        pytest.param(
+            set[datetime.datetime],
+            set(),
+            [],
+            {
+                "type": "array",
+                "items": {"type": "string", "format": "date-time"},
+                "uniqueItems": True,
+            },
+            id="empty-set",
+        ),
+        pytest.param(
+            typing.Mapping[str, datetime.datetime],
+            {"when": datetime.datetime(2024, 1, 2, 3, 4, 5)},
+            {"when": "2024-01-02T03:04:05Z"},
+            {
+                "type": "object",
+                "additionalProperties": {"type": "string", "format": "date-time"},
+            },
+            id="mapping-value",
+        ),
+        pytest.param(
+            tuple[datetime.datetime, uuid.UUID],
+            (
+                datetime.datetime(2024, 1, 2, 3, 4, 5),
+                uuid.UUID("6BA7B810-9DAD-11D1-80B4-00C04FD430C8"),
+            ),
+            ("2024-01-02T03:04:05Z", "6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
+            {
+                "type": "array",
+                "prefixItems": [
+                    {"type": "string", "format": "date-time"},
+                    {"type": "string", "format": "uuid"},
+                ],
+                "minItems": 2,
+                "maxItems": 2,
+            },
+            id="fixed-tuple",
+        ),
+        pytest.param(
+            tuple[datetime.datetime, ...],
+            (
+                datetime.datetime(2024, 1, 2, 3, 4, 5),
+                datetime.datetime(2024, 1, 3, 3, 4, 5),
+            ),
+            ("2024-01-02T03:04:05Z", "2024-01-03T03:04:05Z"),
+            {"type": "array", "items": {"type": "string", "format": "date-time"}},
+            id="variadic-tuple",
+        ),
+        pytest.param(
+            list[dict[str, datetime.datetime | None]],
+            [
+                {"when": datetime.datetime(2024, 1, 2, 3, 4, 5)},
+                {"when": None},
+            ],
+            [{"when": "2024-01-02T03:04:05Z"}, {"when": None}],
+            {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "anyOf": [
+                            {"type": "string", "format": "date-time"},
+                            {"type": "null"},
+                        ]
+                    },
+                },
+            },
+            id="deep-optional",
         ),
     ],
 )
-def test_to_json_value_renders_natives_in_their_wire_form(annotation, value, expected):
+def test_to_json_value_renders_natives_in_their_wire_form(annotation, value, expected_value, expected_schema):
     """A native literal reaches the lang SDK in the one spelling its value_schema advertises."""
-    assert _to_json_value(value, annotation) == expected
+    assert _to_json_value(value, annotation) == expected_value
+    assert _infer_value_schema(annotation) == expected_schema
 
 
 def test_to_json_value_pins_an_offset_on_a_naive_datetime():
@@ -233,6 +373,27 @@ def test_to_json_value_leaves_unconstrained_arguments_alone(annotation):
 def test_to_json_value_passes_through_a_value_the_annotation_does_not_describe():
     """A mismatched literal is the JSON-serializability check's business, not a serializer error."""
     assert _to_json_value({"not": "an int"}, int) == {"not": "an int"}
+
+
+@pytest.mark.parametrize(
+    ("annotation", "value"),
+    [
+        pytest.param(_PlainEnum, _PlainEnum.VALUE, id="plain-enum"),
+        pytest.param(Decimal, Decimal("1.20"), id="decimal"),
+        pytest.param(Path, Path("/tmp/example"), id="path"),
+        pytest.param(_StringEnum, _StringEnum.VALUE, id="string-enum"),
+        pytest.param(_IntegerEnum, _IntegerEnum.VALUE, id="integer-enum"),
+        pytest.param(set[int], {1}, id="set-without-native-leaf"),
+        pytest.param(
+            set[datetime.datetime | Decimal],
+            {Decimal("1.20")},
+            id="set-with-unsupported-member",
+        ),
+    ],
+)
+def test_to_json_value_leaves_other_pydantic_types_and_non_json_containers_alone(annotation, value):
+    """Native conversion must not opt unrelated pydantic types or containers into the wire format."""
+    assert _to_json_value(value, annotation) is value
 
 
 def test_infer_value_schema_degrades_on_pydantic_typeerror(monkeypatch):

--- a/airflow-core/tests/unit/serialization/test_stub_arg_bindings.py
+++ b/airflow-core/tests/unit/serialization/test_stub_arg_bindings.py
@@ -19,12 +19,13 @@ from __future__ import annotations
 import contextlib
 import datetime
 import typing
+import uuid
 from typing import Any
 
 import pendulum
 import pytest
 
-from airflow.serialization.stub_arg_bindings import _infer_value_schema
+from airflow.serialization.stub_arg_bindings import _infer_value_schema, _to_json_value
 
 
 @pytest.mark.parametrize(
@@ -155,6 +156,83 @@ def test_infer_value_schema_cache_returns_isolated_copies():
 def test_infer_value_schema_unhashable_annotation_generates_uncached():
     annotation = typing.Annotated[int, {"unhashable": True}]
     assert _infer_value_schema(annotation) == {"type": "integer", "format": "int64"}
+
+
+@pytest.mark.parametrize(
+    ("annotation", "value", "expected"),
+    [
+        pytest.param(
+            datetime.datetime,
+            datetime.datetime(2024, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc),
+            "2024-01-02T03:04:05Z",
+            id="aware-datetime",
+        ),
+        pytest.param(datetime.date, datetime.date(2024, 1, 2), "2024-01-02", id="date"),
+        pytest.param(datetime.time, datetime.time(3, 4, 5), "03:04:05", id="time"),
+        pytest.param(datetime.timedelta, datetime.timedelta(minutes=5), "PT5M", id="timedelta"),
+        pytest.param(
+            datetime.timedelta,
+            datetime.timedelta(days=1, hours=2, minutes=3, seconds=4),
+            "P1DT2H3M4S",
+            id="timedelta-compound",
+        ),
+        pytest.param(
+            datetime.timedelta, datetime.timedelta(seconds=-90), "-PT1M30S", id="timedelta-negative"
+        ),
+        pytest.param(
+            datetime.timedelta,
+            datetime.timedelta(milliseconds=1500),
+            "PT1.5S",
+            id="timedelta-fractional",
+        ),
+        pytest.param(
+            uuid.UUID,
+            uuid.UUID("6BA7B810-9DAD-11D1-80B4-00C04FD430C8"),
+            "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+            id="uuid-normalized-to-lowercase",
+        ),
+        pytest.param(
+            pendulum.DateTime,
+            pendulum.datetime(2024, 1, 2, 3, 4, 5),
+            "2024-01-02T03:04:05Z",
+            id="pendulum-datetime-via-normalized-annotation",
+        ),
+        # Values that are already JSON pass through unchanged.
+        pytest.param(str, "plain", "plain", id="str-untouched"),
+        pytest.param(int, 3, 3, id="int-untouched"),
+        pytest.param(dict, {"k": "v"}, {"k": "v"}, id="dict-untouched"),
+        pytest.param(
+            list[datetime.datetime],
+            [datetime.datetime(2024, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc)],
+            ["2024-01-02T03:04:05Z"],
+            id="list-of-datetimes",
+        ),
+    ],
+)
+def test_to_json_value_renders_natives_in_their_wire_form(annotation, value, expected):
+    """A native literal reaches the lang SDK in the one spelling its value_schema advertises."""
+    assert _to_json_value(value, annotation) == expected
+
+
+def test_to_json_value_pins_an_offset_on_a_naive_datetime():
+    """An offset-less timestamp means different instants to Go, JavaScript and Java."""
+    rendered = _to_json_value(datetime.datetime(2024, 1, 2, 3, 4, 5), datetime.datetime)
+    assert rendered == "2024-01-02T03:04:05Z"
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [pytest.param(Any, id="any"), pytest.param(None, id="none")],
+)
+def test_to_json_value_leaves_unconstrained_arguments_alone(annotation):
+    """Without an annotation there is no value_schema, so no SDK could interpret a native."""
+    value = datetime.datetime(2024, 1, 2, 3, 4, 5)
+    assert _to_json_value(value, annotation) is value
+
+
+def test_to_json_value_passes_through_a_value_the_annotation_does_not_describe():
+    """A mismatched literal is the JSON-serializability check's business, not a serializer error."""
+    assert _to_json_value({"not": "an int"}, int) == {"not": "an int"}
 
 
 def test_infer_value_schema_degrades_on_pydantic_typeerror(monkeypatch):


### PR DESCRIPTION
- related: #69757 shipped the `@task.stub` TaskFlow arg-binding contract; this fills in the value half of it.
- next: https://github.com/apache/airflow/pull/71809

## Why

A `@task.stub` TaskFlow call may only carry values `json.dumps` already knows, so the most natural arguments to pass a foreign-language task were rejected outright:

```python
@task.stub(queue="golang")
def schedule_window(starts_at: datetime, every: timedelta, trace_id: UUID): ...


schedule_window(datetime(2024, 1, 2, 3, 4, 5), timedelta(minutes=5), UUID("6ba7b810-..."))
```

```
ValueError: @task.stub task 'schedule_window' parameter 'starts_at' received a literal of
type datetime that is not JSON-serializable, so it cannot be passed to the foreign runtime
```

The parameter's `value_schema` already told the runtime this was `{"type": "string", "format": "date-time"}` but the *value* could not travel.

## What

Temporal and UUID literals are now rendered through the **same Pydantic adapter that produced their `value_schema`**, so the value and schema cannot disagree by construction. The conversion recurses through typed lists, sequences, tuples, mapping values, sets, and unions, so supported values use the same wire spelling at every depth. Sets containing supported leaves become deterministically sorted JSON arrays while `uniqueItems: true` tells the runtime it may reconstruct set semantics.

| Python literal | Wire value after this PR | `value_schema` | Rejected before? | Rejected after? |
| --- | --- | --- | --- | --- |
| `datetime(2024, 1, 2, 3, 4, 5)` | `"2024-01-02T03:04:05Z"` | `{"type": "string", "format": "date-time"}` | Yes | No |
| `date(2024, 1, 2)` | `"2024-01-02"` | `{"type": "string", "format": "date"}` | Yes | No |
| `time(3, 4, 5)` | `"03:04:05"` | `{"type": "string", "format": "time"}` | Yes | No |
| `timedelta(days=1, hours=2)` | `"P1DT2H"` | `{"type": "string", "format": "duration"}` | Yes | No |
| `UUID("6BA7B810-...")` | `"6ba7b810-..."` | `{"type": "string", "format": "uuid"}` | Yes | No |
| `[datetime(2024, 1, 2, 3, 4, 5)]` | `["2024-01-02T03:04:05Z"]` | `{"type": "array", "items": {"type": "string", "format": "date-time"}}` | Yes | No |
| `{datetime(2024, 1, 2), datetime(2024, 1, 3)}` | `["2024-01-02T00:00:00Z", "2024-01-03T00:00:00Z"]` | `{"type": "array", "items": {"type": "string", "format": "date-time"}, "uniqueItems": true}` | Yes | No |
| `Status.READY` for plain `Enum` | rejected, no wire value | `{"type": "string", "enum": ["ready"], "title": "Status"}` | Yes | Yes |
| `Status.READY` for `str`-backed Enum | `"ready"` | `{"type": "string", "enum": ["ready"], "title": "Status"}` | No | No |
| `Priority.HIGH` for `int`-backed Enum | `1` | `{"type": "integer", "enum": [1], "title": "Priority"}` | No | No |
| `Decimal("1.20")` | rejected, no wire value | number or numeric string | Yes | Yes |
| `Path("/tmp/example")` | rejected, no wire value | `{"type": "string", "format": "path"}` | Yes | Yes |

Only temporal and UUID leaves opt into Pydantic serialization. Plain Enum members, `Decimal`, and `Path` retain their previous rejection behavior; string- and integer-backed Enums retain their existing JSON-native behavior, and bytes remain unsupported. Schema generation and literal conversion are deliberately separate: Pydantic may describe a type even when its Python object cannot be emitted as JSON.

## Timezone-naive timestamps

A naive `datetime` is pinned to an explicit offset before serializing, via the same `coerce_datetime` the rest of Airflow uses. An offset-less timestamp is a *different instant* to each language runtime, so leaving it naive would make a task's behaviour depend on which language happens to run it.

| Wire value | Go | Java `Instant.parse` | JS `new Date` |
| --- | --- | --- | --- |
| `2024-01-02T03:04:05Z` | `03:04:05Z` | `03:04:05Z` | `03:04:05Z` |
| `2024-01-02T03:04:05` | `03:04:05Z` | throws | `08:04:05Z` (worker-local) |


---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
