### PR TITLE
Document Airflow 3 requirement for Databricks deferral

### DIFF
--- a/providers/databricks/docs/operators/run_now.rst
+++ b/providers/databricks/docs/operators/run_now.rst
@@ -146,4 +146,8 @@ DatabricksRunNowDeferrableOperator
 
 Deferrable version of the :class:`~airflow.providers.databricks.operators.DatabricksRunNowOperator` operator.
 
+.. note::
+  When using Airflow 3, deferrable execution requires Airflow 3.1.0 or later. Airflow 3.0.x
+  cannot fetch the Databricks connection from the Triggerer during asynchronous polling.
+
 It allows to utilize Airflow workers more effectively using `new functionality introduced in Airflow 2.2.0 <https://airflow.apache.org/docs/apache-airflow/2.2.0/concepts/deferring.html#triggering-deferral>`_

--- a/providers/databricks/docs/operators/submit_run.rst
+++ b/providers/databricks/docs/operators/submit_run.rst
@@ -225,4 +225,8 @@ DatabricksSubmitRunDeferrableOperator
 
 Deferrable version of the :class:`~airflow.providers.databricks.operators.DatabricksSubmitRunOperator` operator.
 
+.. note::
+  When using Airflow 3, deferrable execution requires Airflow 3.1.0 or later. Airflow 3.0.x
+  cannot fetch the Databricks connection from the Triggerer during asynchronous polling.
+
 It allows to utilize Airflow workers more effectively using `new functionality introduced in Airflow 2.2.0 <https://airflow.apache.org/docs/apache-airflow/2.2.0/concepts/deferring.html#triggering-deferral>`_


### PR DESCRIPTION
Document the Airflow 3 version requirement for deferrable Databricks run-now and submit-run operators.

Airflow 3.0.x cannot fetch the Databricks connection from the Triggerer during asynchronous polling, while Airflow 3.1.0 and later handle this path in core. Documenting the boundary gives affected users an actionable upgrade path instead of suggesting an unnecessary provider-side fix.

closes: #71525

Validation:

- RST syntax checked with `rstcheck`
- Spelling checked with `codespell`
- `git diff --check`

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---
Drafted-by: Codex (GPT-5) (no human review before posting)
