### PR TITLE
Reject empty match_glob in GCSToS3Operator on old google provider

### DIFF
--- a/generated/known_airflow_exceptions.txt
+++ b/generated/known_airflow_exceptions.txt
@@ -114,7 +114,6 @@ providers/amazon/src/airflow/providers/amazon/aws/sensors/sagemaker.py::8
 providers/amazon/src/airflow/providers/amazon/aws/sensors/sagemaker_unified_studio.py::1
 providers/amazon/src/airflow/providers/amazon/aws/sensors/sqs.py::2
 providers/amazon/src/airflow/providers/amazon/aws/sensors/step_function.py::1
-providers/amazon/src/airflow/providers/amazon/aws/transfers/gcs_to_s3.py::1
 providers/amazon/src/airflow/providers/amazon/aws/transfers/redshift_to_s3.py::1
 providers/amazon/src/airflow/providers/amazon/aws/transfers/s3_to_dynamodb.py::3
 providers/amazon/src/airflow/providers/amazon/aws/transfers/s3_to_redshift.py::3

--- a/generated/known_airflow_exceptions.txt
+++ b/generated/known_airflow_exceptions.txt
@@ -112,7 +112,6 @@ providers/amazon/src/airflow/providers/amazon/aws/sensors/sagemaker.py::8
 providers/amazon/src/airflow/providers/amazon/aws/sensors/sagemaker_unified_studio.py::1
 providers/amazon/src/airflow/providers/amazon/aws/sensors/sqs.py::2
 providers/amazon/src/airflow/providers/amazon/aws/sensors/step_function.py::1
-providers/amazon/src/airflow/providers/amazon/aws/transfers/gcs_to_s3.py::1
 providers/amazon/src/airflow/providers/amazon/aws/transfers/redshift_to_s3.py::1
 providers/amazon/src/airflow/providers/amazon/aws/transfers/s3_to_dynamodb.py::3
 providers/amazon/src/airflow/providers/amazon/aws/transfers/s3_to_redshift.py::3

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/gcs_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/gcs_to_s3.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING
 from packaging.version import Version
 
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
-from airflow.providers.common.compat.sdk import AirflowException, BaseOperator
+from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
 
 if TYPE_CHECKING:
@@ -146,10 +146,8 @@ class GCSToS3Operator(BaseOperator):
                 self.__is_match_glob_supported = False
         except ImportError:  # __version__ was added in 10.1.0, so this means it's < 10.3.0
             self.__is_match_glob_supported = False
-        if not self.__is_match_glob_supported and match_glob:
-            raise AirflowException(
-                "The 'match_glob' parameter requires 'apache-airflow-providers-google>=10.3.0'."
-            )
+        if not self.__is_match_glob_supported and match_glob is not None:
+            raise ValueError("The 'match_glob' parameter requires 'apache-airflow-providers-google>=10.3.0'.")
         self.match_glob = match_glob
         self.gcp_user_project = gcp_user_project
 

--- a/providers/amazon/tests/unit/amazon/aws/transfers/test_gcs_to_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/transfers/test_gcs_to_s3.py
@@ -75,6 +75,39 @@ class TestGCSToS3Operator:
                 user_project=None,
             )
 
+    @pytest.mark.parametrize(
+        "match_glob",
+        [
+            pytest.param("**/*.csv", id="value_supplied"),
+            pytest.param("", id="empty_string_is_still_supplied"),
+        ],
+    )
+    @mock.patch("airflow.providers.google.__version__", "10.2.0")
+    def test_init__match_glob_rejected_on_older_google_provider(self, match_glob):
+        """Supplying match_glob requires apache-airflow-providers-google>=10.3.0.
+
+        The check asks whether the argument was supplied, not whether its value is truthy,
+        so an empty string is rejected too - it was supplied.
+        """
+        with pytest.raises(ValueError, match=r"requires 'apache-airflow-providers-google>=10\.3\.0'"):
+            GCSToS3Operator(
+                task_id=TASK_ID,
+                gcs_bucket=GCS_BUCKET,
+                dest_s3_key=S3_BUCKET,
+                match_glob=match_glob,
+            )
+
+    @mock.patch("airflow.providers.google.__version__", "10.2.0")
+    def test_init__match_glob_omitted_is_accepted_on_older_google_provider(self):
+        """Omitting match_glob leaves nothing to reject, whatever the google provider version."""
+        operator = GCSToS3Operator(
+            task_id=TASK_ID,
+            gcs_bucket=GCS_BUCKET,
+            dest_s3_key=S3_BUCKET,
+        )
+
+        assert operator.match_glob is None
+
     @mock.patch("airflow.providers.amazon.aws.transfers.gcs_to_s3.GCSHook")
     def test_execute_incremental(self, mock_hook):
         mock_hook.return_value.list.return_value = MOCK_FILES

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -7,7 +7,6 @@
 # Burn-down tracked at https://github.com/apache/airflow/issues/70296
 providers/amazon/src/airflow/providers/amazon/aws/operators/neptune.py::NeptuneStartDbClusterOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/neptune.py::NeptuneStopDbClusterOperator
-providers/amazon/src/airflow/providers/amazon/aws/transfers/gcs_to_s3.py::GCSToS3Operator
 providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py::KubernetesPodOperator
 providers/google/src/airflow/providers/google/cloud/operators/cloud_build.py::CloudBuildCreateBuildOperator
 providers/google/src/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py::CloudDataTransferServiceCreateJobOperator

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -7,7 +7,6 @@
 # Burn-down tracked at https://github.com/apache/airflow/issues/70296
 providers/amazon/src/airflow/providers/amazon/aws/operators/neptune.py::NeptuneStartDbClusterOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/neptune.py::NeptuneStopDbClusterOperator
-providers/amazon/src/airflow/providers/amazon/aws/transfers/gcs_to_s3.py::GCSToS3Operator
 providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py::KubernetesPodOperator
 providers/google/src/airflow/providers/google/cloud/operators/cloud_batch.py::CloudBatchSubmitJobOperator
 providers/google/src/airflow/providers/google/cloud/operators/cloud_build.py::CloudBuildCreateBuildOperator


### PR DESCRIPTION
`match_glob` is in `GCSToS3Operator.template_fields`, so the constructor only ever sees the un-rendered Jinja expression, never the value the DAG author meant. The guard that rejects `match_glob` on an unsupported google provider tested it for truthiness:

```python
if not self.__is_match_glob_supported and match_glob:
```

which is what `validate-operators-init` flags, and why the class is on the exemption list.

**The check stays in `__init__`.** It is a provision check, not a value check: it asks whether `match_glob` was supplied, combined with an environment capability the constructor can already answer for itself. It never inspects the value. Per the false-positives section of #70296 those belong in the constructor and get rewritten in place rather than moved — with `render_template_as_native_obj=True` a provided field can render to `None`, so the same check in `execute()` would report a supplied argument as missing; and raising at construction surfaces a static authoring mistake as a Dag import error rather than once per task instance and per retry.

Since #70505 narrowed the hook to sanction `is None` / `is not None` reads, the in-place rewrite passes and the exemption entry still goes.

### What this changes

* rewrites the guard to `match_glob is not None`
* removes `GCSToS3Operator` from `scripts/ci/prek/validate_operators_init_exemptions.txt` — the hook fails on stale exemptions, so this has to land in the same commit as the fix
* adds three test cases where nothing previously covered this error at all

### Behavioural impact

One cell changes, on google providers older than 10.3.0:

| `match_glob` | before | after |
| --- | --- | --- |
| omitted (`None`) | no raise | no raise |
| `"**/*.csv"` | raises | raises |
| `""` | **no raise** | **raises** |

`match_glob=""` was supplied by the user and truthiness read it as absent. An empty glob is not a valid pattern, and on a provider below 10.3.0 it was never going to be honoured anyway — it would have been passed to a `GCSHook.list()` call that cannot accept it. This is the stricter direction that `05_pull_requests.rst` sanctions for provision checks.

### Relationship to #70723

Flagging this up front: #70723 is open against the same entry and reaches the same one-line fix. I worked this independently and only found that PR afterwards, so this is not a deliberate competing implementation — I'm raising it because the two diffs are close enough that a reviewer deserves to know rather than discover it.

Where they differ:

* Following the review on #70723 - @potiuk asking for the narrowing, @shahar1 confirming it matches the precedent one-for-one - this PR now also narrows `AirflowException` to `ValueError` and drops the now-stale `gcs_to_s3.py::1` entry from `generated/known_airflow_exceptions.txt`, per the #70359 precedent. The production change is now equivalent to #70723's.
* This PR covers the omitted-argument case, which #70723 does not. Without it the suite only pins the raising direction, so a regression that made the guard unconditional would still pass.

If maintainers prefer #70723 as the base — which is reasonable, it is older and more complete on the exception-type question — I am happy for this to be closed and will offer the missing test case there instead. I would rather that than have two near-identical PRs consuming review time.

### Deliberately not changed

* **The unreachable `except ImportError`.** `gcs_to_s3.py` already does a module-level `from airflow.providers.google.cloud.hooks.gcs import GCSHook`, so the `except ImportError` around the function-level `from airflow.providers.google import __version__` in `__init__` cannot fire — the module import would have failed first. Real, but a separate concern.
* **The `flatten_structure` / `keep_directory_structure` warning.** Reads two fields that are not template fields, so the rule does not apply and the hook does not flag it.

### Verification

Run in a WSL checkout, from `providers/amazon`:

```bash
# baseline, before any change
uv run pytest tests/unit/amazon/aws/transfers/test_gcs_to_s3.py -q
# 30 passed

# the new tests against the UNFIXED source, to prove they discriminate
git checkout HEAD~1 -- providers/amazon/src/airflow/providers/amazon/aws/transfers/gcs_to_s3.py
uv run pytest tests/unit/amazon/aws/transfers/test_gcs_to_s3.py -q
# 2 failed, 31 passed - one failure per behavioural change:
#   [value_supplied]                 AirflowException raised, not ValueError  (exception type)
#   [empty_string_is_still_supplied] DID NOT RAISE ValueError                 (polarity)
git checkout HEAD -- providers/amazon/src/airflow/providers/amazon/aws/transfers/gcs_to_s3.py

# with the fix
uv run pytest tests/unit/amazon/aws/transfers/test_gcs_to_s3.py -q
# 33 passed
```

```bash
prek run --from-ref main
# validate-operators-init, ruff, ruff-format and codespell all pass on the changed files.
# Three unrelated hooks fail in my local environment only (breeze not on PATH, and
# AIRFLOW_HOME pointing at the checkout); no code hook fails.
```

No newsfragment: `providers/amazon` has no `newsfragments/` directory, and `providers/AGENTS.md` says never to use them for providers.

related: #70296

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
