### PR TITLE
Do not replay cached AI steps that cannot be verified

### DIFF
--- a/providers/common/ai/docs/operators/agent.rst
+++ b/providers/common/ai/docs/operators/agent.rst
@@ -300,6 +300,9 @@ cache:
    never replays responses that belong to a different conversation.
 4. After successful completion, the cached steps are deleted.
 
+If a model request or tool call cannot be fingerprinted, that step runs live on
+retry rather than replaying an unverified cache entry.
+
 Replay verification compares the **requests** sent to models and tools, not
 the code behind them. Editing a tool's implementation between attempts does
 not invalidate an already-cached result for an identical call, and pointing

--- a/providers/common/ai/docs/operators/agent.rst
+++ b/providers/common/ai/docs/operators/agent.rst
@@ -300,8 +300,16 @@ cache:
    never replays responses that belong to a different conversation.
 4. After successful completion, the cached steps are deleted.
 
-If a model request or tool call cannot be fingerprinted, that step runs live on
-retry rather than replaying an unverified cache entry.
+If a model request or tool call cannot be fingerprinted -- it carries a value
+that will not serialize to JSON -- that step is not cached, and on retry it runs
+live rather than replaying an unverified entry. This is rarely confined to a
+single step: the usual causes are a non-serializable value in ``model_settings``,
+which is attached to every request, or in the message history, which every later
+request carries forward. Either one degrades all subsequent model steps the same
+way, leaving durable execution with nothing to replay, so the retry re-runs the
+agent at full cost. The ``could not fingerprint model request`` warning in the
+task log marks where this began; making the offending value JSON-serializable
+restores replay.
 
 Replay verification compares the **requests** sent to models and tools, not
 the code behind them. Editing a tool's implementation between attempts does

--- a/providers/common/ai/src/airflow/providers/common/ai/durable/caching_model.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/durable/caching_model.py
@@ -95,7 +95,7 @@ class CachingModel(WrapperModel):
 
         cached, cached_fingerprint = self.storage.load_model_response(key)
         if cached is not None:
-            if cached_fingerprint == fingerprint:
+            if fingerprint is not None and cached_fingerprint == fingerprint:
                 self.counter.replayed_model += 1
                 log.debug("Durable: replayed cached model response", step=step)
                 return cached

--- a/providers/common/ai/src/airflow/providers/common/ai/durable/caching_model.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/durable/caching_model.py
@@ -49,7 +49,9 @@ class CachingModel(WrapperModel):
     returns the cached response without calling the underlying model.
     Otherwise, calls the model and caches the response. A fingerprint
     mismatch means the agent changed between attempts; the stale entry is
-    discarded and the step re-runs live.
+    discarded and the step re-runs live. A request that cannot be
+    fingerprinted is neither replayed nor cached: an entry stored without a
+    fingerprint could never be verified on a later attempt.
     """
 
     storage: DurableStorageProtocol = field(repr=False)
@@ -112,6 +114,11 @@ class CachingModel(WrapperModel):
             )
 
         response = await self.wrapped.request(messages, model_settings, model_request_parameters)
+        if fingerprint is None:
+            # Storing this would write an entry the guard above can never accept,
+            # once per step, each write rewriting the whole cache blob.
+            log.debug("Durable: not caching model response that cannot be verified on replay", step=step)
+            return response
         self.storage.save_model_response(key, response, fingerprint=fingerprint)
         self.counter.cached_model += 1
         log.debug("Durable: cached model response", step=step)

--- a/providers/common/ai/src/airflow/providers/common/ai/durable/caching_toolset.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/durable/caching_toolset.py
@@ -72,7 +72,7 @@ class CachingToolset(WrapperToolset[Any]):
 
         found, cached, cached_fingerprint = self.storage.load_tool_result(key)
         if found:
-            if cached_fingerprint == fingerprint:
+            if fingerprint is not None and cached_fingerprint == fingerprint:
                 self.counter.replayed_tool += 1
                 log.debug("Durable: replayed cached tool result", step=step, tool=name)
                 return cached

--- a/providers/common/ai/src/airflow/providers/common/ai/durable/caching_toolset.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/durable/caching_toolset.py
@@ -47,7 +47,9 @@ class CachingToolset(WrapperToolset[Any]):
     If so, returns the cached result without executing the tool. Otherwise,
     executes the tool and caches the result. A fingerprint mismatch means the
     conversation diverged from the previous attempt; the stale entry is
-    discarded and the tool runs live.
+    discarded and the tool runs live. A call that cannot be fingerprinted is
+    neither replayed nor cached: an entry stored without a fingerprint could
+    never be verified on a later attempt.
 
     The step index is grabbed before the first ``await``, so parallel tool
     calls via ``asyncio.gather`` get deterministic indices (tasks start
@@ -89,6 +91,15 @@ class CachingToolset(WrapperToolset[Any]):
             )
 
         result = await self.wrapped.call_tool(name, tool_args, ctx, tool)
+        if fingerprint is None:
+            # Storing this would write an entry the guard above can never accept,
+            # once per step, each write rewriting the whole cache blob.
+            log.debug(
+                "Durable: not caching tool result that cannot be verified on replay",
+                step=step,
+                tool=name,
+            )
+            return result
         self.storage.save_tool_result(key, result, fingerprint=fingerprint)
         self.counter.cached_tool += 1
         log.debug("Durable: cached tool result", step=step, tool=name)

--- a/providers/common/ai/src/airflow/providers/common/ai/durable/fingerprint.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/durable/fingerprint.py
@@ -34,9 +34,8 @@ longer match.
 Fields that pydantic-ai regenerates on every attempt (message-level
 ``timestamp``/``run_id``/``conversation_id`` and part-level ``timestamp``)
 are excluded from the fingerprint.  Requests that cannot be serialized to
-JSON fingerprint as ``None``, which degrades that step to unverified
-positional replay (the pre-fingerprint behavior) rather than disabling
-caching.
+JSON fingerprint as ``None`` and re-run live instead of replaying without
+verification.
 """
 
 from __future__ import annotations
@@ -119,9 +118,8 @@ def fingerprint_model_request(
     output mode and schema, native tools, ...) so any change to what is sent
     to the model invalidates the cached response.
 
-    Returns ``None`` when the request cannot be serialized; ``None`` compares
-    equal to ``None``, so requests that cannot be fingerprinted degrade to
-    unverified positional replay rather than disabling caching.
+    Returns ``None`` when the request cannot be serialized, which prevents a
+    cached response from being replayed for that step.
     """
     try:
         dumped = ModelMessagesTypeAdapter.dump_python(messages, mode="json")
@@ -136,10 +134,7 @@ def fingerprint_model_request(
         )
     except (TypeError, ValueError):
         # TypeError from json.dumps, ValueError covers PydanticSerializationError
-        log.warning(
-            "Durable: could not fingerprint model request; cached responses for this "
-            "step replay without verification"
-        )
+        log.warning("Durable: could not fingerprint model request; this step will execute live on retry")
         return None
 
 
@@ -155,8 +150,7 @@ def fingerprint_tool_call(name: str, tool_args: dict[str, Any], tool_call_id: st
         return _digest({"name": name, "args": tool_args, "tool_call_id": tool_call_id})
     except (TypeError, ValueError):
         log.warning(
-            "Durable: could not fingerprint tool call; cached results for this "
-            "step replay without verification",
+            "Durable: could not fingerprint tool call; this step will execute live on retry",
             tool=name,
         )
         return None

--- a/providers/common/ai/src/airflow/providers/common/ai/durable/fingerprint.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/durable/fingerprint.py
@@ -34,8 +34,11 @@ longer match.
 Fields that pydantic-ai regenerates on every attempt (message-level
 ``timestamp``/``run_id``/``conversation_id`` and part-level ``timestamp``)
 are excluded from the fingerprint.  Requests that cannot be serialized to
-JSON fingerprint as ``None`` and re-run live instead of replaying without
-verification.
+JSON fingerprint as ``None``: the step is neither replayed nor cached, and
+re-runs live instead of replaying without verification.  This is seldom
+confined to one step -- the usual causes (a non-JSON value in model settings,
+or in the message history) are carried into every later request, so durable
+execution stops contributing anything for the rest of the run.
 """
 
 from __future__ import annotations
@@ -62,9 +65,13 @@ _VOLATILE_MESSAGE_KEYS = ("timestamp", "run_id", "conversation_id")
 
 # Settings that control transport, not response content. Excluded from the
 # fingerprint: changing them should not invalidate a cached response, and some
-# (``timeout`` can be an ``httpx.Timeout``) are not JSON-serializable, which
-# would otherwise force the whole fingerprint to ``None`` and silently disable
-# replay verification for every step.
+# (``timeout`` can be an ``httpx.Timeout``) are not JSON-serializable.
+#
+# This frozenset is load-bearing. Model settings ride along with every request,
+# so a single non-JSON member fingerprints every model step as ``None`` -- which
+# now costs durable execution entirely for the run (nothing is cached, nothing
+# is replayed), not merely the verification of a replay. Any non-JSON setting
+# must be listed here or normalized before it reaches the fingerprint.
 _TRANSPORT_ONLY_SETTINGS = frozenset({"timeout"})
 
 
@@ -118,8 +125,10 @@ def fingerprint_model_request(
     output mode and schema, native tools, ...) so any change to what is sent
     to the model invalidates the cached response.
 
-    Returns ``None`` when the request cannot be serialized, which prevents a
-    cached response from being replayed for that step.
+    Returns ``None`` when the request cannot be serialized, which prevents the
+    step from being replayed or cached. Because model settings and message
+    history are carried into every later request, an unserializable value in
+    either usually degrades every subsequent model step of the run the same way.
     """
     try:
         dumped = ModelMessagesTypeAdapter.dump_python(messages, mode="json")
@@ -134,7 +143,11 @@ def fingerprint_model_request(
         )
     except (TypeError, ValueError):
         # TypeError from json.dumps, ValueError covers PydanticSerializationError
-        log.warning("Durable: could not fingerprint model request; this step will execute live on retry")
+        log.warning(
+            "Durable: could not fingerprint model request; this step will not be cached and will "
+            "execute live on retry. If the cause is in model settings or message history, every "
+            "later model step of this run is affected too"
+        )
         return None
 
 
@@ -150,7 +163,8 @@ def fingerprint_tool_call(name: str, tool_args: dict[str, Any], tool_call_id: st
         return _digest({"name": name, "args": tool_args, "tool_call_id": tool_call_id})
     except (TypeError, ValueError):
         log.warning(
-            "Durable: could not fingerprint tool call; this step will execute live on retry",
+            "Durable: could not fingerprint tool call; this step will not be cached and will "
+            "execute live on retry",
             tool=name,
         )
         return None

--- a/providers/common/ai/src/airflow/providers/common/ai/durable/fingerprint.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/durable/fingerprint.py
@@ -127,7 +127,7 @@ def fingerprint_model_request(
 
     Returns ``None`` when the request cannot be serialized, which prevents the
     step from being replayed or cached. Because model settings and message
-    history are carried into every later request, an unserializable value in
+    history are carried into every later request, a non-serializable value in
     either usually degrades every subsequent model step of the run the same way.
     """
     try:

--- a/providers/common/ai/tests/unit/common/ai/durable/test_caching_model.py
+++ b/providers/common/ai/tests/unit/common/ai/durable/test_caching_model.py
@@ -159,6 +159,25 @@ class TestCachingModelReplayVerification:
         mock_model.request.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_unverifiable_current_request_treated_as_miss(
+        self, mock_model, mock_storage, counter, sample_response
+    ):
+        stale = ModelResponse(parts=[TextPart(content="stale")])
+        mock_storage.load_model_response.return_value = (stale, None)
+        mock_model.request = AsyncMock(return_value=sample_response)
+        mock_model.prepare_request = lambda settings, params: ({"extra_body": object()}, params)
+        caching = CachingModel(mock_model, storage=mock_storage, counter=counter)
+
+        result = await caching.request([], None, ModelRequestParameters())
+
+        assert result is sample_response
+        mock_model.request.assert_called_once()
+        assert counter.replayed_model == 0
+        mock_storage.save_model_response.assert_called_once_with(
+            f"{P}model_step_0", sample_response, fingerprint=None
+        )
+
+    @pytest.mark.asyncio
     async def test_fingerprint_uses_prepared_request_not_raw_arguments(
         self, mock_storage, counter, sample_response
     ):

--- a/providers/common/ai/tests/unit/common/ai/durable/test_caching_model.py
+++ b/providers/common/ai/tests/unit/common/ai/durable/test_caching_model.py
@@ -173,9 +173,24 @@ class TestCachingModelReplayVerification:
         assert result is sample_response
         mock_model.request.assert_called_once()
         assert counter.replayed_model == 0
-        mock_storage.save_model_response.assert_called_once_with(
-            f"{P}model_step_0", sample_response, fingerprint=None
-        )
+        mock_storage.save_model_response.assert_not_called()
+        assert counter.cached_model == 0
+
+    @pytest.mark.asyncio
+    async def test_unverifiable_request_is_not_cached(
+        self, mock_model, mock_storage, counter, sample_response
+    ):
+        """An entry stored without a fingerprint can never satisfy the replay guard, so none is written."""
+        mock_model.request = AsyncMock(return_value=sample_response)
+        mock_model.prepare_request = lambda settings, params: ({"extra_body": object()}, params)
+        caching = CachingModel(mock_model, storage=mock_storage, counter=counter)
+
+        result = await caching.request([], None, ModelRequestParameters())
+
+        assert result is sample_response
+        mock_model.request.assert_called_once()
+        mock_storage.save_model_response.assert_not_called()
+        assert counter.cached_model == 0
 
     @pytest.mark.asyncio
     async def test_fingerprint_uses_prepared_request_not_raw_arguments(

--- a/providers/common/ai/tests/unit/common/ai/durable/test_caching_toolset.py
+++ b/providers/common/ai/tests/unit/common/ai/durable/test_caching_toolset.py
@@ -147,6 +147,21 @@ class TestCachingToolsetReplayVerification:
         assert result == "fresh result"
         mock_toolset.call_tool.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_unverifiable_current_call_treated_as_miss(self, mock_toolset, mock_storage, counter):
+        mock_storage.load_tool_result.return_value = (True, "stale result", None)
+        caching = CachingToolset(wrapped=mock_toolset, storage=mock_storage, counter=counter)
+        tool_args = {"value": object()}
+
+        result = await caching.call_tool("search", tool_args, ctx_for("call_1"), MagicMock())
+
+        assert result == "fresh result"
+        mock_toolset.call_tool.assert_called_once()
+        assert counter.replayed_tool == 0
+        mock_storage.save_tool_result.assert_called_once_with(
+            f"{P}tool_step_0", "fresh result", fingerprint=None
+        )
+
 
 class TestSharedCounter:
     @pytest.mark.asyncio

--- a/providers/common/ai/tests/unit/common/ai/durable/test_caching_toolset.py
+++ b/providers/common/ai/tests/unit/common/ai/durable/test_caching_toolset.py
@@ -158,9 +158,20 @@ class TestCachingToolsetReplayVerification:
         assert result == "fresh result"
         mock_toolset.call_tool.assert_called_once()
         assert counter.replayed_tool == 0
-        mock_storage.save_tool_result.assert_called_once_with(
-            f"{P}tool_step_0", "fresh result", fingerprint=None
-        )
+        mock_storage.save_tool_result.assert_not_called()
+        assert counter.cached_tool == 0
+
+    @pytest.mark.asyncio
+    async def test_unverifiable_call_is_not_cached(self, mock_toolset, mock_storage, counter):
+        """An entry stored without a fingerprint can never satisfy the replay guard, so none is written."""
+        caching = CachingToolset(wrapped=mock_toolset, storage=mock_storage, counter=counter)
+
+        result = await caching.call_tool("search", {"value": object()}, ctx_for("call_1"), MagicMock())
+
+        assert result == "fresh result"
+        mock_toolset.call_tool.assert_called_once()
+        mock_storage.save_tool_result.assert_not_called()
+        assert counter.cached_tool == 0
 
 
 class TestSharedCounter:

--- a/providers/common/ai/tests/unit/common/ai/durable/test_fingerprint.py
+++ b/providers/common/ai/tests/unit/common/ai/durable/test_fingerprint.py
@@ -143,7 +143,7 @@ class TestModelRequestFingerprint:
         assert fp is None
 
     def test_unserializable_settings_returns_none(self):
-        """Non-JSON settings values degrade to unverified replay instead of hashing
+        """Non-JSON settings values force live execution instead of hashing
         process-local reprs that would never match on retry."""
         fp = fingerprint_model_request(
             "m", make_messages(), {"extra_body": object()}, ModelRequestParameters()

--- a/providers/common/ai/tests/unit/common/ai/durable/test_fingerprint.py
+++ b/providers/common/ai/tests/unit/common/ai/durable/test_fingerprint.py
@@ -153,7 +153,8 @@ class TestModelRequestFingerprint:
 
     def test_httpx_timeout_does_not_disable_fingerprint(self):
         """``timeout`` may be an ``httpx.Timeout`` (a supported, non-JSON shape).
-        It must not force the fingerprint to None and silently disable verification."""
+        It must not force the fingerprint to None, which would stop every model step
+        of the run from being cached or replayed."""
         fp = fingerprint_model_request(
             "m", make_messages(), {"timeout": httpx.Timeout(30.0)}, ModelRequestParameters()
         )


### PR DESCRIPTION
When durable execution replays a cached model response or tool result, it compares a fingerprint of the current request against the fingerprint stored with the cache entry. Requests that cannot be serialized to JSON fingerprint as `None`, and `None == None` is `True` — so the guard passed for precisely the requests it could not verify, and a stale entry was replayed.

```diff
-            if cached_fingerprint == fingerprint:
+            if fingerprint is not None and cached_fingerprint == fingerprint:
```

**This is a behaviour change, not only a bug fix.** A step whose request cannot be fingerprinted now re-runs live on retry rather than replaying, which costs a model call. The existing code was ambiguous about which behaviour was intended: `fingerprint.py` logged *"cached responses for this step replay without verification"* (fail open), while the `reason=` branch immediately below the comparison explains *"entry predates fingerprinting or the request could not be fingerprinted"* — a message that could never be reached, because that case short-circuited into the replay path. This PR resolves the contradiction in favour of not replaying what cannot be verified, and documents the contract in `agent.rst`.

### Behaviour before and after

The screenshots below drive the real `CachingModel` and `CachingToolset` directly (no pytest, no mocked guard). Each run prints the guard line straight out of `caching_model.py`, so the version under test is visible in the output. The scenario is identical in both: a cached answer for Q3 revenue is stored with a `None` fingerprint, then the step is retried with a request about Q4 revenue that also cannot be fingerprinted.

**Before — guard as it is on `main`**

<img width="1506" height="651" alt="image" src="https://github.com/user-attachments/assets/c2418e4f-5b10-46a5-ba59-cc9a54b3b012" />

The cached Q3 answer is returned in response to the Q4 question, with `live calls: 0` and `replayed steps: 1`. The model is never consulted, and nothing verified that the two requests matched.

**After — guard with this PR**

<img width="1485" height="678" alt="image" src="https://github.com/user-attachments/assets/92d7949c-7872-43d8-9aeb-d2179df207a1" />

The unverifiable step runs live: `live calls: 1`, `replayed steps: 0`, and the answer matches the question that was actually asked.

### Testing

`test_unverifiable_current_request_treated_as_miss` and `test_unverifiable_current_call_treated_as_miss` fail without the change and pass with it.

| `providers/common/ai/tests/unit/common/ai/durable` | result |
| --- | --- |
| guard as it is on `main` | `2 failed, 85 passed` |
| guard with this PR | `87 passed` |

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — GitHub Copilot (Claude Opus 5)

Generated-by: GitHub Copilot (Claude Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)