### PR TITLE
Warn when ignore_unknown_values is a no-op in GCSToBigQueryOperator

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -164,21 +164,10 @@ class GCSToBigQueryOperator(BaseOperator):
         by one or more columns. BigQuery supports clustering for both partitioned and
         non-partitioned tables. The order of columns given determines the sort order.
         Not applicable for external tables.
-    :param autodetect: [Optional] Indicates whether the options and schema should be inferred
-        from the source data for CSV and JSON sources. (Default: ``True``). This parameter is
-        three-state:
-
-        * ``True`` - infer the schema from the source files. The inferred schema is sent to
-          BigQuery as the load job's schema, so ``ignore_unknown_values`` has no effect: no field
-          in the source data can be unknown to a schema derived from that same data. If the
-          destination table already exists and the inferred schema differs from it, the load
-          fails with a schema mismatch unless ``schema_update_options`` permits the change.
-        * ``False`` - do not infer the schema. One of ``schema_fields`` or ``schema_object``
-          must be provided, otherwise an exception is raised.
-        * ``None`` - neither infer a schema nor supply one, so the destination table's own
-          schema is used. The table must already exist. This is the setting to use when you want
-          ``ignore_unknown_values`` to drop fields that are present in the source data but absent
-          from the destination table.
+    :param autodetect: [Optional] Whether to infer the schema from the source data for CSV and
+        JSON sources. If ``True``, the schema is inferred from the source data. If ``False``,
+        either ``schema_fields`` or ``schema_object`` must be provided. If ``None``, no schema is
+        supplied and the existing destination table's schema is used. (Default: ``True``).
     :param encryption_configuration: [Optional] Custom encryption configuration (e.g., Cloud KMS keys).
 
         .. code-block:: python
@@ -649,23 +638,6 @@ class GCSToBigQueryOperator(BaseOperator):
         self.log.info("External table created successfully: %s", self.destination_project_dataset_table)
         return table_obj_api_repr
 
-    def _warn_if_ignore_unknown_values_is_ineffective(self) -> None:
-        # Checked against the assembled load config rather than the operator attributes, because
-        # src_fmt_configs and extra_config can still override any of these three keys.
-        load_config = self.configuration["load"]
-        if (
-            load_config.get("autodetect")
-            and load_config.get("ignoreUnknownValues")
-            and "schema" not in load_config
-        ):
-            self.log.warning(
-                "`ignore_unknown_values` is set but will have no effect. With `autodetect` enabled "
-                "and no schema supplied, the load job's schema is inferred from the source data "
-                "itself, so no source field can be unknown to it. To drop source fields that are "
-                "absent from an existing destination table, set `autodetect=None` so that the "
-                "destination table's own schema is used instead."
-            )
-
     def _use_existing_table(self):
         destination_project_id, destination_dataset, destination_table = self.hook.split_tablename(
             table_input=self.destination_project_dataset_table,
@@ -793,7 +765,19 @@ class GCSToBigQueryOperator(BaseOperator):
         if self.extra_config:
             self.configuration["load"].update(self.extra_config)
 
-        self._warn_if_ignore_unknown_values_is_ineffective()
+        # Checked against the assembled load config rather than the operator attributes, because
+        # src_fmt_configs and extra_config can still override any of these three keys.
+        load_config = self.configuration["load"]
+        if (
+            load_config.get("autodetect")
+            and load_config.get("ignoreUnknownValues")
+            and "schema" not in load_config
+        ):
+            self.log.warning(
+                "`ignore_unknown_values` has no effect when `autodetect=True` and no schema is "
+                "provided. Set `autodetect=None` to use the existing destination table's schema "
+                "instead."
+            )
 
         return self.configuration
 

--- a/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -120,6 +120,8 @@ class GCSToBigQueryOperator(BaseOperator):
         If true, the extra values are ignored. If false, records with extra columns
         are treated as bad records, and if there are too many bad records, an
         invalid error is returned in the job result.
+        The values are compared against the schema the load job runs with, so this has no effect
+        when that schema is inferred from the source data itself - see ``autodetect``.
     :param allow_quoted_newlines: Whether to allow quoted newlines (true) or not (false).
     :param allow_jagged_rows: Accept rows that are missing trailing optional columns.
         The missing values are treated as nulls. If false, records with missing trailing
@@ -162,12 +164,21 @@ class GCSToBigQueryOperator(BaseOperator):
         by one or more columns. BigQuery supports clustering for both partitioned and
         non-partitioned tables. The order of columns given determines the sort order.
         Not applicable for external tables.
-    :param autodetect: [Optional] Indicates if we should automatically infer the
-        options and schema for CSV and JSON sources. (Default: ``True``).
-        Parameter must be set to True if 'schema_fields' and 'schema_object' are undefined.
-        It is suggested to set to True if table are create outside of Airflow.
-        If autodetect is None and no schema is provided (neither via schema_fields
-        nor a schema_object), assume the table already exists.
+    :param autodetect: [Optional] Indicates whether the options and schema should be inferred
+        from the source data for CSV and JSON sources. (Default: ``True``). This parameter is
+        three-state:
+
+        * ``True`` - infer the schema from the source files. The inferred schema is sent to
+          BigQuery as the load job's schema, so ``ignore_unknown_values`` has no effect: no field
+          in the source data can be unknown to a schema derived from that same data. If the
+          destination table already exists and the inferred schema differs from it, the load
+          fails with a schema mismatch unless ``schema_update_options`` permits the change.
+        * ``False`` - do not infer the schema. One of ``schema_fields`` or ``schema_object``
+          must be provided, otherwise an exception is raised.
+        * ``None`` - neither infer a schema nor supply one, so the destination table's own
+          schema is used. The table must already exist. This is the setting to use when you want
+          ``ignore_unknown_values`` to drop fields that are present in the source data but absent
+          from the destination table.
     :param encryption_configuration: [Optional] Custom encryption configuration (e.g., Cloud KMS keys).
 
         .. code-block:: python
@@ -239,7 +250,7 @@ class GCSToBigQueryOperator(BaseOperator):
         time_partitioning=None,
         range_partitioning=None,
         cluster_fields=None,
-        autodetect=True,
+        autodetect: bool | None = True,
         encryption_configuration=None,
         location=None,
         impersonation_chain: str | Sequence[str] | None = None,
@@ -638,6 +649,23 @@ class GCSToBigQueryOperator(BaseOperator):
         self.log.info("External table created successfully: %s", self.destination_project_dataset_table)
         return table_obj_api_repr
 
+    def _warn_if_ignore_unknown_values_is_ineffective(self) -> None:
+        # Checked against the assembled load config rather than the operator attributes, because
+        # src_fmt_configs and extra_config can still override any of these three keys.
+        load_config = self.configuration["load"]
+        if (
+            load_config.get("autodetect")
+            and load_config.get("ignoreUnknownValues")
+            and "schema" not in load_config
+        ):
+            self.log.warning(
+                "`ignore_unknown_values` is set but will have no effect. With `autodetect` enabled "
+                "and no schema supplied, the load job's schema is inferred from the source data "
+                "itself, so no source field can be unknown to it. To drop source fields that are "
+                "absent from an existing destination table, set `autodetect=None` so that the "
+                "destination table's own schema is used instead."
+            )
+
     def _use_existing_table(self):
         destination_project_id, destination_dataset, destination_table = self.hook.split_tablename(
             table_input=self.destination_project_dataset_table,
@@ -764,6 +792,8 @@ class GCSToBigQueryOperator(BaseOperator):
 
         if self.extra_config:
             self.configuration["load"].update(self.extra_config)
+
+        self._warn_if_ignore_unknown_values_is_ineffective()
 
         return self.configuration
 

--- a/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -97,13 +97,6 @@ hash_ = "hash"
 REAL_JOB_ID = f"{job_id}_{hash_}"
 
 GCS_TO_BQ_PATH = "airflow.providers.google.cloud.transfers.gcs_to_bigquery.{}"
-IGNORE_UNKNOWN_VALUES_WARNING = (
-    "`ignore_unknown_values` is set but will have no effect. With `autodetect` enabled "
-    "and no schema supplied, the load job's schema is inferred from the source data "
-    "itself, so no source field can be unknown to it. To drop source fields that are "
-    "absent from an existing destination table, set `autodetect=None` so that the "
-    "destination table's own schema is used instead."
-)
 
 
 class TestGCSToBigQueryOperator:
@@ -2138,6 +2131,11 @@ class TestGCSToBigQueryOperator:
             pytest.param({"ignore_unknown_values": True, "autodetect": True}, True, id="autodetect_true"),
             pytest.param({"ignore_unknown_values": True, "autodetect": None}, False, id="autodetect_none"),
             pytest.param(
+                {"ignore_unknown_values": True, "autodetect": False, "schema_fields": SCHEMA_FIELDS},
+                False,
+                id="autodetect_false",
+            ),
+            pytest.param(
                 {"ignore_unknown_values": True, "schema_fields": SCHEMA_FIELDS},
                 False,
                 id="schema_fields_supplied",
@@ -2182,9 +2180,35 @@ class TestGCSToBigQueryOperator:
         with mock.patch.object(operator.log, "warning") as mock_warning:
             operator.execute(context=MagicMock())
 
-        assert mock_warning.call_args_list.count(call(IGNORE_UNKNOWN_VALUES_WARNING)) == (
-            1 if expects_warning else 0
+        if expects_warning:
+            mock_warning.assert_called_once()
+        else:
+            mock_warning.assert_not_called()
+
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_ignore_unknown_values_no_op_warning_names_the_fix(self, bq_hook):
+        bq_hook.return_value.insert_job.side_effect = [
+            MagicMock(job_id=REAL_JOB_ID, error_result=False),
+            REAL_JOB_ID,
+        ]
+        bq_hook.return_value.generate_job_id.return_value = REAL_JOB_ID
+        bq_hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            write_disposition=WRITE_DISPOSITION,
+            project_id=JOB_PROJECT_ID,
+            ignore_unknown_values=True,
         )
+
+        with mock.patch.object(operator.log, "warning") as mock_warning:
+            operator.execute(context=MagicMock())
+
+        mock_warning.assert_called_once()
+        assert "autodetect=None" in mock_warning.call_args.args[0]
 
     @mock.patch(GCS_TO_BQ_PATH.format("GCSHook"))
     @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
@@ -2212,7 +2236,7 @@ class TestGCSToBigQueryOperator:
         with mock.patch.object(operator.log, "warning") as mock_warning:
             operator.execute(context=MagicMock())
 
-        assert call(IGNORE_UNKNOWN_VALUES_WARNING) not in mock_warning.call_args_list
+        mock_warning.assert_not_called()
 
     @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_no_ignore_unknown_values_warning_for_external_table(self, bq_hook):
@@ -2233,7 +2257,7 @@ class TestGCSToBigQueryOperator:
         with mock.patch.object(operator.log, "warning") as mock_warning:
             operator.execute(context=MagicMock())
 
-        assert call(IGNORE_UNKNOWN_VALUES_WARNING) not in mock_warning.call_args_list
+        mock_warning.assert_not_called()
 
 
 @pytest.fixture

--- a/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -97,6 +97,13 @@ hash_ = "hash"
 REAL_JOB_ID = f"{job_id}_{hash_}"
 
 GCS_TO_BQ_PATH = "airflow.providers.google.cloud.transfers.gcs_to_bigquery.{}"
+IGNORE_UNKNOWN_VALUES_WARNING = (
+    "`ignore_unknown_values` is set but will have no effect. With `autodetect` enabled "
+    "and no schema supplied, the load job's schema is inferred from the source data "
+    "itself, so no source field can be unknown to it. To drop source fields that are "
+    "absent from an existing destination table, set `autodetect=None` so that the "
+    "destination table's own schema is used instead."
+)
 
 
 class TestGCSToBigQueryOperator:
@@ -2123,6 +2130,110 @@ class TestGCSToBigQueryOperator:
         operator.render_template_fields({"var": {"value": {"schema_fields": SCHEMA_FIELDS}}})
 
         assert operator.schema_fields == SCHEMA_FIELDS
+
+    @pytest.mark.parametrize(
+        ("operator_kwargs", "expects_warning"),
+        [
+            pytest.param({"ignore_unknown_values": True}, True, id="autodetect_defaults_to_true"),
+            pytest.param({"ignore_unknown_values": True, "autodetect": True}, True, id="autodetect_true"),
+            pytest.param({"ignore_unknown_values": True, "autodetect": None}, False, id="autodetect_none"),
+            pytest.param(
+                {"ignore_unknown_values": True, "schema_fields": SCHEMA_FIELDS},
+                False,
+                id="schema_fields_supplied",
+            ),
+            pytest.param({"ignore_unknown_values": False}, False, id="ignore_unknown_values_off"),
+            pytest.param(
+                {"ignore_unknown_values": True, "extra_config": {"autodetect": None}},
+                False,
+                id="autodetect_cleared_by_extra_config",
+            ),
+            pytest.param(
+                {"ignore_unknown_values": True, "extra_config": {"schema": {"fields": SCHEMA_FIELDS}}},
+                False,
+                id="schema_supplied_by_extra_config",
+            ),
+            pytest.param(
+                {"ignore_unknown_values": False, "extra_config": {"ignoreUnknownValues": True}},
+                True,
+                id="ignore_unknown_values_set_by_extra_config",
+            ),
+        ],
+    )
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_ignore_unknown_values_no_op_warning(self, bq_hook, operator_kwargs, expects_warning):
+        bq_hook.return_value.insert_job.side_effect = [
+            MagicMock(job_id=REAL_JOB_ID, error_result=False),
+            REAL_JOB_ID,
+        ]
+        bq_hook.return_value.generate_job_id.return_value = REAL_JOB_ID
+        bq_hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            write_disposition=WRITE_DISPOSITION,
+            project_id=JOB_PROJECT_ID,
+            **operator_kwargs,
+        )
+
+        with mock.patch.object(operator.log, "warning") as mock_warning:
+            operator.execute(context=MagicMock())
+
+        assert mock_warning.call_args_list.count(call(IGNORE_UNKNOWN_VALUES_WARNING)) == (
+            1 if expects_warning else 0
+        )
+
+    @mock.patch(GCS_TO_BQ_PATH.format("GCSHook"))
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_no_ignore_unknown_values_warning_with_schema_object(self, bq_hook, gcs_hook):
+        bq_hook.return_value.insert_job.side_effect = [
+            MagicMock(job_id=REAL_JOB_ID, error_result=False),
+            REAL_JOB_ID,
+        ]
+        bq_hook.return_value.generate_job_id.return_value = REAL_JOB_ID
+        bq_hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+        gcs_hook.return_value.download.return_value = bytes(json.dumps(SCHEMA_FIELDS), "utf-8")
+
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            schema_object_bucket=SCHEMA_BUCKET,
+            schema_object=SCHEMA_OBJECT,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            write_disposition=WRITE_DISPOSITION,
+            ignore_unknown_values=True,
+            project_id=JOB_PROJECT_ID,
+        )
+
+        with mock.patch.object(operator.log, "warning") as mock_warning:
+            operator.execute(context=MagicMock())
+
+        assert call(IGNORE_UNKNOWN_VALUES_WARNING) not in mock_warning.call_args_list
+
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_no_ignore_unknown_values_warning_for_external_table(self, bq_hook):
+        bq_hook.return_value.generate_job_id.return_value = REAL_JOB_ID
+        bq_hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            write_disposition=WRITE_DISPOSITION,
+            external_table=True,
+            ignore_unknown_values=True,
+            project_id=JOB_PROJECT_ID,
+        )
+
+        with mock.patch.object(operator.log, "warning") as mock_warning:
+            operator.execute(context=MagicMock())
+
+        assert call(IGNORE_UNKNOWN_VALUES_WARNING) not in mock_warning.call_args_list
 
 
 @pytest.fixture


### PR DESCRIPTION
`ignore_unknown_values=True` silently does nothing under the operator's default `autodetect=True`. The load job's schema is inferred from the same source data the values are checked against, so no source field can be unknown to it. Users set the flag expecting fields absent from the destination table to be dropped, and instead get a schema mismatch with nothing in the logs indicating the flag was ignored.

This warns when the assembled load configuration has `autodetect` truthy, `ignoreUnknownValues` set, and no `schema`, pointing at `autodetect=None` - the setting that makes BigQuery use the destination table's own schema.

The check reads the assembled `configuration["load"]` rather than the operator attributes, because `src_fmt_configs` and `extra_config` can override any of those three keys after they are set (all three are in `valid_configs` for the relevant source formats). Two of the added test cases cover exactly that.

It also fixes the `autodetect` docstring, which actively pointed the wrong way: it said the parameter "must be set to True if 'schema_fields' and 'schema_object' are undefined" (`None` is also valid, and is the documented way to load into an existing table), and that it is "suggested to set to True if table are create outside of Airflow" (for a table created outside Airflow, `True` is precisely what triggers the mismatch - `None` is what works). All three states are now documented, and `autodetect` gets a `bool | None` annotation matching the existing `is False` check at the schema-object guard.

Deliberately out of scope: changing the default, making `autodetect=False` fall back to the table schema, and redesigning the flag. The three-state parameter is an artifact of `"autodetect": self.autodetect` being serialized unconditionally, so `None` is the only way to express "omit the field" - worth revisiting separately, but not in a bugfix PR.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
