### PR TITLE
Use the configured region for deferred Neptune cluster tasks

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/neptune.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/neptune.py
@@ -175,6 +175,9 @@ class NeptuneStartDbClusterOperator(AwsBaseOperator[NeptuneHook]):
                     db_cluster_id=self.cluster_id,
                     waiter_delay=self.waiter_delay,
                     waiter_max_attempts=self.waiter_max_attempts,
+                    region_name=self.region_name,
+                    botocore_config=self.botocore_config,
+                    verify=self.verify,
                 ),
                 method_name="execute_complete",
             )
@@ -302,6 +305,9 @@ class NeptuneStopDbClusterOperator(AwsBaseOperator[NeptuneHook]):
                     db_cluster_id=self.cluster_id,
                     waiter_delay=self.waiter_delay,
                     waiter_max_attempts=self.waiter_max_attempts,
+                    region_name=self.region_name,
+                    botocore_config=self.botocore_config,
+                    verify=self.verify,
                 ),
                 method_name="execute_complete",
             )

--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/neptune.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/neptune.py
@@ -58,6 +58,7 @@ class NeptuneClusterAvailableTrigger(AwsBaseWaiterTrigger):
             waiter_delay=waiter_delay,
             waiter_max_attempts=waiter_max_attempts,
             aws_conn_id=aws_conn_id,
+            region_name=region_name,
             **kwargs,
         )
 
@@ -103,6 +104,7 @@ class NeptuneClusterStoppedTrigger(AwsBaseWaiterTrigger):
             waiter_delay=waiter_delay,
             waiter_max_attempts=waiter_max_attempts,
             aws_conn_id=aws_conn_id,
+            region_name=region_name,
             **kwargs,
         )
 
@@ -148,6 +150,7 @@ class NeptuneClusterInstancesAvailableTrigger(AwsBaseWaiterTrigger):
             waiter_delay=waiter_delay,
             waiter_max_attempts=waiter_max_attempts,
             aws_conn_id=aws_conn_id,
+            region_name=region_name,
             **kwargs,
         )
 

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_neptune.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_neptune.py
@@ -39,6 +39,10 @@ from unit.amazon.aws.utils.test_template_fields import validate_template_fields
 
 CLUSTER_ID = "test_cluster"
 REGION_NAME = "eu-west-2"
+VERIFY = False
+BOTOCORE_CONFIG = {"read_timeout": 42}
+WAITER_DELAY = 12
+WAITER_MAX_ATTEMPTS = 34
 
 EXPECTED_RESPONSE = {"db_cluster_id": CLUSTER_ID}
 
@@ -67,7 +71,7 @@ def _create_cluster(hook: NeptuneHook):
     ],
 )
 @mock.patch.object(NeptuneHook, "conn")
-def test_deferred_trigger_receives_region_name(mock_conn, operator_class, trigger_class):
+def test_deferred_trigger_receives_the_operator_configuration(mock_conn, operator_class, trigger_class):
     operator = operator_class(
         task_id="task_test",
         db_cluster_id=CLUSTER_ID,
@@ -75,13 +79,25 @@ def test_deferred_trigger_receives_region_name(mock_conn, operator_class, trigge
         wait_for_completion=False,
         aws_conn_id="aws_default",
         region_name=REGION_NAME,
+        verify=VERIFY,
+        botocore_config=BOTOCORE_CONFIG,
+        waiter_delay=WAITER_DELAY,
+        waiter_max_attempts=WAITER_MAX_ATTEMPTS,
     )
 
     with pytest.raises(TaskDeferred) as deferred:
         operator.execute(None)
 
     assert isinstance(deferred.value.trigger, trigger_class)
-    assert deferred.value.trigger.region_name == REGION_NAME
+    assert deferred.value.trigger.serialize()[1] == {
+        "db_cluster_id": CLUSTER_ID,
+        "aws_conn_id": "aws_default",
+        "region_name": REGION_NAME,
+        "verify": VERIFY,
+        "botocore_config": BOTOCORE_CONFIG,
+        "waiter_delay": WAITER_DELAY,
+        "waiter_max_attempts": WAITER_MAX_ATTEMPTS,
+    }
 
 
 class TestNeptuneStartClusterOperator:

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_neptune.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_neptune.py
@@ -29,11 +29,16 @@ from airflow.providers.amazon.aws.operators.neptune import (
     NeptuneStartDbClusterOperator,
     NeptuneStopDbClusterOperator,
 )
+from airflow.providers.amazon.aws.triggers.neptune import (
+    NeptuneClusterAvailableTrigger,
+    NeptuneClusterStoppedTrigger,
+)
 from airflow.providers.common.compat.sdk import AirflowException, TaskDeferred
 
 from unit.amazon.aws.utils.test_template_fields import validate_template_fields
 
 CLUSTER_ID = "test_cluster"
+REGION_NAME = "eu-west-2"
 
 EXPECTED_RESPONSE = {"db_cluster_id": CLUSTER_ID}
 
@@ -52,6 +57,31 @@ def _create_cluster(hook: NeptuneHook):
     )
     if not hook.conn.describe_db_clusters()["DBClusters"]:
         raise ValueError("AWS not properly mocked")
+
+
+@pytest.mark.parametrize(
+    ("operator_class", "trigger_class"),
+    [
+        (NeptuneStartDbClusterOperator, NeptuneClusterAvailableTrigger),
+        (NeptuneStopDbClusterOperator, NeptuneClusterStoppedTrigger),
+    ],
+)
+@mock.patch.object(NeptuneHook, "conn")
+def test_deferred_trigger_receives_region_name(mock_conn, operator_class, trigger_class):
+    operator = operator_class(
+        task_id="task_test",
+        db_cluster_id=CLUSTER_ID,
+        deferrable=True,
+        wait_for_completion=False,
+        aws_conn_id="aws_default",
+        region_name=REGION_NAME,
+    )
+
+    with pytest.raises(TaskDeferred) as deferred:
+        operator.execute(None)
+
+    assert isinstance(deferred.value.trigger, trigger_class)
+    assert deferred.value.trigger.region_name == REGION_NAME
 
 
 class TestNeptuneStartClusterOperator:

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_neptune.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_neptune.py
@@ -31,6 +31,10 @@ from airflow.triggers.base import TriggerEvent
 
 CLUSTER_ID = "test-cluster"
 REGION_NAME = "eu-west-2"
+VERIFY = False
+BOTOCORE_CONFIG = {"read_timeout": 42}
+WAITER_DELAY = 12
+WAITER_MAX_ATTEMPTS = 34
 
 
 @pytest.mark.parametrize(
@@ -41,11 +45,29 @@ REGION_NAME = "eu-west-2"
         NeptuneClusterInstancesAvailableTrigger,
     ],
 )
-def test_region_name_reaches_the_hook_configuration(trigger_class):
-    trigger = trigger_class(db_cluster_id=CLUSTER_ID, region_name=REGION_NAME)
+def test_hook_configuration_survives_serialization(trigger_class):
+    trigger = trigger_class(
+        db_cluster_id=CLUSTER_ID,
+        aws_conn_id="aws_default",
+        region_name=REGION_NAME,
+        verify=VERIFY,
+        botocore_config=BOTOCORE_CONFIG,
+        waiter_delay=WAITER_DELAY,
+        waiter_max_attempts=WAITER_MAX_ATTEMPTS,
+    )
 
     assert trigger.region_name == REGION_NAME
-    assert trigger.serialize()[1]["region_name"] == REGION_NAME
+    assert trigger.verify == VERIFY
+    assert trigger.botocore_config == BOTOCORE_CONFIG
+    assert trigger.serialize()[1] == {
+        "db_cluster_id": CLUSTER_ID,
+        "aws_conn_id": "aws_default",
+        "region_name": REGION_NAME,
+        "verify": VERIFY,
+        "botocore_config": BOTOCORE_CONFIG,
+        "waiter_delay": WAITER_DELAY,
+        "waiter_max_attempts": WAITER_MAX_ATTEMPTS,
+    }
 
 
 class TestNeptuneClusterAvailableTrigger:

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_neptune.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_neptune.py
@@ -30,6 +30,22 @@ from airflow.providers.amazon.aws.triggers.neptune import (
 from airflow.triggers.base import TriggerEvent
 
 CLUSTER_ID = "test-cluster"
+REGION_NAME = "eu-west-2"
+
+
+@pytest.mark.parametrize(
+    "trigger_class",
+    [
+        NeptuneClusterAvailableTrigger,
+        NeptuneClusterStoppedTrigger,
+        NeptuneClusterInstancesAvailableTrigger,
+    ],
+)
+def test_region_name_reaches_the_hook_configuration(trigger_class):
+    trigger = trigger_class(db_cluster_id=CLUSTER_ID, region_name=REGION_NAME)
+
+    assert trigger.region_name == REGION_NAME
+    assert trigger.serialize()[1]["region_name"] == REGION_NAME
 
 
 class TestNeptuneClusterAvailableTrigger:


### PR DESCRIPTION
All three Neptune triggers declare a `region_name` parameter, document it, and read
`self.region_name` when building their hook — but never forward it to
`AwsBaseWaiterTrigger.__init__`, which is what actually assigns the attribute:

```python
def __init__(self, *, db_cluster_id: str, ..., region_name: str | None = None, **kwargs):
    super().__init__(
        ...,
        aws_conn_id=aws_conn_id,
        # region_name never passed
        **kwargs,
    )

def hook(self) -> AwsGenericHook:
    return NeptuneHook(aws_conn_id=self.aws_conn_id, region_name=self.region_name, ...)
```

Because `region_name` is an explicit named parameter it is not swept up by the `**kwargs`
forwarding either — it is captured and discarded, so `self.region_name` is always `None`
and the deferred waiter polls the account's default region.

The failure is quiet and slow: the waiter simply never finds the cluster in the region it
is looking at, so the task burns through `waiter_max_attempts` and then fails with a
message that does not mention regions at all. `AwsBaseWaiterTrigger.serialize()` writes
`self.region_name`, so the wrong value also survives triggerer restarts.

There is a second, independent layer in the operators. Two of the four defer sites already
pass the hook configuration; the two in `NeptuneStartDbClusterOperator.execute` and
`NeptuneStopDbClusterOperator.execute` pass none of it, so fixing only the triggers would
still leave those paths on the default region. Both are brought in line with the existing
sites, which is why `verify` and `botocore_config` are included alongside `region_name`.

Affects `NeptuneClusterAvailableTrigger`, `NeptuneClusterStoppedTrigger` and
`NeptuneClusterInstancesAvailableTrigger`.

Tests cover both layers — that the triggers retain and serialize `region_name`, and that
the operators hand it to the trigger they defer with. All five fail without the change.

No newsfragment: this is a provider change, and provider changelogs are regenerated from
`git log` by the release manager.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)