### PR TITLE
Show worker pod logs for tasks that failed before writing any log

### DIFF
--- a/airflow-core/src/airflow/utils/log/file_task_handler.py
+++ b/airflow-core/src/airflow/utils/log/file_task_handler.py
@@ -38,6 +38,7 @@ from pydantic import BaseModel, ConfigDict, ValidationError
 from typing_extensions import NotRequired
 
 from airflow.configuration import conf
+from airflow.exceptions import UnknownExecutorException
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.utils.helpers import parse_template_string, render_template
 from airflow.utils.log.log_stream_accumulator import LogStreamAccumulator
@@ -94,6 +95,13 @@ _STATES_WITH_COMPLETED_ATTEMPT = frozenset(
     {
         TaskInstanceState.UP_FOR_RETRY,
         TaskInstanceState.UP_FOR_RESCHEDULE,
+    }
+)
+
+_STATES_WITH_FAILED_ATTEMPT = frozenset(
+    {
+        TaskInstanceState.FAILED,
+        TaskInstanceState.UP_FOR_RETRY,
     }
 )
 
@@ -631,27 +639,40 @@ class FileTaskHandler(logging.Handler):
             # Extend LogSourceInfo
             source_list.extend(sources)
 
-        has_executor_log = False
-        if ti.state == TaskInstanceState.RUNNING:
-            executor = self._get_executor(ti)
-            try:
-                # check for streaming logs first
-                sources, executor_logs = executor.get_streaming_task_log(ti, try_number)
-            except NotImplementedError:
-                # fallback to non-streaming logs if streaming not supported
-                sources, logs = executor.get_task_log(ti, try_number)
-                # make the logs stream-like compatible
-                executor_logs = [_get_compatible_log_stream(logs)]
-
-            if sources:
-                source_list.extend(sources)
-                has_executor_log = True
-
         if not (remote_logs and ti.state not in State.unfinished):
             # when finished, if we have remote logs, no need to check local
             worker_log_full_path = Path(self.local_base, worker_log_rel_path)
             sources, local_logs = self._read_from_local(worker_log_full_path)
             source_list.extend(sources)
+
+        has_executor_log = False
+        # A worker that dies before the task runner starts logging (import error, OOM kill on PID 1)
+        # leaves no local or remote log, so ask the executor for the container log as a last resort.
+        if ti.state == TaskInstanceState.RUNNING or (
+            ti.state in _STATES_WITH_FAILED_ATTEMPT and not (local_logs or remote_logs)
+        ):
+            try:
+                executor = self._get_executor(ti)
+            except UnknownExecutorException:
+                # A finished task can name an executor that was since removed from the config,
+                # which must not stop the rest of its log from being served.
+                logger.debug("Executor %r for task instance %s is no longer configured", ti.executor, ti)
+                executor = None
+
+            if executor is not None:
+                try:
+                    # check for streaming logs first
+                    sources, executor_logs = executor.get_streaming_task_log(ti, try_number)
+                except NotImplementedError:
+                    # fallback to non-streaming logs if streaming not supported
+                    sources, logs = executor.get_task_log(ti, try_number)
+                    # make the logs stream-like compatible
+                    executor_logs = [_get_compatible_log_stream(logs)]
+
+                if sources:
+                    source_list.extend(sources)
+                    has_executor_log = True
+
         if ti.state in (TaskInstanceState.RUNNING, TaskInstanceState.DEFERRED) and not has_executor_log:
             sources, served_logs = self._read_from_logs_server(ti, worker_log_rel_path)
             source_list.extend(sources)

--- a/airflow-core/tests/unit/utils/log/test_file_task_handler.py
+++ b/airflow-core/tests/unit/utils/log/test_file_task_handler.py
@@ -20,6 +20,9 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from airflow.exceptions import UnknownExecutorException
 from airflow.utils.log.file_task_handler import FileTaskHandler
 from airflow.utils.state import TaskInstanceState
 
@@ -236,6 +239,14 @@ class TestFileTaskHandlerExecutorLogs:
         ti.try_number = 1
         return ti
 
+    @staticmethod
+    def _finished_ti(executor_name: str, state: TaskInstanceState) -> MagicMock:
+        ti = MagicMock()
+        ti.executor = executor_name
+        ti.state = state
+        ti.try_number = 1
+        return ti
+
     def test_running_task_prefers_streaming_executor_logs(self):
         """Use executor streaming logs when the executor implements streaming."""
         handler = FileTaskHandler(base_log_folder="")
@@ -294,3 +305,89 @@ class TestFileTaskHandlerExecutorLogs:
             "legacy log",
         ]
         assert metadata == {"end_of_log": False, "log_pos": 1}
+
+    @pytest.mark.parametrize(
+        "state", [TaskInstanceState.FAILED, TaskInstanceState.UP_FOR_RETRY, TaskInstanceState.RUNNING]
+    )
+    def test_reads_executor_logs_when_attempt_left_no_other_logs(self, state):
+        """A worker that dies before writing any log still surfaces the executor's container log."""
+        handler = FileTaskHandler(base_log_folder="")
+        executor = MagicMock()
+        executor.get_streaming_task_log.return_value = (
+            ["Found logs through kube API"],
+            [convert_list_to_stream(["ModuleNotFoundError: No module named 'pandas'"])],
+        )
+        handler.executor_instances = {"KubernetesExecutor": executor}
+        ti = self._finished_ti("KubernetesExecutor", state)
+
+        with (
+            patch.object(handler, "_render_filename", return_value="dag/run/task/1.log"),
+            patch.object(handler, "_read_remote_logs", side_effect=NotImplementedError),
+            patch.object(handler, "_read_from_local", return_value=([], [])),
+            patch.object(handler, "_read_from_logs_server", return_value=([], [])),
+        ):
+            logs, _ = handler._read(ti=ti, try_number=1)
+
+        executor.get_streaming_task_log.assert_called_once_with(ti, 1)
+        assert "ModuleNotFoundError: No module named 'pandas'" in extract_events(logs)
+
+    @pytest.mark.parametrize("state", [TaskInstanceState.SUCCESS, TaskInstanceState.UPSTREAM_FAILED])
+    def test_skips_executor_logs_for_states_without_a_failed_attempt(self, state):
+        """Only a failed attempt falls back to the executor; other finished states must not."""
+        handler = FileTaskHandler(base_log_folder="")
+        executor = MagicMock()
+        handler.executor_instances = {"KubernetesExecutor": executor}
+        ti = self._finished_ti("KubernetesExecutor", state)
+
+        with (
+            patch.object(handler, "_render_filename", return_value="dag/run/task/1.log"),
+            patch.object(handler, "_read_remote_logs", side_effect=NotImplementedError),
+            patch.object(handler, "_read_from_local", return_value=([], [])),
+            patch.object(handler, "_read_from_logs_server", return_value=([], [])),
+        ):
+            handler._read(ti=ti, try_number=1)
+
+        executor.get_streaming_task_log.assert_not_called()
+        executor.get_task_log.assert_not_called()
+
+    def test_unknown_executor_does_not_break_log_reading(self):
+        """A finished task naming an executor that was since removed still serves its other logs."""
+        handler = FileTaskHandler(base_log_folder="")
+        ti = self._finished_ti("RemovedExecutor", TaskInstanceState.FAILED)
+
+        with (
+            patch.object(handler, "_render_filename", return_value="dag/run/task/1.log"),
+            patch.object(handler, "_read_remote_logs", side_effect=NotImplementedError),
+            patch.object(handler, "_read_from_local", return_value=([], [])),
+            patch.object(
+                handler,
+                "_read_from_logs_server",
+                return_value=(["served source"], [convert_list_to_stream(["served log"])]),
+            ),
+            patch.object(handler, "_get_executor", side_effect=UnknownExecutorException("RemovedExecutor")),
+        ):
+            logs, _ = handler._read(ti=ti, try_number=1)
+
+        assert "served log" in extract_events(logs)
+
+    def test_skips_executor_logs_for_failed_task_that_already_has_logs(self):
+        """The executor is a last resort, so an existing worker log must not trigger an API call."""
+        handler = FileTaskHandler(base_log_folder="")
+        executor = MagicMock()
+        handler.executor_instances = {"KubernetesExecutor": executor}
+        ti = self._finished_ti("KubernetesExecutor", TaskInstanceState.FAILED)
+
+        with (
+            patch.object(handler, "_render_filename", return_value="dag/run/task/1.log"),
+            patch.object(handler, "_read_remote_logs", side_effect=NotImplementedError),
+            patch.object(
+                handler,
+                "_read_from_local",
+                return_value=(["local source"], [convert_list_to_stream(["local log"])]),
+            ),
+            patch.object(handler, "_read_from_logs_server", return_value=([], [])),
+        ):
+            handler._read(ti=ti, try_number=1)
+
+        executor.get_streaming_task_log.assert_not_called()
+        executor.get_task_log.assert_not_called()

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/log_handlers/test_log_handlers.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/log_handlers/test_log_handlers.py
@@ -76,7 +76,9 @@ class TestFileTaskLogHandler:
     @mock.patch(
         "airflow.providers.cncf.kubernetes.executors.kubernetes_executor.KubernetesExecutor.get_streaming_task_log"
     )
-    @pytest.mark.parametrize("state", [TaskInstanceState.RUNNING, TaskInstanceState.SUCCESS])
+    @pytest.mark.parametrize(
+        "state", [TaskInstanceState.RUNNING, TaskInstanceState.SUCCESS, TaskInstanceState.FAILED]
+    )
     @pytest.mark.usefixtures("clean_executor_loader")
     def test__read_for_k8s_executor(self, mock_k8s_get_streaming_task_log, create_task_instance, state):
         """Test for k8s executor, the log is read from get_streaming_task_log method."""
@@ -95,10 +97,11 @@ class TestFileTaskLogHandler:
             reload(executor_loader)
             fth = FileTaskHandler("")
             fth._read(ti=ti, try_number=2)
-        if state == TaskInstanceState.RUNNING:
-            mock_k8s_get_streaming_task_log.assert_called_once_with(ti, 2)
-        else:
+        if state == TaskInstanceState.SUCCESS:
             mock_k8s_get_streaming_task_log.assert_not_called()
+        else:
+            # A failed attempt with no worker log falls back to the pod log.
+            mock_k8s_get_streaming_task_log.assert_called_once_with(ti, 2)
 
     @pytest.mark.parametrize(
         ("pod_override", "namespace_to_call"),

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/log_handlers/test_log_handlers.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/log_handlers/test_log_handlers.py
@@ -73,7 +73,9 @@ class TestFileTaskLogHandler:
     @mock.patch(
         "airflow.providers.cncf.kubernetes.executors.kubernetes_executor.KubernetesExecutor.get_streaming_task_log"
     )
-    @pytest.mark.parametrize("state", [TaskInstanceState.RUNNING, TaskInstanceState.SUCCESS])
+    @pytest.mark.parametrize(
+        "state", [TaskInstanceState.RUNNING, TaskInstanceState.SUCCESS, TaskInstanceState.FAILED]
+    )
     @pytest.mark.usefixtures("clean_executor_loader")
     def test__read_for_k8s_executor(self, mock_k8s_get_streaming_task_log, create_task_instance, state):
         """Test for k8s executor, the log is read from get_streaming_task_log method."""
@@ -92,10 +94,11 @@ class TestFileTaskLogHandler:
             reload(executor_loader)
             fth = FileTaskHandler("")
             fth._read(ti=ti, try_number=2)
-        if state == TaskInstanceState.RUNNING:
-            mock_k8s_get_streaming_task_log.assert_called_once_with(ti, 2)
-        else:
+        if state == TaskInstanceState.SUCCESS:
             mock_k8s_get_streaming_task_log.assert_not_called()
+        else:
+            # A failed attempt with no worker log falls back to the pod log.
+            mock_k8s_get_streaming_task_log.assert_called_once_with(ti, 2)
 
     @pytest.mark.parametrize(
         ("pod_override", "namespace_to_call"),

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/log_handlers/test_log_handlers.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/log_handlers/test_log_handlers.py
@@ -42,7 +42,7 @@ from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.db import clear_db_dag_bundles, clear_db_dags, clear_db_runs
 from tests_common.test_utils.taskinstance import create_task_instance, run_task_instance
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_4_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
     from airflow.utils.types import DagRunTriggeredByType
@@ -74,7 +74,18 @@ class TestFileTaskLogHandler:
         "airflow.providers.cncf.kubernetes.executors.kubernetes_executor.KubernetesExecutor.get_streaming_task_log"
     )
     @pytest.mark.parametrize(
-        "state", [TaskInstanceState.RUNNING, TaskInstanceState.SUCCESS, TaskInstanceState.FAILED]
+        "state",
+        [
+            TaskInstanceState.RUNNING,
+            TaskInstanceState.SUCCESS,
+            pytest.param(
+                TaskInstanceState.FAILED,
+                marks=pytest.mark.skipif(
+                    not AIRFLOW_V_3_4_PLUS,
+                    reason="Falling back to the executor log for a failed attempt requires Airflow 3.4+",
+                ),
+            ),
+        ],
     )
     @pytest.mark.usefixtures("clean_executor_loader")
     def test__read_for_k8s_executor(self, mock_k8s_get_streaming_task_log, create_task_instance, state):

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/log_handlers/test_log_handlers.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/log_handlers/test_log_handlers.py
@@ -42,7 +42,11 @@ from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.db import clear_db_dag_bundles, clear_db_dags, clear_db_runs
 from tests_common.test_utils.taskinstance import create_task_instance, run_task_instance
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
+from tests_common.test_utils.version_compat import (
+    AIRFLOW_V_3_0_PLUS,
+    AIRFLOW_V_3_1_PLUS,
+    AIRFLOW_V_3_4_PLUS,
+)
 
 if AIRFLOW_V_3_0_PLUS:
     from airflow.utils.types import DagRunTriggeredByType
@@ -77,7 +81,18 @@ class TestFileTaskLogHandler:
         "airflow.providers.cncf.kubernetes.executors.kubernetes_executor.KubernetesExecutor.get_streaming_task_log"
     )
     @pytest.mark.parametrize(
-        "state", [TaskInstanceState.RUNNING, TaskInstanceState.SUCCESS, TaskInstanceState.FAILED]
+        "state",
+        [
+            TaskInstanceState.RUNNING,
+            TaskInstanceState.SUCCESS,
+            pytest.param(
+                TaskInstanceState.FAILED,
+                marks=pytest.mark.skipif(
+                    not AIRFLOW_V_3_4_PLUS,
+                    reason="Falling back to the executor log for a failed attempt requires Airflow 3.4+",
+                ),
+            ),
+        ],
     )
     @pytest.mark.usefixtures("clean_executor_loader")
     def test__read_for_k8s_executor(self, mock_k8s_get_streaming_task_log, create_task_instance, state):


### PR DESCRIPTION
A Kubernetes worker pod can fail during task-runner startup before writing a log. The UI is blank though the pod contains the traceback.

Fallback asks the executor only when an unsuccessful attempt has no logs. Tasks with logs and successful tasks are unchanged.

Fixes https://github.com/apache/airflow/issues/66795

# Testing Done

Kind v1.30.13 ran the crashed pod through the log handler before and after.

```console
$ BASE=upstream/main R=dev/repro_66795.py
$ F=$(git diff --name-only "$BASE"...@ | head -1); P=${F%%/*}
$ git checkout "$BASE" -- "$F"
$ uv run --project "$P" python "$R"
pod phase=Failed
container exit_code=1 reason='Error' message=None
RESULT: pod traceback in task log = False

$ git checkout @ -- "$F"
$ uv run --project "$P" python "$R"
Found logs through kube API
ModuleNotFoundError: No module named 'pandas_does_not_exist'
RESULT: pod traceback in task log = True
```

<details>
<summary>Reproducer</summary>

```python
import tempfile, time
from unittest.mock import MagicMock

from kubernetes import client, config
from airflow.utils.log.file_task_handler import FileTaskHandler
from airflow.utils.state import TaskInstanceState

config.load_kube_config()
api = client.CoreV1Api()
name = f"repro-66795-{int(time.time())}"
labels = {
    "dag_id": "repro_66795", "task_id": "crashing_task", "run_id": "manual__1",
    "try_number": "1", "kubernetes_executor": "True", "airflow-worker": "1",
}
pod = client.V1Pod(
    metadata=client.V1ObjectMeta(name=name, labels=labels),
    spec=client.V1PodSpec(
        restart_policy="Never",
        containers=[client.V1Container(
            name="base", image="python:3.12-slim",
            command=["python", "-c", "import pandas_does_not_exist"],
        )],
    ),
)
api.create_namespaced_pod("default", pod)
while api.read_namespaced_pod(name, "default").status.phase != "Failed":
    time.sleep(2)
ti = MagicMock(
    dag_id="repro_66795", task_id="crashing_task", run_id="manual__1",
    map_index=-1, try_number=1, queued_by_job_id="1",
    executor="KubernetesExecutor", executor_config={}, hostname=name,
    state=TaskInstanceState.FAILED,
)
handler = FileTaskHandler(tempfile.mkdtemp())
handler._render_filename = lambda *_: "unused"
handler._read_from_logs_server = lambda *_: ([], [])
events = [message.event for message in handler._read(ti=ti, try_number=1)[0]]
print(*events, sep="\n")
print(f"RESULT: pod traceback in task log = {any('ModuleNotFoundError' in event for event in events)}")
```

</details>
