### PR TITLE
Fix reap_process_group sudo fallback passing the process group id as the signal number

### DIFF
--- a/airflow-core/src/airflow/utils/process_utils.py
+++ b/airflow-core/src/airflow/utils/process_utils.py
@@ -109,7 +109,9 @@ def reap_process_group(
                     os.kill(process_group_id, sig)
                 except OSError as err_kill:
                     if err_kill.errno == errno.EPERM:
-                        subprocess.check_call(["sudo", "-n", "kill", "-" + str(process_group_id)])
+                        subprocess.check_call(
+                            ["sudo", "-n", "kill", "-" + str(int(sig)), str(process_group_id)]
+                        )
                     else:
                         raise
             else:

--- a/airflow-core/tests/unit/utils/test_process_utils.py
+++ b/airflow-core/tests/unit/utils/test_process_utils.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import errno
 import logging
 import multiprocessing
 import os
@@ -87,6 +88,33 @@ time.sleep(300)
                 os.kill(parent.pid, signal.SIGKILL)
             parent.stdout.close()
             parent.wait()
+
+
+class TestReapProcessGroupSudoFallback:
+    def test_sudo_kill_gets_a_signal_and_a_pid(self):
+        """The sudo fallback must name the signal and the target, like the killpg one."""
+        pgid = 4242
+        calls: list[list[str]] = []
+
+        def fake_killpg(pgid_arg, sig):
+            raise OSError(errno.ESRCH, "No such process")
+
+        def fake_kill(pid, sig):
+            raise OSError(errno.EPERM, "Operation not permitted")
+
+        with (
+            mock.patch("os.getpgid", return_value=1),
+            mock.patch("os.killpg", side_effect=fake_killpg),
+            mock.patch("os.kill", side_effect=fake_kill),
+            mock.patch("psutil.Process", side_effect=psutil.NoSuchProcess(pgid)),
+            mock.patch("psutil.process_iter", return_value=[]),
+            mock.patch("psutil.wait_procs", return_value=([], [])),
+            mock.patch("subprocess.check_call", side_effect=lambda a, **k: calls.append(a)),
+        ):
+            process_utils.reap_process_group(pgid, logging.getLogger(__name__))
+
+        assert calls, "the sudo fallback was never invoked"
+        assert calls[0] == ["sudo", "-n", "kill", "-15", str(pgid)]
 
 
 @pytest.mark.db_test


### PR DESCRIPTION
`reap_process_group` has two sudo fallbacks for `EPERM`. The first passes a signal and the pids:

```python
["sudo", "-n", "kill", "-" + str(int(sig))] + [str(p.pid) for p in all_processes_in_the_group]
```

The second, fourteen lines below, passes the process group id where the signal belongs and names no target at all:

```python
subprocess.check_call(["sudo", "-n", "kill", "-" + str(process_group_id)])
```

That builds `sudo -n kill -4242`, which `/bin/kill` rejects with a usage error and exit 2, so `check_call` raises `CalledProcessError` and the process is never signalled. The path needs `killpg` to fail with `ESRCH` and then `os.kill` with `EPERM`, which is the `run_as_user` case where the group has already gone but the process has not.

Mocking both errnos and capturing the call:

```
before: ['sudo', '-n', 'kill', '-4242']
after:  ['sudo', '-n', 'kill', '-15', '4242']
```

#9202 reported this in 2020 against 1.10.9 and named `reap_process_group`. It was closed without a fix. The line is unchanged.

The added test fails on current main with `['sudo', '-n', 'kill', '-4242'] != ['sudo', '-n', 'kill', '-15', '4242']` and passes with the change. `test_process_utils.py` goes from 27 passing to 28. It mocks the signal calls, so it needs no database and carries no `db_test` marker.
