### PR TITLE
Drop the stale RFC 9457 TODO on the task-instance-run endpoint

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -221,11 +221,6 @@ def ti_run(
             previous_state=previous_state,
         )
 
-        # TODO: Pass a RFC 9457 compliant error message in "detail" field
-        # https://datatracker.ietf.org/doc/html/rfc9457
-        # to provide more information about the error
-        # FastAPI will automatically convert this to a JSON response
-        # This might be added in FastAPI in https://github.com/fastapi/fastapi/issues/10370
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail={


### PR DESCRIPTION
The whole execution API returns errors as `{"reason": …, "message": …, ...extras}` today — that shape is the de-facto contract, applied uniformly across every route in `airflow-core/src/airflow/api_fastapi/execution_api/routes/` (task instances, dag runs, xcoms, connections, variables, dags, assets, asset events, asset state store, hitl, connection tests, task state store), and it's parsed by the task SDK client (`task-sdk/src/airflow/sdk/api/client.py:255` raises `TaskAlreadyRunningError` on `detail["reason"] == "invalid_state"` and `detail["previous_state"] == "running"`).

The `TODO: Pass a RFC 9457 compliant error message` comment on this one 409 site predates that convention and is now misleading. Any single-endpoint migration to RFC 9457 would (a) break the SDK parser and (b) make this endpoint the only RFC-9457 endpoint in the module, which is a worse inconsistency than the current uniform shape.

Removing the comment so it stops attracting drive-by "fix RFC 9457" PRs. If we ever want the execution API on RFC 9457, that's a cross-cutting migration of every route + every SDK parser + docs — an AIP-shaped conversation, not a one-liner.

related: #69360

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)