### PR TITLE
Expose ResumableJobMixin's reconnect decision as a standalone method

### DIFF
--- a/task-sdk/src/airflow/sdk/bases/resumablejobmixin.py
+++ b/task-sdk/src/airflow/sdk/bases/resumablejobmixin.py
@@ -17,7 +17,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
 
 from opentelemetry import trace
 
@@ -31,6 +32,26 @@ if TYPE_CHECKING:
     from airflow.sdk.types import Logger
 
 tracer = trace.get_tracer(__name__)
+
+
+@dataclass(frozen=True)
+class ResumeDecision:
+    """
+    Result of :meth:`ResumableJobMixin.resolve_reconnect`.
+
+    ``action`` is one of:
+
+    - ``"reconnect"``: a stored job is still active. ``external_id`` is set; callers should
+      resume tracking that job (e.g. poll it, or defer a trigger on it) rather than submitting.
+    - ``"already_succeeded"``: a stored job already finished successfully. ``external_id`` is
+      set; callers should fetch/return its result without submitting or polling.
+    - ``"fresh_submit"``: nothing usable was found (no stored id, no task_state_store, or the
+      stored job ended in a terminal failure). ``external_id`` is ``None``; callers should
+      submit a new job.
+    """
+
+    action: Literal["reconnect", "already_succeeded", "fresh_submit"]
+    external_id: JsonValue | None = None
 
 
 class ResumableJobMixin(ABC):
@@ -100,6 +121,90 @@ class ResumableJobMixin(ABC):
         super().__init__(**kwargs)
         self.durable = durable
 
+    def resolve_reconnect(self, context: Context) -> ResumeDecision:
+        """
+        Decide whether to reconnect, treat the job as already succeeded, or submit fresh.
+
+        This is the crash-recovery decision step -- read the stored external ID, call
+        ``get_job_status``, and apply ``is_job_active``/``is_job_succeeded`` -- factored out of
+        ``execute_resumable`` so it can be called on its own. It does not submit, persist, or
+        poll; it only decides.
+
+        This matters for operators that support both ``deferrable=True`` and durable execution.
+        On the deferrable path, ``execute()`` typically calls ``submit_job`` directly rather than
+        ``execute_resumable``, bypassing this decision and the ``task_state_store`` read
+        entirely -- so a deferrable retry has no cheap way to check "is there already a job I can
+        reconnect to" without it. Such an operator can call this method itself, before ``defer()``
+        and again on a deferred retry, to reconnect via the same ``task_state_store`` lookup used
+        here instead of falling back to an operator-specific bootstrap scan every retry. See
+        https://github.com/apache/airflow/issues/71485.
+        """
+        stats_tags = {"operator": type(self).__name__}
+        ti = context.get("ti")
+        if ti is not None and (team_name := ti.stats_tags.get("team_name")):
+            stats_tags["team_name"] = team_name
+
+        with tracer.start_as_current_span("resumable_job.resume_decision") as span:
+            span.set_attribute("operator", type(self).__name__)
+            span.set_attribute("resumable.external_id_key", self.external_id_key)
+
+            task_state_store = context.get("task_state_store")
+
+            if task_state_store is None:
+                span.set_attribute("resumable.decision", "no_task_state_store")
+                self.log.warning(
+                    "task_state_store not available in context, crash recovery is disabled for this run"
+                )
+                return ResumeDecision(action="fresh_submit")
+
+            external_id = task_state_store.get(self.external_id_key)
+            if not external_id:
+                span.set_attribute("resumable.decision", "fresh_submit")
+                stats.incr("resumable_job.fresh_submit", tags=stats_tags)
+                self.log.debug(
+                    "No stored external ID found; submitting fresh job",
+                    external_id_key=self.external_id_key,
+                )
+                return ResumeDecision(action="fresh_submit")
+
+            stats.incr("resumable_job.reconnect_attempt", tags=stats_tags)
+
+            status = self.get_job_status(external_id, context)
+
+            span.set_attribute("resumable.external_id", str(external_id))
+            span.set_attribute("resumable.prior_status", status)
+
+            if self.is_job_active(status):
+                span.set_attribute("resumable.decision", "reconnect")
+                stats.incr("resumable_job.reconnect_success", tags=stats_tags)
+                self.log.info(
+                    "Reconnecting to existing job",
+                    external_id_key=self.external_id_key,
+                    external_id=external_id,
+                    status=status,
+                )
+                return ResumeDecision(action="reconnect", external_id=external_id)
+
+            if self.is_job_succeeded(status):
+                span.set_attribute("resumable.decision", "already_succeeded")
+                stats.incr("resumable_job.already_succeeded", tags=stats_tags)
+                self.log.info(
+                    "Job already completed successfully, skipping resubmission",
+                    external_id_key=self.external_id_key,
+                    external_id=external_id,
+                )
+                return ResumeDecision(action="already_succeeded", external_id=external_id)
+
+            span.set_attribute("resumable.decision", "terminal_resubmit")
+            stats.incr("resumable_job.terminal_resubmit", tags=stats_tags)
+            self.log.warning(
+                "Prior job in terminal state, resubmitting fresh",
+                external_id_key=self.external_id_key,
+                external_id=external_id,
+                status=status,
+            )
+            return ResumeDecision(action="fresh_submit")
+
     def execute_resumable(self, context: Context) -> Any:
         """
         Core of the resumable execution logic. Call this from execute() when reconnection is supported.
@@ -122,83 +227,16 @@ class ResumableJobMixin(ABC):
             self.poll_until_complete(external_id, context)
             return self.get_job_result(external_id, context)
 
-        stats_tags = {"operator": type(self).__name__}
-        # The task is team-scoped in multi-team deployments; surface team_name on the
-        # resumable_job metrics via the running task instance's stats tags (omitted when
-        # not multi-team or the task has no team).
-        ti = context.get("ti")
-        if ti is not None and (team_name := ti.stats_tags.get("team_name")):
-            stats_tags["team_name"] = team_name
+        decision = self.resolve_reconnect(context)
 
-        reconnect_to: Any = None
-        already_succeeded_id: Any = None
+        if decision.action == "reconnect":
+            return self.poll_until_complete(decision.external_id, context)
+        if decision.action == "already_succeeded":
+            return self.get_job_result(decision.external_id, context)
 
-        with tracer.start_as_current_span("resumable_job.resume_decision") as span:
-            span.set_attribute("operator", type(self).__name__)
-            span.set_attribute("resumable.external_id_key", self.external_id_key)
-
-            task_state_store = context.get("task_state_store")
-
-            if task_state_store is None:
-                span.set_attribute("resumable.decision", "no_task_state_store")
-                self.log.warning(
-                    "task_state_store not available in context, crash recovery is disabled for this run"
-                )
-            else:
-                external_id = task_state_store.get(self.external_id_key)
-                if external_id:
-                    stats.incr("resumable_job.reconnect_attempt", tags=stats_tags)
-
-                    status = self.get_job_status(external_id, context)
-
-                    span.set_attribute("resumable.external_id", str(external_id))
-                    span.set_attribute("resumable.prior_status", status)
-
-                    if self.is_job_active(status):
-                        # Job is still running, skip submission and reconnect to it.
-                        span.set_attribute("resumable.decision", "reconnect")
-                        stats.incr("resumable_job.reconnect_success", tags=stats_tags)
-                        self.log.info(
-                            "Reconnecting to existing job",
-                            external_id_key=self.external_id_key,
-                            external_id=external_id,
-                            status=status,
-                        )
-                        reconnect_to = external_id
-                    elif self.is_job_succeeded(status):
-                        # Job already finished successfully, skip polling and return result directly.
-                        span.set_attribute("resumable.decision", "already_succeeded")
-                        stats.incr("resumable_job.already_succeeded", tags=stats_tags)
-                        self.log.info(
-                            "Job already completed successfully, skipping resubmission",
-                            external_id_key=self.external_id_key,
-                            external_id=external_id,
-                        )
-                        already_succeeded_id = external_id
-                    else:
-                        # Job is in a terminal failed state, fall through and submit a new job.
-                        span.set_attribute("resumable.decision", "terminal_resubmit")
-                        stats.incr("resumable_job.terminal_resubmit", tags=stats_tags)
-                        self.log.warning(
-                            "Prior job in terminal state, resubmitting fresh",
-                            external_id_key=self.external_id_key,
-                            external_id=external_id,
-                            status=status,
-                        )
-                else:
-                    span.set_attribute("resumable.decision", "fresh_submit")
-                    stats.incr("resumable_job.fresh_submit", tags=stats_tags)
-                    self.log.debug(
-                        "No stored external ID found; submitting fresh job",
-                        external_id_key=self.external_id_key,
-                    )
-
-        if reconnect_to is not None:
-            return self.poll_until_complete(reconnect_to, context)
-        if already_succeeded_id is not None:
-            return self.get_job_result(already_succeeded_id, context)
         external_id = self.submit_job(context)
 
+        task_state_store = context.get("task_state_store")
         if task_state_store is not None and external_id is not None:
             task_state_store.set(self.external_id_key, external_id)
             self.log.debug(

--- a/task-sdk/tests/task_sdk/bases/test_resumablejobmixin.py
+++ b/task-sdk/tests/task_sdk/bases/test_resumablejobmixin.py
@@ -554,3 +554,79 @@ class TestAbstractMethodEnforcement:
         assert partial_cls.__abstractmethods__ == frozenset({missing_method})
         with pytest.raises(TypeError):
             partial_cls(task_id="test_task")
+
+
+class TestResolveReconnect:
+    """
+    Tests for resolve_reconnect(), extracted from execute_resumable() so a deferrable
+    operator can call it directly. Regression tests for
+    https://github.com/apache/airflow/issues/71485.
+    """
+
+    def test_does_not_submit_poll_or_return_result(self):
+        op = ConcreteResumableOperator(task_id="test_task")
+        op.resolve_reconnect(make_context(FakeTaskState()))
+        assert op.submitted_ids == []
+        assert op.polled_ids == []
+
+    def test_fresh_submit_when_no_stored_id(self):
+        op = ConcreteResumableOperator(task_id="test_task")
+        decision = op.resolve_reconnect(make_context(FakeTaskState()))
+        assert decision.action == "fresh_submit"
+        assert decision.external_id is None
+
+    def test_fresh_submit_when_no_task_state_store(self):
+        op = ConcreteResumableOperator(task_id="test_task")
+        decision = op.resolve_reconnect(make_context(task_store=None))
+        assert decision.action == "fresh_submit"
+        assert decision.external_id is None
+
+    def test_reconnect_when_stored_job_active(self):
+        op = ConcreteResumableOperator(task_id="test_task")
+        op._status_map["job-001"] = "RUNNING"
+        decision = op.resolve_reconnect(make_context(FakeTaskState({"test_job_id": "job-001"})))
+        assert decision.action == "reconnect"
+        assert decision.external_id == "job-001"
+
+    def test_already_succeeded_when_stored_job_succeeded(self):
+        op = ConcreteResumableOperator(task_id="test_task")
+        op._status_map["job-001"] = "SUCCEEDED"
+        decision = op.resolve_reconnect(make_context(FakeTaskState({"test_job_id": "job-001"})))
+        assert decision.action == "already_succeeded"
+        assert decision.external_id == "job-001"
+
+    def test_fresh_submit_when_stored_job_terminal_failed(self):
+        op = ConcreteResumableOperator(task_id="test_task")
+        op._status_map["job-001"] = "FAILED"
+        decision = op.resolve_reconnect(make_context(FakeTaskState({"test_job_id": "job-001"})))
+        assert decision.action == "fresh_submit"
+        assert decision.external_id is None
+
+    def test_callable_before_defer_then_again_on_retry(self):
+        """The exact usage pattern from the issue."""
+        op = ConcreteResumableOperator(task_id="test_task")
+        store = FakeTaskState()
+        ctx = make_context(store)
+
+        first_decision = op.resolve_reconnect(ctx)
+        assert first_decision.action == "fresh_submit"
+        external_id = op.submit_job(ctx)
+        store.set(op.external_id_key, external_id)
+
+        op._status_map[external_id] = "RUNNING"
+
+        second_decision = op.resolve_reconnect(ctx)
+        assert second_decision.action == "reconnect"
+        assert second_decision.external_id == external_id
+        assert op.submitted_ids == [external_id]
+
+    def test_execute_resumable_still_uses_resolve_reconnect_consistently(self):
+        op = ConcreteResumableOperator(task_id="test_task")
+        op._status_map["job-001"] = "RUNNING"
+        ctx = make_context(FakeTaskState({"test_job_id": "job-001"}))
+
+        decision = op.resolve_reconnect(ctx)
+        op.execute_resumable(ctx)
+
+        assert decision.action == "reconnect"
+        assert op.polled_ids == ["job-001"]


### PR DESCRIPTION
closes: #71485

Summary
ResumableJobMixin.execute_resumable() bundled its crash-recovery decision
(read stored external ID, call get_job_status, apply is_job_active /
is_job_succeeded) together with submission and polling in one method.
Deferrable operators typically call submit_job directly from execute()
rather than execute_resumable(), so they had no way to reuse this decision
step and had to fall back to their own operator-specific bootstrap scans
on every retry (e.g. GlueJobOperator's task-UUID scan).

Root cause
The reconnect-decision logic was private to execute_resumable(), with no
public entry point that returned "reconnect / already succeeded / submit
fresh" without also submitting, persisting, or polling.

Fix
Extracted the decision block into a new public method,
resolve_reconnect(context) -> ResumeDecision, with identical logging,
metrics, and OpenTelemetry span attributes. execute_resumable() now just
calls resolve_reconnect() and acts on the result. A deferrable operator
can call resolve_reconnect() itself before defer() and again on a
deferred retry, reconnecting via the same task_state_store lookup instead
of an operator-specific scan.

Was generative AI tooling used ?

- [X] Yes - Claude

Generated-by: Claude following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)