### PR TITLE
Mark three unused config.yml options as deprecated

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1142,6 +1142,10 @@ logging:
         A comma separated list of keywords related to errors whose presence should display the line in red
         color in UI
       version_added: 2.10.0
+      version_deprecated: 3.4.0
+      deprecation_reason: |
+        This option was used by the legacy Flask-based webserver UI for log-line coloring.
+        That UI was removed in Airflow 3.0 and the new React UI does not read this setting.
       type: string
       example: ~
       default: "error,exception"
@@ -1150,6 +1154,10 @@ logging:
         A comma separated list of keywords related to warning whose presence should display the line in yellow
         color in UI
       version_added: 2.10.0
+      version_deprecated: 3.4.0
+      deprecation_reason: |
+        This option was used by the legacy Flask-based webserver UI for log-line coloring.
+        That UI was removed in Airflow 3.0 and the new React UI does not read this setting.
       type: string
       example: ~
       default: "warn"
@@ -2742,6 +2750,10 @@ scheduler:
         in the DB with a logical_date earlier than it., i.e. no manual marking
         success will be needed for a newly added task to be scheduled.
       version_added: 2.3.0
+      version_deprecated: 3.4.0
+      deprecation_reason: |
+        This option is no longer read. The default value for ``ignore_first_depends_on_past``
+        is now hardcoded in the Task SDK and cannot be changed via configuration.
       type: boolean
       example: ~
       default: "True"

--- a/airflow-core/tests/unit/core/test_configuration.py
+++ b/airflow-core/tests/unit/core/test_configuration.py
@@ -1908,6 +1908,30 @@ sql_alchemy_conn=sqlite://test
                 assert not airflow_cfg.has_option("test_deprecated_section", deprecated_key)
 
 
+@pytest.mark.parametrize(
+    ("section", "option"),
+    [
+        ("logging", "color_log_error_keywords"),
+        ("logging", "color_log_warning_keywords"),
+        ("scheduler", "ignore_first_depends_on_past_by_default"),
+    ],
+)
+def test_unused_config_options_are_deprecated(section, option):
+    """Options that are no longer read must carry deprecation markers and be excluded from defaults."""
+    from airflow.configuration import retrieve_configuration_description
+
+    config_description = retrieve_configuration_description(include_providers=False)
+    option_desc = config_description[section]["options"][option]
+
+    assert option_desc.get("version_deprecated"), f"[{section}] {option} must have version_deprecated set"
+    assert option_desc.get("deprecation_reason"), f"[{section}] {option} must have deprecation_reason set"
+
+    airflow_cfg = AirflowConfigParser()
+    assert not airflow_cfg.has_option(section, option), (
+        f"[{section}] {option} is deprecated and must not appear in defaults"
+    )
+
+
 @skip_if_force_lowest_dependencies_marker
 def test_sensitive_values():
     from airflow.settings import conf


### PR DESCRIPTION
Fixes #71259

**Description**

color_log_error_keywords and color_log_warning_keywords were read by the legacy Flask webserver UI for log-line coloring. That UI was removed in Airflow 3.0 and the new React UI does not use these settings.

ignore_first_depends_on_past_by_default was read by AbstractOperator in airflow/models/abstractoperator.py. When AbstractOperator moved to the Task SDK in Airflow 3.0, the config read was removed and the SDK uses a hardcoded default instead.

All three options remain in config.yml but are now marked with version_deprecated and deprecation_reason so they are excluded from generated defaults and the configuration reference honestly reflects that they have no effect.

**Testing**

Added a parametrized unit test in `test_configuration.py` to verify that these three options carry deprecation markers and are excluded from defaults. Verified existing tests pass.