### PR TITLE
Add deferrable mode to EmrServerlessJobSensor

### DIFF
--- a/providers/amazon/docs/operators/emr/emr_serverless.rst
+++ b/providers/amazon/docs/operators/emr/emr_serverless.rst
@@ -130,6 +130,9 @@ Wait on an EMR Serverless Job state
 
 To monitor the state of an EMR Serverless Job you can use
 :class:`~airflow.providers.amazon.aws.sensors.emr.EmrServerlessJobSensor`.
+This sensor can be run in deferrable mode by passing ``deferrable=True`` as a parameter. This requires
+the aiobotocore module to be installed. In deferrable mode the sensor waits for job completion
+(``SUCCESS``); ``max_attempts`` caps waiter polls. Poke mode uses ``timeout``, not ``max_attempts``.
 
 .. exampleinclude:: /../../amazon/tests/system/amazon/aws/example_emr_serverless.py
    :language: python

--- a/providers/amazon/docs/operators/emr/emr_serverless.rst
+++ b/providers/amazon/docs/operators/emr/emr_serverless.rst
@@ -131,8 +131,7 @@ Wait on an EMR Serverless Job state
 To monitor the state of an EMR Serverless Job you can use
 :class:`~airflow.providers.amazon.aws.sensors.emr.EmrServerlessJobSensor`.
 This sensor can be run in deferrable mode by passing ``deferrable=True`` as a parameter. This requires
-the aiobotocore module to be installed. In deferrable mode the sensor waits for job completion
-(``SUCCESS``); ``max_attempts`` caps waiter polls. Poke mode uses ``timeout``, not ``max_attempts``.
+the aiobotocore module to be installed.
 
 .. exampleinclude:: /../../amazon/tests/system/amazon/aws/example_emr_serverless.py
    :language: python

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/emr.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/emr.py
@@ -26,7 +26,7 @@ from airflow.providers.amazon.aws.links.emr import EmrClusterLink, EmrLogsLink, 
 from airflow.providers.amazon.aws.sensors.base_aws import AwsBaseSensor
 from airflow.providers.amazon.aws.triggers.emr import (
     EmrContainerTrigger,
-    EmrServerlessStartJobTrigger,
+    EmrServerlessJobSensorTrigger,
     EmrStepSensorTrigger,
     EmrTerminateJobFlowTrigger,
 )
@@ -116,7 +116,7 @@ class EmrBaseSensor(AwsBaseSensor[EmrHook]):
 
 class EmrServerlessJobSensor(AwsBaseSensor[EmrServerlessHook]):
     """
-    Poll the state of the job run until it reaches a terminal state; fails if the job run fails.
+    Poll the state of the job run until it reaches one of the target states; fails if the job run fails.
 
     .. seealso::
         For more information on how to use this sensor, take a look at the guide:
@@ -124,10 +124,7 @@ class EmrServerlessJobSensor(AwsBaseSensor[EmrServerlessHook]):
 
     :param application_id: application_id to check the state of
     :param job_run_id: job_run_id to check the state of
-    :param target_states: a set of states to wait for, defaults to ``SUCCESS``. In deferrable mode
-        the waiter waits for a terminal success state regardless of ``target_states``.
-    :param max_attempts: Maximum waiter attempts in deferrable mode. Ignored when
-        ``deferrable=False``; poke mode uses ``timeout`` (default ``sensors.default_timeout``, 7 days).
+    :param target_states: a set of states to wait for, defaults to ``SUCCESS``.
     :param deferrable: Run sensor in the deferrable mode.
     :param aws_conn_id: The Airflow connection used for AWS credentials.
         If this is ``None`` or empty then the default boto3 behaviour is used. If
@@ -151,14 +148,12 @@ class EmrServerlessJobSensor(AwsBaseSensor[EmrServerlessHook]):
         application_id: str,
         job_run_id: str,
         target_states: set | frozenset = frozenset(EmrServerlessHook.JOB_SUCCESS_STATES),
-        max_attempts: int = 60,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
         **kwargs: Any,
     ) -> None:
         self.target_states = target_states
         self.application_id = application_id
         self.job_run_id = job_run_id
-        self.max_attempts = max_attempts
         self.deferrable = deferrable
         super().__init__(**kwargs)
 
@@ -167,14 +162,16 @@ class EmrServerlessJobSensor(AwsBaseSensor[EmrServerlessHook]):
             super().execute(context=context)
         elif not self.poke(context):
             self.defer(
-                timeout=timedelta(seconds=self.max_attempts * self.poke_interval),
-                trigger=EmrServerlessStartJobTrigger(
+                timeout=timedelta(seconds=self.timeout),
+                trigger=EmrServerlessJobSensorTrigger(
                     application_id=self.application_id,
-                    job_id=self.job_run_id,
+                    job_run_id=self.job_run_id,
+                    target_states=self.target_states,
                     waiter_delay=int(self.poke_interval),
-                    waiter_max_attempts=self.max_attempts,
                     aws_conn_id=self.aws_conn_id,
-                    cancel_on_kill=False,
+                    region_name=self.region_name,
+                    verify=self.verify,
+                    botocore_config=self.botocore_config,
                 ),
                 method_name="execute_complete",
             )
@@ -185,7 +182,7 @@ class EmrServerlessJobSensor(AwsBaseSensor[EmrServerlessHook]):
         if validated_event["status"] != "success":
             raise RuntimeError(f"Error while running job: {validated_event}")
 
-        self.log.info("EMR Serverless job %s completed.", self.job_run_id)
+        self.log.info("EMR Serverless job %s reached a target state.", self.job_run_id)
 
     def poke(self, context: Context) -> bool:
         response = self.hook.conn.get_job_run(applicationId=self.application_id, jobRunId=self.job_run_id)

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/emr.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/emr.py
@@ -26,6 +26,7 @@ from airflow.providers.amazon.aws.links.emr import EmrClusterLink, EmrLogsLink, 
 from airflow.providers.amazon.aws.sensors.base_aws import AwsBaseSensor
 from airflow.providers.amazon.aws.triggers.emr import (
     EmrContainerTrigger,
+    EmrServerlessStartJobTrigger,
     EmrStepSensorTrigger,
     EmrTerminateJobFlowTrigger,
 )
@@ -123,7 +124,11 @@ class EmrServerlessJobSensor(AwsBaseSensor[EmrServerlessHook]):
 
     :param application_id: application_id to check the state of
     :param job_run_id: job_run_id to check the state of
-    :param target_states: a set of states to wait for, defaults to 'SUCCESS'
+    :param target_states: a set of states to wait for, defaults to ``SUCCESS``. In deferrable mode
+        the waiter waits for a terminal success state regardless of ``target_states``.
+    :param max_attempts: Maximum waiter attempts in deferrable mode. Ignored when
+        ``deferrable=False``; poke mode uses ``timeout`` (default ``sensors.default_timeout``, 7 days).
+    :param deferrable: Run sensor in the deferrable mode.
     :param aws_conn_id: The Airflow connection used for AWS credentials.
         If this is ``None`` or empty then the default boto3 behaviour is used. If
         running Airflow in a distributed manner and aws_conn_id is None or
@@ -146,12 +151,41 @@ class EmrServerlessJobSensor(AwsBaseSensor[EmrServerlessHook]):
         application_id: str,
         job_run_id: str,
         target_states: set | frozenset = frozenset(EmrServerlessHook.JOB_SUCCESS_STATES),
+        max_attempts: int = 60,
+        deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
         **kwargs: Any,
     ) -> None:
         self.target_states = target_states
         self.application_id = application_id
         self.job_run_id = job_run_id
+        self.max_attempts = max_attempts
+        self.deferrable = deferrable
         super().__init__(**kwargs)
+
+    def execute(self, context: Context) -> None:
+        if not self.deferrable:
+            super().execute(context=context)
+        elif not self.poke(context):
+            self.defer(
+                timeout=timedelta(seconds=self.max_attempts * self.poke_interval),
+                trigger=EmrServerlessStartJobTrigger(
+                    application_id=self.application_id,
+                    job_id=self.job_run_id,
+                    waiter_delay=int(self.poke_interval),
+                    waiter_max_attempts=self.max_attempts,
+                    aws_conn_id=self.aws_conn_id,
+                    cancel_on_kill=False,
+                ),
+                method_name="execute_complete",
+            )
+
+    def execute_complete(self, context: Context, event: dict[str, Any] | None = None) -> None:
+        validated_event = validate_execute_complete_event(event)
+
+        if validated_event["status"] != "success":
+            raise RuntimeError(f"Error while running job: {validated_event}")
+
+        self.log.info("EMR Serverless job %s completed.", self.job_run_id)
 
     def poke(self, context: Context) -> bool:
         response = self.hook.conn.get_job_run(applicationId=self.application_id, jobRunId=self.job_run_id)

--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/emr.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/emr.py
@@ -398,30 +398,12 @@ class EmrServerlessJobSensorTrigger(AwsBaseWaiterTrigger):
         verify: bool | str | None = None,
         botocore_config: dict | None = None,
     ) -> None:
-        serialized_target_states = sorted(set(target_states))
-        failure_acceptors = [
-            {
-                "matcher": "path",
-                "argument": "jobRun.state",
-                "expected": state,
-                "state": "failure",
-            }
-            for state in sorted(EmrServerlessHook.JOB_FAILURE_STATES)
-        ]
-        success_acceptors = [
-            {
-                "matcher": "path",
-                "argument": "jobRun.state",
-                "expected": state,
-                "state": "success",
-            }
-            for state in serialized_target_states
-        ]
+        normalized_target_states = sorted(set(target_states))
         super().__init__(
             serialized_fields={
                 "application_id": application_id,
                 "job_run_id": job_run_id,
-                "target_states": serialized_target_states,
+                "target_states": normalized_target_states,
             },
             waiter_name="serverless_job_completed",
             waiter_args={"applicationId": application_id, "jobRunId": job_run_id},
@@ -431,12 +413,30 @@ class EmrServerlessJobSensorTrigger(AwsBaseWaiterTrigger):
             return_value=None,
             waiter_delay=waiter_delay,
             waiter_max_attempts=waiter_max_attempts,
-            waiter_config_overrides={"acceptors": [*failure_acceptors, *success_acceptors]},
+            waiter_config_overrides={"acceptors": self._build_waiter_acceptors(normalized_target_states)},
             aws_conn_id=aws_conn_id,
             region_name=region_name,
             verify=verify,
             botocore_config=botocore_config,
         )
+
+    @staticmethod
+    def _build_waiter_acceptors(target_states: list[str]) -> list[dict[str, str]]:
+        acceptors = []
+        for states, waiter_state in (
+            (EmrServerlessHook.JOB_FAILURE_STATES, "failure"),
+            (target_states, "success"),
+        ):
+            for state in states:
+                acceptors.append(
+                    {
+                        "matcher": "path",
+                        "argument": "jobRun.state",
+                        "expected": state,
+                        "state": waiter_state,
+                    }
+                )
+        return acceptors
 
     def hook(self) -> EmrServerlessHook:
         return EmrServerlessHook(

--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/emr.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/emr.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from collections.abc import AsyncIterator, Collection
+from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING
 
 from asgiref.sync import sync_to_async
@@ -390,7 +390,7 @@ class EmrServerlessJobSensorTrigger(AwsBaseWaiterTrigger):
         self,
         application_id: str,
         job_run_id: str,
-        target_states: Collection[str],
+        target_states: set[str] | frozenset[str],
         waiter_delay: int = 60,
         waiter_max_attempts: int = sys.maxsize,
         aws_conn_id: str | None = "aws_default",
@@ -398,7 +398,7 @@ class EmrServerlessJobSensorTrigger(AwsBaseWaiterTrigger):
         verify: bool | str | None = None,
         botocore_config: dict | None = None,
     ) -> None:
-        normalized_target_states = sorted(set(target_states))
+        normalized_target_states = set(target_states)
         super().__init__(
             serialized_fields={
                 "application_id": application_id,
@@ -421,7 +421,7 @@ class EmrServerlessJobSensorTrigger(AwsBaseWaiterTrigger):
         )
 
     @staticmethod
-    def _build_waiter_acceptors(target_states: list[str]) -> list[dict[str, str]]:
+    def _build_waiter_acceptors(target_states: set[str]) -> list[dict[str, str]]:
         acceptors = []
         for states, waiter_state in (
             (EmrServerlessHook.JOB_FAILURE_STATES, "failure"),

--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/emr.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/emr.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Collection
 from typing import TYPE_CHECKING
 
 from asgiref.sync import sync_to_async
@@ -369,6 +369,82 @@ class EmrServerlessStopApplicationTrigger(AwsBaseWaiterTrigger):
 
     def hook(self) -> AwsGenericHook:
         return EmrServerlessHook(self.aws_conn_id)
+
+
+class EmrServerlessJobSensorTrigger(AwsBaseWaiterTrigger):
+    """
+    Poll an EMR Serverless job run until it reaches a target or failure state.
+
+    :param application_id: The ID of the application the job is running on.
+    :param job_run_id: The ID of the job run.
+    :param target_states: The states that indicate the sensor has succeeded.
+    :param waiter_delay: The time in seconds to wait between polling attempts.
+    :param waiter_max_attempts: The maximum number of attempts to be made. Defaults to an infinite wait.
+    :param aws_conn_id: Reference to the AWS connection ID.
+    :param region_name: The AWS region where the job is running.
+    :param verify: Whether to verify SSL certificates.
+    :param botocore_config: Configuration dictionary for the botocore client.
+    """
+
+    def __init__(
+        self,
+        application_id: str,
+        job_run_id: str,
+        target_states: Collection[str],
+        waiter_delay: int = 60,
+        waiter_max_attempts: int = sys.maxsize,
+        aws_conn_id: str | None = "aws_default",
+        region_name: str | None = None,
+        verify: bool | str | None = None,
+        botocore_config: dict | None = None,
+    ) -> None:
+        serialized_target_states = sorted(set(target_states))
+        failure_acceptors = [
+            {
+                "matcher": "path",
+                "argument": "jobRun.state",
+                "expected": state,
+                "state": "failure",
+            }
+            for state in sorted(EmrServerlessHook.JOB_FAILURE_STATES)
+        ]
+        success_acceptors = [
+            {
+                "matcher": "path",
+                "argument": "jobRun.state",
+                "expected": state,
+                "state": "success",
+            }
+            for state in serialized_target_states
+        ]
+        super().__init__(
+            serialized_fields={
+                "application_id": application_id,
+                "job_run_id": job_run_id,
+                "target_states": serialized_target_states,
+            },
+            waiter_name="serverless_job_completed",
+            waiter_args={"applicationId": application_id, "jobRunId": job_run_id},
+            failure_message="EMR Serverless job failed",
+            status_message="EMR Serverless job status is",
+            status_queries=["jobRun.state", "jobRun.stateDetails"],
+            return_value=None,
+            waiter_delay=waiter_delay,
+            waiter_max_attempts=waiter_max_attempts,
+            waiter_config_overrides={"acceptors": [*failure_acceptors, *success_acceptors]},
+            aws_conn_id=aws_conn_id,
+            region_name=region_name,
+            verify=verify,
+            botocore_config=botocore_config,
+        )
+
+    def hook(self) -> EmrServerlessHook:
+        return EmrServerlessHook(
+            aws_conn_id=self.aws_conn_id,
+            region_name=self.region_name,
+            verify=self.verify,
+            config=self.botocore_config,
+        )
 
 
 class EmrServerlessStartJobTrigger(AwsBaseWaiterTrigger):

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_emr_serverless_job.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_emr_serverless_job.py
@@ -17,12 +17,14 @@
 # under the License.
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest import mock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from airflow.providers.amazon.aws.sensors.emr import EmrServerlessJobSensor
-from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.amazon.aws.triggers.emr import EmrServerlessStartJobTrigger
+from airflow.providers.common.compat.sdk import AirflowException, TaskDeferred
 
 
 class TestEmrServerlessJobSensor:
@@ -78,3 +80,59 @@ class TestPokeRaisesAirflowException(TestEmrServerlessJobSensor):
 
         assert exception_msg == str(ctx.value)
         self.assert_get_job_run_was_called_once_with_app_and_run_id()
+
+
+class TestEmrServerlessJobSensorDeferrable(TestEmrServerlessJobSensor):
+    def test_sensor_defer(self):
+        sensor = EmrServerlessJobSensor(
+            task_id="test_emr_serverless_job_sensor",
+            application_id=self.app_id,
+            job_run_id=self.job_run_id,
+            aws_conn_id="aws_default",
+            deferrable=True,
+        )
+
+        with patch.object(EmrServerlessJobSensor, "poke", return_value=False):
+            with pytest.raises(TaskDeferred) as exc:
+                sensor.execute(context=None)
+        assert isinstance(exc.value.trigger, EmrServerlessStartJobTrigger), (
+            "Trigger is not an EmrServerlessStartJobTrigger"
+        )
+
+    def test_sensor_defer_trigger_parameters(self):
+        sensor = EmrServerlessJobSensor(
+            task_id="test_emr_serverless_job_sensor",
+            application_id=self.app_id,
+            job_run_id=self.job_run_id,
+            aws_conn_id="aws_default",
+            deferrable=True,
+            max_attempts=100,
+        )
+        sensor.poke_interval = 10
+
+        with patch.object(EmrServerlessJobSensor, "poke", return_value=False):
+            with pytest.raises(TaskDeferred) as exc:
+                sensor.execute(context=None)
+
+        trigger = exc.value.trigger
+        assert isinstance(trigger, EmrServerlessStartJobTrigger)
+        assert trigger.application_id == self.app_id
+        assert trigger.job_id == self.job_run_id
+        assert trigger.waiter_delay == 10
+        assert trigger.attempts == 100
+        assert trigger.aws_conn_id == "aws_default"
+        assert trigger.cancel_on_kill is False
+
+    @mock.patch("airflow.providers.amazon.aws.sensors.emr.EmrServerlessJobSensor.poke")
+    def test_sensor_defer_skipped_when_poke_succeeds(self, mock_poke):
+        self.sensor.deferrable = True
+        mock_poke.return_value = True
+        self.sensor.execute(context=None)
+        mock_poke.assert_called_once()
+
+    def test_execute_complete_success(self):
+        self.sensor.execute_complete(context={}, event={"status": "success", "job_details": {}})
+
+    def test_execute_complete_failure(self):
+        with pytest.raises(RuntimeError, match="Error while running job"):
+            self.sensor.execute_complete(context={}, event={"status": "failure", "message": "Job failed"})

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_emr_serverless_job.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_emr_serverless_job.py
@@ -17,13 +17,14 @@
 # under the License.
 from __future__ import annotations
 
+from datetime import timedelta
 from unittest import mock
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
 from airflow.providers.amazon.aws.sensors.emr import EmrServerlessJobSensor
-from airflow.providers.amazon.aws.triggers.emr import EmrServerlessStartJobTrigger
+from airflow.providers.amazon.aws.triggers.emr import EmrServerlessJobSensorTrigger
 from airflow.providers.common.compat.sdk import AirflowException, TaskDeferred
 
 
@@ -83,47 +84,40 @@ class TestPokeRaisesAirflowException(TestEmrServerlessJobSensor):
 
 
 class TestEmrServerlessJobSensorDeferrable(TestEmrServerlessJobSensor):
-    def test_sensor_defer(self):
-        sensor = EmrServerlessJobSensor(
-            task_id="test_emr_serverless_job_sensor",
-            application_id=self.app_id,
-            job_run_id=self.job_run_id,
-            aws_conn_id="aws_default",
-            deferrable=True,
-        )
-
-        with patch.object(EmrServerlessJobSensor, "poke", return_value=False):
-            with pytest.raises(TaskDeferred) as exc:
-                sensor.execute(context=None)
-        assert isinstance(exc.value.trigger, EmrServerlessStartJobTrigger), (
-            "Trigger is not an EmrServerlessStartJobTrigger"
-        )
-
     def test_sensor_defer_trigger_parameters(self):
         sensor = EmrServerlessJobSensor(
             task_id="test_emr_serverless_job_sensor",
             application_id=self.app_id,
             job_run_id=self.job_run_id,
+            target_states={"RUNNING"},
             aws_conn_id="aws_default",
+            region_name="eu-west-1",
+            verify=False,
+            botocore_config={"read_timeout": 42},
             deferrable=True,
-            max_attempts=100,
+            poke_interval=10,
+            timeout=300,
         )
-        sensor.poke_interval = 10
 
-        with patch.object(EmrServerlessJobSensor, "poke", return_value=False):
+        with mock.patch.object(EmrServerlessJobSensor, "poke", autospec=True, return_value=False):
             with pytest.raises(TaskDeferred) as exc:
                 sensor.execute(context=None)
 
         trigger = exc.value.trigger
-        assert isinstance(trigger, EmrServerlessStartJobTrigger)
-        assert trigger.application_id == self.app_id
-        assert trigger.job_id == self.job_run_id
+        assert isinstance(trigger, EmrServerlessJobSensorTrigger)
+        assert trigger.serialized_fields == {
+            "application_id": self.app_id,
+            "job_run_id": self.job_run_id,
+            "target_states": ["RUNNING"],
+        }
         assert trigger.waiter_delay == 10
-        assert trigger.attempts == 100
         assert trigger.aws_conn_id == "aws_default"
-        assert trigger.cancel_on_kill is False
+        assert trigger.region_name == "eu-west-1"
+        assert trigger.verify is False
+        assert trigger.botocore_config == {"read_timeout": 42}
+        assert exc.value.timeout == timedelta(seconds=300)
 
-    @mock.patch("airflow.providers.amazon.aws.sensors.emr.EmrServerlessJobSensor.poke")
+    @mock.patch("airflow.providers.amazon.aws.sensors.emr.EmrServerlessJobSensor.poke", autospec=True)
     def test_sensor_defer_skipped_when_poke_succeeds(self, mock_poke):
         self.sensor.deferrable = True
         mock_poke.return_value = True
@@ -131,8 +125,8 @@ class TestEmrServerlessJobSensorDeferrable(TestEmrServerlessJobSensor):
         mock_poke.assert_called_once()
 
     def test_execute_complete_success(self):
-        self.sensor.execute_complete(context={}, event={"status": "success", "job_details": {}})
+        self.sensor.execute_complete(context={}, event={"status": "success", "value": None})
 
     def test_execute_complete_failure(self):
         with pytest.raises(RuntimeError, match="Error while running job"):
-            self.sensor.execute_complete(context={}, event={"status": "failure", "message": "Job failed"})
+            self.sensor.execute_complete(context={}, event={"status": "error", "message": "Job failed"})

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_emr_serverless_job.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_emr_serverless_job.py
@@ -108,7 +108,7 @@ class TestEmrServerlessJobSensorDeferrable(TestEmrServerlessJobSensor):
         assert trigger.serialized_fields == {
             "application_id": self.app_id,
             "job_run_id": self.job_run_id,
-            "target_states": ["RUNNING"],
+            "target_states": {"RUNNING"},
         }
         assert trigger.waiter_delay == 10
         assert trigger.aws_conn_id == "aws_default"

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_emr.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_emr.py
@@ -30,6 +30,7 @@ from airflow.providers.amazon.aws.triggers.emr import (
     EmrServerlessCancelJobsTrigger,
     EmrServerlessCreateApplicationTrigger,
     EmrServerlessDeleteApplicationTrigger,
+    EmrServerlessJobSensorTrigger,
     EmrServerlessStartApplicationTrigger,
     EmrServerlessStartJobTrigger,
     EmrServerlessStopApplicationTrigger,
@@ -313,6 +314,96 @@ class TestEmrServerlessStopApplicationTrigger:
             "waiter_delay": 30,
             "waiter_max_attempts": 60,
             "aws_conn_id": "aws_default",
+        }
+
+
+class TestEmrServerlessJobSensorTrigger:
+    @staticmethod
+    def build_trigger(**kwargs):
+        trigger_kwargs = {
+            "application_id": "test_application_id",
+            "job_run_id": "test_job_run_id",
+            "target_states": {"RUNNING"},
+            "waiter_delay": 10,
+            "aws_conn_id": "aws_default",
+            **kwargs,
+        }
+        return EmrServerlessJobSensorTrigger(**trigger_kwargs)
+
+    def test_serialization(self):
+        trigger = self.build_trigger(
+            target_states={"SUCCESS", "RUNNING"},
+            region_name="eu-west-1",
+            verify=False,
+            botocore_config={"read_timeout": 42},
+        )
+
+        classpath, kwargs = trigger.serialize()
+
+        assert classpath == "airflow.providers.amazon.aws.triggers.emr.EmrServerlessJobSensorTrigger"
+        assert kwargs == {
+            "application_id": "test_application_id",
+            "job_run_id": "test_job_run_id",
+            "target_states": ["RUNNING", "SUCCESS"],
+            "waiter_delay": 10,
+            "waiter_max_attempts": sys.maxsize,
+            "aws_conn_id": "aws_default",
+            "region_name": "eu-west-1",
+            "verify": False,
+            "botocore_config": {"read_timeout": 42},
+        }
+        recreated_trigger = EmrServerlessJobSensorTrigger(**kwargs)
+        assert recreated_trigger.waiter_config_overrides == trigger.waiter_config_overrides
+
+        assert trigger.waiter_name == "serverless_job_completed"
+        assert trigger.waiter_args == {
+            "applicationId": "test_application_id",
+            "jobRunId": "test_job_run_id",
+        }
+        assert trigger.attempts == sys.maxsize
+        assert trigger.status_queries == ["jobRun.state", "jobRun.stateDetails"]
+        hook = trigger.hook()
+        assert hook.aws_conn_id == "aws_default"
+        assert hook._region_name == "eu-west-1"
+        assert hook._verify is False
+        assert hook._config.read_timeout == 42
+
+    def test_failure_acceptors_precede_success_acceptors(self):
+        trigger = self.build_trigger(target_states={"FAILED", "RUNNING"})
+
+        assert trigger.waiter_config_overrides == {
+            "acceptors": [
+                {
+                    "matcher": "path",
+                    "argument": "jobRun.state",
+                    "expected": "CANCELLED",
+                    "state": "failure",
+                },
+                {
+                    "matcher": "path",
+                    "argument": "jobRun.state",
+                    "expected": "CANCELLING",
+                    "state": "failure",
+                },
+                {
+                    "matcher": "path",
+                    "argument": "jobRun.state",
+                    "expected": "FAILED",
+                    "state": "failure",
+                },
+                {
+                    "matcher": "path",
+                    "argument": "jobRun.state",
+                    "expected": "FAILED",
+                    "state": "success",
+                },
+                {
+                    "matcher": "path",
+                    "argument": "jobRun.state",
+                    "expected": "RUNNING",
+                    "state": "success",
+                },
+            ]
         }
 
 

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_emr.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_emr.py
@@ -22,7 +22,7 @@ from unittest import mock
 
 import pytest
 
-from airflow.providers.amazon.aws.hooks.emr import EmrContainerHook
+from airflow.providers.amazon.aws.hooks.emr import EmrContainerHook, EmrServerlessHook
 from airflow.providers.amazon.aws.triggers.emr import (
     EmrAddStepsTrigger,
     EmrContainerTrigger,
@@ -371,40 +371,22 @@ class TestEmrServerlessJobSensorTrigger:
     def test_failure_acceptors_precede_success_acceptors(self):
         trigger = self.build_trigger(target_states={"FAILED", "RUNNING"})
 
-        assert trigger.waiter_config_overrides == {
-            "acceptors": [
-                {
-                    "matcher": "path",
-                    "argument": "jobRun.state",
-                    "expected": "CANCELLED",
-                    "state": "failure",
-                },
-                {
-                    "matcher": "path",
-                    "argument": "jobRun.state",
-                    "expected": "CANCELLING",
-                    "state": "failure",
-                },
-                {
-                    "matcher": "path",
-                    "argument": "jobRun.state",
-                    "expected": "FAILED",
-                    "state": "failure",
-                },
-                {
-                    "matcher": "path",
-                    "argument": "jobRun.state",
-                    "expected": "FAILED",
-                    "state": "success",
-                },
-                {
-                    "matcher": "path",
-                    "argument": "jobRun.state",
-                    "expected": "RUNNING",
-                    "state": "success",
-                },
-            ]
-        }
+        waiter_config_overrides = trigger.waiter_config_overrides
+        assert waiter_config_overrides is not None
+        acceptors = waiter_config_overrides["acceptors"]
+        failure_acceptors = [acceptor for acceptor in acceptors if acceptor["state"] == "failure"]
+        success_acceptors = [acceptor for acceptor in acceptors if acceptor["state"] == "success"]
+
+        assert acceptors == [*failure_acceptors, *success_acceptors]
+        assert len(failure_acceptors) == len(EmrServerlessHook.JOB_FAILURE_STATES)
+        assert {acceptor["expected"] for acceptor in failure_acceptors} == (
+            EmrServerlessHook.JOB_FAILURE_STATES
+        )
+        assert len(success_acceptors) == 2
+        assert {acceptor["expected"] for acceptor in success_acceptors} == {"FAILED", "RUNNING"}
+        assert all(
+            acceptor["matcher"] == "path" and acceptor["argument"] == "jobRun.state" for acceptor in acceptors
+        )
 
 
 class TestEmrServerlessStartJobTrigger:

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_emr.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_emr.py
@@ -332,7 +332,7 @@ class TestEmrServerlessJobSensorTrigger:
 
     def test_serialization(self):
         trigger = self.build_trigger(
-            target_states={"SUCCESS", "RUNNING"},
+            target_states=frozenset({"SUCCESS", "RUNNING"}),
             region_name="eu-west-1",
             verify=False,
             botocore_config={"read_timeout": 42},
@@ -344,7 +344,7 @@ class TestEmrServerlessJobSensorTrigger:
         assert kwargs == {
             "application_id": "test_application_id",
             "job_run_id": "test_job_run_id",
-            "target_states": ["RUNNING", "SUCCESS"],
+            "target_states": {"RUNNING", "SUCCESS"},
             "waiter_delay": 10,
             "waiter_max_attempts": sys.maxsize,
             "aws_conn_id": "aws_default",
@@ -353,7 +353,14 @@ class TestEmrServerlessJobSensorTrigger:
             "botocore_config": {"read_timeout": 42},
         }
         recreated_trigger = EmrServerlessJobSensorTrigger(**kwargs)
-        assert recreated_trigger.waiter_config_overrides == trigger.waiter_config_overrides
+        waiter_config_overrides = trigger.waiter_config_overrides
+        recreated_waiter_config_overrides = recreated_trigger.waiter_config_overrides
+        assert waiter_config_overrides is not None
+        assert recreated_waiter_config_overrides is not None
+        assert {
+            (acceptor["expected"], acceptor["state"])
+            for acceptor in recreated_waiter_config_overrides["acceptors"]
+        } == {(acceptor["expected"], acceptor["state"]) for acceptor in waiter_config_overrides["acceptors"]}
 
         assert trigger.waiter_name == "serverless_job_completed"
         assert trigger.waiter_args == {

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_serialization.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_serialization.py
@@ -38,6 +38,7 @@ from airflow.providers.amazon.aws.triggers.emr import (
     EmrServerlessCancelJobsTrigger,
     EmrServerlessCreateApplicationTrigger,
     EmrServerlessDeleteApplicationTrigger,
+    EmrServerlessJobSensorTrigger,
     EmrServerlessStartApplicationTrigger,
     EmrServerlessStartJobTrigger,
     EmrServerlessStopApplicationTrigger,
@@ -249,6 +250,14 @@ class TestTriggersSerialization:
                 aws_conn_id=AWS_CONN_ID,
                 waiter_delay=WAITER_DELAY,
                 waiter_max_attempts=MAX_ATTEMPTS,
+            ),
+            EmrServerlessJobSensorTrigger(
+                application_id=TEST_APPLICATION_ID,
+                job_run_id=TEST_JOB_ID,
+                target_states={"RUNNING", "SUCCESS"},
+                waiter_delay=WAITER_DELAY,
+                aws_conn_id=AWS_CONN_ID,
+                region_name=AWS_REGION,
             ),
             EmrServerlessStartJobTrigger(
                 application_id=TEST_APPLICATION_ID,


### PR DESCRIPTION
Add deferrable mode to `EmrServerlessJobSensor` so waiting on a long-running EMR Serverless job does not occupy a worker slot.

Follows `EmrJobFlowSensor` / `EmrStepSensor`: poke once, then `defer()` to a dedicated `EmrServerlessJobSensorTrigger`. The trigger uses the existing `serverless_job_completed` waiter with acceptors overridden to preserve the sensor's configured `target_states`. Poke/reschedule behaviour is unchanged when `deferrable=False`.

Docs: class docstring plus `providers/amazon/docs/operators/emr/emr_serverless.rst`.

### Implementation notes

- **Waiter configuration overrides:** The trigger reuses the existing `serverless_job_completed` waiter and overrides only its acceptors. A static waiter cannot represent runtime-configurable `target_states`, so this avoids adding separate waiter JSON for each possible target-state combination.
- **Failure exceptions:** `poke()` still raises `AirflowException` on `JOB_FAILURE_STATES`, as before. `execute_complete()` raises `RuntimeError` because new direct `raise AirflowException` usages are blocked by the `check-no-new-airflow-exceptions` pre-commit hook. This also follows the existing DynamoDB and SSM sensor patterns.
- **Dedicated trigger:** `EmrServerlessStartJobTrigger` remains unchanged for `EmrServerlessStartJobOperator`. The new `EmrServerlessJobSensorTrigger` is sensor-specific because it must support runtime-configurable `target_states` and sensor timeout semantics.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Cursor Grok 4.5

Generated-by: Cursor Grok 4.5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

### Tests run locally

- **prek (pre-commit):** passed, including ruff, ruff-format, and `check-no-new-airflow-exceptions` on the changed files.
- **mypy:** `breeze run mypy providers/amazon/src/airflow/providers/amazon/aws/sensors/emr.py providers/amazon/src/airflow/providers/amazon/aws/triggers/emr.py` — passed
- **Sensor + EMR trigger unit tests:** `breeze testing providers-tests --python 3.10 providers/amazon/tests/unit/amazon/aws/sensors/test_emr_serverless_job.py providers/amazon/tests/unit/amazon/aws/triggers/test_emr.py providers/amazon/tests/unit/amazon/aws/triggers/test_serialization.py -xvs` — passed
- **Amazon provider suite:** `breeze testing providers-tests --python 3.10 --test-type "Providers[amazon]"` — passed

---