### PR TITLE
Honor impersonation_chain in deferred Cloud Build tasks

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/triggers/cloud_build.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/cloud_build.py
@@ -125,4 +125,7 @@ class CloudBuildCreateBuildTrigger(BaseTrigger):
             yield TriggerEvent({"status": "error", "message": str(e)})
 
     def _get_async_hook(self) -> CloudBuildAsyncHook:
-        return CloudBuildAsyncHook(gcp_conn_id=self.gcp_conn_id)
+        return CloudBuildAsyncHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )

--- a/providers/google/tests/unit/google/cloud/triggers/test_cloud_build.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_cloud_build.py
@@ -45,6 +45,7 @@ TEST_BUILD_WORKING = {
 TEST_CONN_ID = "google_cloud_default"
 TEST_POLL_INTERVAL = 4.0
 TEST_LOCATION = "global"
+TEST_IMPERSONATION_CHAIN = "impersonated-account@developer.gserviceaccount.com"
 TEST_BUILD_INSTANCE = dict(
     id="test-build-id-9832662",
     status=3,
@@ -118,6 +119,24 @@ class TestCloudBuildCreateBuildTrigger:
             "poll_interval": TEST_POLL_INTERVAL,
             "location": TEST_LOCATION,
         }
+
+    @mock.patch(CLOUD_BUILD_PATH.format("CloudBuildAsyncHook"), autospec=True)
+    def test_get_async_hook_builds_hook_with_impersonation_chain(self, mock_hook):
+        trigger = CloudBuildCreateBuildTrigger(
+            id_=TEST_BUILD_ID,
+            project_id=TEST_PROJECT_ID,
+            gcp_conn_id=TEST_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+            poll_interval=TEST_POLL_INTERVAL,
+            location=TEST_LOCATION,
+        )
+
+        trigger._get_async_hook()
+
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=TEST_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
 
     @pytest.mark.asyncio
     @mock.patch(CLOUD_BUILD_PATH.format("CloudBuildAsyncHook"))


### PR DESCRIPTION
`CloudBuildCreateBuildTrigger` accepts an `impersonation_chain`, stores it, and
serializes it — but built its hook without it:

```python
def _get_async_hook(self) -> CloudBuildAsyncHook:
    return CloudBuildAsyncHook(gcp_conn_id=self.gcp_conn_id)
```

So the value travels correctly from `CloudBuildCreateBuildOperator` all the way into the
triggerer and is then discarded at the point of use. Once a `CloudBuildCreateBuildOperator`
task defers, its polling calls authenticate as the connection's service account rather than
the impersonated one.

Two ways this surfaces:

- where impersonation exists because the base account deliberately lacks permission, the
  deferred poll fails with a 403 that does not mention impersonation;
- where the base account has broader rights, the poll quietly succeeds under an identity
  the Dag author did not select.

The non-deferrable path is unaffected, so switching `deferrable` off appears to "fix" it.

Worth noting for reviewers: `GoogleBaseHook.__init__` falls back to the connection's
`impersonation_chain` extra when the argument is absent, so deployments that configure
impersonation on the *connection* were never affected. The bug is limited to impersonation
configured on the operator — which is the documented parameter on every Google operator.

No newsfragment: this is a provider change, and provider changelogs are regenerated from
`git log` by the release manager.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)