### PR TITLE
Support .md file in LLMFileAnalysisOperator

### DIFF
--- a/providers/common/ai/docs/operators/llm_file_analysis.rst
+++ b/providers/common/ai/docs/operators/llm_file_analysis.rst
@@ -153,10 +153,10 @@ This operator also inherits ``LLMOperator``'s HITL review parameters --
 Supported Formats
 -----------------
 
-- Text-like: ``.log``, ``.json``, ``.csv``, ``.parquet``, ``.avro``
+- Text-like: ``.log``, ``.txt``, ``.md``, ``.json``, ``.csv``, ``.parquet``, ``.avro``
 - Multimodal: ``.png``, ``.jpg``, ``.jpeg``, ``.pdf`` when ``multi_modal=True``
 - Gzip-compressed text inputs are supported for ``.log.gz``, ``.json.gz``, and
-  ``.csv.gz``.
+  ``.csv.gz``, ``.txt.gz``, and ``.md.gz``.
 - Gzip is not supported for ``.parquet``, ``.avro``, image, or PDF inputs.
 
 Parquet and Avro readers require their corresponding optional extras:

--- a/providers/common/ai/src/airflow/providers/common/ai/utils/file_analysis.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/utils/file_analysis.py
@@ -49,13 +49,14 @@ SUPPORTED_FILE_FORMATS: tuple[str, ...] = (
     "jpg",
     "json",
     "log",
+    "md",
     "parquet",
     "pdf",
     "png",
     "txt",
 )
 
-_TEXT_LIKE_FORMATS = frozenset({"csv", "json", "log", "avro", "parquet", "txt"})
+_TEXT_LIKE_FORMATS = frozenset({"csv", "json", "log", "avro", "parquet", "txt", "md"})
 _MULTI_MODAL_FORMATS = frozenset({"jpeg", "jpg", "pdf", "png"})
 _COMPRESSION_SUFFIXES = {
     "bz2": "bzip2",
@@ -64,7 +65,7 @@ _COMPRESSION_SUFFIXES = {
     "xz": "xz",
     "zst": "zstd",
 }
-_GZIP_SUPPORTED_FORMATS = frozenset({"csv", "json", "log", "txt"})
+_GZIP_SUPPORTED_FORMATS = frozenset({"csv", "json", "log", "txt", "md"})
 _TEXT_SAMPLE_HEAD_CHARS = 8_000
 _TEXT_SAMPLE_TAIL_CHARS = 2_000
 _MEDIA_TYPES = {

--- a/providers/common/ai/tests/unit/common/ai/utils/test_file_analysis.py
+++ b/providers/common/ai/tests/unit/common/ai/utils/test_file_analysis.py
@@ -90,6 +90,28 @@ class TestBuildFileAnalysisRequest:
         assert "first line" in request.user_content
         assert "format=txt" in request.user_content
 
+    def test_markdown_file_analysis(self, tmp_path):
+        path = tmp_path / "notes.md"
+        path.write_text("# Notes\n\nFirst finding.\n", encoding="utf-8")
+
+        request = build_file_analysis_request(
+            file_path=str(path),
+            file_conn_id=None,
+            prompt="Summarize the notes",
+            multi_modal=False,
+            max_files=20,
+            max_file_size_bytes=1024,
+            max_total_size_bytes=2048,
+            max_text_chars=500,
+            sample_rows=10,
+        )
+
+        assert isinstance(request, FileAnalysisRequest)
+        assert request.resolved_paths == [str(path)]
+        assert "Summarize the notes" in request.user_content
+        assert "First finding" in request.user_content
+        assert "format=md" in request.user_content
+
     def test_file_conn_id_overrides_embedded_connection(self, tmp_path):
         path = tmp_path / "data.json"
         path.write_text('{"status": "ok"}', encoding="utf-8")
@@ -360,6 +382,8 @@ class TestFileAnalysisHelpers:
             ("app", "log", None),
             ("notes.txt", "txt", None),
             ("notes.txt.gz", "txt", "gzip"),
+            ("notes.md", "md", None),
+            ("notes.md.gz", "md", "gzip"),
         ],
     )
     def test_detect_file_format(self, tmp_path, filename, expected_format, expected_compression):


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Why
---

`LLMFileAnalysisOperator` do not support `.md` file and return `LLMFileAnalysisUnsupportedFormatError`.

What
---

- add `md` in `SUPPORTED_FILE_FORMATS`
- update `LLMFileAnalysisOperator` docs 

Test
---
Use the testing dag with self host LLM.

```python
from pathlib import Path

from airflow.providers.common.ai.operators.llm_file_analysis import LLMFileAnalysisOperator
from airflow.providers.common.compat.sdk import dag, task

MARKDOWN_PATH = "/tmp/llm_file_analysis_repro.md"


@dag(
    dag_id="repro_llm_file_analysis_markdown",
    schedule=None,
    catchup=False,
    tags=["manual", "repro", "common-ai"],
)
def repro_llm_file_analysis_markdown():
    @task
    def create_markdown_file() -> str:
        Path(MARKDOWN_PATH).write_text(
            "# Incident report\n\nThe API returned HTTP 503 for five minutes.\n",
            encoding="utf-8",
        )
        return MARKDOWN_PATH

    markdown_path = create_markdown_file()

    LLMFileAnalysisOperator(
        task_id="analyze_markdown",
        prompt="Summarize the incident report.",
        llm_conn_id="pydanticai_default",
        file_path=markdown_path,
    )


repro_llm_file_analysis_markdown()
```

### Log

Before

```
[2026-08-14 18:36:35] INFO - Preparing file analysis request for path=/tmp/llm_file_analysis_repro.md, file_conn_id=None, multi_modal=False, max_files=20, max_file_size_bytes=5242880, max_total_size_bytes=20971520, max_text_chars=100000, sample_rows=10
[2026-08-14 18:36:35] INFO - Resolved 1 file(s) from /tmp/llm_file_analysis_repro.md
[2026-08-14 18:36:35] ERROR - Task failed with exception
LLMFileAnalysisUnsupportedFormatError: Unsupported file format 'md' for /tmp/llm_file_analysis_repro.md. Supported formats: avro, csv, jpeg, jpg, json, log, parquet, pdf, png, txt.
```

After
```
[2026-08-14 19:05:40] INFO - Preparing file analysis request for path=/tmp/llm_file_analysis_repro.md, file_conn_id=None, multi_modal=False, max_files=20, max_file_size_bytes=5242880, max_total_size_bytes=20971520, max_text_chars=100000, sample_rows=10
[2026-08-14 19:05:40] INFO - Resolved 1 file(s) from /tmp/llm_file_analysis_repro.md
[2026-08-14 19:05:41] WARNING - You are using a Python version (3.10.20) which Google will stop supporting in new releases of google.api_core once it reaches its end of life (2026-10-04). Please upgrade to the latest Python version, or at least Python 3.11, to continue receiving updates for google.api_core past that date. category=FutureWarning
[2026-08-14 19:05:42] WARNING - You are using a Python version (3.10.20) which Google will stop supporting in new releases of google.cloud.secretmanager_v1 once it reaches its end of life (2026-10-04). Please upgrade to the latest Python version, or at least Python 3.11, to continue receiving updates for google.cloud.secretmanager_v1 past that date. category=FutureWarning
[2026-08-14 19:05:42] INFO - Validated byte limits for 1 file(s) before reading file contents; total_size_bytes=63.
[2026-08-14 19:05:43] INFO - Prepared file analysis request with 1 text file(s), 0 attachment(s), total_size_bytes=63.
[2026-08-14 19:05:43] INFO - Calling model for file analysis: files=1, attachments=0, text_files=1, total_size_bytes=63, omitted_files=0, text_truncated=False, multi_modal=False, sample_rows=10
[2026-08-14 19:05:43] INFO - Using explicit credentials for provider with model 'openai:Qwen/Qwen3-0.6B': ['api_key', 'base_url']
```

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (Codex:GPT-5.6-sol)
Generated-by: (Codex:GPT-5.6-sol) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
