### PR TITLE
Add gzip compression option for GCS remote task logs

### DIFF
--- a/providers/google/docs/logging/gcs.rst
+++ b/providers/google/docs/logging/gcs.rst
@@ -77,3 +77,27 @@ be used. Make sure that with those credentials, you can read and write the logs.
   They should usually be different than the ``google_cloud_default`` ones, having only capability to read and write
   the logs. For security reasons, limiting the access of the log reader to only allow log reading and writing is
   an important security measure.
+
+Compressing logs
+""""""""""""""""
+
+Task logs are plain text and compress well, so storing them gzipped can reduce the size of the bucket.
+Enable it through ``[logging] remote_task_handler_kwargs``:
+
+.. code-block:: ini
+
+    [logging]
+    remote_logging = True
+    remote_base_log_folder = gs://my-bucket/path/to/logs
+    remote_log_conn_id = my_gcs_conn
+    remote_task_handler_kwargs = {"gzip": true}
+
+Compressed logs are uploaded with a ``.gz`` suffix, for example
+``gs://my-bucket/path/to/logs/dag_id=example/run_id=manual__2024-01-01T00:00:00+00:00/task_id=my_task/attempt=1.log.gz``.
+Airflow decides whether to decompress a log object from that suffix rather than from the current
+value of this setting, so logs written while compression was disabled remain readable after you
+enable it, and vice versa.
+
+Note that objects stored this way are raw gzip data. Airflow decompresses them when serving logs in
+the UI, but tools reading the bucket directly get the compressed bytes and need to decompress them
+themselves, for example ``gcloud storage cat gs://my-bucket/path/to/logs/.../attempt=1.log.gz | gunzip``.

--- a/providers/google/src/airflow/providers/google/cloud/log/gcs_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/gcs_task_handler.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import gzip as gz
 import inspect
 import logging
 import os
@@ -44,6 +45,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 if TYPE_CHECKING:
     from io import TextIOWrapper
+    from typing import IO
 
     from airflow.models.taskinstance import TaskInstance
     from airflow.sdk.types import RuntimeTaskInstanceProtocol as RuntimeTI
@@ -54,6 +56,8 @@ _DEFAULT_SCOPESS = frozenset(
         "https://www.googleapis.com/auth/devstorage.read_write",
     ]
 )
+
+_GZIP_SUFFIX = ".gz"
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +72,7 @@ class GCSRemoteLogIO(LoggingMixin):  # noqa: D101
     gcp_key_path: str | None = None
     gcp_keyfile_dict: dict | None = None
     scopes: Collection[str] | None = _DEFAULT_SCOPESS
+    gzip: bool = False
 
     processors = ()
 
@@ -106,6 +111,11 @@ class GCSRemoteLogIO(LoggingMixin):  # noqa: D101
         else:
             local_loc = self.base_log_folder.joinpath(path)
             remote_loc = os.path.join(self.remote_base, path)
+
+        # The ``.gz`` suffix — not ``self.gzip`` — is what ``write`` and ``stream`` key off, so logs
+        # written before and after this setting was flipped both stay readable.
+        if self.gzip:
+            remote_loc += _GZIP_SUFFIX
 
         if local_loc.is_file():
             # read log and remove old logs to get just the latest additions
@@ -160,9 +170,11 @@ class GCSRemoteLogIO(LoggingMixin):  # noqa: D101
         :param remote_log_location: the log's location in remote storage
         :return: whether the log is successfully written to remote location or not.
         """
+        compress = remote_log_location.endswith(_GZIP_SUFFIX)
         try:
             blob = storage.Blob.from_string(remote_log_location, self.client)
-            old_log = blob.download_as_bytes().decode()
+            old_log_bytes = blob.download_as_bytes()
+            old_log = (gz.decompress(old_log_bytes) if compress else old_log_bytes).decode()
             log = f"{old_log}\n{log}" if old_log else log
         except Exception as e:
             if not self.no_log_found(e):
@@ -181,7 +193,10 @@ class GCSRemoteLogIO(LoggingMixin):  # noqa: D101
                 return False
         try:
             blob = storage.Blob.from_string(remote_log_location, self.client)
-            blob.upload_from_string(log, content_type="text/plain")
+            if compress:
+                blob.upload_from_string(gz.compress(log.encode()), content_type="application/gzip")
+            else:
+                blob.upload_from_string(log, content_type="text/plain")
         except Exception as e:
             self.log.error("Could not write logs to %s: %s", remote_log_location, e)
             return False
@@ -233,24 +248,31 @@ class GCSRemoteLogIO(LoggingMixin):  # noqa: D101
         try:
             for key in sorted(uris):
                 blob = storage.Blob.from_string(key, self.client)
-                stream = blob.open("r")
-                log_streams.append(self._get_log_stream(stream))
+                if key.endswith(_GZIP_SUFFIX):
+                    raw = blob.open("rb")
+                    log_streams.append(self._get_log_stream(gz.open(raw, "rt"), raw))
+                else:
+                    log_streams.append(self._get_log_stream(blob.open("r")))
         except Exception as e:
             if not AIRFLOW_V_3_0_PLUS:
                 messages.append(f"Unable to read remote log {e}")
         return messages, log_streams
 
-    def _get_log_stream(self, stream: TextIOWrapper) -> RawLogStream:
+    def _get_log_stream(self, stream: TextIOWrapper, raw: IO[bytes] | None = None) -> RawLogStream:
         """
         Yield lines from the given stream.
 
         :param stream: The opened stream to read from.
+        :param raw: Underlying binary stream to close alongside ``stream``. A ``gzip`` wrapper does
+            not close the file object it was handed, so the caller passes it in to be closed here.
         :yield: Lines of the log file.
         """
         try:
             yield from stream
         finally:
             stream.close()
+            if raw is not None:
+                raw.close()
 
 
 class GCSTaskHandler(FileTaskHandler, LoggingMixin):
@@ -275,6 +297,8 @@ class GCSTaskHandler(FileTaskHandler, LoggingMixin):
         will be used.
     :param delete_local_copy: Whether local log files should be deleted after they are downloaded when using
         remote logging
+    :param gzip: Whether logs should be gzip compressed before being uploaded. Compressed logs are stored
+        with a ``.gz`` suffix; logs written while this was disabled stay readable.
     """
 
     trigger_should_wrap = True
@@ -291,6 +315,7 @@ class GCSTaskHandler(FileTaskHandler, LoggingMixin):
         max_bytes: int = 0,
         backup_count: int = 0,
         delay: bool = False,
+        gzip: bool = False,
         **kwargs,
     ) -> None:
         # support log file size handling of FileTaskHandler
@@ -311,6 +336,7 @@ class GCSTaskHandler(FileTaskHandler, LoggingMixin):
             gcp_keyfile_dict=gcp_keyfile_dict,
             scopes=gcp_scopes,
             project_id=project_id,
+            gzip=gzip,
         )
 
     def set_context(self, ti: TaskInstance, *, identifier: str | None = None) -> None:

--- a/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import copy
+import gzip
 import io
 import logging
 import os
@@ -85,6 +86,15 @@ class TestGCSRemoteLogIOFromConfig:
     def test_from_config_rejects_non_dict_remote_task_handler_kwargs(self):
         with pytest.raises(ValueError, match="remote_task_handler_kwargs"):
             GCSRemoteLogIO.from_config()
+
+    @conf_vars(
+        {
+            ("logging", "remote_base_log_folder"): "gs://bucket/remote/log/location",
+            ("logging", "remote_task_handler_kwargs"): '{"gzip": true}',
+        }
+    )
+    def test_from_config_enables_gzip(self):
+        assert GCSRemoteLogIO.from_config().gzip is True
 
     def test_provider_registers_gs_scheme(self):
         from airflow.providers_manager import ProvidersManager
@@ -375,6 +385,103 @@ class TestGCSRemoteLogIO:
             else:
                 assert logs is None
 
+    @pytest.mark.parametrize(
+        ("gzip_enabled", "expected_remote_name"),
+        [
+            pytest.param(True, "existing.log.gz", id="gzip"),
+            pytest.param(False, "existing.log", id="no-gzip"),
+        ],
+    )
+    @mock.patch("google.cloud.storage.Client")
+    @mock.patch("google.cloud.storage.Blob")
+    def test_upload_adds_gz_suffix_when_gzip_enabled(
+        self,
+        mock_blob,
+        mock_client,
+        mock_creds,
+        gzip_enabled: bool,
+        expected_remote_name: str,
+        tmp_path: Path,
+    ):
+        gcs_remote_log_io = GCSRemoteLogIO(
+            remote_base=self.gcs_log_folder,
+            base_log_folder=tmp_path.as_posix(),
+            delete_local_copy=False,
+            gzip=gzip_enabled,
+        )
+        (tmp_path / "existing.log").write_text("log content")
+
+        with mock.patch.object(gcs_remote_log_io, "write", return_value=True) as mock_write_method:
+            gcs_remote_log_io.upload("existing.log", self.ti)
+
+        assert mock_write_method.call_args[0][1] == f"{self.gcs_log_folder}/{expected_remote_name}"
+
+    @pytest.mark.parametrize(
+        ("old_log_exists", "expected_uploaded"),
+        [
+            pytest.param(True, b"OLD LOG CONTENT\nNEW LOG CONTENT", id="append-to-existing"),
+            pytest.param(False, b"NEW LOG CONTENT", id="fresh-blob"),
+        ],
+    )
+    @mock.patch("google.cloud.storage.Client")
+    @mock.patch("google.cloud.storage.Blob")
+    def test_write_compresses_gzip_location(
+        self,
+        mock_blob,
+        mock_client,
+        mock_creds,
+        old_log_exists: bool,
+        expected_uploaded: bytes,
+    ):
+        if old_log_exists:
+            mock_blob.from_string.return_value.download_as_bytes.return_value = gzip.compress(
+                b"OLD LOG CONTENT"
+            )
+        else:
+            mock_blob.from_string.return_value.download_as_bytes.side_effect = Exception(
+                "No such object: bucket/airflow/logs/task_1/attempt_1.log.gz"
+            )
+
+        gcs_remote_log_io = GCSRemoteLogIO(
+            remote_base=self.gcs_log_folder,
+            base_log_folder=self.base_log_folder,
+            delete_local_copy=False,
+            gzip=True,
+        )
+
+        result = gcs_remote_log_io.write("NEW LOG CONTENT", f"{self.gcs_log_folder}/task_1/attempt_1.log.gz")
+
+        assert result is True
+        args, kwargs = mock_blob.from_string.return_value.upload_from_string.call_args
+        assert gzip.decompress(args[0]) == expected_uploaded
+        assert kwargs["content_type"] == "application/gzip"
+
+    @mock.patch("google.cloud.storage.Client")
+    @mock.patch("google.cloud.storage.Blob")
+    def test_stream_reads_both_gzipped_and_plain_blobs(self, mock_blob, mock_client, mock_creds):
+        """Logs written before and after ``gzip`` was enabled live side by side and must both be readable."""
+        patch_mock_client_for_list_blobs(
+            mock_client,
+            ["airflow/logs/task_1/attempt_1.log", "airflow/logs/task_1/attempt_2.log.gz"],
+        )
+
+        def fake_open(mode):
+            if mode == "rb":
+                return io.BytesIO(gzip.compress(b"GZIPPED\nLOG"))
+            return io.TextIOWrapper(io.BytesIO(b"PLAIN\nLOG"), encoding="utf-8")
+
+        mock_blob.from_string.return_value.open.side_effect = fake_open
+
+        gcs_remote_log_io = GCSRemoteLogIO(
+            remote_base=self.gcs_log_folder,
+            base_log_folder=self.base_log_folder,
+            delete_local_copy=False,
+        )
+
+        _, log_streams = gcs_remote_log_io.stream("airflow/logs/task_1", self.ti)
+
+        assert ["".join(log_stream) for log_stream in log_streams] == ["PLAIN\nLOG", "GZIPPED\nLOG"]
+
 
 @pytest.mark.db_test
 class TestGCSTaskHandler:
@@ -406,6 +513,15 @@ class TestGCSTaskHandler:
             gcs_log_folder="gs://bucket/remote/log/location",
         )
         return self.gcs_task_handler
+
+    def test_gzip_is_forwarded_to_io(self, local_log_location):
+        handler = GCSTaskHandler(
+            base_log_folder=local_log_location,
+            gcs_log_folder="gs://bucket/remote/log/location",
+            gzip=True,
+        )
+
+        assert handler.io.gzip is True
 
     @mock.patch("airflow.providers.google.cloud.log.gcs_task_handler.GCSHook")
     @mock.patch("google.cloud.storage.Client")


### PR DESCRIPTION
## Why

- `GCSRemoteLogIO.write()` hardcodes `blob.upload_from_string(log, content_type="text/plain")`. Users don't have a way to compress uploaded logs.

## How

- Add a `gzip` field (default `False`) to `GCSRemoteLogIO`. Use `remote_task_handler_kwargs = {"gzip": true}` to forward the argument.
- The `upload()` appends a `.gz` suffix to the remote path when enabled.
- Both `write()` and `stream()` derive compression from the object name. That is what makes the setting safe to toggle: logs written while compression was off remain readable after enabling it, and vice versa.

## Verification

- `uv run --project providers/google --with-editable shared/secrets_masker pytest providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py -q`

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
* closes: #12609
---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
