### PR TITLE
Add require_approval preflight check to @task.llm_schema_compare

### DIFF
--- a/providers/common/ai/src/airflow/providers/common/ai/decorators/llm_schema_compare.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/decorators/llm_schema_compare.py
@@ -28,7 +28,10 @@ from collections.abc import Callable, Collection, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from airflow.providers.common.ai.operators.llm_schema_compare import LLMSchemaCompareOperator
-from airflow.providers.common.ai.utils.validation import validate_prompt
+from airflow.providers.common.ai.utils.validation import (
+    reject_sequence_with_unsupported_feature,
+    validate_prompt,
+)
 from airflow.providers.common.compat.sdk import (
     DecoratedOperator,
     TaskDecorator,
@@ -89,6 +92,12 @@ class _LLMSchemaCompareDecoratedOperator(DecoratedOperator, LLMSchemaCompareOper
         self.prompt = self.python_callable(*self.op_args, **kwargs)
 
         validate_prompt(self.prompt, decorator_name="@task.llm_schema_compare")
+        reject_sequence_with_unsupported_feature(
+            self.prompt,
+            decorator_name="@task.llm_schema_compare",
+            feature_name="require_approval",
+            feature_enabled=self.require_approval,
+        )
 
         self.render_template_fields(context)
         return LLMSchemaCompareOperator.execute(self, context)

--- a/providers/common/ai/tests/unit/common/ai/decorators/test_llm_schema_compare.py
+++ b/providers/common/ai/tests/unit/common/ai/decorators/test_llm_schema_compare.py
@@ -124,6 +124,27 @@ class TestLLMSchemaCompareDecoratedOperator:
 
     @patch("airflow.providers.common.ai.operators.llm.PydanticAIHook", autospec=True)
     @patch.object(LLMSchemaCompareOperator, "_build_schema_context", return_value="mocked schema")
+    def test_sequence_prompt_with_require_approval_raises_before_run_sync(
+        self, mock_build_ctx, mock_hook_cls
+    ):
+        mock_agent = _make_mock_agent(_make_compare_result())
+        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+
+        op = _LLMSchemaCompareDecoratedOperator(
+            task_id="test",
+            python_callable=lambda: ["Compare these schemas:", ImageUrl(url="https://example.com/x.png")],
+            llm_conn_id="llm_conn",
+            db_conn_ids=["postgres_default", "snowflake_default"],
+            table_names=["test_table"],
+            require_approval=True,
+        )
+        with pytest.raises(TypeError, match=r"^@task\.llm_schema_compare: Sequence\[UserContent\]"):
+            op.execute(context={})
+
+        mock_agent.run_sync.assert_not_called()
+
+    @patch("airflow.providers.common.ai.operators.llm.PydanticAIHook", autospec=True)
+    @patch.object(LLMSchemaCompareOperator, "_build_schema_context", return_value="mocked schema")
     def test_execute_merges_op_kwargs_into_callable(self, mock_build_ctx, mock_hook_cls):
         """op_kwargs are resolved by the callable to build the prompt."""
         mock_hook_cls.get_hook.return_value.create_agent.return_value = _make_mock_agent(


### PR DESCRIPTION
### Sumarry

`@task.llm`, `@task.llm_branch`, and `@task.llm_sql` all reject a non-string `Sequence[UserContent]` prompt combined with `require_approval=True` before the LLM ever runs, raising a `TypeError` that names the decorator the caller actually used (e.g. `@task.llm_branch: ...`).

`@task.llm_schema_compare` was missing this decorator-level check. The same misuse still fails before any LLM call (the underlying operator has its own fallback guard), but the error instead names the internal `_LLMSchemaCompareDecoratedOperator` class -- an implementation detail the caller never wrote, which is confusing when debugging.

This adds the same `reject_sequence_with_unsupported_feature` preflight call that the other three decorators already use, so all four give a consistent, decorator-named error message.

### Reproduce

Reproduced by running two tasks against the same misuse (`require_approval=True` with a `Sequence[UserContent]` prompt) -- one via `@task.llm_branch`, one via `@task.llm_schema_compare` -- and comparing the task logs.

```python
from __future__ import annotations

from pydantic_ai.messages import ImageUrl

from airflow.providers.standard.operators.empty import EmptyOperator
from airflow.sdk import DAG, task

with DAG(
    dag_id="demo_require_approval_inconsistency",
    schedule=None,
    catchup=False,
):

    @task.llm_branch(
        llm_conn_id="demo_llm_conn",
        require_approval=True,
    )
    def branch_with_bad_prompt():
        return ["Compare these schemas:", ImageUrl(url="https://example.com/x.png")]

    @task.llm_schema_compare(
        llm_conn_id="demo_llm_conn",
        db_conn_ids=["demo_db_conn_a", "demo_db_conn_b"],
        table_names=["demo_table"],
        require_approval=True,
    )
    def schema_compare_with_bad_prompt():
        return ["Compare these schemas:", ImageUrl(url="https://example.com/x.png")]

    branch_with_bad_prompt() >> EmptyOperator(task_id="downstream_placeholder")
    schema_compare_with_bad_prompt()
```

**Before this change:**

```
INFO - Failure caused by _LLMSchemaCompareDecoratedOperator: require_approval=True is not supported with a non-string prompt (got list). The approval review body renders the prompt as text; passing a Sequence[UserContent] would expose object reprs (and any embedded bytes) in the human review UI. Return a str prompt, or disable require_approval.
INFO - Failure caused by @task.llm_branch: Sequence[UserContent] prompts are not supported with require_approval=True. Return a str prompt, or disable require_approval.
```

Note the first line names `_LLMSchemaCompareDecoratedOperator` -- an internal class the caller never wrote -- while the second names `@task.llm_branch`, the decorator actually used.

**After this change**:

The same misuse via `@task.llm_schema_compare` instead raises:

```
@task.llm_schema_compare: Sequence[UserContent] prompts are not supported with require_approval=True. Return a str prompt, or disable require_approval.
```

now consistent with the other three decorators.
