### PR TITLE
Move SendGrid and SES email backend setup docs to their providers

### DIFF
--- a/airflow-core/docs/howto/email-config.rst
+++ b/airflow-core/docs/howto/email-config.rst
@@ -93,7 +93,5 @@ community provider to send email through a third-party service's API. To use one
 provider distribution, set ``email_backend`` to the dotted path of its ``send_email`` function, and set
 ``email_conn_id`` to a connection holding the credentials it needs.
 
-Community providers currently offering an email backend:
-
-* **SendGrid** — see :doc:`apache-airflow-providers-sendgrid:email-backend` for setup instructions.
-* **Amazon SES** — see :doc:`apache-airflow-providers-amazon:email-backend` for setup instructions.
+The list of email backends provided by community-managed providers is available in
+:doc:`apache-airflow-providers:core-extensions/email-backends`.

--- a/airflow-core/docs/howto/email-config.rst
+++ b/airflow-core/docs/howto/email-config.rst
@@ -50,12 +50,17 @@ Equivalent environment variables look like:
 
   AIRFLOW__EMAIL__FROM_EMAIL="John Doe <johndoe@example.com>"
 
+By default, ``email_backend`` is set to ``airflow.utils.email.send_email_smtp``, which sends email over SMTP.
 
 To configure SMTP settings, checkout the :ref:`SMTP <config:smtp>` section in the standard configuration.
 If you do not want to store the SMTP credentials in the config or in the environment variables, you can create a
 connection called ``smtp_default`` of ``Email`` type, or choose a custom connection name and set the ``email_conn_id`` with its name in
 the configuration & store SMTP username-password in it. Other SMTP settings like host, port etc always gets picked up
 from the configuration only. The connection can be of any type (for example 'HTTP connection').
+
+.. image:: ../img/ui-dark/email_connection.png
+    :align: center
+    :alt: create email connection
 
 If you want to check which email backend is currently set, you can use ``airflow config get-value email email_backend`` command as in
 the example below.
@@ -80,119 +85,15 @@ For example a ``html_content_template`` file could look like this:
 .. note::
     For more information on setting the configuration, see :doc:`set-config`
 
-.. _email-configuration-sendgrid:
+Alternative email backends
+---------------------------
 
-Send email using SendGrid
--------------------------
+Instead of sending email over SMTP, you can point ``email_backend`` at an implementation provided by a
+community provider to send email through a third-party service's API. To use one, install the relevant
+provider distribution, set ``email_backend`` to the dotted path of its ``send_email`` function, and set
+``email_conn_id`` to a connection holding the credentials it needs.
 
-Using Default SMTP
-^^^^^^^^^^^^^^^^^^
+Community providers currently offering an email backend:
 
-You can use the default Airflow SMTP backend to send email with SendGrid
-
-  .. code-block:: ini
-
-     [smtp]
-     smtp_host=smtp.sendgrid.net
-     smtp_starttls=False
-     smtp_ssl=False
-     smtp_port=587
-     smtp_mail_from=<your-from-email>
-
-Equivalent environment variables looks like
-
-  .. code-block::
-
-     AIRFLOW__SMTP__SMTP_HOST=smtp.sendgrid.net
-     AIRFLOW__SMTP__SMTP_STARTTLS=False
-     AIRFLOW__SMTP__SMTP_SSL=False
-     AIRFLOW__SMTP__SMTP_PORT=587
-     AIRFLOW__SMTP__SMTP_MAIL_FROM=<your-from-email>
-
-
-Using SendGrid Provider
-^^^^^^^^^^^^^^^^^^^^^^^
-
-Airflow can be configured to send e-mail using `SendGrid <https://sendgrid.com/>`__.
-
-Follow the steps below to enable it:
-
-1. Setup your SendGrid account, The SMTP and copy username and API Key.
-
-2. Include ``sendgrid`` provider as part of your Airflow installation, e.g.,
-
-  .. code-block:: bash
-
-     pip install 'apache-airflow[sendgrid]' --constraint ...
-
-or
-  .. code-block:: bash
-
-     pip install 'apache-airflow-providers-sendgrid' --constraint ...
-
-
-3. Update ``email_backend`` property in ``[email]`` section in ``airflow.cfg``, i.e.
-
-   .. code-block:: ini
-
-      [email]
-      email_backend = airflow.providers.sendgrid.utils.emailer.send_email
-      email_conn_id = sendgrid_default
-      from_email = "hello@eg.com"
-
-   Equivalent environment variables looks like
-
-   .. code-block::
-
-      AIRFLOW__EMAIL__EMAIL_BACKEND=airflow.providers.sendgrid.utils.emailer.send_email
-      AIRFLOW__EMAIL__EMAIL_CONN_ID=sendgrid_default
-      SENDGRID_MAIL_FROM=hello@thelearning.dev
-
-4. Create a connection called ``sendgrid_default``, or choose a custom connection
-   name and set it in ``email_conn_id`` of  'Email' type. Only login and password
-   are used from the connection.
-
-
-.. image:: ../img/ui-dark/email_connection.png
-    :align: center
-    :alt: create email connection
-
-.. note:: The callbacks for success, failure and retry will use the same configuration to send the email
-
-
-.. _email-configuration-ses:
-
-Send email using AWS SES
-------------------------
-
-Airflow can be configured to send e-mail using `AWS SES <https://aws.amazon.com/ses/>`__.
-
-Follow the steps below to enable it:
-
-1. Include ``amazon`` subpackage as part of your Airflow installation:
-
-  .. code-block:: ini
-
-     pip install 'apache-airflow[amazon]'
-
-2. Update ``email_backend`` property in ``[email]`` section in ``airflow.cfg``:
-
-   .. code-block:: ini
-
-      [email]
-      email_backend = airflow.providers.amazon.aws.utils.emailer.send_email
-      email_conn_id = aws_default
-      from_email = From email <email@example.com>
-
-   Equivalent environment variables looks like
-
-   .. code-block::
-
-      AIRFLOW__EMAIL__EMAIL_BACKEND=airflow.providers.amazon.aws.utils.emailer.send_email
-      AIRFLOW__EMAIL__EMAIL_CONN_ID=aws_default
-      AIRFLOW__EMAIL__FROM_EMAIL=email@example.com
-
-Note that for SES, you must configure from_email to the valid email that can send messages from SES.
-
-3. Create a connection called ``aws_default``, or choose a custom connection
-   name and set it in ``email_conn_id``. The type of connection should be ``Amazon Web Services``.
+* **SendGrid** — see :doc:`apache-airflow-providers-sendgrid:email-backend` for setup instructions.
+* **Amazon SES** — see :doc:`apache-airflow-providers-amazon:email-backend` for setup instructions.

--- a/airflow-core/src/airflow/provider.yaml.schema.json
+++ b/airflow-core/src/airflow/provider.yaml.schema.json
@@ -590,6 +590,13 @@
                 "type": "string"
             }
         },
+        "email-backends": {
+            "type": "array",
+            "description": "Email backend function names",
+            "items": {
+                "type": "string"
+            }
+        },
         "auth-managers": {
             "type": "array",
             "description": "Auth managers class names",

--- a/airflow-core/src/airflow/provider_info.schema.json
+++ b/airflow-core/src/airflow/provider_info.schema.json
@@ -324,6 +324,13 @@
                 "type": "string"
             }
         },
+        "email-backends": {
+            "type": "array",
+            "description": "Email backend function names",
+            "items": {
+                "type": "string"
+            }
+        },
         "logging": {
             "type": "array",
             "description": "Logging Task Handlers class names",

--- a/contributing-docs/12_provider_distributions.rst
+++ b/contributing-docs/12_provider_distributions.rst
@@ -89,8 +89,9 @@ This file contains:
 * description of the distribution that is available in the documentation
 * list of versions of distribution that have been released so far
 * list of integrations, operators, hooks, sensors, transfers provided by the provider (useful for documentation generation)
-* list of connection types, extra-links, secret backends, auth backends, and logging handlers (useful to both
-  register them as they are needed by Airflow and to include them in documentation automatically).
+* list of connection types, extra-links, secret backends, auth backends, email backends, and logging
+  handlers (useful to both register them as they are needed by Airflow and to include them in
+  documentation automatically).
 
 Note that the ``provider.yaml`` file is regenerated automatically when the provider is released so you should
 not modify it - except updating dependencies, as your changes will be lost.

--- a/dev/breeze/tests/test_packages.py
+++ b/dev/breeze/tests/test_packages.py
@@ -376,6 +376,7 @@ def test_get_provider_info_dict():
     assert len(provider_info_dict["connection-types"]) > 3
     assert len(provider_info_dict["notifications"]) > 2
     assert len(provider_info_dict["secrets-backends"]) > 1
+    assert len(provider_info_dict["email-backends"]) > 0
     assert len(provider_info_dict["logging"]) > 1
     assert len(provider_info_dict["config"].keys()) > 1
     assert len(provider_info_dict["executors"]) > 0

--- a/devel-common/src/sphinx_exts/operators_and_hooks_ref.py
+++ b/devel-common/src/sphinx_exts/operators_and_hooks_ref.py
@@ -402,6 +402,19 @@ class LoggingDirective(BaseJinjaReferenceDirective):
         )
 
 
+class EmailBackendsDirective(BaseJinjaReferenceDirective):
+    """Generate list of email backends"""
+
+    def render_content(
+        self, *, tags: set[str] | None, header_separator: str = DEFAULT_HEADER_SEPARATOR
+    ) -> str:
+        return _common_render_list_content(
+            header_separator=header_separator,
+            resource_type="email-backends",
+            template="email-backends.rst.jinja2",
+        )
+
+
 class AuthConfigurations(BaseJinjaReferenceDirective):
     """Generate list of configurations"""
 
@@ -553,6 +566,7 @@ def setup(app):
     app.add_directive("operators-hooks-ref", OperatorsHooksReferenceDirective)
     app.add_directive("transfers-ref", TransfersReferenceDirective)
     app.add_directive("airflow-logging", LoggingDirective)
+    app.add_directive("airflow-email-backends", EmailBackendsDirective)
     app.add_directive("airflow-configurations", AuthConfigurations)
     app.add_directive("airflow-secrets-backends", SecretsBackendDirective)
     app.add_directive("airflow-connections", ConnectionsDirective)
@@ -621,6 +635,19 @@ def secret_backends(header_separator: str):
             header_separator=header_separator,
             resource_type="secrets-backends",
             template="secret_backend.rst.jinja2",
+        )
+    )
+
+
+@cli.command()
+@option_header_separator
+def email_backends(header_separator: str):
+    """Renders Email Backends content"""
+    print(
+        _common_render_list_content(
+            header_separator=header_separator,
+            resource_type="email-backends",
+            template="email-backends.rst.jinja2",
         )
     )
 

--- a/devel-common/src/sphinx_exts/templates/email-backends.rst.jinja2
+++ b/devel-common/src/sphinx_exts/templates/email-backends.rst.jinja2
@@ -1,0 +1,29 @@
+{#
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+#}
+{%for provider, provider_dict in items.items() %}
+{{ provider_dict['name'] }}
+{{ header_separator * (provider_dict['name']|length) }}
+
+:doc:`{{ provider }}:email-backend`
+
+{% for backend in provider_dict['email-backends'] -%}
+- :func:`~{{ backend }}`
+{% endfor -%}
+
+{% endfor %}

--- a/providers-summary-docs/core-extensions/email-backends.rst
+++ b/providers-summary-docs/core-extensions/email-backends.rst
@@ -1,0 +1,34 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Email backends
+---------------
+
+This is a summary of all Apache Airflow Community provided implementations of email backends
+exposed via community-managed providers.
+
+Airflow can send email (for example, task success/failure/retry callbacks) through a pluggable
+``email_backend`` instead of the default SMTP implementation, letting a provider send that email
+through a third-party service's API.
+
+You can read about the general email configuration mechanism in
+:doc:`apache-airflow:howto/email-config` and here you can see the email backends
+provided by the community-managed providers:
+
+.. airflow-email-backends::
+   :tags: None
+   :header-separator: "

--- a/providers-summary-docs/index.rst
+++ b/providers-summary-docs/index.rst
@@ -128,6 +128,17 @@ You can see all the notifications available via community-managed providers in
 :doc:`/core-extensions/notifications`.
 
 
+Email backends
+''''''''''''''
+
+Airflow can send email (for example, task success/failure/retry callbacks) through a pluggable
+``email_backend`` instead of the default SMTP implementation. Providers can add email backends that
+send that email through a third-party service's API.
+
+You can see all the email backends available via community-managed providers in
+:doc:`/core-extensions/email-backends`.
+
+
 Installing and upgrading providers
 ----------------------------------
 

--- a/providers/amazon/docs/email-backend.rst
+++ b/providers/amazon/docs/email-backend.rst
@@ -1,0 +1,62 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+.. _email-configuration-ses:
+
+Send email using AWS SES
+==========================
+
+Airflow can be configured to send e-mail using `AWS SES <https://aws.amazon.com/ses/>`__ as the
+``email_backend``, so that task callback emails (success, failure, retry) go out through SES instead
+of SMTP. See :doc:`apache-airflow:howto/email-config` for the general Airflow email configuration this
+page builds on.
+
+.. note::
+
+   If you instead want to send an email as a Dag task, use the
+   :ref:`SesEmailOperator <howto/operator:SesEmailOperator>` documented in :doc:`operators/ses`.
+
+Follow the steps below to enable it:
+
+1. Install the ``amazon`` provider as part of your Airflow installation:
+
+   .. code-block:: bash
+
+      pip install 'apache-airflow[amazon]'
+
+2. Update the ``[email]`` section in ``airflow.cfg``:
+
+   .. code-block:: ini
+
+      [email]
+      email_backend = airflow.providers.amazon.aws.utils.emailer.send_email
+      email_conn_id = aws_default
+      from_email = From email <email@example.com>
+
+   Equivalent environment variables look like:
+
+   .. code-block:: sh
+
+      AIRFLOW__EMAIL__EMAIL_BACKEND=airflow.providers.amazon.aws.utils.emailer.send_email
+      AIRFLOW__EMAIL__EMAIL_CONN_ID=aws_default
+      AIRFLOW__EMAIL__FROM_EMAIL=email@example.com
+
+   ``from_email`` is required and must be a sender address verified with SES.
+
+3. Create a connection called ``aws_default``, or choose a custom connection name and set it in
+   ``email_conn_id``, of type ``Amazon Web Services``. See :doc:`apache-airflow:howto/connection` for
+   how to create a connection.

--- a/providers/amazon/docs/index.rst
+++ b/providers/amazon/docs/index.rst
@@ -35,6 +35,7 @@
 
     Bundles <bundles/index>
     Connection types <connections/index>
+    Email backend <email-backend>
     Notifications <notifications/index>
     Operators <operators/index>
     Transfers <transfer/index>

--- a/providers/amazon/provider.yaml
+++ b/providers/amazon/provider.yaml
@@ -1129,6 +1129,9 @@ secrets-backends:
   - airflow.providers.amazon.aws.secrets.secrets_manager.SecretsManagerBackend
   - airflow.providers.amazon.aws.secrets.systems_manager.SystemsManagerParameterStoreBackend
 
+email-backends:
+  - airflow.providers.amazon.aws.utils.emailer.send_email
+
 logging:
   - airflow.providers.amazon.aws.log.s3_task_handler.S3TaskHandler
   - airflow.providers.amazon.aws.log.cloudwatch_task_handler.CloudwatchTaskHandler

--- a/providers/amazon/src/airflow/providers/amazon/aws/utils/emailer.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/utils/emailer.py
@@ -38,7 +38,12 @@ def send_email(
     custom_headers: dict[str, Any] | None = None,
     **kwargs,
 ) -> None:
-    """Email backend for SES."""
+    """
+    Email backend for SES.
+
+    .. note::
+        For more information, see :ref:`email-configuration-ses`
+    """
     if from_email is None:
         raise RuntimeError("The `from_email' configuration has to be set for the SES emailer.")
     hook = SesHook(aws_conn_id=conn_id)

--- a/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
+++ b/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
@@ -1254,6 +1254,7 @@ def get_provider_info():
             "airflow.providers.amazon.aws.secrets.secrets_manager.SecretsManagerBackend",
             "airflow.providers.amazon.aws.secrets.systems_manager.SystemsManagerParameterStoreBackend",
         ],
+        "email-backends": ["airflow.providers.amazon.aws.utils.emailer.send_email"],
         "logging": [
             "airflow.providers.amazon.aws.log.s3_task_handler.S3TaskHandler",
             "airflow.providers.amazon.aws.log.cloudwatch_task_handler.CloudwatchTaskHandler",

--- a/providers/sendgrid/docs/email-backend.rst
+++ b/providers/sendgrid/docs/email-backend.rst
@@ -1,0 +1,92 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+.. _email-configuration-sendgrid:
+
+Send email using SendGrid
+==========================
+
+Airflow can be configured to send e-mail using `SendGrid <https://sendgrid.com/>`__, either through
+its SMTP relay or through this provider's API-based backend. See :doc:`apache-airflow:howto/email-config`
+for the general Airflow email configuration this page builds on.
+
+Using Default SMTP
+-------------------
+
+You can use the default Airflow SMTP backend to send email with SendGrid without installing this provider:
+
+.. code-block:: ini
+
+   [smtp]
+   smtp_host=smtp.sendgrid.net
+   smtp_starttls=False
+   smtp_ssl=False
+   smtp_port=587
+   smtp_mail_from=<your-from-email>
+
+Equivalent environment variables look like:
+
+.. code-block:: sh
+
+   AIRFLOW__SMTP__SMTP_HOST=smtp.sendgrid.net
+   AIRFLOW__SMTP__SMTP_STARTTLS=False
+   AIRFLOW__SMTP__SMTP_SSL=False
+   AIRFLOW__SMTP__SMTP_PORT=587
+   AIRFLOW__SMTP__SMTP_MAIL_FROM=<your-from-email>
+
+Using the SendGrid Provider
+-----------------------------
+
+To send email through SendGrid's API instead, follow the steps below:
+
+1. Set up your SendGrid account, then locate your SMTP username and API Key.
+
+2. Install the ``sendgrid`` provider as part of your Airflow installation, e.g.:
+
+   .. code-block:: bash
+
+      pip install 'apache-airflow[sendgrid]' --constraint ...
+
+   or
+
+   .. code-block:: bash
+
+      pip install 'apache-airflow-providers-sendgrid' --constraint ...
+
+3. Update the ``[email]`` section in ``airflow.cfg``:
+
+   .. code-block:: ini
+
+      [email]
+      email_backend = airflow.providers.sendgrid.utils.emailer.send_email
+      email_conn_id = sendgrid_default
+      from_email = "hello@eg.com"
+
+   Equivalent environment variables look like:
+
+   .. code-block:: sh
+
+      AIRFLOW__EMAIL__EMAIL_BACKEND=airflow.providers.sendgrid.utils.emailer.send_email
+      AIRFLOW__EMAIL__EMAIL_CONN_ID=sendgrid_default
+      SENDGRID_MAIL_FROM=hello@thelearning.dev
+
+4. Create a connection called ``sendgrid_default``, or choose a custom connection name and set it in
+   ``email_conn_id``, of ``Email`` type. Only the login and password fields are used from the connection;
+   set the password field to your SendGrid API Key. See :doc:`apache-airflow:howto/connection` for how
+   to create a connection.
+
+.. note:: The callbacks for success, failure and retry will use the same configuration to send the email.

--- a/providers/sendgrid/docs/index.rst
+++ b/providers/sendgrid/docs/index.rst
@@ -32,6 +32,13 @@
 .. toctree::
     :hidden:
     :maxdepth: 1
+    :caption: Guides
+
+    Email backend <email-backend>
+
+.. toctree::
+    :hidden:
+    :maxdepth: 1
     :caption: References
 
     Python API <_api/airflow/providers/sendgrid/index>

--- a/providers/sendgrid/provider.yaml
+++ b/providers/sendgrid/provider.yaml
@@ -24,6 +24,10 @@ description: |
 state: ready
 lifecycle: production
 source-date-epoch: 1780426378
+
+email-backends:
+  - airflow.providers.sendgrid.utils.emailer.send_email
+
 # Note that those versions are maintained by release manager - do not update them manually
 # with the exception of case where other provider in sources has >= new provider version.
 # In such case adding >= NEW_VERSION and bumping to NEW_VERSION in a provider have

--- a/providers/sendgrid/src/airflow/providers/sendgrid/get_provider_info.py
+++ b/providers/sendgrid/src/airflow/providers/sendgrid/get_provider_info.py
@@ -26,4 +26,5 @@ def get_provider_info():
         "package-name": "apache-airflow-providers-sendgrid",
         "name": "Sendgrid",
         "description": "`Sendgrid <https://sendgrid.com/>`__\n",
+        "email-backends": ["airflow.providers.sendgrid.utils.emailer.send_email"],
     }


### PR DESCRIPTION
Split the SendGrid and Amazon SES email backend setup instructions out
of airflow-core/docs/howto/email-config.rst into dedicated pages under
each provider's docs (providers/sendgrid/docs/email-backend.rst and
providers/amazon/docs/email-backend.rst).

The core doc now only covers the general email configuration mechanism
(SMTP defaults, templates, from_email, the email_backend/email_conn_id
pattern) and links out to the provider pages for setup. Each provider
page links back to the core doc for the shared concepts, and the SES
emailer docstring gets the same :ref: cross-link SendGrid's already had.

This avoids duplicating provider setup steps in core docs and keeps
each provider's docs as the source of truth for its own setup.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude (Sonnet 5)

Generated-by: Claude (Sonnet 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)