### PR TITLE
Build lang-SDK k8s test artifacts from the checkout's own SDKs

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
@@ -32,7 +32,6 @@ from typing import Any
 import click
 import yaml
 
-from airflow_breeze.branch_defaults import AIRFLOW_BRANCH
 from airflow_breeze.commands.common_options import (
     option_answer,
     option_debug_resources,
@@ -2510,41 +2509,32 @@ LANG_SDK_AWS_CONN_URI = (
     "aws://test:test@/?region_name=us-east-1&"
     "endpoint_url=http%3A%2F%2Flocalstack.airflow.svc.cluster.local%3A4566"
 )
-# Runs targeting a branch other than main build the Go/Java SDKs from upstream main, so
-# release/backport branches with stale or missing go-sdk/java-sdk copies still test current SDK
-# sources. See kubernetes-tests/lang_sdk/README.md.
+# A checkout that predates go-sdk/java-sdk builds them from upstream main instead, so the test can
+# still run there. See kubernetes-tests/lang_sdk/README.md.
 LANG_SDK_UPSTREAM_GIT_URL = "https://github.com/apache/airflow.git"
 LANG_SDK_UPSTREAM_REF = "main"
-# The target branch for which the lang-SDK artifacts are built from this checkout's own SDK
-# sources rather than fetched from upstream. Distinct from LANG_SDK_UPSTREAM_REF (the ref fetched
-# from upstream) even though both are "main" today -- one names a git ref, the other a sentinel.
-LANG_SDK_LOCAL_SOURCE_BRANCH = "main"
-
-
-def _lang_sdk_target_branch() -> str:
-    """Branch this run targets: GITHUB_BASE_REF or DEFAULT_BRANCH if set, else this checkout's."""
-    return os.environ.get("GITHUB_BASE_REF") or os.environ.get("DEFAULT_BRANCH") or AIRFLOW_BRANCH
 
 
 def _lang_sdk_resolve_sdk_sources(staging: Path, output: Output | None) -> tuple[Path, Path]:
-    """Resolve the go-sdk/java-sdk trees the lang-SDK artifacts are built from.
-
-    A run targeting main builds the checked-out branch's own SDK sources, so a PR's SDK changes
-    are what the k8s test exercises -- without this, ``java_example``/``go_example`` (harness code
-    that tracks the branch) is compiled against a different SDK than the branch it belongs to, and
-    any SDK rename breaks the build. Runs targeting anything else fall back to upstream main.
-    """
-    target = _lang_sdk_target_branch()
-    if target == LANG_SDK_LOCAL_SOURCE_BRANCH:
+    """Resolve the go-sdk/java-sdk trees the lang-SDK artifacts are built from."""
+    go_sdk = AIRFLOW_ROOT_PATH / "go-sdk"
+    java_sdk = AIRFLOW_ROOT_PATH / "java-sdk"
+    missing = [path.name for path in (go_sdk, java_sdk) if not path.is_dir()]
+    if not missing:
         get_console(output=output).print(
-            f"[info]Run targets {target}: building the lang-SDK Go/Java artifacts from this branch"
+            "[info]Building the lang-SDK Go/Java artifacts from this checkout's own go-sdk/java-sdk"
         )
-        return AIRFLOW_ROOT_PATH / "go-sdk", AIRFLOW_ROOT_PATH / "java-sdk"
+        return go_sdk, java_sdk
     get_console(output=output).print(
-        f"[info]Run targets {target}, not {LANG_SDK_LOCAL_SOURCE_BRANCH}: building the lang-SDK Go/Java "
-        f"artifacts from upstream {LANG_SDK_UPSTREAM_REF}"
+        f"[info]This checkout has no {', '.join(missing)}: building that part of the lang-SDK "
+        f"artifacts from upstream {LANG_SDK_UPSTREAM_REF} instead"
     )
-    return _lang_sdk_fetch_upstream_sdk_sources(staging, output)
+    # Only what the checkout lacks comes from upstream; an SDK the branch does carry is still its own.
+    upstream_go_sdk, upstream_java_sdk = _lang_sdk_fetch_upstream_sdk_sources(staging, output)
+    return (
+        upstream_go_sdk if "go-sdk" in missing else go_sdk,
+        upstream_java_sdk if "java-sdk" in missing else java_sdk,
+    )
 
 
 def _lang_sdk_fetch_upstream_sdk_sources(staging: Path, output: Output | None) -> tuple[Path, Path]:
@@ -2646,11 +2636,11 @@ def _lang_sdk_build_go_bundle(
     # CGO_ENABLED=0 yields a fully static binary that runs on the stock worker. The package built is
     # the current dir (".") because go_example is its own module.
     #
-    # go_example's go.sum is tidied against the in-repo go-sdk, but the bundle is built against the
-    # upstream-main go-sdk copied in above. When a branch changes go-sdk's dependency graph those two
-    # go-sdks differ, and Go refuses to build on the resulting go.sum drift. Re-tidy the scratch copy
-    # first so the build reconciles to whichever go-sdk it is actually compiled against; the committed
-    # go.sum is untouched and stays guarded by the check-go-example-mod-tidy prek hook.
+    # go_example's go.sum is tidied against the in-repo go-sdk, which is the go-sdk copied in above
+    # unless this checkout has none. When the two differ in dependency graph Go refuses to build on
+    # the resulting go.sum drift, so re-tidy the scratch copy first and let the build reconcile to
+    # whichever go-sdk it is actually compiled against; the committed go.sum is untouched and stays
+    # guarded by the check-go-example-mod-tidy prek hook.
     if native:
         get_console(output=output).print("[info]Building Go bundle with the host Go toolchain")
         go_env = {**os.environ, "CGO_ENABLED": "0"}
@@ -2722,8 +2712,8 @@ def _lang_sdk_build_java_jar(
 
     Both gradle invocations run against ``java_sdk_source``; only ``-p`` stays pointed at the local
     ``java_example``, which is test-harness code that keeps tracking the checked-out branch. The two
-    therefore only agree when the source is the local ``java-sdk/`` -- on a run targeting a non-main
-    branch the example is compiled against upstream main's SDK, so it must stay compatible with it.
+    therefore only agree when the source is the local ``java-sdk/`` -- a checkout without one compiles
+    the example against upstream main's SDK, so it must stay compatible with it.
     """
     java_dir = staging / "java-artifacts"
     java_dir.mkdir(parents=True, exist_ok=True)
@@ -2751,7 +2741,7 @@ def _lang_sdk_build_java_jar(
         # --user keeps build outputs owned by the host user; HOME is set explicitly because that UID has
         # no /etc/passwd entry. GRADLE_USER_HOME and the mounted ~/.m2 persist the Gradle distribution
         # and dependency caches between runs -- outside /repo/java-sdk, which is remounted to the
-        # (per-run) upstream copy below.
+        # resolved SDK source below.
         LANG_SDK_MAVEN_CACHE_PATH.mkdir(parents=True, exist_ok=True)
         LANG_SDK_GRADLE_CACHE_PATH.mkdir(parents=True, exist_ok=True)
         java_docker_prefix = [
@@ -3077,7 +3067,7 @@ def _setup_lang_sdk_test(
 ) -> None:
     """Provision the lang-SDK coordinator env on an already-deployed KubernetesExecutor cluster.
 
-    Fetches go-sdk/java-sdk from upstream main, then builds the Go/Java artifacts, the Java worker
+    Resolves the go-sdk/java-sdk sources, then builds the Go/Java artifacts, the Java worker
     image and deploys localstack in parallel, then serially uploads the artifacts, applies the
     config + secret, and helm-upgrades Airflow with the lang-SDK values.
     """

--- a/dev/breeze/tests/test_kubernetes_lang_sdk_commands.py
+++ b/dev/breeze/tests/test_kubernetes_lang_sdk_commands.py
@@ -20,14 +20,12 @@ from unittest import mock
 
 import pytest
 
-from airflow_breeze.branch_defaults import AIRFLOW_BRANCH
 from airflow_breeze.commands import kubernetes_commands
 from airflow_breeze.commands.kubernetes_commands import (
     _lang_sdk_build_go_bundle,
     _lang_sdk_build_java_jar,
     _lang_sdk_fetch_upstream_sdk_sources,
     _lang_sdk_resolve_sdk_sources,
-    _lang_sdk_target_branch,
     _lang_sdk_upload_artifacts,
 )
 from airflow_breeze.utils import shared_options
@@ -379,54 +377,58 @@ class TestSetupLangSdkTestNativeSelection:
         }
 
 
-class TestLangSdkTargetBranch:
+class TestLangSdkResolveSdkSources:
+    @pytest.fixture
+    def repo_root(self, tmp_path, monkeypatch):
+        """A checkout root whose go-sdk/java-sdk presence each test decides for itself."""
+        root = tmp_path / "repo"
+        root.mkdir()
+        monkeypatch.setattr(kubernetes_commands, "AIRFLOW_ROOT_PATH", root)
+        return root
+
     @pytest.mark.parametrize(
-        ("env", "expected"),
+        "env",
         [
-            pytest.param({"GITHUB_BASE_REF": "main"}, "main", id="pr-targeting-main"),
-            pytest.param({"GITHUB_BASE_REF": "v3-3-test"}, "v3-3-test", id="pr-targeting-release"),
-            pytest.param({"DEFAULT_BRANCH": "v3-3-test"}, "v3-3-test", id="ci-default-branch"),
+            pytest.param({}, id="no-ci-env"),
             pytest.param(
-                {"GITHUB_BASE_REF": "main", "DEFAULT_BRANCH": "v3-3-test"},
-                "main",
-                id="pr-target-wins-over-default-branch",
+                {"GITHUB_BASE_REF": "v3-3-test", "DEFAULT_BRANCH": "v3-3-test"},
+                id="run-targeting-a-release-branch",
             ),
-            pytest.param({}, AIRFLOW_BRANCH, id="falls-back-to-this-checkouts-branch"),
         ],
     )
-    def test_resolves_target_branch(self, env, expected, monkeypatch):
-        monkeypatch.delenv("GITHUB_BASE_REF", raising=False)
-        monkeypatch.delenv("DEFAULT_BRANCH", raising=False)
+    @mock.patch.object(kubernetes_commands, "_lang_sdk_fetch_upstream_sdk_sources")
+    def test_checkout_with_both_sdks_builds_its_own(self, mock_fetch, env, repo_root, tmp_path, monkeypatch):
+        """The branch a run targets does not divert it to upstream main's newer SDKs."""
+        (repo_root / "go-sdk").mkdir()
+        (repo_root / "java-sdk").mkdir()
         for key, value in env.items():
             monkeypatch.setenv(key, value)
 
-        assert _lang_sdk_target_branch() == expected
-
-    def test_empty_env_var_does_not_mask_the_fallback(self, monkeypatch):
-        """GitHub sets GITHUB_BASE_REF to an empty string on non-PR events (push, schedule)."""
-        monkeypatch.setenv("GITHUB_BASE_REF", "")
-        monkeypatch.setenv("DEFAULT_BRANCH", "v3-3-test")
-
-        assert _lang_sdk_target_branch() == "v3-3-test"
-
-
-class TestLangSdkResolveSdkSources:
-    @mock.patch.object(kubernetes_commands, "_lang_sdk_fetch_upstream_sdk_sources")
-    def test_targeting_main_uses_the_checked_out_branch(self, mock_fetch, tmp_path, monkeypatch):
-        monkeypatch.setenv("GITHUB_BASE_REF", "main")
-
         go_sdk, java_sdk = _lang_sdk_resolve_sdk_sources(tmp_path, None)
 
-        assert go_sdk == kubernetes_commands.AIRFLOW_ROOT_PATH / "go-sdk"
-        assert java_sdk == kubernetes_commands.AIRFLOW_ROOT_PATH / "java-sdk"
+        assert (go_sdk, java_sdk) == (repo_root / "go-sdk", repo_root / "java-sdk")
         mock_fetch.assert_not_called()
 
+    @pytest.mark.parametrize(
+        ("present", "expected_go_sdk", "expected_java_sdk"),
+        [
+            pytest.param([], "upstream-go-sdk", "upstream-java-sdk", id="neither-sdk"),
+            pytest.param(["go-sdk"], "go-sdk", "upstream-java-sdk", id="only-go-sdk"),
+            pytest.param(["java-sdk"], "upstream-go-sdk", "java-sdk", id="only-java-sdk"),
+        ],
+    )
     @mock.patch.object(kubernetes_commands, "_lang_sdk_fetch_upstream_sdk_sources")
-    def test_targeting_another_branch_falls_back_to_upstream_main(self, mock_fetch, tmp_path, monkeypatch):
-        monkeypatch.setenv("GITHUB_BASE_REF", "v3-3-test")
-        mock_fetch.return_value = (tmp_path / "go-sdk", tmp_path / "java-sdk")
+    def test_only_the_sdks_a_checkout_lacks_come_from_upstream_main(
+        self, mock_fetch, present, expected_go_sdk, expected_java_sdk, repo_root, tmp_path
+    ):
+        for name in present:
+            (repo_root / name).mkdir()
+        upstream = {name: tmp_path / f"upstream-{name}" for name in ("go-sdk", "java-sdk")}
+        mock_fetch.return_value = (upstream["go-sdk"], upstream["java-sdk"])
+        local = {name: repo_root / name for name in ("go-sdk", "java-sdk")}
+        resolved = {**local, **{f"upstream-{name}": path for name, path in upstream.items()}}
 
         go_sdk, java_sdk = _lang_sdk_resolve_sdk_sources(tmp_path, None)
 
         mock_fetch.assert_called_once_with(tmp_path, None)
-        assert (go_sdk, java_sdk) == (tmp_path / "go-sdk", tmp_path / "java-sdk")
+        assert (go_sdk, java_sdk) == (resolved[expected_go_sdk], resolved[expected_java_sdk])

--- a/kubernetes-tests/lang_sdk/README.md
+++ b/kubernetes-tests/lang_sdk/README.md
@@ -65,21 +65,25 @@ The Go binary, Java jar, and stub Dag share one object store (localstack) but li
 
 ## Which SDK sources get built
 
-`go-sdk/` and `java-sdk/` are only developed on `main`; a release/backport branch may lack them
-entirely or carry a stale, branch-cut-frozen copy. So `breeze k8s setup-lang-sdk-test` (and
-`run-complete-tests --lang-sdk-test`) picks the sources from the branch the run **targets**, resolved
-by `_lang_sdk_resolve_sdk_sources()` in `kubernetes_commands.py`:
+`breeze k8s setup-lang-sdk-test` (and `run-complete-tests --lang-sdk-test`) builds the SDKs the
+checkout carries, resolved by `_lang_sdk_resolve_sdk_sources()` in `kubernetes_commands.py`:
 
-| Target branch | Go/Java SDK sources |
+| Checkout | Go/Java SDK sources |
 | --- | --- |
-| `main` | the checked-out branch's own `go-sdk/` and `java-sdk/` |
-| anything else (`v3-*-test`, …) | upstream `main`, fetched fresh via `_lang_sdk_fetch_upstream_sdk_sources()` |
+| has `go-sdk/` and `java-sdk/` | its own copies |
+| missing one or both | the missing ones from upstream `main`, fetched fresh via `_lang_sdk_fetch_upstream_sdk_sources()` |
 
-The target is `GITHUB_BASE_REF` for a PR, then `DEFAULT_BRANCH` if set, falling back to this
-checkout's own `AIRFLOW_BRANCH`. Building a main-targeting PR's own SDK is what makes the k8s test
-exercise that PR: `go_example`/`java_example` are harness fixtures that track the checked-out branch,
-so compiling them against a *different* SDK means any SDK rename in the PR fails to build. A
-backport to a release-test branch still gets current SDK code, as before.
+The whole point of the test is the SDK/supervisor pair: a Go or Java worker announces the AIP-72
+supervisor schema version it was compiled against, and the Python supervisor rejects a bundle whose
+version it does not know. Only the SDKs sitting next to `task-sdk/` in the same checkout are a pair
+that ships together — substituting upstream `main`'s newer SDK on a release branch pairs it with
+that branch's older supervisor, a combination no release contains, and every worker task fails the
+moment `main` moves the schema forward. The same reasoning applies to `go_example`/`java_example`:
+they are harness fixtures that track the checked-out branch, so compiling them against a *different*
+SDK means any SDK rename breaks the build.
+
+The upstream fallback is for a checkout old enough to predate `go-sdk/`/`java-sdk/` — without it the
+test cannot run there at all.
 
 Everything else — `airflow-core/`, `task-sdk/`, the deployed Airflow image, and this directory's own
 `go_example`/`java_example` fixtures — always comes from the checked-out branch.


### PR DESCRIPTION
## Summary

The lang-SDK Kubernetes test builds its Go and Java worker artifacts from upstream `main` on any run that does not target `main`, pairing main's SDK with the checked-out branch's supervisor — a combination no release ships. Since #69757 moved the AIP-72 supervisor schema to `2026-10-30`, every `v3-3-test` run fails: the Go bundle announces a version that branch's supervisor does not know, so it is rejected and `go_extract` dies with `cannot find executable bundle with usable supervisor_schema_version`.

A worker and a supervisor only agree on the wire schema when they come from the same checkout, so that is what the test builds now. The upstream fetch survives for a checkout that has no `go-sdk/`/`java-sdk/` at all, narrowed to whichever SDK is absent.

`main` keeps building its own SDKs as it already does. `v3-3-test` stays red until this is cherry-picked there, so it needs the `backport-to-v3-3-test` label before merge.

related: #71527, #71588

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
