### PR TITLE
Collect the test classes pytest silently skipped

### DIFF
--- a/providers/apache/hive/tests/unit/apache/hive/operators/test_hive.py
+++ b/providers/apache/hive/tests/unit/apache/hive/operators/test_hive.py
@@ -22,7 +22,7 @@ from unittest import mock
 
 import pytest
 
-from airflow.models import DagRun, TaskInstance
+from airflow.models import TaskInstance
 from airflow.providers.apache.hive.operators.hive import HiveOperator
 from airflow.providers.common.compat.sdk import conf, timezone
 
@@ -36,8 +36,10 @@ def get_hive_cli_connection():
     return connection
 
 
-class HiveOperatorConfigTest(TestHiveEnvironment):
-    def test_hive_airflow_default_config_queue(self):
+class TestHiveOperatorConfig(TestHiveEnvironment):
+    @mock.patch("airflow.providers.apache.hive.hooks.hive.HiveCliHook.get_connection")
+    def test_hive_airflow_default_config_queue(self, mock_get_connection):
+        mock_get_connection.return_value = get_hive_cli_connection()
         op = HiveOperator(
             task_id="test_default_config_queue",
             hql=self.hql,
@@ -50,7 +52,9 @@ class HiveOperatorConfigTest(TestHiveEnvironment):
         test_config_hive_mapred_queue = conf.get("hive", "default_hive_mapred_queue")
         assert op.hook.mapred_queue == test_config_hive_mapred_queue
 
-    def test_hive_airflow_default_config_queue_override(self):
+    @mock.patch("airflow.providers.apache.hive.hooks.hive.HiveCliHook.get_connection")
+    def test_hive_airflow_default_config_queue_override(self, mock_get_connection):
+        mock_get_connection.return_value = get_hive_cli_connection()
         specific_mapred_queue = "default"
         op = HiveOperator(
             task_id="test_default_config_queue",
@@ -80,7 +84,7 @@ class TestHiveOperatorJdbcParams(TestHiveEnvironment):
         assert op.hook.jdbc_params == jdbc_params
 
 
-class HiveOperatorTest(TestHiveEnvironment):
+class TestHiveOperator(TestHiveEnvironment):
     def test_hiveconf_jinja_translate(self):
         hql = "SELECT ${num_col} FROM ${hiveconf:table};"
         op = HiveOperator(hiveconf_jinja_translate=True, task_id="dry_run_basic_hql", hql=hql, dag=self.dag)
@@ -99,21 +103,20 @@ class HiveOperatorTest(TestHiveEnvironment):
         assert op.hql == "SELECT * FROM ${hiveconf:table} PARTITION (${hiveconf:day});"
 
     @mock.patch("airflow.providers.apache.hive.operators.hive.HiveOperator.hook", mock.MagicMock())
-    def test_mapred_job_name(self, mock_hook):
+    def test_mapred_job_name(self):
         op = HiveOperator(task_id="test_mapred_job_name", hql=self.hql, dag=self.dag)
 
-        fake_run_id = "test_mapred_job_name"
         fake_logical_date = timezone.datetime(2018, 6, 19)
-        fake_ti = TaskInstance(task=op)
-        fake_ti.dag_run = DagRun(run_id=fake_run_id, logical_date=fake_logical_date)
-        fake_ti.hostname = "fake_hostname"
-        fake_context = {"ti": fake_ti}
+        fake_ti = mock.MagicMock(
+            spec=TaskInstance, dag_id=self.dag.dag_id, task_id=op.task_id, hostname="fake_hostname"
+        )
+        fake_context = {"ti": fake_ti, "logical_date": fake_logical_date}
 
         op.execute(fake_context)
-        assert (
+
+        assert op.hook.mapred_job_name == (
             "Airflow HiveOperator task for "
-            f"{fake_ti.hostname}.{self.dag.dag_id}.{op.task_id}.{fake_logical_date.isoformat()}"
-            == mock_hook.mapred_job_name
+            f"fake_hostname.{self.dag.dag_id}.{op.task_id}.{fake_logical_date.isoformat()}"
         )
 
 

--- a/providers/google/tests/unit/google/cloud/sensors/test_bigtable.py
+++ b/providers/google/tests/unit/google/cloud/sensors/test_bigtable.py
@@ -25,7 +25,10 @@ from google.cloud.bigtable.instance import Instance
 from google.cloud.bigtable.table import ClusterState
 
 from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.google.cloud.links.bigtable import BigtableTablesLink
 from airflow.providers.google.cloud.sensors.bigtable import BigtableTableReplicationCompletedSensor
+
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 PROJECT_ID = "test_project_id"
 INSTANCE_ID = "test-instance-id"
@@ -34,7 +37,7 @@ TABLE_ID = "test-table-id"
 IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 
-class BigtableWaitForTableReplicationTest:
+class TestBigtableWaitForTableReplication:
     @pytest.mark.parametrize(
         ("missing_attribute", "project_id", "instance_id", "table_id"),
         [
@@ -43,7 +46,7 @@ class BigtableWaitForTableReplicationTest:
         ],
     )
     @mock.patch("airflow.providers.google.cloud.sensors.bigtable.BigtableHook")
-    def test_empty_attribute(self, missing_attribute, project_id, instance_id, table_id, mock_hook):
+    def test_empty_attribute(self, mock_hook, missing_attribute, project_id, instance_id, table_id):
         with pytest.raises(AirflowException) as ctx:
             BigtableTableReplicationCompletedSensor(
                 project_id=project_id,
@@ -126,8 +129,16 @@ class BigtableWaitForTableReplicationTest:
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
-        assert op.poke(None)
+        ti = mock.MagicMock()
+
+        assert op.poke({"ti": ti, "task": op})
+
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
+        )
+        # Only this path reaches BigtableTablesLink.persist, which does context["ti"].xcom_push().
+        ti.xcom_push.assert_called_once_with(
+            key=BigtableTablesLink.key,
+            value={} if AIRFLOW_V_3_0_PLUS else {"instance_id": INSTANCE_ID, "project_id": PROJECT_ID},
         )


### PR DESCRIPTION
## Why

* `python_classes` defaults to `Test*` and is not overridden anywhere in this repo, so three test classes named with a trailing Test have never been collected. They produce no PASSED, no FAILED, and not even a SKIPPED line.

## How

* Rename the three classes: `HiveOperatorConfigTest` → `TestHiveOperatorConfig`, `HiveOperatorTest` → `TestHiveOperator`, `BigtableWaitForTableReplicationTest` → `TestBigtableWaitForTableReplication`.

## Verification

### Hive

* setup: `uv sync --project providers/apache/hive`
* `uv run --project providers/apache/hive --no-sync pytest providers/apache/hive/tests/unit/apache/hive/operators/test_hive.py --verbosity=0 --strict-markers --maxfail=50 --disable-warnings -rfEX --skip-db-tests`
  * 6 passed, 4 skipped in this PR
  * 1 passed, 4 skipped on main branch

### Google

* setup: `uv sync --project providers/google`
* `uv run --project providers/google --no-sync pytest providers/google/tests/unit/google/cloud/sensors/test_bigtable.py --verbosity=0 --strict-markers --maxfail=50 --disable-warnings -rfEX --skip-db-tests`
  * 6 passed in this PR
  * collected 0 items on main branch

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
