### PR TITLE
Fix slow triggerer log draining for large records

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -2314,11 +2314,8 @@ def make_buffered_socket_reader(
         nonlocal search_from
         # We could have read multiple lines in one go, yield them all
         while (newline_pos := buffer.find(b"\n", search_from)) != -1:
-            # Copy the record out as immutable bytes before sending it: the generator's
-            # local may still reference this value at its next suspension point, so it
-            # must not alias the buffer we're about to resize below -- resizing a
-            # bytearray while a memoryview onto it is live raises BufferError.
-            line = bytes(buffer[: newline_pos + 1])
+            # Avoid an intermediate bytearray copy while producing the immutable record.
+            line = bytes(memoryview(buffer)[: newline_pos + 1])
             gen.send(line)
             buffer = buffer[newline_pos + 1 :]  # Update the buffer with remaining data
             search_from = 0

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -863,7 +863,9 @@ class WatchedSubprocess:
             logs,
             selectors.EVENT_READ,
             make_buffered_socket_reader(
-                process_log_messages_from_subprocess(target_loggers), on_close=self._on_socket_closed
+                process_log_messages_from_subprocess(target_loggers),
+                on_close=self._on_socket_closed,
+                drop_incomplete_at_eof=True,
             ),
         )
         self.selector.register(
@@ -1993,7 +1995,9 @@ class ActivitySubprocess(WatchedSubprocess):
             read_logs,
             selectors.EVENT_READ,
             make_buffered_socket_reader(
-                process_log_messages_from_subprocess(target_loggers), on_close=self._on_socket_closed
+                process_log_messages_from_subprocess(target_loggers),
+                on_close=self._on_socket_closed,
+                drop_incomplete_at_eof=True,
             ),
         )
         # We don't explicitly close the old log socket, that will get handled for us if/when the other end is
@@ -2291,6 +2295,7 @@ def make_buffered_socket_reader(
     data: bytes = b"",
     on_close: Callable[[socket], None],
     buffer_size: int = 4096,
+    drop_incomplete_at_eof: bool = False,
 ):
     buffer = bytearray(data)  # This will hold our accumulated binary data
     read_buffer = bytearray(buffer_size)  # Temporary buffer for each read
@@ -2331,18 +2336,28 @@ def make_buffered_socket_reader(
 
         if not n_received:
             # Connection closed. Any bytes left in the buffer are an incomplete,
-            # non-newline-terminated fragment. The protocol is line-based, so a cleanly
-            # closed stream should never leave a trailing partial record -- this means
-            # the writer terminated mid-record, failed to flush, or violated the
-            # framing contract. We cannot reconstruct the missing bytes, so report it
-            # once with bounded metadata (length only; the fragment may contain
-            # secrets or multi-megabyte content) and drop it rather than handing a
-            # truncated value to the JSON decoder as if it were complete. See #66158.
+            # non-newline-terminated fragment.
+            #
+            # For newline-delimited JSON channels (drop_incomplete_at_eof=True),
+            # this means the writer terminated mid-record, failed to flush, or
+            # violated the framing contract -- we cannot reconstruct the missing
+            # bytes, so we report it once with bounded metadata (length only; the
+            # fragment may contain secrets or multi-megabyte content) and drop it
+            # rather than handing a truncated value to the JSON decoder as if it
+            # were complete. See #66158.
+            #
+            # For plain stdout/stderr forwarding, a trailing unterminated line at
+            # process exit (e.g. print(..., end="")) is ordinary, valid output --
+            # forward it as before.
             if len(buffer):
-                log.warning(
-                    "Discarding incomplete record at socket EOF",
-                    fragment_length=len(buffer),
-                )
+                if drop_incomplete_at_eof:
+                    log.warning(
+                        "Discarding incomplete record at socket EOF",
+                        fragment_length=len(buffer),
+                    )
+                else:
+                    with suppress(StopIteration):
+                        gen.send(buffer)
             return False
 
         buffer.extend(read_buffer[:n_received])

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -2294,16 +2294,30 @@ def make_buffered_socket_reader(
 ):
     buffer = bytearray(data)  # This will hold our accumulated binary data
     read_buffer = bytearray(buffer_size)  # Temporary buffer for each read
+    # Position up to which `buffer` has already been searched for a newline. Persisting
+    # this across calls to `process()` (i.e. across selector callbacks) means a large
+    # record spread over many small reads is scanned once per byte instead of once per
+    # byte *per chunk*, which was quadratic in the record size. Reset to 0 whenever a
+    # complete record is consumed and the buffer is sliced, since the new tail is
+    # unsearched. See #66158.
+    search_from = 0
 
     # We need to start up the generator to get it to the point it's at waiting on the yield
     next(gen)
 
     def process(buffer: bytearray) -> bytearray:
+        nonlocal search_from
         # We could have read multiple lines in one go, yield them all
-        while (newline_pos := buffer.find(b"\n")) != -1:
-            line = buffer[: newline_pos + 1]
+        while (newline_pos := buffer.find(b"\n", search_from)) != -1:
+            # Copy the record out as immutable bytes before sending it: the generator's
+            # local may still reference this value at its next suspension point, so it
+            # must not alias the buffer we're about to resize below -- resizing a
+            # bytearray while a memoryview onto it is live raises BufferError.
+            line = bytes(buffer[: newline_pos + 1])
             gen.send(line)
             buffer = buffer[newline_pos + 1 :]  # Update the buffer with remaining data
+            search_from = 0
+        search_from = len(buffer)
         return buffer
 
     # Flush any complete lines that arrived before the selector was running.
@@ -2316,10 +2330,19 @@ def make_buffered_socket_reader(
         n_received = sock.recv_into(read_buffer)
 
         if not n_received:
-            # If no data is returned, the connection is closed. Return whatever is left in the buffer
+            # Connection closed. Any bytes left in the buffer are an incomplete,
+            # non-newline-terminated fragment. The protocol is line-based, so a cleanly
+            # closed stream should never leave a trailing partial record -- this means
+            # the writer terminated mid-record, failed to flush, or violated the
+            # framing contract. We cannot reconstruct the missing bytes, so report it
+            # once with bounded metadata (length only; the fragment may contain
+            # secrets or multi-megabyte content) and drop it rather than handing a
+            # truncated value to the JSON decoder as if it were complete. See #66158.
             if len(buffer):
-                with suppress(StopIteration):
-                    gen.send(buffer)
+                log.warning(
+                    "Discarding incomplete record at socket EOF",
+                    fragment_length=len(buffer),
+                )
             return False
 
         buffer.extend(read_buffer[:n_received])

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -4768,7 +4768,9 @@ class TestMakeBufferedSocketReader:
         on_close = MagicMock()
         r, w = socket.socketpair()
         try:
-            cb, _ = make_buffered_socket_reader(self._collecting_gen(received), on_close=on_close)
+            cb, _ = make_buffered_socket_reader(
+                self._collecting_gen(received), on_close=on_close, drop_incomplete_at_eof=True
+            )
             w.sendall(b'{"incomplete": "record"')  # no trailing newline
             w.close()
             result = True
@@ -4787,7 +4789,9 @@ class TestMakeBufferedSocketReader:
         on_close = MagicMock()
         r, w = socket.socketpair()
         try:
-            cb, _ = make_buffered_socket_reader(self._collecting_gen(received), on_close=on_close)
+            cb, _ = make_buffered_socket_reader(
+                self._collecting_gen(received), on_close=on_close, drop_incomplete_at_eof=True
+            )
             w.sendall(b'{"secret": "do-not-leak-me"')
             w.close()
             result = True
@@ -4797,6 +4801,26 @@ class TestMakeBufferedSocketReader:
             call_str = str(mock_logger.warning.call_args)
             assert "do-not-leak-me" not in call_str
             assert "secret" not in call_str
+        finally:
+            r.close()
+
+    def test_eof_with_incomplete_record_forwarded_by_default(self):
+        """Default behavior (drop_incomplete_at_eof=False, used by stdout/stderr
+        forwarding) must still forward a trailing unterminated fragment at EOF --
+        e.g. print(..., end="") right before process exit is ordinary output, not
+        a malformed record. Only JSON log channels opt into dropping it."""
+        received: list[bytes] = []
+        on_close = MagicMock()
+        r, w = socket.socketpair()
+        try:
+            cb, _ = make_buffered_socket_reader(self._collecting_gen(received), on_close=on_close)
+            w.sendall(b"final output, no newline")
+            w.close()
+            result = True
+            while result:
+                result = cb(r)
+            assert received == [b"final output, no newline"]
+            assert result is False
         finally:
             r.close()
 

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -4824,6 +4824,7 @@ class TestMakeBufferedSocketReader:
         finally:
             r.close()
 
+
 class TestLengthPrefixedFrameReader:
     def test_recovers_from_short_read_on_header(self):
         received: list[_RequestFrame] = []

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -4824,41 +4824,6 @@ class TestMakeBufferedSocketReader:
         finally:
             r.close()
 
-    @pytest.mark.flaky(reruns=2)
-    def test_large_record_scan_is_not_quadratic(self):
-        """Regression test for #66158: buffer scanning must not re-scan the
-        accumulated prefix on every chunk. On the pre-fix quadratic scan, a
-        20 MiB single-line record takes ~2.6s; a linear-scan cursor should
-        comfortably finish under 1s.
-        """
-        received: list[bytes] = []
-        on_close = MagicMock()
-        r, w = socket.socketpair()
-        payload = (b"a" * (20 * 1024 * 1024)) + b"\n"
-        try:
-            cb, _ = make_buffered_socket_reader(self._collecting_gen(received), on_close=on_close)
-
-            def writer():
-                chunk = 4096
-                for i in range(0, len(payload), chunk):
-                    w.sendall(payload[i : i + chunk])
-                w.close()
-
-            t = threading.Thread(target=writer, daemon=True)
-            t.start()
-            start = time.monotonic()
-            while not received:
-                if not cb(r):
-                    break
-            elapsed = time.monotonic() - start
-            t.join(timeout=10)
-
-            assert received == [payload]
-            assert elapsed < 1.0, f"Buffer scan took {elapsed:.3f}s -- looks quadratic again?"
-        finally:
-            r.close()
-
-
 class TestLengthPrefixedFrameReader:
     def test_recovers_from_short_read_on_header(self):
         received: list[_RequestFrame] = []

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -27,6 +27,7 @@ import signal
 import socket
 import subprocess
 import sys
+import threading
 import time
 from contextlib import nullcontext
 from dataclasses import dataclass, field
@@ -4703,6 +4704,135 @@ class TestMakeBufferedSocketReader:
         finally:
             r.close()
             w.close()
+
+    def test_eof_after_complete_line_dispatches_record_and_returns_false(self):
+        received: list[bytes] = []
+        on_close = MagicMock()
+        r, w = socket.socketpair()
+        try:
+            cb, _ = make_buffered_socket_reader(self._collecting_gen(received), on_close=on_close)
+            w.sendall(b"complete line\n")
+            w.close()
+            result = True
+            while result:
+                result = cb(r)
+            assert received == [b"complete line\n"]
+            assert result is False
+        finally:
+            r.close()
+
+    def test_empty_eof_dispatches_nothing_and_returns_false(self):
+        received: list[bytes] = []
+        on_close = MagicMock()
+        r, w = socket.socketpair()
+        try:
+            cb, _ = make_buffered_socket_reader(self._collecting_gen(received), on_close=on_close)
+            w.close()
+            result = cb(r)
+            assert received == []
+            assert result is False
+        finally:
+            r.close()
+
+    def test_large_record_across_many_small_reads(self):
+        """A single large JSON line delivered across many small socket reads must
+        arrive as exactly one byte-identical record."""
+        received: list[bytes] = []
+        on_close = MagicMock()
+        r, w = socket.socketpair()
+        payload = b"a" * (5 * 1024 * 1024)
+        line = payload + b"\n"
+        try:
+            cb, _ = make_buffered_socket_reader(self._collecting_gen(received), on_close=on_close)
+
+            def writer():
+                chunk = 4096
+                for i in range(0, len(line), chunk):
+                    w.sendall(line[i : i + chunk])
+                w.close()
+
+            t = threading.Thread(target=writer, daemon=True)
+            t.start()
+            while not received:
+                if not cb(r):
+                    break
+            t.join(timeout=10)
+            assert received == [line]
+        finally:
+            r.close()
+
+    def test_eof_with_incomplete_record_not_sent_to_generator(self):
+        """An unterminated fragment at EOF (writer died mid-record, didn't flush) must
+        never reach the JSON decoder as if it were a complete record."""
+        received: list[bytes] = []
+        on_close = MagicMock()
+        r, w = socket.socketpair()
+        try:
+            cb, _ = make_buffered_socket_reader(self._collecting_gen(received), on_close=on_close)
+            w.sendall(b'{"incomplete": "record"')  # no trailing newline
+            w.close()
+            result = True
+            while result:
+                result = cb(r)
+            assert received == []
+            assert result is False
+        finally:
+            r.close()
+
+    def test_eof_with_incomplete_record_logs_bounded_warning_without_payload(self, mocker):
+        """The EOF-fragment diagnostic must report only bounded metadata (e.g. byte
+        count) -- never the fragment content, which may contain secrets."""
+        mock_logger = mocker.patch("airflow.sdk.execution_time.supervisor.log")
+        received: list[bytes] = []
+        on_close = MagicMock()
+        r, w = socket.socketpair()
+        try:
+            cb, _ = make_buffered_socket_reader(self._collecting_gen(received), on_close=on_close)
+            w.sendall(b'{"secret": "do-not-leak-me"')
+            w.close()
+            result = True
+            while result:
+                result = cb(r)
+            mock_logger.warning.assert_called_once()
+            call_str = str(mock_logger.warning.call_args)
+            assert "do-not-leak-me" not in call_str
+            assert "secret" not in call_str
+        finally:
+            r.close()
+
+    @pytest.mark.flaky(reruns=2)
+    def test_large_record_scan_is_not_quadratic(self):
+        """Regression test for #66158: buffer scanning must not re-scan the
+        accumulated prefix on every chunk. On the pre-fix quadratic scan, a
+        20 MiB single-line record takes ~2.6s; a linear-scan cursor should
+        comfortably finish under 1s.
+        """
+        received: list[bytes] = []
+        on_close = MagicMock()
+        r, w = socket.socketpair()
+        payload = (b"a" * (20 * 1024 * 1024)) + b"\n"
+        try:
+            cb, _ = make_buffered_socket_reader(self._collecting_gen(received), on_close=on_close)
+
+            def writer():
+                chunk = 4096
+                for i in range(0, len(payload), chunk):
+                    w.sendall(payload[i : i + chunk])
+                w.close()
+
+            t = threading.Thread(target=writer, daemon=True)
+            t.start()
+            start = time.monotonic()
+            while not received:
+                if not cb(r):
+                    break
+            elapsed = time.monotonic() - start
+            t.join(timeout=10)
+
+            assert received == [payload]
+            assert elapsed < 1.0, f"Buffer scan took {elapsed:.3f}s -- looks quadratic again?"
+        finally:
+            r.close()
 
 
 class TestLengthPrefixedFrameReader:


### PR DESCRIPTION
`make_buffered_socket_reader` re-scanned the entire accumulated buffer from offset 0 on every socket read, making newline scanning O(N²) in the size of a single record. A 5 MiB single-line trigger log record, as reported in #66158, could cost gigabytes of cumulative prefix scanning before the terminating newline was found, delaying drainage of supervised sockets under triggerer load.

This PR:

* Adds a persistent scan cursor (`search_from`) so each byte in the buffer is examined once per delivery, rather than once per chunk.
* Sends each completed record to the generator as an immutable `bytes` value.
* Drops incomplete records at EOF only for the newline-delimited JSON log channel and reports bounded metadata without exposing the fragment content.
* Preserves the existing behavior for stdout and stderr, where a final line without a newline is valid output and must still be forwarded.
* Adds deterministic socket tests covering large records split across many reads and both EOF policies.

The newline-delimited wire protocol is unchanged. The helper's existing consumers retain their previous behavior unless they explicitly opt into dropping an incomplete JSON record at EOF.

A separate GCS-handler symptom mentioned later in #66158, involving missing files for ordinary-sized messages, is outside the scope of this change.

closes: #66158

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code and OpenAI Codex (GPT-5) assisted with planning and review; the implementation was written and reviewed by the contributor.

Generated-by: Claude Code and OpenAI Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---
