### PR TITLE
Bound and harden the Glue job-UUID scan fallback

### DIFF
--- a/providers/amazon/docs/operators/glue.rst
+++ b/providers/amazon/docs/operators/glue.rst
@@ -198,7 +198,7 @@ existed unless ``resume_glue_job_on_retry`` is set. On Airflow 3.3+, ``durable``
 .. note::
   The task-UUID scan fallback (used on retry whenever XCom has no cached run id -- always the case
   on Airflow 3.0-3.2, and on Airflow 2.x once XCom itself has expired or been cleared) calls
- ``glue:GetJobRuns`` against the job's run history. Grant this action, in addition to
+  ``glue:GetJobRuns`` against the job's run history. Grant this action, in addition to
   ``glue:StartJobRun`` and ``glue:GetJobRun``, to any IAM policy relying on ``durable=True`` (or
   ``resume_glue_job_on_retry=True`` below Airflow 3.3) for crash recovery -- without it, the scan
   fails, is logged as an error, and the operator submits a fresh run instead of reconnecting.

--- a/providers/amazon/docs/operators/glue.rst
+++ b/providers/amazon/docs/operators/glue.rst
@@ -195,6 +195,14 @@ DAG change, does not turn it on either: below 3.3, behavior is unchanged from be
 existed unless ``resume_glue_job_on_retry`` is set. On Airflow 3.3+, ``durable`` defaults to
 ``True`` as described above, since the task state store makes it cheap.
 
+.. note::
+  The task-UUID scan fallback (used on retry whenever XCom has no cached run id -- always the case
+  on Airflow 3.0-3.2, and on Airflow 2.x once XCom itself has expired or been cleared) calls
+ ``glue:GetJobRuns`` against the job's run history. Grant this action, in addition to
+  ``glue:StartJobRun`` and ``glue:GetJobRun``, to any IAM policy relying on ``durable=True`` (or
+  ``resume_glue_job_on_retry=True`` below Airflow 3.3) for crash recovery -- without it, the scan
+  fails, is logged as an error, and the operator submits a fresh run instead of reconnecting.
+
 Like the persisted state itself, the stored run id isn't deleted automatically, that only happens
 when someone runs ``airflow state-store clean`` or ``airflow db clean`` (which also targets the
 ``task_state_store`` table). If a task's ``retry_delay`` is longer than

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/glue.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/glue.py
@@ -94,6 +94,9 @@ JOB_RUN_SUCCESS_STATES = ("SUCCEEDED",)
 JOB_RUN_TERMINAL_STATES = (*JOB_RUN_SUCCESS_STATES, "STOPPED", "FAILED", "TIMEOUT", "ERROR", "EXPIRED")
 # Synthetic state for a run id Glue no longer knows about, so a retry submits fresh rather than failing.
 NOT_FOUND_STATE = "NOT_FOUND"
+# Page cap for the task-UUID scan fallback (see _find_job_run_id_by_task_uuid): bounds a no-match
+# scan to 1000 runs (MaxResults=50/page) instead of the job's entire history.
+TASK_UUID_SCAN_MAX_PAGES = 20
 
 
 class GlueJobOperator(ResumableJobMixin, AwsBaseOperator[GlueJobHook]):
@@ -328,11 +331,19 @@ class GlueJobOperator(ResumableJobMixin, AwsBaseOperator[GlueJobHook]):
             script_args[self.TASK_UUID_ARG] = task_uuid
         return script_args, task_uuid
 
-    def _find_job_run_id_by_task_uuid(self, task_uuid: str) -> tuple[str, str] | None:
-        # Unbounded walk with no page cap; a no-match run is the common retry shape and pays the
-        # full scan. Tracked at https://github.com/apache/airflow/issues/71489.
+    def _find_job_run_id_by_task_uuid(self, task_uuid: str, context: Context) -> tuple[str, str] | None:
+        """
+        Scan job run history for a run tagged with this task instance's UUID.
+
+        Runs are newest-first, so the scan stops at the first run older than this DAG run,
+        with ``TASK_UUID_SCAN_MAX_PAGES`` as a backstop. Requires ``glue:GetJobRuns``.
+
+        """
+        dag_run = context.get("dag_run")
+        cutoff = getattr(dag_run, "start_date", None) if dag_run is not None else None
+
         next_token: str | None = None
-        while True:
+        for _ in range(TASK_UUID_SCAN_MAX_PAGES):
             request = {"JobName": self.job_name, "MaxResults": 50}
             if next_token:
                 request["NextToken"] = next_token
@@ -344,9 +355,22 @@ class GlueJobOperator(ResumableJobMixin, AwsBaseOperator[GlueJobHook]):
                     job_run_state = job_run.get("JobRunState")
                     if job_run_id and job_run_state:
                         return job_run_id, job_run_state
+                started_on = job_run.get("StartedOn")
+                if cutoff is not None and started_on is not None and started_on < cutoff:
+                    self.log.info(
+                        "Stopping Glue job run UUID scan: reached a run started before this DAG run."
+                    )
+                    return None
             next_token = response.get("NextToken")
             if not next_token:
                 return None
+        self.log.error(
+            "Glue job run UUID scan for %s exceeded %d pages without finding a match or reaching "
+            "this DAG run's start; giving up and submitting a fresh run.",
+            self.job_name,
+            TASK_UUID_SCAN_MAX_PAGES,
+        )
+        return None
 
     def execute(self, context: Context) -> str | None:
         """
@@ -447,11 +471,14 @@ class GlueJobOperator(ResumableJobMixin, AwsBaseOperator[GlueJobHook]):
                 self.log.info("Previous Glue job_run_id: %s, state: %s", previous_job_run_id, state)
                 if self.is_job_active(state):
                     return previous_job_run_id
-            except Exception:
-                self.log.warning("Failed to get previous Glue job run state", exc_info=True)
+            except ClientError:
+                self.log.exception(
+                    "Failed to get previous Glue job run state for run_id=%s",
+                    previous_job_run_id,
+                )
         else:
             try:
-                existing = self._find_job_run_id_by_task_uuid(task_uuid)
+                existing = self._find_job_run_id_by_task_uuid(task_uuid, context)
                 if existing:
                     existing_job_run_id, existing_job_run_state = existing
                     self.log.info(
@@ -461,8 +488,11 @@ class GlueJobOperator(ResumableJobMixin, AwsBaseOperator[GlueJobHook]):
                     )
                     if self.is_job_active(existing_job_run_state):
                         return existing_job_run_id
-            except Exception:
-                self.log.warning("Failed to find previous Glue job run by task UUID", exc_info=True)
+            except ClientError:
+                self.log.exception(
+                    "Failed to find previous Glue job run by task UUID for job_name=%s",
+                    self.job_name,
+                )
         return None
 
     def _has_stored_external_id(self, context: Context) -> bool:


### PR DESCRIPTION
Closes #71489

## Summary
Bounds and hardens the Glue task-UUID scan fallback used on retry.

## Root Cause
The scan looped over `GetJobRuns` with no page cap. A no-match run —
the common retry case — walked the job's entire run history before
giving up. Failures were also swallowed by a broad `except Exception`
and logged only at `warning`, so a fallback failure gave no clear
signal before the operator submitted a fresh run into a still-active
one.

## Fix
- Added a page cap (`TASK_UUID_SCAN_MAX_PAGES`) and an early exit once
  a run's `StartedOn` predates the DAG run (runs come back newest-first).
- Narrowed `except Exception` to `except ClientError`.
- Raised the fallthrough log level to `error` with the actual reason.
- Documented the `glue:GetJobRuns` IAM requiremen

Was generative AI tooling used ?

- [X] Yes - Claude

Generated-by: Claude following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)