### PR TITLE
Show assets materialized from an AssetAlias in the Assets tab

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -85,6 +85,7 @@ from airflow.models.asset import (
     PartitionedAssetKeyLog,
     TaskInletAssetReference,
     TaskOutletAssetReference,
+    alias_association_table,
     association_table,
 )
 from airflow.models.asset_state_store import AssetStateStoreModel
@@ -3831,8 +3832,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         Check assets orphanization and update their active entry.
 
         An orphaned asset is no longer referenced in any DAG schedule parameters,
-        task outlets, or task inlets. Active assets (non-orphaned) have entries in
-        AssetActive and must have unique names and URIs.
+        task outlets, task inlets, or alias associations. Active assets (non-orphaned)
+        have entries in AssetActive and must have unique names and URIs.
 
         :seealso: :meth:`AssetModelOperation.activate_assets_if_possible`.
         """
@@ -3842,6 +3843,10 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 func.count(DagScheduleAssetReference.dag_id)
                 + func.count(TaskOutletAssetReference.dag_id)
                 + func.count(TaskInletAssetReference.dag_id)
+                # An asset materialized from an ``AssetAlias`` outlet is referenced only through
+                # the alias association, not the schedule/outlet/inlet tables. Count it so it is
+                # activated (and shown in the UI) instead of being treated as orphaned. See #58058.
+                + func.count(alias_association_table.c.alias_id)
             )
             == 0
         ).label("orphaned")
@@ -3850,6 +3855,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             .outerjoin(DagScheduleAssetReference)
             .outerjoin(TaskOutletAssetReference)
             .outerjoin(TaskInletAssetReference)
+            .outerjoin(alias_association_table, alias_association_table.c.asset_id == AssetModel.id)
             .group_by(AssetModel.id)
         )
 

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -8835,6 +8835,35 @@ class TestSchedulerJob:
         assert active == [asset1, asset3, asset5]
         assert orphaned == [asset2, asset4]
 
+    def test_asset_orphaning_keeps_alias_materialized_asset_active(self, session):
+        """An asset linked only through an ``AssetAlias`` association must stay active, not orphaned.
+
+        Reproduces #58058: a task with an ``AssetAlias`` outlet materializes a concrete asset at
+        runtime (via ``Metadata``). It has no schedule/outlet/inlet reference — only the alias
+        association — so the orphanage pass used to treat it as orphaned, leaving it out of the
+        Assets tab despite having events and a live alias.
+        """
+        self.job_runner = SchedulerJobRunner(job=Job())
+
+        asset = AssetModel(uri="test://alias_materialized", name="alias_materialized_asset", group="asset")
+        alias = AssetAliasModel(name="materializing_alias", group="asset")
+        asset.aliases.append(alias)
+        session.add_all([asset, alias])
+        session.flush()
+
+        # Referenced only via the alias association, so inactive before the pass.
+        orphaned, active = self._find_assets_activation(session)
+        assert asset in orphaned
+        assert asset not in active
+
+        self.job_runner._update_asset_orphanage(session=session)
+        session.flush()
+
+        # The alias association now counts as a reference, so the asset is activated.
+        orphaned, active = self._find_assets_activation(session)
+        assert asset in active
+        assert asset not in orphaned
+
     def test_asset_orphaning_ignore_orphaned_assets(self, dag_maker, session):
         self.job_runner = SchedulerJobRunner(job=Job())
 


### PR DESCRIPTION
closes: #58058

An asset created at runtime by attaching it to an `AssetAlias` outlet via `Metadata` or `outlet_events` is referenced only through the alias association (`asset_alias_asset`), not the schedule/outlet/inlet reference tables. The scheduler's asset-orphanage pass (`_update_asset_orphanage`) therefore counts it as orphaned and never writes an `AssetActive` row, so the Assets tab — which defaults to `only_active` — never shows it, even though it has events and a live alias.

This counts the alias association as a reference in the orphanage pass, so an asset attached to a live alias is activated like any other.

Repro dag:
```python
"""
Minimal reproduction for https://github.com/apache/airflow/issues/58058.

A task declares an ``AssetAlias`` outlet and, at runtime, materializes a concrete
asset attached to that alias via ``Metadata``. Before the fix the materialized
asset ("materialized_from_alias_58058") never appears in the Assets tab because it
is only linked through the alias association and is therefore treated as orphaned
(never activated). After the fix it should show up like any other asset once the
producer task has run.
"""

from datetime import datetime, timezone

from airflow.providers.standard.operators.python import PythonOperator
from airflow.sdk import Asset, AssetAlias, Metadata, dag

alias = AssetAlias(name="materialized_alias_58058")


@dag(schedule=None, tags=["test", "58058"])
def repro_58058_producer():
    def produce():
        yield Metadata(
            asset=Asset(name="materialized_from_alias_58058", uri="s3://bucket/58058.csv"),
            extra={"ts": datetime.now(tz=timezone.utc).isoformat()},
            alias=alias,
        )

    PythonOperator(task_id="produce", python_callable=produce, outlets=[alias])


repro_58058_producer()
```

Dag has a run (that materializes the alias)

## Before
<img width="1915" height="914" alt="Screenshot 2026-08-14 at 13 36 36" src="https://github.com/user-attachments/assets/f87c42c7-63f5-4137-b154-878fa8cd15d4" />
<img width="1893" height="848" alt="Screenshot 2026-08-14 at 13 36 56" src="https://github.com/user-attachments/assets/ca8e608b-8c5a-4809-aef7-8d721a9a8c05" />


## After
<img width="1917" height="899" alt="Screenshot 2026-08-14 at 15 02 53" src="https://github.com/user-attachments/assets/1f0e16cc-f3ed-4d4c-a2e9-9206b77961c9" />
<img width="1920" height="607" alt="Screenshot 2026-08-14 at 15 03 17" src="https://github.com/user-attachments/assets/87b280bc-9884-4c29-91ae-4335d701586c" />


---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)