### PR TITLE
Fix HttpHook double slash in URL when connection host has trailing slash and endpoint has leading slash

### DIFF
--- a/providers/http/src/airflow/providers/http/hooks/http.py
+++ b/providers/http/src/airflow/providers/http/hooks/http.py
@@ -47,7 +47,11 @@ if TYPE_CHECKING:
 
 def _url_from_endpoint(base_url: str | None, endpoint: str | None) -> str:
     """Combine base url with endpoint."""
-    if base_url and not base_url.endswith("/") and endpoint and not endpoint.startswith("/"):
+    if base_url and endpoint:
+        if base_url.endswith("/") and endpoint.startswith("/"):
+            return f"{base_url}{endpoint[1:]}"
+        if base_url.endswith("/") or endpoint.startswith("/"):
+            return f"{base_url}{endpoint}"
         return f"{base_url}/{endpoint}"
     return (base_url or "") + (endpoint or "")
 

--- a/providers/http/tests/unit/http/hooks/test_http.py
+++ b/providers/http/tests/unit/http/hooks/test_http.py
@@ -599,6 +599,24 @@ class TestHttpHook:
         [
             pytest.param("https://example.org", "/v1/test", "https://example.org/v1/test", id="both-set"),
             pytest.param("", "http://foo/bar/v1/test", "http://foo/bar/v1/test", id="only-endpoint"),
+            pytest.param(
+                "https://example.org/",
+                "/v1/test",
+                "https://example.org/v1/test",
+                id="trailing-and-leading-slash",
+            ),
+            pytest.param(
+                "https://example.org/v1",
+                "/test",
+                "https://example.org/v1/test",
+                id="leading-slash-only",
+            ),
+            pytest.param(
+                "https://example.org/v1/",
+                "test",
+                "https://example.org/v1/test",
+                id="trailing-slash-only",
+            ),
         ],
     )
     def test_url_from_endpoint(self, base_url: str, endpoint: str, expected_url: str):


### PR DESCRIPTION
closes #71658

### What is changing and why

`HttpHook._url_from_endpoint()` (used by both `HttpHook` and `HttpAsyncHook`) only guarded against a *missing* slash between `base_url` and `endpoint` — it did not guard against a *double* one. When a connection host is configured with a trailing `/` (common) and an endpoint is passed with a leading `/` (also common REST convention), the resulting URL contained `//`:

```python
hook.base_url = "https://api.example.com/v1/"
hook.url_from_endpoint("/users")
# before: https://api.example.com/v1//users
# after:  https://api.example.com/v1/users
```

Many API frameworks (Flask, FastAPI, Django) do not normalize `//` in a path and return 404, so this produced a silent, confusing failure.

The fix joins `base_url` and `endpoint` with exactly one `/` in all cases, preserving the existing behavior for every other input combination (including scheme-only base URLs such as `http://`, and endpoint-only requests).

### Tests

- Added parametrized regression cases to `test_url_from_endpoint` covering trailing-slash, leading-slash, and both.
- `providers/http/tests/unit/http/hooks/test_http.py`: 60 passed, 1 pre-existing environment error (verified identical on `main`).
- `ruff check` and `ruff format --check` clean on both changed files.