### PR TITLE
Fix Keycloak multi-team permission repair

### DIFF
--- a/providers/keycloak/docs/changelog.rst
+++ b/providers/keycloak/docs/changelog.rst
@@ -27,10 +27,10 @@ Changelog
 
 .. note::
     Upgrading the provider does not update existing Keycloak permissions. For each existing team,
-    run ``airflow keycloak-auth-manager create-team <team>`` again to update the team ReadOnly
-    permission. For non-team installations, run
-    ``airflow keycloak-auth-manager create-permissions`` again without ``--teams`` to update the
-    global Admin permission.
+    run ``airflow keycloak-auth-manager create-team <team>`` again to update the team-specific
+    permissions and repair the global ``ReadOnly`` and ``Admin`` permissions. For non-team
+    installations, run ``airflow keycloak-auth-manager create-permissions`` again without
+    ``--teams`` to update the global ``ReadOnly`` and ``Admin`` permissions.
 
     Manually added policies attached to these permissions will also be evaluated under the
     ``AFFIRMATIVE`` strategy after the update.

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/commands.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/commands.py
@@ -306,6 +306,40 @@ def _attach_default_role_permissions(
         )
 
 
+def _update_read_only_permission_resources(
+    client: KeycloakAdmin, client_uuid: str, *, _dry_run: bool = False
+) -> None:
+    if _dry_run:
+        print("Would update permission 'ReadOnly' with unscoped readable resources.")
+        return
+
+    permissions = client.get_client_authz_permissions(client_uuid)
+    match = next((perm for perm in permissions if perm.get("name") == "ReadOnly"), None)
+    if not match:
+        return
+
+    permission_id = match["id"]
+    scopes = client.get_client_authz_scopes(client_uuid)
+    resources = client.get_client_authz_resources(client_uuid)
+    scope_ids = [s["id"] for s in scopes if s["name"] in ["GET", "MENU", "LIST"]]
+    resource_names = TEAM_SCOPED_RESOURCE_NAMES | GLOBAL_SCOPED_RESOURCE_NAMES
+    resource_ids = [r["_id"] for r in resources if r["name"] in resource_names]
+    policy_ids = _get_permission_policy_ids(client, client_uuid, permission_id)
+    payload = {
+        "id": permission_id,
+        "name": "ReadOnly",
+        "type": "scope",
+        "logic": "POSITIVE",
+        "decisionStrategy": "AFFIRMATIVE",
+        "scopes": scope_ids,
+        "resources": resource_ids,
+        "policies": policy_ids,
+    }
+    client.update_client_authz_scope_permission(
+        payload=payload, client_id=client_uuid, scope_id=permission_id
+    )
+
+
 def _preview_scopes(*args, **kwargs):
     """Preview scopes that would be created."""
     scopes = _get_scopes_to_create()
@@ -701,7 +735,11 @@ def _update_admin_permission_resources(
         or r["name"] in GLOBAL_SCOPED_RESOURCE_NAMES
     ]
 
-    policy_ids = _get_permission_policy_ids(client, client_uuid, permission_id)
+    existing_policy_ids = _get_permission_policy_ids(client, client_uuid, permission_id)
+    super_admin_policy_id = _get_policy_id(client, client_uuid, _role_policy_name(SUPER_ADMIN_ROLE_NAME))
+    policy_ids = [policy_id for policy_id in existing_policy_ids if policy_id == super_admin_policy_id]
+    if super_admin_policy_id and super_admin_policy_id not in policy_ids:
+        policy_ids.append(super_admin_policy_id)
     payload = {
         "id": permission_id,
         "name": "Admin",
@@ -735,6 +773,7 @@ def create_team_command(args):
     _attach_team_permissions(client, client_uuid, team, _dry_run=args.dry_run)
     _attach_team_menu_permissions(client, client_uuid, team, _dry_run=args.dry_run)
     _attach_superadmin_permissions(client, client_uuid, team, _dry_run=args.dry_run)
+    _update_read_only_permission_resources(client, client_uuid, _dry_run=args.dry_run)
     _update_admin_permission_resources(client, client_uuid, _dry_run=args.dry_run)
 
 

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/cli/test_commands.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/cli/test_commands.py
@@ -29,6 +29,8 @@ from airflow.providers.keycloak.auth_manager.cli.commands import (
     TEAM_SCOPED_RESOURCE_NAMES,
     _get_extended_resource_methods,
     _get_resource_methods,
+    _update_admin_permission_resources,
+    _update_read_only_permission_resources,
     add_user_to_team_command,
     create_all_command,
     create_permissions_command,
@@ -427,6 +429,72 @@ class TestCommands:
             skip_exists=True,
         )
 
+    @patch("airflow.providers.keycloak.auth_manager.cli.commands._get_permission_policy_ids")
+    def test_update_read_only_permission_resources_excludes_team_resources(
+        self, mock_get_permission_policy_ids
+    ):
+        client = Mock()
+        client.get_client_authz_permissions.return_value = [{"id": "readonly-id", "name": "ReadOnly"}]
+        client.get_client_authz_scopes.return_value = [
+            {"id": "scope-get", "name": "GET"},
+            {"id": "scope-list", "name": "LIST"},
+            {"id": "scope-menu", "name": "MENU"},
+            {"id": "scope-put", "name": "PUT"},
+        ]
+        client.get_client_authz_resources.return_value = [
+            {"_id": "dag-global", "name": "Dag"},
+            {"_id": "dag-team-a", "name": "Dag:team-a"},
+            {"_id": "variable-global", "name": "Variable"},
+            {"_id": "variable-team-a", "name": "Variable:team-a"},
+            {"_id": "asset-global", "name": "Asset"},
+        ]
+        mock_get_permission_policy_ids.return_value = ["viewer-policy", "admin-policy"]
+
+        _update_read_only_permission_resources(client, "test-id")
+
+        client.update_client_authz_scope_permission.assert_called_once_with(
+            client_id="test-id",
+            scope_id="readonly-id",
+            payload={
+                "id": "readonly-id",
+                "name": "ReadOnly",
+                "type": "scope",
+                "logic": "POSITIVE",
+                "decisionStrategy": "AFFIRMATIVE",
+                "scopes": ["scope-get", "scope-list", "scope-menu"],
+                "resources": ["dag-global", "variable-global", "asset-global"],
+                "policies": ["viewer-policy", "admin-policy"],
+            },
+        )
+
+    @patch("airflow.providers.keycloak.auth_manager.cli.commands._get_policy_id")
+    @patch("airflow.providers.keycloak.auth_manager.cli.commands._get_permission_policy_ids")
+    def test_update_admin_permission_resources_removes_admin_role_policy(
+        self, mock_get_permission_policy_ids, mock_get_policy_id
+    ):
+        client = Mock()
+        client.get_client_authz_permissions.return_value = [{"id": "admin-id", "name": "Admin"}]
+        client.get_client_authz_scopes.return_value = [
+            {"id": "scope-get", "name": "GET"},
+            {"id": "scope-list", "name": "LIST"},
+            {"id": "scope-put", "name": "PUT"},
+        ]
+        client.get_client_authz_resources.return_value = [
+            {"_id": "dag-global", "name": "Dag"},
+            {"_id": "dag-team-a", "name": "Dag:team-a"},
+            {"_id": "dag-team-b", "name": "Dag:team-b"},
+            {"_id": "asset-global", "name": "Asset"},
+        ]
+        mock_get_permission_policy_ids.return_value = ["admin-policy", "superadmin-policy"]
+        mock_get_policy_id.return_value = "superadmin-policy"
+
+        _update_admin_permission_resources(client, "test-id")
+
+        client.update_client_authz_scope_permission.assert_called_once()
+        payload = client.update_client_authz_scope_permission.call_args.kwargs["payload"]
+        assert payload["policies"] == ["superadmin-policy"]
+        assert payload["resources"] == ["dag-team-a", "dag-team-b", "asset-global"]
+
     @patch("airflow.providers.keycloak.auth_manager.cli.commands._attach_policy_to_resource_permission")
     @patch("airflow.providers.keycloak.auth_manager.cli.commands._attach_policy_to_scope_permission")
     @patch("airflow.providers.keycloak.auth_manager.cli.commands._ensure_role_policy")
@@ -501,6 +569,7 @@ class TestCommands:
         )
 
     @patch("airflow.providers.keycloak.auth_manager.cli.commands._update_admin_permission_resources")
+    @patch("airflow.providers.keycloak.auth_manager.cli.commands._update_read_only_permission_resources")
     @patch("airflow.providers.keycloak.auth_manager.cli.commands._ensure_scope_permission")
     @patch("airflow.providers.keycloak.auth_manager.cli.commands._attach_policy_to_resource_permission")
     @patch("airflow.providers.keycloak.auth_manager.cli.commands._attach_policy_to_scope_permission")
@@ -521,6 +590,7 @@ class TestCommands:
         mock_attach_policy,
         mock_attach_resource_policy,
         mock_ensure_scope_permission,
+        mock_update_read_only_permission_resources,
         mock_update_admin_permission_resources,
     ):
         client = Mock()
@@ -557,6 +627,7 @@ class TestCommands:
         mock_create_permissions.assert_called_once_with(
             client, "test-id", teams=["team-a"], include_global_admin=False, _dry_run=False
         )
+        mock_update_read_only_permission_resources.assert_called_once_with(client, "test-id", _dry_run=False)
         mock_update_admin_permission_resources.assert_called_once_with(client, "test-id", _dry_run=False)
         mock_ensure_group_policy.assert_called_once_with(client, "test-id", "team-a", _dry_run=False)
         assert mock_ensure_aggregate_policy.call_count == 4


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Why:

In multi-team Keycloak setups, permissions created by older provider versions can leave global `ReadOnly` and `Admin` permissions broad enough to authorize team-scoped resources outside the user's team. That lets a user with a regular team role see Dags, Variables, or Connections owned by another team through REST API list/read endpoints.

relates: #71277

## Solution:

Update `create-team` to repair the global Keycloak permissions used by existing installations. The global `ReadOnly` permission is restricted to unscoped/global resources, while the global `Admin` permission keeps cross-team access only for `SuperAdmin`. Regular `Admin` users continue to get access through team-specific group-and-role policies.



##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

-  `[X]` Yes (please specify the tool below)


Generated-by: [Codex] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
