### PR TITLE
Add padding bottom to log content to make last section header clickable.

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
@@ -350,6 +350,7 @@ export const TaskLogContent = ({
           data-testid="virtualized-list"
           display="block"
           overflowX="auto"
+          pb={2}
           textWrap={wrap ? "pre" : "nowrap"}
           width="100%"
         >


### PR DESCRIPTION
The log content component has no bottom padding and the cursor makes the scroll bar visible which makes the last section like "Post Execute" harder to click.

Before 

<img width="1848" height="1046" alt="image" src="https://github.com/user-attachments/assets/75f081a6-68be-4194-a4e4-c4c0ea1b37f2" />

With PR

<img width="1848" height="1046" alt="image" src="https://github.com/user-attachments/assets/dd80f943-02e6-4f4f-97f4-4f364da28792" />

Similar to Airflow 2 PR https://github.com/apache/airflow/pull/38610

##### Was generative AI tooling used to co-author this PR?

No
