### PR TITLE
Skip provider dependency generation for help command in breeze cli 

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/main_command.py
+++ b/dev/breeze/src/airflow_breeze/commands/main_command.py
@@ -124,7 +124,8 @@ def main(ctx: click.Context, **kwargs: dict[str, Any]):
 
     check_for_rosetta_environment()
     check_for_python_emulation()
-    generate_provider_dependencies_if_needed()
+    if not any(argument in {"-h", "--help"} for argument in sys.argv[1:]):
+        generate_provider_dependencies_if_needed()
 
     if not ctx.invoked_subcommand:
         ctx.forward(shell, extra_args={})


### PR DESCRIPTION
## Summary

Breeze currently regenerates provider dependency metadata during startup, including when the user only requests help. That work can scan thousands of Python files and make `breeze --help` appear to hang before help is displayed.

This change skips provider-dependency regeneration whenever `-h` or `--help` is present in the command arguments. Help therefore remains a fast path and does not depend on provider metadata generation.

## Testing

- Ruff format and check passed.
- Existing provider-dependency tests: `uv run --project dev/breeze pytest dev/breeze/tests/test_provider_dependencies.py -q` — 8 passed.

The existing test file validates the provider-dependency cache behavior; the change itself is a startup help-path guard.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)