### PR TITLE
helm - allow empty pass for metadataConnection ( token authent )

### DIFF
--- a/chart/templates/secrets/metadata-connection-secret.yaml
+++ b/chart/templates/secrets/metadata-connection-secret.yaml
@@ -53,15 +53,21 @@ metadata:
 type: Opaque
 data:
   {{- with .Values.data.metadataConnection }}
-  connection: {{ urlJoin (dict "scheme" .protocol "userinfo" (printf "%s:%s" ($metadataUser | urlquery) (.pass | urlquery) ) "host" (printf "%s:%s" $host $port) "path" (printf "/%s" $database) "query" $query) | b64enc | quote }}
+  {{- $pass := .pass | urlquery }}
+  {{- $userinfo := ternary ($metadataUser | urlquery) (printf "%s:%s" ($metadataUser | urlquery) $pass) (empty .pass) }}
+  connection: {{ urlJoin (dict "scheme" .protocol "userinfo" $userinfo "host" (printf "%s:%s" $host $port) "path" (printf "/%s" $database) "query" $query) | b64enc | quote }}
   {{- end }}
   {{- if or $workersKedaNeedsPgbouncerBypass $triggererKedaNeedsPgbouncerBypass }}
   {{- with .Values.data.metadataConnection }}
-  kedaConnection: {{ urlJoin (dict "scheme" .protocol "userinfo" (printf "%s:%s" ($metadataUser | urlquery) (.pass | urlquery) ) "host" (printf "%s:%s" $metadataHost $metadataPort) "path" (printf "/%s" $metadataDatabase) "query" $query) | b64enc | quote }}
+  {{- $pass := .pass | urlquery }}
+  {{- $userinfo := ternary ($metadataUser | urlquery) (printf "%s:%s" ($metadataUser | urlquery) $pass) (empty .pass) }}
+  kedaConnection: {{ urlJoin (dict "scheme" .protocol "userinfo" $userinfo "host" (printf "%s:%s" $metadataHost $metadataPort) "path" (printf "/%s" $metadataDatabase) "query" $query) | b64enc | quote }}
   {{- end }}
   {{- else if and (or .Values.workers.celery.keda.enabled $triggererKedaEnabled) (eq .Values.data.metadataConnection.protocol "mysql") }}
   {{- with .Values.data.metadataConnection }}
-  kedaConnection: {{ urlJoin (dict "userinfo" (printf "%s:%s" ($metadataUser | urlquery) (.pass | urlquery) ) "host" (printf "tcp(%s:%s)" $metadataHost $metadataPort) "path" (printf "/%s" $metadataDatabase) "query" $query) | trimPrefix "//" | b64enc | quote }}
+  {{- $pass := .pass | urlquery }}
+  {{- $userinfo := ternary ($metadataUser | urlquery) (printf "%s:%s" ($metadataUser | urlquery) $pass) (empty .pass) }}
+  kedaConnection: {{ urlJoin (dict "userinfo" $userinfo "host" (printf "tcp(%s:%s)" $metadataHost $metadataPort) "path" (printf "/%s" $metadataDatabase) "query" $query) | trimPrefix "//" | b64enc | quote }}
   {{- end }}
   {{- end }}
-{{- end }}
+  {{- end }}

--- a/chart/tests/helm_tests/security/test_metadata_connection_secret.py
+++ b/chart/tests/helm_tests/security/test_metadata_connection_secret.py
@@ -93,6 +93,20 @@ class TestMetadataConnectionSecret:
 
         assert connection == "postgresql://someuser:somepass@somehost:7777/somedb?sslmode=require"
 
+    def test_should_correctly_use_empty_pass(self):
+        new_dict = self.non_chart_database_values.copy()
+        new_dict["pass"] = ""
+        values = {
+            "data": {
+                "metadataConnection": {
+                    **new_dict,
+                }
+            }
+        }
+        connection = self._get_connection(values)
+
+        assert connection == "postgresql://someuser@somehost:7777/somedb?sslmode=disable"
+
     def test_should_support_non_postgres_db(self):
         values = {
             "data": {


### PR DESCRIPTION
I want to be able to set an empty password for the `metadataConnection`

```yaml
data:
  metadataConnection:
    user: airflow_iam_user
    pass: ""
    host: xxx.yyyy.rds.amazonaws.com
    port: 5432
    db: airflow_db
```

to get `postgresql://airflow_iam_user@xxx.yyyy.rds.amazonaws.com:5432/airflow_db`

currently I get `postgresql://airflow_iam_user:@xxx.yyyy.rds.amazonaws.com:5432/airflow_db`

