### PR TITLE
fix: FAB get_application_builder should use create_metadata_engine hook

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/cli_commands/utils.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/cli_commands/utils.py
@@ -37,7 +37,7 @@ from airflow.providers.fab.www.extensions.init_session import init_airflow_sessi
 from airflow.providers.fab.www.extensions.init_views import init_plugins
 
 if TYPE_CHECKING:
-    from flask.sansio.app import App
+    from sqlalchemy.engine import Engine
 
     from airflow.providers.fab.www.extensions.init_appbuilder import AirflowAppBuilder
 
@@ -53,11 +53,14 @@ class _AirflowFlaskSQLAlchemy(SQLAlchemy):
     creation through the same hook Airflow's own metadata engine uses.
     """
 
-    def _make_engine(self, bind_key: str | None, options: dict, app: App):
+    def _make_engine(self, bind_key: str | None, options: dict, app: Flask) -> Engine:
         if bind_key is not None:
             return super()._make_engine(bind_key, options, app)
+            # Use this app's configured URI (a `str`), rather than the module-level
+            # `settings.SQL_ALCHEMY_CONN` (typed `str | None`), to build the engine.
+        sql_alchemy_conn: str = app.config["SQLALCHEMY_DATABASE_URI"]
         return settings.create_metadata_engine(
-            settings.SQL_ALCHEMY_CONN,
+            sql_alchemy_conn,
             engine_args=settings.prepare_engine_args(),
             connect_args=settings._get_connect_args("sync"),
         )

--- a/providers/fab/src/airflow/providers/fab/auth_manager/cli_commands/utils.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/cli_commands/utils.py
@@ -29,6 +29,7 @@ from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.engine import make_url
 
 import airflow
+from airflow import settings
 from airflow.exceptions import AirflowConfigException
 from airflow.providers.common.compat.sdk import conf
 from airflow.providers.fab.www.extensions.init_appbuilder import init_appbuilder
@@ -36,7 +37,30 @@ from airflow.providers.fab.www.extensions.init_session import init_airflow_sessi
 from airflow.providers.fab.www.extensions.init_views import init_plugins
 
 if TYPE_CHECKING:
+    from flask.sansio.app import App
+
     from airflow.providers.fab.www.extensions.init_appbuilder import AirflowAppBuilder
+
+
+class _AirflowFlaskSQLAlchemy(SQLAlchemy):
+    """
+    Flask-SQLAlchemy extension whose engine is created via Airflow's engine hook.
+
+    Flask-SQLAlchemy normally builds its own Engine straight from
+    SQLALCHEMY_DATABASE_URI, bypassing airflow.settings.create_metadata_engine.
+    That means an override in airflow_local_settings.py (e.g. an IAM/token
+    do_connect listener) never gets applied to this engine. Route engine
+    creation through the same hook Airflow's own metadata engine uses.
+    """
+
+    def _make_engine(self, bind_key: str | None, options: dict, app: App):
+        if bind_key is not None:
+            return super()._make_engine(bind_key, options, app)
+        return settings.create_metadata_engine(
+            settings.SQL_ALCHEMY_CONN,
+            engine_args=settings.prepare_engine_args(),
+            connect_args=settings._get_connect_args("sync"),
+        )
 
 
 @cache
@@ -65,6 +89,6 @@ def get_application_builder() -> Generator[AirflowAppBuilder, None, None]:
             )
         flask_app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 
-        db = SQLAlchemy(flask_app)
+        db = _AirflowFlaskSQLAlchemy(flask_app)
         yield _return_appbuilder(flask_app, db)
         db.engine.dispose(close=True)

--- a/providers/fab/src/airflow/providers/fab/auth_manager/cli_commands/utils.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/cli_commands/utils.py
@@ -29,40 +29,45 @@ from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.engine import make_url
 
 import airflow
-from airflow import settings
 from airflow.exceptions import AirflowConfigException
 from airflow.providers.common.compat.sdk import conf
 from airflow.providers.fab.www.extensions.init_appbuilder import init_appbuilder
 from airflow.providers.fab.www.extensions.init_session import init_airflow_session_interface
 from airflow.providers.fab.www.extensions.init_views import init_plugins
 
-if TYPE_CHECKING:
-    from sqlalchemy.engine import Engine
+try:
+    # create_metadata_engine may not exist on all Airflow core versions we test
+    # provider compatibility against (see PROVIDERS.rst min-supported-version policy).
+    from airflow.settings import create_metadata_engine
+except ImportError:
+    create_metadata_engine = None
 
+
+if TYPE_CHECKING:
     from airflow.providers.fab.www.extensions.init_appbuilder import AirflowAppBuilder
 
 
 class _AirflowFlaskSQLAlchemy(SQLAlchemy):
     """
-    Flask-SQLAlchemy extension whose engine is created via Airflow's engine hook.
+    Flask-SQLAlchemy subclass that builds its engine via Airflow's engine-creation hook.
 
-    Flask-SQLAlchemy normally builds its own Engine straight from
-    SQLALCHEMY_DATABASE_URI, bypassing airflow.settings.create_metadata_engine.
-    That means an override in airflow_local_settings.py (e.g. an IAM/token
-    do_connect listener) never gets applied to this engine. Route engine
-    creation through the same hook Airflow's own metadata engine uses.
+    Airflow's ``airflow.settings.create_metadata_engine`` can be overridden in
+    ``airflow_local_settings.py`` (e.g. for IAM/token based DB auth). The stock
+    Flask-SQLAlchemy engine creation bypasses that hook entirely, so FAB CLI
+    commands (createUserJob, roles, etc.) silently ignored it. This routes engine
+    creation through the same hook the rest of Airflow uses.
     """
 
-    def _make_engine(self, bind_key: str | None, options: dict, app: Flask) -> Engine:
-        if bind_key is not None:
+    def _make_engine(self, bind_key, options, app):
+        if create_metadata_engine is None:
             return super()._make_engine(bind_key, options, app)
-            # Use this app's configured URI (a `str`), rather than the module-level
-            # `settings.SQL_ALCHEMY_CONN` (typed `str | None`), to build the engine.
-        sql_alchemy_conn: str = app.config["SQLALCHEMY_DATABASE_URI"]
-        return settings.create_metadata_engine(
-            sql_alchemy_conn,
-            engine_args=settings.prepare_engine_args(),
-            connect_args=settings._get_connect_args("sync"),
+
+        sa_url = options.pop("url", app.config["SQLALCHEMY_DATABASE_URI"])
+        connect_args = options.pop("connect_args", {}) or {}
+        return create_metadata_engine(
+            str(sa_url) if not isinstance(sa_url, str) else sa_url,
+            engine_args=options,
+            connect_args=connect_args,
         )
 
 


### PR DESCRIPTION
## Summary
Fixes createUserJob (and other FAB CLI/API user & role management commands) failing to
connect to the database when a custom `create_metadata_engine` is defined in
`airflow_local_settings.py` (e.g. for IAM/token-based DB auth).

## Root cause
`get_application_builder()` created its own Flask-SQLAlchemy engine directly from
`SQLALCHEMY_DATABASE_URI`, bypassing `airflow.settings.create_metadata_engine`. So any
custom engine-creation logic in `airflow_local_settings.py` was silently ignored for
this engine, even though it works correctly for Airflow's main metadata engine.

## Fix
Added an `_AirflowFlaskSQLAlchemy` subclass that overrides `_make_engine` to build the
engine via `airflow.settings.create_metadata_engine`, so it now honors the same
override as the rest of Airflow.

Closes: #71664

Was generative AI tooling used ?

- [X] Yes - Claude

Generated-by: Claude following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
