### PR TITLE
Complete French UI translations

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/assets.json
@@ -43,7 +43,10 @@
     "title": "Créer un événement d'Asset pour {{name}}"
   },
   "events": "Événements",
-  "extra": "Extra",
+  "filters": {
+    "groupPlaceholder": "Rechercher un groupe",
+    "lastEventDateRange": "Date du dernier événement"
+  },
   "group": "Group",
   "lastAssetEvent": "Dernier événement d'Asset",
   "name": "Nom",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/common.json
@@ -92,6 +92,7 @@
   "dagRun_one": "Exécution de Dag",
   "dagRun_other": "Exécutions de Dag",
   "dagRunId": "ID d'exécution du Dag",
+  "dagRunState": "État de l'exécution du Dag",
   "dagWarnings": "Avertissements/erreurs du Dag",
   "defaultToGraphView": "Vue par défaut : graphe",
   "defaultToGridView": "Vue par défaut : grille",
@@ -296,6 +297,10 @@
   },
   "showDetailsPanel": "Afficher le panneau des détails",
   "signedInAs": "Connecté en tant que",
+  "slot": "Slot",
+  "slot_many": "Slots",
+  "slot_one": "Slot",
+  "slot_other": "Slots",
   "source": {
     "hide": "Masquer la source",
     "hotkey": "s",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/components.json
@@ -8,9 +8,15 @@
     "backwards": "Exécuter à rebours",
     "dateRange": "Plage de dates",
     "errorStartDateBeforeEndDate": "La date de début doit être antérieure à la date de fin",
+    "exceptionReason": {
+      "alreadyExists": "Existe déjà",
+      "inFlight": "En cours",
+      "unknown": "Inconnu"
+    },
     "maxRuns": "Nombre maximum d'exécutions actives",
     "missingAndErroredRuns": "Exécutions manquantes et en erreur",
     "missingRuns": "Exécutions manquantes",
+    "notCreatedReason": "Raison de non-création",
     "overrideExistingParams": "Remplacer les paramètres sur les exécutions existantes",
     "permissionDenied": "Échec de l'exécution à blanc : l'utilisateur n'a pas l'autorisation de créer des rattrapages.",
     "reprocessBehavior": "Comportement de réexécution",
@@ -30,7 +36,8 @@
     "validation": {
       "datesRequired": "Les dates de début et de fin de l'intervalle de données doivent être renseignées.",
       "startBeforeEnd": "La date de début de l'intervalle de données doit être antérieure ou égale à la date de fin."
-    }
+    },
+    "viewSlots": "Voir les slots pour le rattrapage n°{{id}}"
   },
   "banner": {
     "backfillInProgress": "Rattrapage en cours",
@@ -122,6 +129,10 @@
     "location": "ligne {{line}} dans {{name}}"
   },
   "reparseDag": "Analyser le Dag",
+  "slowestTaskInstances": {
+    "empty": "Aucune instance de tâche terminée dans cette période",
+    "title": "Instances de tâche les plus lentes"
+  },
   "sortedAscending": "tri croissant",
   "sortedDescending": "tri décroissant",
   "sortedUnsorted": "non trié",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/dag.json
@@ -42,6 +42,7 @@
   },
   "deadlineAlerts": {
     "completionRule": "Doit se terminer dans un délai de {{interval}} après {{reference}}",
+    "completionRuleDynamic": "Doit se terminer dans un intervalle variable mesuré à partir de {{reference}}",
     "count_many": "{{count}} échéances",
     "count_one": "{{count}} échéance",
     "count_other": "{{count}} échéances",
@@ -150,13 +151,7 @@
       "label": "Nombre de Runs du Dag"
     },
     "dependencies": {
-      "label": "Dépendances",
-      "options": {
-        "allDagDependencies": "Toutes les dépendances du Dag",
-        "externalConditions": "Conditions externes",
-        "onlyTasks": "Tâches uniquement"
-      },
-      "placeholder": "Dépendances"
+      "allDagDependencies": "Toutes les dépendances du Dag"
     },
     "graphDirection": {
       "label": "Orientation du graphe"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/dags.json
@@ -17,12 +17,14 @@
       "unfavorite": "Non favoris"
     },
     "lastRunState": "Dernier Run",
+    "noTimetableTypesFound": "Aucun type de calendrier trouvé",
     "paused": {
       "active": "Actif",
       "all": "Tous",
       "paused": "En pause"
     },
-    "runIdPatternFilter": "Rechercher des exécutions de Dag"
+    "runIdPatternFilter": "Rechercher des exécutions de Dag",
+    "timetableType": "Type de calendrier"
   },
   "ownerLink": "Lien du propriétaire pour {{owner}}",
   "runAndTaskActions": {


### PR DESCRIPTION
## Complete missing French (fr) translations

Closes the translation gap that opened up in `fr` since the last completeness pass . Coverage had drifted from 100% down to 98.3% (18 missing keys) as new UI strings shipped.

### Verification
`breeze ui check-translation-completeness --language fr`

`fr` coverage: 98.3% → 100.0% (0 missing).

<img width="1450" height="670" alt="image" src="https://github.com/user-attachments/assets/8aa3551b-5863-44d4-b160-d98394ed7ad3" />
