### PR TITLE
[KubernetesPodOperator] Add on_deferrable_finish_log_tail_lines param

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -272,6 +272,10 @@ class KubernetesPodOperator(BaseOperator):
     :param logging_interval: max time in seconds that task should be in deferred state before
         resuming to fetch the latest logs. If ``None``, then the task will remain in deferred state until pod
         is done, and no logs will be visible until that time.
+    :param on_deferrable_finish_log_tail_lines: only write the last N lines of the container log
+        to the task log in the single bulk log fetch after the pod finishes (deferrable mode).
+        Does not affect log streaming (non-deferrable mode) or the periodic log relay
+        (``logging_interval``). If ``None`` (default), the full container log is written.
     :param trigger_kwargs: additional keyword parameters passed to the trigger
     :param container_name_log_prefix_enabled: if True, will prefix container name to each log line.
         Default to True.
@@ -394,6 +398,7 @@ class KubernetesPodOperator(BaseOperator):
         ) = None,
         progress_callback: Callable[[str], None] | None = None,
         logging_interval: int | None = None,
+        on_deferrable_finish_log_tail_lines: int | None = None,
         trigger_kwargs: dict | None = None,
         container_name_log_prefix_enabled: bool = True,
         log_formatter: Callable[[str, str], str] | None = None,
@@ -503,6 +508,7 @@ class KubernetesPodOperator(BaseOperator):
         self.termination_message_policy = termination_message_policy
         self.active_deadline_seconds = active_deadline_seconds
         self.logging_interval = logging_interval
+        self.on_deferrable_finish_log_tail_lines = on_deferrable_finish_log_tail_lines
         self.trigger_kwargs = trigger_kwargs
 
         self._config_dict: dict | None = None  # TODO: remove it when removing convert_config_file_to_dict
@@ -1152,7 +1158,12 @@ class KubernetesPodOperator(BaseOperator):
             if event["status"] in ("error", "failed", "timeout", "success"):
                 if self.get_logs:
                     try:
-                        self._write_logs(self.pod, follow=follow, since_time=last_log_time)
+                        self._write_logs(
+                            self.pod,
+                            follow=follow,
+                            since_time=last_log_time,
+                            tail_lines=self.on_deferrable_finish_log_tail_lines,
+                        )
                     except (HTTPError, ApiException) as e:
                         self.log.warning(
                             "Reading of logs interrupted with error %r. "
@@ -1261,7 +1272,13 @@ class KubernetesPodOperator(BaseOperator):
         before_sleep=tenacity.before_sleep_log(log, logging.WARNING),
         reraise=True,
     )
-    def _write_logs(self, pod: k8s.V1Pod, follow: bool = False, since_time: DateTime | None = None) -> None:
+    def _write_logs(
+        self,
+        pod: k8s.V1Pod,
+        follow: bool = False,
+        since_time: DateTime | None = None,
+        tail_lines: int | None = None,
+    ) -> None:
         since_seconds = None
         if since_time:
             try:
@@ -1282,6 +1299,7 @@ class KubernetesPodOperator(BaseOperator):
             follow=follow,
             timestamps=False,
             since_seconds=since_seconds,
+            tail_lines=tail_lines,
             _preload_content=False,
         )
         for raw_line in logs:


### PR DESCRIPTION
## AI Usage
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Model: Fable 5

Used AI to assist in writing code + PR summary, but hand verified the results and the PR summary is correct. Can provide any more detail as needed.

## Why

Supporting an explicit max tail lines will help improve UI performance for high-volume jobs. We do want _some logs_, on failure we print the error near the end, so that is helpful. For the rest we have a separate log-ingestion solution.

More context (below is AI-generated, but accurate to my knowledge):

In deferrable mode, when the trigger fires its terminal event, `trigger_reentry` calls `_write_logs`, which re-emits the **entire pod log** into the task log in one bulk fetch. For chatty workloads this is problematic:

- Most production setups already ship pod stdout to a log aggregator directly from the node; the bulk replay double-ingests every line (and stores a second copy in remote task logs).
- The "full log" is illusory anyway: the kubelet rotates container logs (`containerLogMaxSize`, default 10Mi), and the pod logs API only serves the current file — so long-running chatty pods already get a silent, size-based, node-config-dependent tail today.



## What

Adds `on_deferrable_finish_log_tail_lines: int | None = None` to `KubernetesPodOperator`:

- `None` (default) preserves existing behavior exactly.
- When set, `_write_logs` passes `tail_lines` through to `read_namespaced_pod_log`, so only the last N lines are written to the task log in the single bulk fetch after the pod finishes.
- Deliberately scoped to that one fetch: it does **not** affect live log streaming (non-deferrable mode) or the periodic `logging_interval` relay, where tailing each window would silently drop lines. `_write_logs` takes `tail_lines` as a plain parameter, so call sites stay explicit.
- When `logging_interval` is set, the finish-time fetch already passes `since_time`; the Kubernetes API applies both (time window first, tail within it), which keeps the semantics consistent.

Happy to adjust the parameter name if reviewers prefer something shorter.

## Testing

Verified in a production-like staging deployment (Airflow 3.3.0, provider vendored with this patch): a deferrable pod task with `on_deferrable_finish_log_tail_lines=5` wrote exactly the last 5 lines of the container log after resume, with defer/resume/XCom/cleanup behavior unchanged.