### PR TITLE
Pin the Go SDK CI toolchain to the patched Go release

### DIFF
--- a/.github/workflows/ci-amd.yml
+++ b/.github/workflows/ci-amd.yml
@@ -999,6 +999,10 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version: 1.25
+          # The actions/go-versions manifest trails Go security releases by weeks, so without
+          # this the pin resolves to a stale patch and the vulnerability scan below fails on
+          # standard library advisories that are already fixed upstream.
+          check-latest: true
           cache-dependency-path: go-sdk/go.sum
       # keep this in sync with go.mod in go-sdk/
       - name: Setup Gotestsum

--- a/.github/workflows/ci-amd.yml
+++ b/.github/workflows/ci-amd.yml
@@ -998,11 +998,10 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
-          go-version: 1.25
-          # The actions/go-versions manifest trails Go security releases by weeks, so without
-          # this the pin resolves to a stale patch and the vulnerability scan below fails on
-          # standard library advisories that are already fixed upstream.
-          check-latest: true
+          # Pinned to the patch: actions/go-versions trails Go security releases by weeks, and
+          # setup-go resolves from that manifest whenever it can match, so a bare 1.25 lands on a
+          # toolchain whose standard library still carries advisories the scan below fails on.
+          go-version: '1.25.13'
           cache-dependency-path: go-sdk/go.sum
       # keep this in sync with go.mod in go-sdk/
       - name: Setup Gotestsum

--- a/.github/workflows/ci-arm.yml
+++ b/.github/workflows/ci-arm.yml
@@ -987,11 +987,10 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
-          go-version: 1.25
-          # The actions/go-versions manifest trails Go security releases by weeks, so without
-          # this the pin resolves to a stale patch and the vulnerability scan below fails on
-          # standard library advisories that are already fixed upstream.
-          check-latest: true
+          # Pinned to the patch: actions/go-versions trails Go security releases by weeks, and
+          # setup-go resolves from that manifest whenever it can match, so a bare 1.25 lands on a
+          # toolchain whose standard library still carries advisories the scan below fails on.
+          go-version: '1.25.13'
           cache-dependency-path: go-sdk/go.sum
       # keep this in sync with go.mod in go-sdk/
       - name: Setup Gotestsum

--- a/.github/workflows/ci-arm.yml
+++ b/.github/workflows/ci-arm.yml
@@ -988,6 +988,10 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version: 1.25
+          # The actions/go-versions manifest trails Go security releases by weeks, so without
+          # this the pin resolves to a stale patch and the vulnerability scan below fails on
+          # standard library advisories that are already fixed upstream.
+          check-latest: true
           cache-dependency-path: go-sdk/go.sum
       # keep this in sync with go.mod in go-sdk/
       - name: Setup Gotestsum


### PR DESCRIPTION
The Go SDK job fails on `govulncheck`, which reports seven reachable standard
library advisories:

```
Vulnerability #1: GO-2026-6218
    Avoid quadratic complexity in resolvePath in net/url
  Standard library
    Found in: net/url@go1.25.12
    Fixed in: net/url@go1.25.13
```

All seven are fixed in go1.25.13, which is stable on go.dev. CI never gets it:
setup-go resolves `go-version: 1.25` against the `actions/go-versions` manifest,
and that manifest tops out at 1.25.12. It was last updated on 2026-07-08 with no
pending update, so the job stays red for weeks after a Go security release.

Naming the patch is what moves it. setup-go prefers the manifest whenever it can
match the spec and only falls back to go.dev when the lookup misses, so
`check-latest` changes nothing here — `1.25` still matches 1.25.12. Asking for
`1.25.13`, which the manifest does not carry, is what triggers the direct
download. The pinned minor is unchanged, so `check-go-version-in-sync` and the
go.mod relationship both hold.

# Testing Done

Confirmed on this PR's own run, which is the only place the resolution can be
observed:

| # | Scenario | Result |
|---|---|---|
| 1 | Go SDK job before the pin | Resolved 1.25.12, 7 advisories, job failed |
| 2 | Go SDK job after the pin | Resolved 1.25.13, no vulnerabilities, job passed |
| 3 | `check-go-version-in-sync` prek hook | Consistent across all 8 pin sites |
| 4 | Workflow hooks: yamllint, zizmor, amd/arm sync | Passed |

<details><summary>Raw logs</summary>

Before, from the failing job:

```console
Setup go version spec 1.25
Attempting to resolve the latest version from the manifest...
matching 1.25...
Resolved as '1.25.12'
go version go1.25.12 linux/amd64

$ govulncheck ./...
Vulnerability #1: GO-2026-6218  Found in: net/url@go1.25.12       Fixed in: net/url@go1.25.13
Vulnerability #2: GO-2026-6091  Found in: html/template@go1.25.12  Fixed in: html/template@go1.25.13
Vulnerability #3: GO-2026-6090  Found in: crypto/tls@go1.25.12     Fixed in: crypto/tls@go1.25.13
Vulnerability #4: GO-2026-6089  Found in: net/http@go1.25.12       Fixed in: net/http@go1.25.13
```

After, same job on the pinned toolchain:

```console
Setup go version spec 1.25.13
Attempting to download 1.25.13...
go version go1.25.13 linux/amd64

$ govulncheck ./...
No vulnerabilities found.
```

Version pinning stays consistent:

```console
$ uv run --project scripts python scripts/ci/prek/check_go_version_in_sync.py
OK: Go version is consistently 1.25 across all 8 pin sites.

$ prek run --files .github/workflows/ci-amd.yml .github/workflows/ci-arm.yml --stage pre-commit
Check ci-arm.yml and ci-amd.yml stay in sync.............................Passed
Check Go toolchain version is consistent across build files..............Passed
Check YAML files with yamllint...........................................Passed
Run zizmor to check for github workflow syntax errors....................Passed
```

</details>