### PR TITLE
Fix HttpHook double slash when base_url and endpoint both have slashes

### DIFF
--- a/providers/http/src/airflow/providers/http/hooks/http.py
+++ b/providers/http/src/airflow/providers/http/hooks/http.py
@@ -47,9 +47,18 @@ if TYPE_CHECKING:
 
 def _url_from_endpoint(base_url: str | None, endpoint: str | None) -> str:
     """Combine base url with endpoint."""
-    if base_url and not base_url.endswith("/") and endpoint and not endpoint.startswith("/"):
-        return f"{base_url}/{endpoint}"
-    return (base_url or "") + (endpoint or "")
+    if not base_url:
+        return endpoint or ""
+    if not endpoint:
+        return base_url
+    # Strip at most one slash from each side, not all of them: base_url can
+    # legitimately end in "//" (e.g. a bare "http://" with an empty host),
+    # and a full rstrip("/")/lstrip("/") would eat the scheme separator too.
+    if base_url.endswith("/"):
+        base_url = base_url[:-1]
+    if endpoint.startswith("/"):
+        endpoint = endpoint[1:]
+    return f"{base_url}/{endpoint}"
 
 
 def _process_extra_options_from_connection(

--- a/providers/http/tests/unit/http/hooks/test_http.py
+++ b/providers/http/tests/unit/http/hooks/test_http.py
@@ -599,6 +599,12 @@ class TestHttpHook:
         [
             pytest.param("https://example.org", "/v1/test", "https://example.org/v1/test", id="both-set"),
             pytest.param("", "http://foo/bar/v1/test", "http://foo/bar/v1/test", id="only-endpoint"),
+            pytest.param(
+                "https://example.org/",
+                "/v1/test",
+                "https://example.org/v1/test",
+                id="trailing-and-leading-slash",
+            ),
         ],
     )
     def test_url_from_endpoint(self, base_url: str, endpoint: str, expected_url: str):


### PR DESCRIPTION
_url_from_endpoint() only guarded against a missing slash between base_url and endpoint, not a double one. When a connection's host has a trailing slash and the endpoint passed to run()/url_from_endpoint() has a leading slash, the resulting URL contained '//', which many API frameworks (Flask, FastAPI, Django) do not normalize and will 404 on.

Fix by stripping at most one trailing slash from base_url and at most one leading slash from endpoint before joining. A full rstrip('/')/ lstrip('/') was tried first but is too aggressive: base_url can legitimately end in '//' on its own (e.g. a bare 'http://' with an empty host), and stripping all trailing slashes there eats the scheme separator itself, breaking an existing test
(test_build_request_url_from_endpoint_param). Stripping at most one slash from each side fixes the double-slash bug without that regression. Affects both HttpHook and HttpAsyncHook since both call this shared helper.

Closes #71658

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
