### PR TITLE
Fix Dags with deadlines failing to parse after a database retry

### DIFF
--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -346,9 +346,16 @@ class SerializedDagModel(Base):
     load_op_links = True
     __table_args__ = (Index("idx_serialized_dag_dag_id_created_at", dag_id, created_at),)
 
-    def __init__(self, dag: LazyDeserializedDAG) -> None:
+    def __init__(self, dag: LazyDeserializedDAG, *, _data: dict | None = None) -> None:
+        """
+        Build a serialized Dag row.
+
+        :param _data: serialized data to store instead of ``dag.data``. ``write_dag`` uses this to
+            store its own copy, rewritten with deadline UUID references, without mutating the Dag
+            the caller handed it.
+        """
         self.dag_id = dag.dag_id
-        dag_data = dag.data
+        dag_data = dag.data if _data is None else _data
         self.dag_hash = SerializedDagModel.hash(dag_data)
 
         # partially ordered json data
@@ -646,7 +653,14 @@ class SerializedDagModel(Base):
 
         name_updated = False
         reused_deadline_data: dict[str, dict] | None = None
-        if dag.data.get("dag", {}).get("deadline"):
+        # Deadline handling rewrites the deadline entries from definitions to UUID references. Do
+        # that on our own copy: callers reuse the same LazyDeserializedDAG across the retry in
+        # ``update_dag_parsing_results_in_db``, and a rewritten one no longer parses on re-entry.
+        # Only the "dag" sub-dict is copied, so the bulk of the serialized structure is shared.
+        dag_data = dag.data
+        if dag_data.get("dag", {}).get("deadline"):
+            dag_data = {**dag_data, "dag": {**dag_data["dag"]}}
+
             # Try to reuse existing deadline UUIDs if the deadline definitions haven't changed.
             # This preserves the hash and avoids unnecessary SerializedDagModel recreations.
             existing_serialized_dag = session.scalar(
@@ -660,7 +674,7 @@ class SerializedDagModel(Base):
             ):
                 reuse_result = cls._try_reuse_deadline_uuids(
                     existing_deadline_uuids,
-                    dag.data["dag"]["deadline"],
+                    dag_data["dag"]["deadline"],
                     session,
                 )
 
@@ -676,19 +690,19 @@ class SerializedDagModel(Base):
                             .values(name=new_name)
                         )
                     name_updated = bool(name_updates)
-                    dag.data["dag"]["deadline"] = existing_deadline_uuids
+                    dag_data["dag"]["deadline"] = existing_deadline_uuids
                     reused_deadline_data = deadline_uuid_mapping
                     deadline_uuid_mapping = {}
                 else:
                     # At least one deadline has changed, generate new UUIDs and update the hash.
-                    deadline_uuid_mapping = cls._generate_deadline_uuids(dag.data)
+                    deadline_uuid_mapping = cls._generate_deadline_uuids(dag_data)
             else:
                 # First time seeing this Dag with deadlines, generate new UUIDs and update the hash.
-                deadline_uuid_mapping = cls._generate_deadline_uuids(dag.data)
+                deadline_uuid_mapping = cls._generate_deadline_uuids(dag_data)
         else:
             deadline_uuid_mapping = {}
 
-        new_dag_hash = cls.hash(dag.data)
+        new_dag_hash = cls.hash(dag_data)
 
         if serialized_dag_hash == new_dag_hash and dag_version and dag_version.bundle_name == bundle_name:
             # Serialized content is unchanged, so we don't create a new DagVersion.
@@ -728,7 +742,7 @@ class SerializedDagModel(Base):
             # This is for dynamic DAGs that the hashes changes often. We should update
             # the serialized dag, the dag_version and the dag_code instead of a new version
             # if the dag_version is not associated with any task instances
-            new_serialized_dag = cls(dag)
+            new_serialized_dag = cls(dag, _data=dag_data)
 
             # Use direct UPDATE to avoid loading the full serialized DAG
             result = session.execute(
@@ -781,9 +795,9 @@ class SerializedDagModel(Base):
 
         if reused_deadline_data:
             deadline_uuid_mapping = {str(uuid6.uuid7()): data for data in reused_deadline_data.values()}
-            dag.data["dag"]["deadline"] = list(deadline_uuid_mapping.keys())
+            dag_data["dag"]["deadline"] = list(deadline_uuid_mapping.keys())
 
-        new_serialized_dag = cls(dag)
+        new_serialized_dag = cls(dag, _data=dag_data)
         new_serialized_dag.dag_version = dagv
         session.add(new_serialized_dag)
 

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+import itertools
 import logging
 import warnings
 from collections.abc import Generator
@@ -51,6 +52,7 @@ from airflow.models.asset import (
 )
 from airflow.models.dag import DagTag
 from airflow.models.dagbundle import DagBundleModel
+from airflow.models.dagcode import DagCode
 from airflow.models.dagwarning import DagWarning, DagWarningType
 from airflow.models.errors import ParseImportError
 from airflow.models.serialized_dag import SerializedDagModel
@@ -61,6 +63,8 @@ from airflow.partition_mappers.window import DayWindow
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.triggers.file import FileDeleteTrigger
 from airflow.sdk import DAG, Asset, AssetAlias, AssetAll, AssetWatcher
+from airflow.sdk.definitions.callback import AsyncCallback
+from airflow.sdk.definitions.deadline import DeadlineAlert, DeadlineReference
 from airflow.sdk.definitions.timetables.assets import PartitionedAssetTimetable
 from airflow.serialization.definitions.assets import SerializedAsset
 from airflow.serialization.encoders import encode_trigger, ensure_serialized_asset
@@ -80,6 +84,11 @@ from tests_common.test_utils.db import (
 
 if TYPE_CHECKING:
     from kgb import SpyAgency
+
+
+async def _empty_deadline_callback():
+    """Callback body is irrelevant; the deadline just has to serialize."""
+
 
 mark_fab_auth_manager_test = pytest.mark.skipif(
     condition="FabAuthManager" not in conf.get("core", "auth_manager"),
@@ -1435,6 +1444,70 @@ class TestUpdateDagParsingResults:
             update_dag_parsing_results_in_db("testing", None, [dag], {}, 0.1, set(), session)
             orm_dag = session.get(DagModel, "dag_max_failed_runs_default")
             assert orm_dag.max_consecutive_failed_dag_runs == 6
+
+
+@pytest.mark.db_test
+class TestDeadlineDagRetry:
+    """A Dag with a deadline must survive the database retry in update_dag_parsing_results_in_db."""
+
+    @pytest.fixture(autouse=True)
+    def clean_db(self):
+        yield
+        clear_db_serialized_dags()
+        clear_db_dags()
+        clear_db_import_errors()
+
+    @patch.object(ParseImportError, "full_file_path", autospec=True, return_value="deadline_retry.py")
+    def test_deadline_dag_is_written_after_a_retried_operational_error(
+        self, _mock_full_path, session, testing_dag_bundle, tmp_path
+    ):
+        # The retry path rolls the session back, which would otherwise discard the bundle row the
+        # fixture just inserted and fail the Dag insert on its foreign key.
+        session.commit()
+
+        dag_file = tmp_path / "deadline_retry.py"
+        dag_file.write_text("# deadline retry fixture\n")
+
+        dag = DAG(
+            dag_id="deadline_retry_dag",
+            schedule=None,
+            deadline=DeadlineAlert(
+                reference=DeadlineReference.DAGRUN_QUEUED_AT,
+                interval=timedelta(minutes=5),
+                callback=AsyncCallback(_empty_deadline_callback),
+            ),
+        )
+        EmptyOperator(task_id="task1", dag=dag)
+        dag.fileloc = str(dag_file)
+        dag.relative_fileloc = dag_file.name
+        lazy_dag = LazyDeserializedDAG.from_dag(dag)
+
+        # Fail once at the point where the old implementation had already rewritten dag.data's
+        # deadline entries, so the retry would re-enter write_dag with mutated input.
+        real_write_code = DagCode.write_code
+        attempts = itertools.count()
+
+        def flaky_write_code(*args, **kwargs):
+            if next(attempts) == 0:
+                raise OperationalError("simulated contention", None, Exception())
+            return real_write_code(*args, **kwargs)
+
+        import_errors: dict[tuple[str, str], str] = {}
+        with mock.patch.object(DagCode, "write_code", autospec=True, side_effect=flaky_write_code):
+            update_dag_parsing_results_in_db(
+                "testing",
+                None,
+                [lazy_dag],
+                import_errors,
+                None,
+                set(),
+                session,
+                files_parsed={("testing", dag_file.name)},
+            )
+
+        assert import_errors == {}, f"retry should not have produced an import error: {import_errors}"
+        serdag = session.scalar(select(SerializedDagModel).where(SerializedDagModel.dag_id == dag.dag_id))
+        assert serdag is not None, "the Dag should have been written on the retry"
 
 
 @pytest.mark.db_test

--- a/airflow-core/tests/unit/models/test_serialized_dag.py
+++ b/airflow-core/tests/unit/models/test_serialized_dag.py
@@ -454,6 +454,21 @@ class TestSerializedDagModel:
         assert len(latest) == 1
         assert latest[0].dag_version.version_number == 2
 
+    def test_sync_dag_to_db_refreshes_cached_serialized_dag(self, testing_dag_bundle, session):
+        dag = DAG("cached_serialized_dag", schedule=None)
+        EmptyOperator(task_id="task1", dag=dag)
+        sync_dag_to_db(dag, session=session)
+
+        serialized_dag = SDM.get(dag.dag_id, session=session)
+        assert serialized_dag is not None
+        assert serialized_dag.data is not None
+
+        EmptyOperator(task_id="task2", dag=dag)
+        scheduler_dag = sync_dag_to_db(dag, session=session)
+
+        assert set(scheduler_dag.task_ids) == {"task1", "task2"}
+        assert set(serialized_dag.dag.task_ids) == {"task1", "task2"}
+
     def test_get_returns_latest_version_when_created_at_ordering_disagrees(self, dag_maker, session):
         """SDM.get (latest_item_select_object) must pick the max version_number, not max created_at."""
         self._seed_two_versions(dag_maker, session, "tie_dag2")

--- a/devel-common/src/tests_common/test_utils/dag.py
+++ b/devel-common/src/tests_common/test_utils/dag.py
@@ -68,14 +68,23 @@ def sync_dags_to_db(
     session.merge(DagBundleModel(name=bundle_name))
     session.flush()
 
-    def _write_dag(dag: DAG) -> SerializedDAG:
+    def _write_dag(dag: DAG) -> None:
         data = DagSerialization.to_dict(dag)
         SerializedDagModel.write_dag(
             LazyDeserializedDAG(data=data), bundle_name, bundle_version, session=session
         )
-        return DagSerialization.from_dict(data)
+
+    def _read_dag(dag: DAG) -> SerializedDAG:
+        serialized_dag = SerializedDagModel.get(dag.dag_id, session=session)
+        if serialized_dag is None:
+            raise RuntimeError(f"Serialized Dag {dag.dag_id!r} was not written")
+        session.refresh(serialized_dag, attribute_names=["_data", "_data_compressed"])
+        # The deserialized data cache is separate from the mapped columns refreshed above.
+        serialized_dag._SerializedDagModel__data_cache = None
+        return serialized_dag.dag
 
     SerializedDAG.bulk_write_to_db(bundle_name, bundle_version, dags, session=session)
-    scheduler_dags = [_write_dag(dag) for dag in dags]
+    for dag in dags:
+        _write_dag(dag)
     session.flush()
-    return scheduler_dags
+    return [_read_dag(dag) for dag in dags]


### PR DESCRIPTION
Writing a Dag with a deadline rewrites its serialized deadline entries from definitions into UUID references, and it did so on the object the caller passed in. When update_dag_parsing_results_in_db hit a transient database error it rolled back and retried the same objects, which by then held UUID strings where definitions were expected. The retry raised AttributeError while re-encoding them, and since that is not a database error it escaped the retry entirely, so the manager discarded the whole file's parse results rather than one Dag's.

Rewrite a copy instead. Only the "dag" sub-dict is copied, so the bulk of the serialized structure is still shared, and the Dag the caller holds stays in the shape it arrived in however many times the write is attempted.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Opus 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)



