### PR TITLE
Fail Glue job tasks promptly when a verbose job run errors

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/glue.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/glue.py
@@ -145,7 +145,7 @@ class GlueJobCompleteTrigger(AwsBaseWaiterTrigger):
                     return
 
                 # STOPPED means the run was cancelled before it produced its output, not that it succeeded.
-                if job_run_state in ("FAILED", "TIMEOUT", "STOPPED"):
+                if job_run_state in ("FAILED", "TIMEOUT", "STOPPED", "ERROR"):
                     yield TriggerEvent(
                         {
                             "status": "error",

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_glue.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_glue.py
@@ -171,7 +171,7 @@ class TestGlueJobTrigger:
         assert logs_client.get_log_events.call_count >= 2
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("job_run_state", ["FAILED", "TIMEOUT", "STOPPED"])
+    @pytest.mark.parametrize("job_run_state", ["FAILED", "TIMEOUT", "STOPPED", "ERROR"])
     @mock.patch.object(AwsLogsHook, "get_async_conn")
     @mock.patch.object(GlueJobHook, "get_async_conn")
     async def test_verbose_run_failure_states(self, mock_glue_conn, mock_logs_conn, job_run_state):


### PR DESCRIPTION
## Summary

A Glue job in `ERROR` is already finished and cannot reach `SUCCEEDED`, but the verbose polling loop continues until it exhausts its attempts. With the default settings, this means waiting up to 75 minutes for `GlueJobOperator` or two hours for `GlueJobSensor` before reporting `waiter exceeded max attempts`, which looks like a timeout instead of the actual job failure.

The `job_complete` waiter used by the non-verbose path already treats `ERROR` as a failure, so this change makes the two deferrable paths consistent.

## Scope

Stacked on #71495, whose commit is included here until it merges.

`EXPIRED` is intentionally out of scope. It is terminal for `GlueJobOperator`, but the waiter does not currently handle it either. Handling it here would make the verbose path behave differently from the non-verbose path.

Raised during review of #71495.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)