### PR TITLE
Fix inverted docstring for config write hide_sensitive option

### DIFF
--- a/shared/configuration/src/airflow_shared/configuration/parser.py
+++ b/shared/configuration/src/airflow_shared/configuration/parser.py
@@ -2100,7 +2100,7 @@ class AirflowConfigParser(ConfigParser):
         :param include_env_vars: Include environment variables corresponding to each config option
         :param include_providers: Include providers configuration
         :param comment_out_everything: Comment out all values
-        :param hide_sensitive_values: Include sensitive values in the output
+        :param hide_sensitive: Replace sensitive values in the output with "< hidden >"
         :param extra_spacing: Add extra spacing before examples and after variables
         :param only_defaults: Only include default values when writing the config, not the actual values
         """


### PR DESCRIPTION
### Sumarry

`AirflowConfigParser.write()` documents its masking flag as
`:param hide_sensitive_values: Include sensitive values in the output`.

Both halves are wrong. The parameter is named `hide_sensitive`, and the
implementation does the opposite of what the description says:

```python
if hide_sensitive and is_sensitive:
    value = "< hidden >"
```

This PR fixed the both problems of documents (The wrong name and wrong implementation description)

Just fixed documents, no any behavior be changed.