### PR TITLE
Fix task duration increasing forever after Dag run timeout skips it

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2946,8 +2946,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 default=None,
             )
             for task_instance in unfinished_task_instances:
-                task_instance.state = TaskInstanceState.SKIPPED
-                session.merge(task_instance)
+                task_instance.set_state(TaskInstanceState.SKIPPED, session=session)
             session.flush()
             self.log.info("Run %s of %s has timed-out", dag_run.run_id, dag_run.dag_id)
 

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2945,8 +2945,13 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 key=lambda ti: ti.start_date or timezone.make_aware(datetime.min),
                 default=None,
             )
+            # Mirror TI.set_state inline so the whole batch flushes once instead of per task.
+            now = timezone.utcnow()
             for task_instance in unfinished_task_instances:
-                task_instance.set_state(TaskInstanceState.SKIPPED, session=session)
+                task_instance.state = TaskInstanceState.SKIPPED
+                task_instance.start_date = task_instance.start_date or now
+                task_instance.end_date = task_instance.end_date or now
+                task_instance.duration = (task_instance.end_date - task_instance.start_date).total_seconds()
             session.flush()
             self.log.info("Run %s of %s has timed-out", dag_run.run_id, dag_run.dag_id)
 

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -4246,14 +4246,21 @@ class TestSchedulerJob:
         session.close()
 
     @pytest.mark.parametrize(
-        ("initial_state", "started_ago", "expected_duration"),
+        ("initial_state", "started_ago", "ended_ago", "expected_duration"),
         [
-            pytest.param(TaskInstanceState.RUNNING, datetime.timedelta(hours=1), 3600.0, id="running"),
-            pytest.param(None, None, 0.0, id="never_started"),
+            pytest.param(TaskInstanceState.RUNNING, datetime.timedelta(hours=1), None, 3600.0, id="running"),
+            pytest.param(None, None, None, 0.0, id="never_started"),
+            pytest.param(
+                TaskInstanceState.UP_FOR_RETRY,
+                datetime.timedelta(hours=1),
+                datetime.timedelta(minutes=30),
+                1800.0,
+                id="up_for_retry_keeps_previous_try_end_date",
+            ),
         ],
     )
     def test_dagrun_timeout_sets_end_date_and_duration_on_skipped_tasks(
-        self, dag_maker, initial_state, started_ago, expected_duration
+        self, dag_maker, initial_state, started_ago, ended_ago, expected_duration
     ):
         """Without an end_date the UI keeps growing the duration of a task the timeout already skipped."""
         session = settings.Session()
@@ -4269,6 +4276,7 @@ class TestSchedulerJob:
         ti = dr.get_task_instance("dummy", session=session)
         ti.state = initial_state
         ti.start_date = now - started_ago if started_ago else None
+        ti.end_date = now - ended_ago if ended_ago else None
         session.merge(ti)
         session.flush()
 
@@ -4281,7 +4289,7 @@ class TestSchedulerJob:
 
         session.refresh(ti)
         assert ti.state == TaskInstanceState.SKIPPED
-        assert ti.end_date is not None
+        assert ti.end_date == (now - ended_ago if ended_ago else now)
         assert ti.duration == expected_duration
 
         session.rollback()

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -4245,6 +4245,48 @@ class TestSchedulerJob:
         session.rollback()
         session.close()
 
+    @pytest.mark.parametrize(
+        ("initial_state", "started_ago", "expected_duration"),
+        [
+            pytest.param(TaskInstanceState.RUNNING, datetime.timedelta(hours=1), 3600.0, id="running"),
+            pytest.param(None, None, 0.0, id="never_started"),
+        ],
+    )
+    def test_dagrun_timeout_sets_end_date_and_duration_on_skipped_tasks(
+        self, dag_maker, initial_state, started_ago, expected_duration
+    ):
+        """Without an end_date the UI keeps growing the duration of a task the timeout already skipped."""
+        session = settings.Session()
+        with dag_maker(
+            dag_id="test_dagrun_timeout_sets_end_date_and_duration",
+            dagrun_timeout=datetime.timedelta(seconds=60),
+            session=session,
+        ):
+            EmptyOperator(task_id="dummy")
+
+        now = timezone.utcnow()
+        dr = dag_maker.create_dagrun(start_date=now - datetime.timedelta(days=1))
+        ti = dr.get_task_instance("dummy", session=session)
+        ti.state = initial_state
+        ti.start_date = now - started_ago if started_ago else None
+        session.merge(ti)
+        session.flush()
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+
+        with time_machine.travel(now, tick=False):
+            self.job_runner._schedule_dag_run(dr, session)
+        session.flush()
+
+        session.refresh(ti)
+        assert ti.state == TaskInstanceState.SKIPPED
+        assert ti.end_date is not None
+        assert ti.duration == expected_duration
+
+        session.rollback()
+        session.close()
+
     @mock.patch("airflow._shared.observability.metrics.stats._get_backend")
     def test_dagrun_timeout_duration_metric_has_run_type(self, mock_get_backend, dag_maker):
         """


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

closes: #58536

When a Dag run times out, unfinished tasks are marked SKIPPED but left with no `end_date`, causing the UI to show their duration growing indefinitely. Fixed by routing through `set_state()` which properly sets both `end_date` and `duration`.

## Screenshots
Triggered a Dag with dagrun_timeout=60s and a long-running task, so the run times out while the task is unfinished and gets skipped.
- Before: the skipped task's duration keeps growing on refresh (no end_date).
- After: duration is fixed (~1m) with end_date set.

### Before
<img width="917" height="235" alt="image" src="https://github.com/user-attachments/assets/62eef5c8-9e5e-4351-b2b0-d1a572565446" />

### After
<img width="918" height="295" alt="image" src="https://github.com/user-attachments/assets/46eeb48e-0140-4fc3-a762-d9612e3bf3dd" />


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
  - Opus 5

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
