### PR TITLE
Fix SSO docs pointing at the pre-Airflow 3 OAuth redirect path

### DIFF
--- a/providers/fab/docs/auth-manager/sso.rst
+++ b/providers/fab/docs/auth-manager/sso.rst
@@ -297,12 +297,14 @@ Troubleshooting
 
   - Check Airflow and webserver logs for detailed error messages
   - Ensure all environment variables are set and exported correctly
-  - Verify callback URLs in your SSO provider match your Airflow webserver URL (typically ``http://your-airflow-domain/oauth-authorized``)
+  - Verify callback URLs in your SSO provider match your Airflow webserver URL (typically ``http://your-airflow-domain/auth/oauth-authorized/<provider>``)
 
 - **Redirect URI mismatch**:
 
-  - In your OAuth provider, set the redirect URI to: ``http://your-airflow-domain/oauth-authorized``
-  - For development, this might be: ``http://localhost:8080/oauth-authorized``
+  - In your OAuth provider, set the redirect URI to: ``http://your-airflow-domain/auth/oauth-authorized/<provider>``,
+    where ``<provider>`` is the ``name`` you gave it in ``OAUTH_PROVIDERS``
+  - For development, this might be: ``http://localhost:8080/auth/oauth-authorized/google``
+  - On Airflow 2 the path had no ``/auth`` prefix: ``http://your-airflow-domain/oauth-authorized/<provider>``
 
 - **Scope-related errors**:
 


### PR DESCRIPTION
The FAB auth manager's app is mounted at `/auth` and its OAuth callback route is per-provider, so the redirect URI is `/auth/oauth-authorized/<provider>`. The troubleshooting section of the SSO guide still shows the Airflow 2 webserver path, with no `/auth` prefix and no provider segment. Following it registers a redirect URI the provider never calls back, which is the exact mismatch that section is meant to resolve.

`webserver-authentication.rst` and `api-authentication.rst` already document the correct path. This brings `sso.rst` in line with them, and notes the Airflow 2 path for anyone who hit this while upgrading.

closes: #71569

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
