### PR TITLE
Fix Secrets Masker for non-string values

### DIFF
--- a/shared/secrets_masker/src/airflow_shared/secrets_masker/secrets_masker.py
+++ b/shared/secrets_masker/src/airflow_shared/secrets_masker/secrets_masker.py
@@ -328,7 +328,7 @@ class SecretsMasker(logging.Filter):
         *,
         replacement: str = "***",
     ) -> Redacted:
-        if depth > max_depth or isinstance(item, str):
+        if depth > max_depth or not isinstance(item, (dict, tuple, set, list)):
             return replacement
         if isinstance(item, dict):
             return {

--- a/shared/secrets_masker/tests/secrets_masker/test_secrets_masker.py
+++ b/shared/secrets_masker/tests/secrets_masker/test_secrets_masker.py
@@ -1204,8 +1204,8 @@ class TestDirectMethodCalls:
         result = secrets_masker._redact_all(test_data, depth=0, replacement="***")
 
         assert result["string"] == "***"
-        assert result["number"] == 12345
-        assert result["boolean"] is True
+        assert result["number"] == "***"
+        assert result["boolean"] == "***"
         assert all(val == "***" for val in result["list"])
         assert all(val == "***" for val in result["dict"].values())
         assert all(val == "***" for val in result["nested"]["tuple"])


### PR DESCRIPTION
Fixes #71275

**Description**

The `SecretsMasker` previously only redacted `str` scalar values. This meant that non-string scalars like `int`, `float`, `bool`, and `None` passed through in cleartext via the REST API even when their keys matched sensitive keywords (e.g. `test-password`). 

This PR updates `_redact_all` to invert the type check: it now masks any value that is not explicitly traversed as a collection (`dict`, `tuple`, `set`, `list`), ensuring that numeric API keys and PINs are securely masked. 

Note that `merge()` seamlessly restores the original non-string scalar without issues because it only checks if the incoming payload contains the string `"***"` before discarding it in favor of the original value.

**Testing**
* Added assertions for numeric and boolean redaction to `test_redact_all_directly`. All `airflow_shared/secrets_masker` tests pass successfully.