### PR TITLE
Autolabel tests-only PRs with kind:tests

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -610,6 +610,24 @@ labelPRBasedOnFilePath:
     - dev/breeze/tests/test_publish_registry_versions.py
     - .github/workflows/registry-*
 
+  # Applied only when EVERY file changed in the PR is a test file, and removed
+  # again if the PR later touches anything else (allFilesMatch rules are kept
+  # in sync on PR updates even with labelOnPRUpdates disabled).
+  kind:tests:
+    allFilesMatch: true
+    paths:
+      - airflow-core/tests/**
+      - task-sdk/tests/**
+      - airflow-ctl/tests/**
+      - devel-common/tests/**
+      - providers/**/tests/**
+      - shared/**/tests/**
+      - airflow-ctl-tests/**
+      - airflow-e2e-tests/**
+      - task-sdk-integration-tests/**
+      - kubernetes-tests/**
+      - docker-tests/**
+
 # Various Flags to control behaviour of the "Labeler"
 labelerFlags:
   # If this flag is changed to 'false', labels would only be added when the PR is first created


### PR DESCRIPTION
Adds a boring-cyborg labeler rule that applies the `kind:tests` label when **every** file changed in a PR is a test file, for better stat collection.

closes: #61377

## How it works

The rule uses a new `allFilesMatch: true` labeler option submitted to boring-cyborg in kaxil/boring-cyborg#133. Unlike the existing any-file-matches rules, it:

- adds the label only when **all** changed files match the test path globs (so it does not land on every PR that happens to touch a test, which was the problem with the first attempt in #61382),
- removes the label again if the PR later gains a non-test file (as discussed in #61382 review), and
- stays in sync on PR updates even though this repo sets `labelOnPRUpdates: false`, because it tracks the current state of the PR rather than suggesting an area.

The path list covers the `tests/` directories of airflow-core, task-sdk, airflow-ctl, devel-common, providers and shared, plus the standalone test projects (airflow-ctl-tests, airflow-e2e-tests, task-sdk-integration-tests, kubernetes-tests, docker-tests). Happy to adjust the list per reviewer preference (e.g. whether Go/Java/TS SDK test files should count).

## Merge-ordering dependency

⚠️ Please merge only after kaxil/boring-cyborg#133 is merged and the bot redeployed. The currently deployed bot would read this rule's `paths` but ignore the unknown `allFilesMatch` flag, i.e. it would apply `kind:tests` with the usual any-file-matches semantics — labeling every PR that touches a test file. With the updated bot the rule behaves as described above.

The `kind:tests` label does not exist yet; the GitHub API auto-creates it on first use, but a maintainer may prefer to create it upfront with a color/description matching the other `kind:*` labels.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)