### PR TITLE
Fix Dag run filtering for null start dates

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/parameters.py
+++ b/airflow-core/src/airflow/api_fastapi/common/parameters.py
@@ -1209,7 +1209,7 @@ class NullableDatetimeRangeFilter(RangeFilter):
         super().__init__(value, attribute)
         self.null_lower_bound_clause = null_lower_bound_clause
 
-    def _get_null_lower_bound_clause(self):
+    def _get_null_lower_bound_clause(self) -> ColumnElement[bool]:
         null_clause = self.attribute.is_(None)
         if self.null_lower_bound_clause is not None:
             null_clause = and_(null_clause, self.null_lower_bound_clause)
@@ -1239,7 +1239,11 @@ class NullableDatetimeRangeFilter(RangeFilter):
 
 
 def datetime_range_filter_factory(
-    filter_name: str, model: Base, attribute_name: str | None = None
+    filter_name: str,
+    model: Base,
+    attribute_name: str | None = None,
+    *,
+    null_lower_bound_clause: ColumnElement[bool] | None = None,
 ) -> Callable[[datetime | None, datetime | None, datetime | None, datetime | None], RangeFilter]:
     def depends_datetime(
         lower_bound_gte: datetime | None = Query(alias=f"{filter_name}_gte", default=None),
@@ -1254,13 +1258,7 @@ def datetime_range_filter_factory(
             upper_bound_lte=upper_bound_lte,
             upper_bound_lt=upper_bound_lt,
         )
-        attr_name = attribute_name or filter_name
-        if filter_name in ("start_date", "end_date") or (model is DagRun and attr_name == "start_date"):
-            null_lower_bound_clause: ColumnElement[bool] | None = None
-            if model is DagRun:
-                null_lower_bound_clause = DagRun.id.is_not(None)
-                if attr_name == "start_date":
-                    null_lower_bound_clause = and_(null_lower_bound_clause, DagRun.end_date.is_(None))
+        if filter_name in ("start_date", "end_date"):
             return NullableDatetimeRangeFilter(
                 range_val, attr, null_lower_bound_clause=null_lower_bound_clause
             )

--- a/airflow-core/src/airflow/api_fastapi/common/parameters.py
+++ b/airflow-core/src/airflow/api_fastapi/common/parameters.py
@@ -1210,7 +1210,7 @@ class NullableDatetimeRangeFilter(RangeFilter):
         self.null_lower_bound_clause = null_lower_bound_clause
 
     def _get_null_lower_bound_clause(self) -> ColumnElement[bool]:
-        null_clause = self.attribute.is_(None)
+        null_clause: ColumnElement[bool] = self.attribute.is_(None)
         if self.null_lower_bound_clause is not None:
             null_clause = and_(null_clause, self.null_lower_bound_clause)
         return null_clause

--- a/airflow-core/src/airflow/api_fastapi/common/parameters.py
+++ b/airflow-core/src/airflow/api_fastapi/common/parameters.py
@@ -1254,14 +1254,13 @@ def datetime_range_filter_factory(
             upper_bound_lte=upper_bound_lte,
             upper_bound_lt=upper_bound_lt,
         )
-        if filter_name in ("start_date", "end_date"):
-            null_lower_bound_clause = None
-            if (
-                model is DagRun
-                and filter_name == "start_date"
-                and (attribute_name or filter_name) == "start_date"
-            ):
-                null_lower_bound_clause = DagRun.end_date.is_(None)
+        attr_name = attribute_name or filter_name
+        if filter_name in ("start_date", "end_date") or (model is DagRun and attr_name == "start_date"):
+            null_lower_bound_clause: ColumnElement[bool] | None = None
+            if model is DagRun:
+                null_lower_bound_clause = DagRun.id.is_not(None)
+                if attr_name == "start_date":
+                    null_lower_bound_clause = and_(null_lower_bound_clause, DagRun.end_date.is_(None))
             return NullableDatetimeRangeFilter(
                 range_val, attr, null_lower_bound_clause=null_lower_bound_clause
             )

--- a/airflow-core/src/airflow/api_fastapi/common/parameters.py
+++ b/airflow-core/src/airflow/api_fastapi/common/parameters.py
@@ -1194,11 +1194,26 @@ class NullableDatetimeRangeFilter(RangeFilter):
     ``OR`` predicates so each branch can be satisfied by an independent index scan.
 
     NULL semantics: ``start_date=NULL`` means the task has not started yet; ``end_date=NULL`` means
-    the task is still running. For lower bounds the NULL branch passes unconditionally — a not-yet-
-    started/ended task will eventually satisfy any past lower bound. For upper bounds the NULL branch
-    is ``col IS NULL AND now() <= x``, preserving the COALESCE(col, now()) semantics without the
-    function-wrap index penalty.
+    the task is still running. For lower bounds the NULL branch usually passes unconditionally, but
+    callers may narrow it with an extra clause when NULL cannot still evolve into an in-range value.
+    For upper bounds the NULL branch is ``col IS NULL AND now() <= x``, preserving the
+    COALESCE(col, now()) semantics without the function-wrap index penalty.
     """
+
+    def __init__(
+        self,
+        value: Range | None,
+        attribute: InstrumentedAttribute,
+        null_lower_bound_clause: ColumnElement[bool] | None = None,
+    ) -> None:
+        super().__init__(value, attribute)
+        self.null_lower_bound_clause = null_lower_bound_clause
+
+    def _get_null_lower_bound_clause(self):
+        null_clause = self.attribute.is_(None)
+        if self.null_lower_bound_clause is not None:
+            null_clause = and_(null_clause, self.null_lower_bound_clause)
+        return null_clause
 
     def to_orm(self, select: Select) -> Select:
         if self.skip_none is False:
@@ -1209,10 +1224,10 @@ class NullableDatetimeRangeFilter(RangeFilter):
 
         if self.value.lower_bound_gte:
             x = self.value.lower_bound_gte
-            select = select.where(or_(self.attribute >= x, self.attribute.is_(None)))
+            select = select.where(or_(self.attribute >= x, self._get_null_lower_bound_clause()))
         if self.value.lower_bound_gt:
             x = self.value.lower_bound_gt
-            select = select.where(or_(self.attribute > x, self.attribute.is_(None)))
+            select = select.where(or_(self.attribute > x, self._get_null_lower_bound_clause()))
         if self.value.upper_bound_lte:
             x = self.value.upper_bound_lte
             select = select.where(or_(self.attribute <= x, and_(self.attribute.is_(None), func.now() <= x)))
@@ -1240,7 +1255,16 @@ def datetime_range_filter_factory(
             upper_bound_lt=upper_bound_lt,
         )
         if filter_name in ("start_date", "end_date"):
-            return NullableDatetimeRangeFilter(range_val, attr)
+            null_lower_bound_clause = None
+            if (
+                model is DagRun
+                and filter_name == "start_date"
+                and (attribute_name or filter_name) == "start_date"
+            ):
+                null_lower_bound_clause = DagRun.end_date.is_(None)
+            return NullableDatetimeRangeFilter(
+                range_val, attr, null_lower_bound_clause=null_lower_bound_clause
+            )
         return RangeFilter(range_val, attr)
 
     return depends_datetime

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -506,7 +506,14 @@ def get_dag_runs(
     offset: QueryOffset,
     run_after: Annotated[RangeFilter, Depends(datetime_range_filter_factory("run_after", DagRun))],
     logical_date: Annotated[RangeFilter, Depends(datetime_range_filter_factory("logical_date", DagRun))],
-    start_date_range: Annotated[RangeFilter, Depends(datetime_range_filter_factory("start_date", DagRun))],
+    start_date_range: Annotated[
+        RangeFilter,
+        Depends(
+            datetime_range_filter_factory(
+                "start_date", DagRun, null_lower_bound_clause=DagRun.end_date.is_(None)
+            )
+        ),
+    ],
     end_date_range: Annotated[RangeFilter, Depends(datetime_range_filter_factory("end_date", DagRun))],
     duration_range: Annotated[RangeFilter, Depends(float_range_filter_factory("duration", DagRun))],
     update_at_range: Annotated[RangeFilter, Depends(datetime_range_filter_factory("updated_at", DagRun))],

--- a/airflow-core/tests/unit/api_fastapi/common/test_parameters.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_parameters.py
@@ -528,6 +528,27 @@ class TestDatetimeRangeFilterFactory:
         assert "now()" not in sql
         assert "coalesce" not in sql
 
+    def test_null_lower_bound_clause_is_added_to_null_branch(self):
+        """Custom NULL lower-bound clause is ANDed with the attribute IS NULL check."""
+        bound = datetime(2026, 5, 3, 12, 0, 0, tzinfo=timezone.utc)
+        depends = datetime_range_filter_factory(
+            "start_date",
+            DagRun,
+            null_lower_bound_clause=DagRun.end_date.is_(None),
+        )
+        rf = depends(
+            lower_bound_gte=bound,
+            lower_bound_gt=None,
+            upper_bound_lte=None,
+            upper_bound_lt=None,
+        )
+
+        sql = _compile(rf.to_orm(select(DagRun)))
+
+        assert "start_date is null" in sql
+        assert "end_date is null" in sql
+        assert "start_date is null and" in sql
+
     def test_upper_bound_includes_now_for_running_tasks(self):
         """NULL branch on upper bounds uses now() to proxy the in-progress task's current time."""
         bound = datetime(2026, 5, 3, 12, 0, 0, tzinfo=timezone.utc)

--- a/airflow-core/tests/unit/api_fastapi/common/test_parameters.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_parameters.py
@@ -504,11 +504,14 @@ class TestDatetimeRangeFilterFactory:
         rf = _make_datetime_filter("end_date")
         assert isinstance(rf, NullableDatetimeRangeFilter)
 
-    def test_aliased_start_date_returns_nullable_filter(self):
+    def test_aliased_filter_name_returns_plain_filter(self):
+        """dag_run_start_date uses attribute_name='start_date' via outer join; NULL means 'no run',
+        not 'currently running', so it must return a plain RangeFilter to avoid inflating counts."""
         rf = _make_datetime_filter("dag_run_start_date", model=DagRun, attribute_name="start_date")
-        assert isinstance(rf, NullableDatetimeRangeFilter)
+        assert type(rf) is RangeFilter
 
     def test_aliased_end_date_returns_plain_filter(self):
+        """dag_run_end_date uses attribute_name='end_date' via outer join; must return plain RangeFilter."""
         rf = _make_datetime_filter("dag_run_end_date", model=DagRun, attribute_name="end_date")
         assert type(rf) is RangeFilter
 

--- a/airflow-core/tests/unit/api_fastapi/common/test_parameters.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_parameters.py
@@ -504,14 +504,11 @@ class TestDatetimeRangeFilterFactory:
         rf = _make_datetime_filter("end_date")
         assert isinstance(rf, NullableDatetimeRangeFilter)
 
-    def test_aliased_filter_name_returns_plain_filter(self):
-        """dag_run_start_date uses attribute_name='start_date' via outer join; NULL means 'no run',
-        not 'currently running', so it must return a plain RangeFilter to avoid inflating counts."""
+    def test_aliased_start_date_returns_nullable_filter(self):
         rf = _make_datetime_filter("dag_run_start_date", model=DagRun, attribute_name="start_date")
-        assert type(rf) is RangeFilter
+        assert isinstance(rf, NullableDatetimeRangeFilter)
 
     def test_aliased_end_date_returns_plain_filter(self):
-        """dag_run_end_date uses attribute_name='end_date' via outer join; must return plain RangeFilter."""
         rf = _make_datetime_filter("dag_run_end_date", model=DagRun, attribute_name="end_date")
         assert type(rf) is RangeFilter
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -840,6 +840,23 @@ class TestGetDagRuns:
         assert len(collected) == len(set(collected)), "cursor pages overlapped"
         assert set(collected) == full_ids, "cursor pagination dropped rows across the NULL boundary"
 
+    @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
+    def test_start_date_lower_bound_excludes_finished_runs_with_null_start_date(self, test_client, session):
+        run = session.scalar(select(DagRun).where(DagRun.run_id == DAG1_RUN2_ID))
+        run.start_date = None
+        run.end_date = START_DATE1 + timedelta(minutes=5)
+        session.commit()
+
+        response = test_client.get(
+            "/dags/~/dagRuns",
+            params={"start_date_gte": START_DATE2.isoformat(), "order_by": "dag_run_id"},
+        )
+
+        assert response.status_code == 200, response.json()
+        body = response.json()
+        assert body["total_entries"] == 2
+        assert [run["dag_run_id"] for run in body["dag_runs"]] == [DAG2_RUN1_ID, DAG2_RUN2_ID]
+
     @pytest.mark.parametrize(
         ("dag_id", "query_params", "expected_dag_id_list"),
         [

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
@@ -459,24 +459,6 @@ class TestGetDags(TestDagEndpoint):
 
         assert actual_ids == expected_ids
 
-    def test_get_dags_start_date_lower_bound_excludes_finished_latest_run_with_null_start_date(
-        self, test_client, session
-    ):
-        run = session.scalar(select(DagRun).where(DagRun.dag_id == DAG1_ID))
-        run.start_date = None
-        run.end_date = DAG1_START_DATE + timedelta(minutes=5)
-        session.commit()
-
-        response = test_client.get(
-            "/dags",
-            params={"dag_run_start_date_gte": DAG2_START_DATE.isoformat(), "exclude_stale": False},
-        )
-
-        assert response.status_code == 200
-        body = response.json()
-        assert body["total_entries"] == 0
-        assert [dag["dag_id"] for dag in body["dags"]] == []
-
     # Ordering of nulls values is DB specific.
     @pytest.mark.backend("sqlite")
     @pytest.mark.parametrize(

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
@@ -459,6 +459,24 @@ class TestGetDags(TestDagEndpoint):
 
         assert actual_ids == expected_ids
 
+    def test_get_dags_start_date_lower_bound_excludes_finished_latest_run_with_null_start_date(
+        self, test_client, session
+    ):
+        run = session.scalar(select(DagRun).where(DagRun.dag_id == DAG1_ID))
+        run.start_date = None
+        run.end_date = DAG1_START_DATE + timedelta(minutes=5)
+        session.commit()
+
+        response = test_client.get(
+            "/dags",
+            params={"dag_run_start_date_gte": DAG2_START_DATE.isoformat(), "exclude_stale": False},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total_entries"] == 0
+        assert [dag["dag_id"] for dag in body["dags"]] == []
+
     # Ordering of nulls values is DB specific.
     @pytest.mark.backend("sqlite")
     @pytest.mark.parametrize(


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Why
`GET /dags/~/dagRuns` can return old finished Dag runs when filtering with `start_date_gte` or `start_date_gt` if those runs have `start_date=NULL`.

The nullable datetime filter treated `NULL` start dates as matching lower-bound filters unconditionally. That is useful for unfinished runs whose start date may still be populated later, but it is incorrect for runs that have already ended.

relates: #70627

## Solution
Limit the `NULL` lower-bound match for `DagRun.start_date` to runs whose `end_date` is also `NULL`.

This keeps the existing nullable datetime behavior for unfinished Dag runs, while excluding already-ended runs from recent start-date lower-bound queries.



##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- `[X]` Yes (please specify the tool below)


Generated-by: [Codex] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
