### PR TITLE
Validate connection port bounds (0-65535)

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
@@ -191,7 +191,7 @@ class ConnectionBody(StrictBaseModel):
     host: str | None = Field(default=None)
     login: str | None = Field(default=None)
     schema_: str | None = Field(None, alias="schema")
-    port: int | None = Field(default=None)
+    port: int | None = Field(default=None, ge=0, le=65535)
     password: str | None = Field(default=None)
     extra: str | None = Field(default=None)
     team_name: str | None = Field(max_length=50, default=None)

--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -28,7 +28,7 @@ from typing import Any
 from urllib.parse import parse_qsl, quote, unquote, urlencode, urlsplit
 
 from sqlalchemy import ForeignKey, Integer, String, Text, select
-from sqlalchemy.orm import Mapped, mapped_column, reconstructor
+from sqlalchemy.orm import Mapped, mapped_column, reconstructor, validates
 
 from airflow._shared.module_loading import import_string
 from airflow._shared.secrets_backend.base import call_secrets_backend_method
@@ -202,6 +202,14 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
             mask_secret(quote(self.password))
         self.team_name = team_name
 
+    @validates("port")
+    def validate_port(self, key, port):
+        if port is not None:
+            if isinstance(port, str):
+                port = int(port)
+            if not (0 <= port <= 65535):
+                raise ValueError(f"Port must be between 0 and 65535, got {port}")
+        return port
     @staticmethod
     def _validate_extra(extra, conn_id) -> None:
         """Verify that ``extra`` is a JSON-encoded Python dict."""

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -311,6 +311,22 @@ class TestPostConnection(TestConnectionEndpoint):
         assert len(connection) == 1
         _check_last_log(session, dag_id=None, event="post_connection", logical_date=None)
 
+    @pytest.mark.parametrize(
+        "invalid_port",
+        [-1, 65536, 999999, -8080],
+    )
+    def test_post_should_respond_422_invalid_port(self, test_client, invalid_port):
+        response = test_client.post(
+            "/connections",
+            json={
+                "connection_id": TEST_CONN_ID,
+                "conn_type": TEST_CONN_TYPE,
+                "port": invalid_port,
+            },
+        )
+        assert response.status_code == 422
+        assert "Input should be" in response.json()["detail"][0]["msg"]
+
     @conf_vars({("core", "multi_team"): "True"})
     def test_post_should_respond_201_with_team(self, test_client, session, testing_team):
         response = test_client.post(
@@ -647,6 +663,24 @@ class TestPatchConnection(TestConnectionEndpoint):
         _check_last_log(session, dag_id=None, event="patch_connection", logical_date=None)
 
         assert response.json() == expected_result
+
+    @pytest.mark.parametrize(
+        "invalid_port",
+        [-1, 65536, 999999, -8080],
+    )
+    def test_patch_should_respond_422_invalid_port(self, test_client, invalid_port):
+        self.create_connection()
+        response = test_client.patch(
+            f"/connections/{TEST_CONN_ID}",
+            json={
+                "connection_id": TEST_CONN_ID,
+                "conn_type": TEST_CONN_TYPE,
+                "port": invalid_port,
+            },
+        )
+        assert response.status_code == 422
+        assert "Input should be" in response.json()["detail"][0]["msg"]
+
 
     @conf_vars({("core", "multi_team"): "True"})
     def test_patch_with_team_should_respond_200(self, test_client, testing_team, session):

--- a/airflow-core/tests/unit/models/test_connection.py
+++ b/airflow-core/tests/unit/models/test_connection.py
@@ -540,3 +540,24 @@ class TestConnection:
             "test_conn2": None,
         }
         clear_db_connections()
+
+@pytest.mark.parametrize(
+    "invalid_port",
+    [-1, 65536, 999999, -8080],
+)
+def test_connection_port_bounds_validation(invalid_port):
+    """Test that connection port bounds (0-65535) are validated."""
+    with pytest.raises(ValueError, match="Port must be between 0 and 65535"):
+        Connection(conn_id="test_invalid_port", port=invalid_port)
+
+
+def test_connection_port_valid_bounds():
+    """Test that valid connection ports are accepted."""
+    conn1 = Connection(conn_id="test_valid_port_1", port=0)
+    assert conn1.port == 0
+
+    conn2 = Connection(conn_id="test_valid_port_2", port=65535)
+    assert conn2.port == 65535
+
+    conn3 = Connection(conn_id="test_valid_port_3", port="8080")
+    assert conn3.port == 8080

--- a/task-sdk/src/airflow/sdk/definitions/connection.py
+++ b/task-sdk/src/airflow/sdk/definitions/connection.py
@@ -153,6 +153,12 @@ class Connection:
         else:
             self.__dict__.update(attrs.asdict(self.from_uri(uri, conn_id=conn_id), recurse=False))
 
+        if self.port is not None:
+            if isinstance(self.port, str):
+                self.port = int(self.port)
+            if not (0 <= self.port <= 65535):
+                raise ValueError(f"Port must be between 0 and 65535, got {self.port}")
+
     def get_uri(self) -> str:
         """Generate and return connection in URI format."""
         from urllib.parse import parse_qsl

--- a/task-sdk/tests/task_sdk/definitions/test_connection.py
+++ b/task-sdk/tests/task_sdk/definitions/test_connection.py
@@ -234,6 +234,26 @@ class TestConnections:
         connection.extra = '{"auth": {"type": "oauth"}, "headers": {"User-Agent": "Airflow"}}'
         assert connection.extra_dejson == {"auth": {"type": "oauth"}, "headers": {"User-Agent": "Airflow"}}
 
+    @pytest.mark.parametrize(
+        "invalid_port",
+        [-1, 65536, 999999, -8080],
+    )
+    def test_connection_port_bounds_validation(self, invalid_port):
+        """Test that connection port bounds (0-65535) are validated in SDK."""
+        with pytest.raises(ValueError, match="Port must be between 0 and 65535"):
+            Connection(conn_id="test_invalid_port", port=invalid_port)
+
+    def test_connection_port_valid_bounds(self):
+        """Test that valid connection ports are accepted in SDK."""
+        conn1 = Connection(conn_id="test_valid_port_1", port=0)
+        assert conn1.port == 0
+
+        conn2 = Connection(conn_id="test_valid_port_2", port=65535)
+        assert conn2.port == 65535
+
+        conn3 = Connection(conn_id="test_valid_port_3", port="8080")
+        assert conn3.port == 8080
+
 
 class TestConnectionsFromSecrets:
     def test_get_connection_secrets_backend(self, mock_supervisor_comms, tmp_path):


### PR DESCRIPTION
Fixes #68382

**Description**

Airflow previously accepted invalid connection port numbers (-1, 999999) without validation. This PR adds strict validation (0-65535) at three critical layers to ensure bad data is never accepted or persisted:
1. Core `Connection` model via SQLAlchemy `@validates`
2. Task SDK `Connection` via `__init__`
3. REST API `ConnectionBody` via Pydantic `Field(ge=0, le=65535)`

**Testing**

Added parameterized pytest coverage for:
* SQLAlchemy `Connection` model boundary rejections.
* Task SDK `Connection` initialization and payload parsing.
* FastAPI public REST API (`/connections`) `POST` and `PATCH` returning `422 Unprocessable Entity` for out-of-bounds ports.
