### PR TITLE
Add DatadogMonitorSensorAsync waiting on a monitor's overall state

### DIFF
--- a/providers/datadog/provider.yaml
+++ b/providers/datadog/provider.yaml
@@ -74,6 +74,11 @@ sensors:
     python-modules:
       - airflow.providers.datadog.sensors.datadog
 
+triggers:
+  - integration-name: Datadog
+    python-modules:
+      - airflow.providers.datadog.triggers.datadog
+
 hooks:
   - integration-name: Datadog
     python-modules:

--- a/providers/datadog/src/airflow/providers/datadog/sensors/datadog.py
+++ b/providers/datadog/src/airflow/providers/datadog/sensors/datadog.py
@@ -17,13 +17,33 @@
 # under the License.
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 from datadog import api
 
-from airflow.providers.common.compat.sdk import AirflowException, BaseSensorOperator
+from airflow.providers.common.compat.sdk import (
+    AirflowException,
+    AirflowSensorTimeout,
+    AirflowSkipException,
+    BaseSensorOperator,
+)
 from airflow.providers.datadog.hooks.datadog import DatadogHook
+from airflow.providers.datadog.triggers.datadog import DatadogMonitorTrigger
+
+try:
+    from airflow.sdk.exceptions import TaskDeferralError, TaskDeferralTimeout
+except ImportError:  # Airflow 2.x
+    from airflow.exceptions import TaskDeferralError
+
+    try:
+        from airflow.exceptions import TaskDeferralTimeout
+    except ImportError:
+
+        class TaskDeferralTimeout(TaskDeferralError):  # type: ignore[no-redef]
+            """Not raised before Airflow 3; timeouts arrive as TaskDeferralError."""
+
 
 if TYPE_CHECKING:
     from airflow.providers.common.compat.sdk import Context
@@ -98,3 +118,71 @@ class DatadogSensor(BaseSensorOperator):
 
         # If no check was inserted, assume any event that matched yields true.
         return bool(response)
+
+
+class DatadogMonitorSensorAsync(BaseSensorOperator):
+    """
+    Waits for a Datadog monitor to reach one of the target states.
+
+    This sensor always runs deferred: it waits in the triggerer and never
+    occupies a worker slot while waiting.
+
+    :param monitor_id: The id of the Datadog monitor to watch.
+    :param target_states: Monitor overall states that complete the wait
+        (e.g. ``("OK",)`` or ``("Alert", "Warn")``).
+    :param datadog_conn_id: The connection to datadog, containing metadata for api keys.
+    """
+
+    ui_color = "#66c3dd"
+    deferrable = True
+
+    def __init__(
+        self,
+        *,
+        monitor_id: int,
+        target_states: Sequence[str] = ("OK",),
+        datadog_conn_id: str = "datadog_default",
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.monitor_id = monitor_id
+        self.target_states = target_states
+        self.datadog_conn_id = datadog_conn_id
+
+    def execute(self, context: Context) -> None:
+        self.defer(
+            trigger=DatadogMonitorTrigger(
+                monitor_id=self.monitor_id,
+                target_states=self.target_states,
+                datadog_conn_id=self.datadog_conn_id,
+                poke_interval=self.poke_interval,
+            ),
+            method_name="execute_complete",
+            timeout=timedelta(seconds=self.timeout),
+        )
+
+    def execute_complete(self, context: Context, event: dict[str, Any]) -> None:
+        if event.get("status") != "success":
+            raise AirflowException(f"DatadogMonitorTrigger failed: {event}")
+        self.log.info("Monitor %s reached state %s", self.monitor_id, event.get("state"))
+
+    def resume_execution(self, next_method: str, next_kwargs: dict[str, Any] | None, context: Context):
+        """
+        Resume from deferral, applying ``soft_fail`` only to timeouts.
+
+        ``BaseSensorOperator.resume_execution`` converts any deferral-path failure into a skip when
+        ``soft_fail`` is set, including trigger crashes (e.g. a bad monitor id or auth failure),
+        which silently skips the downstream branch. This sensor instead keeps parity with poke and
+        reschedule modes, where only timeouts are skippable and other errors fail the task.
+        """
+        try:
+            return super(BaseSensorOperator, self).resume_execution(next_method, next_kwargs, context)
+        except TaskDeferralError as e:
+            timed_out = isinstance(e, TaskDeferralTimeout) or str(e) == "Trigger/execution timeout"
+            if timed_out and self.soft_fail:
+                raise AirflowSkipException(str(e)) from e
+            if getattr(self, "never_fail", False):
+                raise AirflowSkipException(str(e)) from e
+            if timed_out:
+                raise AirflowSensorTimeout(*e.args) from e
+            raise

--- a/providers/datadog/src/airflow/providers/datadog/triggers/__init__.py
+++ b/providers/datadog/src/airflow/providers/datadog/triggers/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/datadog/src/airflow/providers/datadog/triggers/datadog.py
+++ b/providers/datadog/src/airflow/providers/datadog/triggers/datadog.py
@@ -1,0 +1,83 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Sequence
+from typing import Any
+
+from datadog import api
+
+from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.datadog.hooks.datadog import DatadogHook
+from airflow.triggers.base import BaseTrigger, TriggerEvent
+
+
+def get_monitor_state(monitor_id: int, datadog_conn_id: str) -> str:
+    """Return the current overall state of a Datadog monitor."""
+    # This instantiates the hook, but doesn't need it further, because the
+    # API authenticates globally (see DatadogSensor.poke).
+    DatadogHook(datadog_conn_id=datadog_conn_id)
+    response = api.Monitor.get(monitor_id)
+    if isinstance(response, dict) and "errors" in response:
+        raise AirflowException(f"Datadog monitor {monitor_id}: {response['errors']}")
+    return response["overall_state"]
+
+
+class DatadogMonitorTrigger(BaseTrigger):
+    """
+    Polls a Datadog monitor until it reaches one of the target states.
+
+    :param monitor_id: The id of the Datadog monitor to watch.
+    :param target_states: Monitor overall states that complete the wait.
+    :param datadog_conn_id: The connection to datadog, containing metadata for api keys.
+    :param poke_interval: Seconds to wait between checks of the monitor state.
+    """
+
+    def __init__(
+        self,
+        monitor_id: int,
+        target_states: Sequence[str],
+        datadog_conn_id: str,
+        poke_interval: float,
+    ):
+        super().__init__()
+        self.monitor_id = monitor_id
+        self.target_states = list(target_states)
+        self.datadog_conn_id = datadog_conn_id
+        self.poke_interval = poke_interval
+
+    def serialize(self) -> tuple[str, dict[str, Any]]:
+        return (
+            "airflow.providers.datadog.triggers.datadog.DatadogMonitorTrigger",
+            {
+                "monitor_id": self.monitor_id,
+                "target_states": self.target_states,
+                "datadog_conn_id": self.datadog_conn_id,
+                "poke_interval": self.poke_interval,
+            },
+        )
+
+    async def run(self) -> AsyncIterator[TriggerEvent]:
+        while True:
+            state = await asyncio.to_thread(get_monitor_state, self.monitor_id, self.datadog_conn_id)
+            self.log.info("Monitor %s overall_state=%s", self.monitor_id, state)
+            if state in self.target_states:
+                yield TriggerEvent({"status": "success", "state": state})
+                return
+            await asyncio.sleep(self.poke_interval)

--- a/providers/datadog/tests/unit/datadog/sensors/test_datadog.py
+++ b/providers/datadog/tests/unit/datadog/sensors/test_datadog.py
@@ -22,9 +22,19 @@ from unittest.mock import patch
 
 import pytest
 
+from airflow.exceptions import TaskDeferred
 from airflow.models import Connection
-from airflow.providers.common.compat.sdk import AirflowException
-from airflow.providers.datadog.sensors.datadog import DatadogSensor
+from airflow.providers.common.compat.sdk import (
+    AirflowException,
+    AirflowSensorTimeout,
+    AirflowSkipException,
+)
+from airflow.providers.datadog.sensors.datadog import (
+    DatadogMonitorSensorAsync,
+    DatadogSensor,
+    TaskDeferralError,
+)
+from airflow.providers.datadog.triggers.datadog import DatadogMonitorTrigger
 
 at_least_one_event = [
     {
@@ -133,3 +143,58 @@ class TestDatadogSensor:
         )
         with pytest.raises(AirflowException):
             sensor.poke({})
+
+
+monitor_ok = {"overall_state": "OK"}
+monitor_alert = {"overall_state": "Alert"}
+monitor_missing = {"errors": ["Monitor not found"]}
+
+
+class TestDatadogMonitorSensorAsync:
+    @pytest.fixture(autouse=True)
+    def setup_connections(self, create_connection_without_db):
+        create_connection_without_db(
+            Connection(
+                conn_id="datadog_default",
+                conn_type="datadog",
+                login="login",
+                password="password",
+                extra=json.dumps({"api_key": "api_key", "app_key": "app_key"}),
+            )
+        )
+
+    def test_execute_defers_with_trigger(self):
+        sensor = DatadogMonitorSensorAsync(task_id="t", monitor_id=1)
+        with pytest.raises(TaskDeferred) as ctx:
+            sensor.execute({})
+        assert isinstance(ctx.value.trigger, DatadogMonitorTrigger)
+
+    def test_execute_complete_raises_on_non_success(self):
+        sensor = DatadogMonitorSensorAsync(task_id="t", monitor_id=1)
+        with pytest.raises(AirflowException, match="DatadogMonitorTrigger failed"):
+            sensor.execute_complete({}, {"status": "error"})
+
+    def test_execute_complete_succeeds(self):
+        sensor = DatadogMonitorSensorAsync(task_id="t", monitor_id=1)
+        assert sensor.execute_complete({}, {"status": "success", "state": "OK"}) is None
+
+    def test_resume_execution_trigger_failure_fails_despite_soft_fail(self):
+        sensor = DatadogMonitorSensorAsync(task_id="t", monitor_id=1, soft_fail=True)
+        with pytest.raises(TaskDeferralError):
+            sensor.resume_execution(
+                next_method="__fail__", next_kwargs={"error": "Trigger failure"}, context={}
+            )
+
+    def test_resume_execution_timeout_skips_with_soft_fail(self):
+        sensor = DatadogMonitorSensorAsync(task_id="t", monitor_id=1, soft_fail=True)
+        with pytest.raises(AirflowSkipException):
+            sensor.resume_execution(
+                next_method="__fail__", next_kwargs={"error": "Trigger/execution timeout"}, context={}
+            )
+
+    def test_resume_execution_timeout_fails_without_soft_fail(self):
+        sensor = DatadogMonitorSensorAsync(task_id="t", monitor_id=1)
+        with pytest.raises(AirflowSensorTimeout):
+            sensor.resume_execution(
+                next_method="__fail__", next_kwargs={"error": "Trigger/execution timeout"}, context={}
+            )

--- a/providers/datadog/tests/unit/datadog/triggers/__init__.py
+++ b/providers/datadog/tests/unit/datadog/triggers/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/datadog/tests/unit/datadog/triggers/test_datadog.py
+++ b/providers/datadog/tests/unit/datadog/triggers/test_datadog.py
@@ -1,0 +1,78 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from airflow.models import Connection
+from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.datadog.triggers.datadog import DatadogMonitorTrigger
+from airflow.triggers.base import TriggerEvent
+
+pytestmark = pytest.mark.db_test
+
+
+def make_trigger():
+    return DatadogMonitorTrigger(
+        monitor_id=42,
+        target_states=["OK"],
+        datadog_conn_id="datadog_default",
+        poke_interval=0.01,
+    )
+
+
+class TestDatadogMonitorTrigger:
+    @pytest.fixture(autouse=True)
+    def setup_connections(self, create_connection_without_db):
+        create_connection_without_db(
+            Connection(
+                conn_id="datadog_default",
+                conn_type="datadog",
+                login="login",
+                password="password",
+                extra=json.dumps({"api_key": "api_key", "app_key": "app_key"}),
+            )
+        )
+
+    def test_serialize(self):
+        classpath, kwargs = make_trigger().serialize()
+        assert classpath == "airflow.providers.datadog.triggers.datadog.DatadogMonitorTrigger"
+        assert kwargs == {
+            "monitor_id": 42,
+            "target_states": ["OK"],
+            "datadog_conn_id": "datadog_default",
+            "poke_interval": 0.01,
+        }
+
+    @pytest.mark.asyncio
+    @patch("airflow.providers.datadog.triggers.datadog.api.Monitor.get")
+    async def test_run_yields_success_when_target_state_reached(self, monitor_get):
+        monitor_get.side_effect = [{"overall_state": "Alert"}, {"overall_state": "OK"}]
+        events = [event async for event in make_trigger().run()]
+        assert events == [TriggerEvent({"status": "success", "state": "OK"})]
+
+    @pytest.mark.asyncio
+    @patch("airflow.providers.datadog.triggers.datadog.api.Monitor.get")
+    async def test_run_raises_on_api_error(self, monitor_get):
+        monitor_get.return_value = {"errors": ["Monitor not found"]}
+        with pytest.raises(AirflowException, match="Monitor not found"):
+            async for _ in make_trigger().run():
+                pass


### PR DESCRIPTION
## Why

The existing `DatadogSensor` queries the event stream for transition events in a time window. That shape cannot answer "is this monitor healthy right now": a monitor that entered Alert before the window (or recovered before it) emits no event inside it, so gating a pipeline on monitor health requires reconstructing state from transitions.

This adds `DatadogMonitorSensorAsync`, which checks a monitor's current `overall_state` — an already-alerting or already-recovered monitor is observed regardless of when it last changed state.

## What

- `DatadogMonitorSensorAsync`: waits for a monitor to reach one of `target_states` (default `("OK",)`). Deferrable-only, and named `*Async` to make that explicit: it waits in the triggerer via a new `DatadogMonitorTrigger` and never occupies a worker slot while waiting; there is deliberately no poke-mode fallback.
- `DatadogMonitorTrigger`: polls the monitor state off the event loop (`asyncio.to_thread`, since the datadog client is sync) and fires when a target state is reached.
- `soft_fail` on the deferral path applies only to timeouts, matching poke/reschedule semantics elsewhere: a trigger crash (bad monitor id, auth failure) fails the task loudly instead of being converted into a skip that silently skips the downstream branch. Works on both Airflow 3.x (`TaskDeferralTimeout`) and 2.11 (timeout arrives as `TaskDeferralError("Trigger/execution timeout")`).
- The datadog library returns API errors as a payload instead of raising; they surface as a clear `AirflowException` (e.g. `Datadog monitor 999999999: ['Monitor not found']`).
- provider.yaml gains a `triggers` section; unit tests for the sensor (defer, completion, soft_fail semantics) and trigger (serialize round-trip, poll-until-target, API error).

## Testing

`uv run --project providers/datadog pytest providers/datadog/tests/unit/datadog`: 18 passed. Also validated end to end in a production-like Airflow 3.3 deployment with canary tasks covering pass / timeout / timeout-with-soft_fail / missing-monitor / missing-with-soft_fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)