### PR TITLE
Apply impersonation_chain to deferred BigQuery existence checks

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/sensors/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/sensors/bigquery.py
@@ -128,6 +128,7 @@ class BigQueryTableExistenceSensor(BaseSensorOperator):
                         project_id=self.project_id,
                         poll_interval=self.poke_interval,
                         gcp_conn_id=self.gcp_conn_id,
+                        impersonation_chain=self.impersonation_chain,
                         hook_params={
                             "impersonation_chain": self.impersonation_chain,
                         },
@@ -298,6 +299,7 @@ class BigQueryTablePartitionExistenceSensor(BaseSensorOperator):
                         partition_id=self.partition_id,
                         poll_interval=self.poke_interval,
                         gcp_conn_id=self.gcp_conn_id,
+                        impersonation_chain=self.impersonation_chain,
                         hook_params={
                             "impersonation_chain": self.impersonation_chain,
                         },

--- a/providers/google/tests/unit/google/cloud/sensors/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/sensors/test_bigquery.py
@@ -43,39 +43,6 @@ TEST_PARTITION_ID = "20200101"
 TEST_IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 
-@pytest.mark.parametrize(
-    ("sensor_class", "trigger_class", "extra_kwargs"),
-    [
-        (BigQueryTableExistenceSensor, BigQueryTableExistenceTrigger, {}),
-        (
-            BigQueryTablePartitionExistenceSensor,
-            BigQueryTablePartitionExistenceTrigger,
-            {"partition_id": TEST_PARTITION_ID},
-        ),
-    ],
-)
-@mock.patch("airflow.providers.google.cloud.sensors.bigquery.BigQueryHook")
-def test_deferred_trigger_receives_impersonation_chain(mock_hook, sensor_class, trigger_class, extra_kwargs):
-    task = sensor_class(
-        task_id="check_existence",
-        project_id=TEST_PROJECT_ID,
-        dataset_id=TEST_DATASET_ID,
-        table_id=TEST_TABLE_ID,
-        gcp_conn_id=TEST_GCP_CONN_ID,
-        impersonation_chain=TEST_IMPERSONATION_CHAIN,
-        deferrable=True,
-        **extra_kwargs,
-    )
-    mock_hook.return_value.table_exists.return_value = False
-    mock_hook.return_value.table_partition_exists.return_value = False
-
-    with pytest.raises(TaskDeferred) as exc:
-        task.execute(mock.MagicMock())
-
-    assert isinstance(exc.value.trigger, trigger_class)
-    assert exc.value.trigger.impersonation_chain == TEST_IMPERSONATION_CHAIN
-
-
 class TestBigqueryTableExistenceSensor:
     @mock.patch("airflow.providers.google.cloud.sensors.bigquery.BigQueryHook")
     def test_passing_arguments_to_hook(self, mock_hook):
@@ -135,6 +102,24 @@ class TestBigqueryTableExistenceSensor:
         assert isinstance(exc.value.trigger, BigQueryTableExistenceTrigger), (
             "Trigger is not a BigQueryTableExistenceTrigger"
         )
+
+    @mock.patch("airflow.providers.google.cloud.sensors.bigquery.BigQueryHook")
+    def test_deferred_trigger_receives_impersonation_chain(self, mock_hook):
+        task = BigQueryTableExistenceSensor(
+            task_id="check_table_exists",
+            project_id=TEST_PROJECT_ID,
+            dataset_id=TEST_DATASET_ID,
+            table_id=TEST_TABLE_ID,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+            deferrable=True,
+        )
+        mock_hook.return_value.table_exists.return_value = False
+
+        with pytest.raises(TaskDeferred) as exc:
+            task.execute(mock.MagicMock())
+
+        assert exc.value.trigger.impersonation_chain == TEST_IMPERSONATION_CHAIN
 
     def test_execute_deferred_failure(self):
         """Tests that an expected exception is raised in case of error event"""
@@ -238,6 +223,25 @@ class TestBigqueryTablePartitionExistenceSensor:
         assert isinstance(exc.value.trigger, BigQueryTablePartitionExistenceTrigger), (
             "Trigger is not a BigQueryTablePartitionExistenceTrigger"
         )
+
+    @mock.patch("airflow.providers.google.cloud.sensors.bigquery.BigQueryHook")
+    def test_deferred_trigger_receives_impersonation_chain(self, mock_hook):
+        task = BigQueryTablePartitionExistenceSensor(
+            task_id="test_task_id",
+            project_id=TEST_PROJECT_ID,
+            dataset_id=TEST_DATASET_ID,
+            table_id=TEST_TABLE_ID,
+            partition_id=TEST_PARTITION_ID,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+            deferrable=True,
+        )
+        mock_hook.return_value.table_partition_exists.return_value = False
+
+        with pytest.raises(TaskDeferred) as exc:
+            task.execute(context={})
+
+        assert exc.value.trigger.impersonation_chain == TEST_IMPERSONATION_CHAIN
 
     def test_execute_with_deferrable_mode_execute_failure(self):
         """Tests that an AirflowException is raised in case of error event"""

--- a/providers/google/tests/unit/google/cloud/sensors/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/sensors/test_bigquery.py
@@ -43,6 +43,39 @@ TEST_PARTITION_ID = "20200101"
 TEST_IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 
+@pytest.mark.parametrize(
+    ("sensor_class", "trigger_class", "extra_kwargs"),
+    [
+        (BigQueryTableExistenceSensor, BigQueryTableExistenceTrigger, {}),
+        (
+            BigQueryTablePartitionExistenceSensor,
+            BigQueryTablePartitionExistenceTrigger,
+            {"partition_id": TEST_PARTITION_ID},
+        ),
+    ],
+)
+@mock.patch("airflow.providers.google.cloud.sensors.bigquery.BigQueryHook")
+def test_deferred_trigger_receives_impersonation_chain(mock_hook, sensor_class, trigger_class, extra_kwargs):
+    task = sensor_class(
+        task_id="check_existence",
+        project_id=TEST_PROJECT_ID,
+        dataset_id=TEST_DATASET_ID,
+        table_id=TEST_TABLE_ID,
+        gcp_conn_id=TEST_GCP_CONN_ID,
+        impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        deferrable=True,
+        **extra_kwargs,
+    )
+    mock_hook.return_value.table_exists.return_value = False
+    mock_hook.return_value.table_partition_exists.return_value = False
+
+    with pytest.raises(TaskDeferred) as exc:
+        task.execute(mock.MagicMock())
+
+    assert isinstance(exc.value.trigger, trigger_class)
+    assert exc.value.trigger.impersonation_chain == TEST_IMPERSONATION_CHAIN
+
+
 class TestBigqueryTableExistenceSensor:
     @mock.patch("airflow.providers.google.cloud.sensors.bigquery.BigQueryHook")
     def test_passing_arguments_to_hook(self, mock_hook):


### PR DESCRIPTION
`BigQueryTableExistenceSensor` and `BigQueryTablePartitionExistenceSensor` hand their
impersonation chain to the trigger inside `hook_params`:

```python
trigger=BigQueryTableExistenceTrigger(
    ...,
    hook_params={"impersonation_chain": self.impersonation_chain},
)
```

but the trigger authenticates from a different attribute entirely:

```python
def _get_async_hook(self) -> BigQueryTableAsyncHook:
    return BigQueryTableAsyncHook(
        gcp_conn_id=self.gcp_conn_id, impersonation_chain=self.impersonation_chain
    )
```

Nothing ever sets `self.impersonation_chain` from those call sites, so it stays `None` and
the deferred existence check runs as the connection's service account. `hook_params` is
stored and serialized but never read anywhere in the module — it carries the value and
then drops it.

`poke()` builds its hook correctly, so the sensor honours impersonation when
`deferrable=False` and ignores it when `deferrable=True`. That divergence is the awkward
part: turning deferrable off appears to "fix" the permissions error, which points
investigation away from the real cause.

The trigger already grew a proper `impersonation_chain` parameter in #36341; the sensors
were simply never moved onto it. This change passes it explicitly at both defer sites.

`hook_params` is left untouched here. It is a required argument on the trigger's public
`__init__`, and now that nothing reads it, removing or deprecating it is a separate
decision — happy to follow up if maintainers would like it gone.

For reviewers: `GoogleBaseHook.__init__` falls back to the connection's
`impersonation_chain` extra when the argument is absent, so deployments that configure
impersonation on the connection were never affected. This only bites when impersonation is
set on the sensor, which is the documented parameter.

No newsfragment: this is a provider change, and provider changelogs are regenerated from
`git log` by the release manager.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)