### PR TITLE
Prek: Honor source encodings during provider dependency generation

### DIFF
--- a/scripts/ci/prek/common_prek_utils.py
+++ b/scripts/ci/prek/common_prek_utils.py
@@ -27,6 +27,7 @@ import subprocess
 import sys
 import textwrap
 import time
+import tokenize
 from collections.abc import Callable, Generator, Iterable
 from contextlib import contextmanager
 from pathlib import Path
@@ -821,7 +822,8 @@ def get_imports_from_file(file_path: Path, *, only_top_level: bool) -> list[str]
     When only_top_level = False then returns
         ['os', 'collections.defaultdict', 'numpy', 'pandas.DataFrame', 'json', 'pathlib.Path', 'pathlib.PurePath']
     """
-    root = ast.parse(file_path.read_text(), file_path.name)
+    with tokenize.open(file_path) as source_file:
+        root = ast.parse(source_file.read(), file_path.name)
     imports: list[str] = []
 
     nodes = ast.iter_child_nodes(root) if only_top_level else ast.walk(root)

--- a/scripts/tests/ci/prek/test_common_prek_utils.py
+++ b/scripts/tests/ci/prek/test_common_prek_utils.py
@@ -244,6 +244,12 @@ class TestGetImportsFromFile:
         result = get_imports_from_file(path, only_top_level=True)
         assert result == []
 
+    def test_reads_source_with_declared_encoding(self, tmp_path):
+        path = tmp_path / "provider.py"
+        path.write_bytes(b"# -*- coding: latin-1 -*-\n# caf\xe9\nimport os\n")
+
+        assert get_imports_from_file(path, only_top_level=True) == ["os"]
+
 
 class TestInsertDocumentation:
     def test_replaces_content_between_header_and_footer(self, write_text_file):


### PR DESCRIPTION
## Summary

Provider dependency generation parses Python source files using the platform default text encoding. On Windows, this is commonly `cp1252`, which can fail on valid provider files and abort dependency-cache generation.

This change uses Python’s `tokenize.open()` to read provider source files. It honors PEP 263 encoding declarations and uses Python’s UTF-8 default when no declaration is present, while preserving support for source files that explicitly declare another encoding.

A regression test covers a Latin-1 source file with an encoding declaration.

## Testing

- Ruff format and check passed.
- Focused parser tests: `uv run --project scripts pytest scripts/tests/ci/prek/test_common_prek_utils.py -q -k TestGetImportsFromFile` — 8 passed.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)