### PR TITLE
[v3-3-test] Add regression test for Connection extra redact safeguard (#71439)

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/core_api/datamodels/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/datamodels/test_connections.py
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from airflow.api_fastapi.core_api.datamodels.connections import ConnectionResponse
+
+
+def _payload(**overrides):
+    base = {
+        "conn_id": "conn_1",
+        "conn_type": "generic",
+        "description": None,
+        "host": None,
+        "login": None,
+        "schema": None,
+        "port": None,
+        "password": None,
+        "extra": None,
+        "team_name": None,
+    }
+    return {**base, **overrides}
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        pytest.param("bearer-token", id="raw-token"),
+        pytest.param("key=value&other=x", id="query-string"),
+        pytest.param("<xml/>", id="xml"),
+    ],
+)
+def test_redact_extra_rejects_non_json(extra):
+    """
+    The DB layer (``Connection._validate_extra``) is meant to guarantee ``extra``
+    is valid JSON, so this response-model branch is defense-in-depth. If a row
+    ever slips past the DB guard (direct SQL, buggy migration, legacy data), we
+    must fail closed rather than return the raw value — that was the leak
+    described in #63160 before the safeguard.
+    """
+    with pytest.raises(ValidationError):
+        ConnectionResponse.model_validate(_payload(extra=extra))


### PR DESCRIPTION
#63883 added a fail-closed safeguard on ``ConnectionResponse.redact_extra``: if the ``extra`` column ever slips past ``Connection._validate_extra`` (direct SQL, buggy migration, legacy data) and reaches the response serializer as a non-JSON string, the validator raises rather than returning the raw value. The path is unreachable through normal ORM access because ``Connection.get_extra`` already fails on read, so the model-level guard is defense in depth. It had no test until now — this feeds the Pydantic model directly to exercise the branch and pin the fail-closed behavior.

closes: #63160
(cherry picked from commit 9ced296e169045144e4e475fdcc39d3d87959e5a)

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
