### PR TITLE
Allow OpensearchTaskHandler and OpensearchRemoteLogIO to take empty username and password

### DIFF
--- a/providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py
+++ b/providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py
@@ -219,7 +219,7 @@ def _create_opensearch_client(
     connection_kwargs: dict[str, Any] = {
         "hosts": [{"host": parsed_url.hostname, "port": resolved_port, "scheme": parsed_url.scheme}]
     }
-    if username and password:
+    if username or password:
         connection_kwargs["http_auth"] = (username, password)
     return OpenSearch(
         **connection_kwargs,

--- a/providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py
+++ b/providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py
@@ -222,7 +222,7 @@ def _create_opensearch_client(
     connection_kwargs: dict[str, Any] = {
         "hosts": [{"host": parsed_url.hostname, "port": resolved_port, "scheme": parsed_url.scheme}]
     }
-    if username and password:
+    if username or password:
         connection_kwargs["http_auth"] = (username, password)
     return OpenSearch(
         **connection_kwargs,

--- a/providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py
+++ b/providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py
@@ -219,9 +219,13 @@ def _create_opensearch_client(
 ) -> OpenSearch:
     parsed_url = urlparse(_format_url(host))
     resolved_port = port if port is not None else (parsed_url.port or 9200)
+    connection_kwargs: dict[str, Any] = {
+        "hosts": [{"host": parsed_url.hostname, "port": resolved_port, "scheme": parsed_url.scheme}]
+    }
+    if username and password:
+        connection_kwargs["http_auth"] = (username, password)
     return OpenSearch(
-        hosts=[{"host": parsed_url.hostname, "port": resolved_port, "scheme": parsed_url.scheme}],
-        http_auth=(username, password),
+        **connection_kwargs,
         **os_kwargs,
     )
 

--- a/providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py
+++ b/providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py
@@ -216,9 +216,13 @@ def _create_opensearch_client(
 ) -> OpenSearch:
     parsed_url = urlparse(_format_url(host))
     resolved_port = port if port is not None else (parsed_url.port or 9200)
+    connection_kwargs: dict[str, Any] = {
+        "hosts": [{"host": parsed_url.hostname, "port": resolved_port, "scheme": parsed_url.scheme}]
+    }
+    if username and password:
+        connection_kwargs["http_auth"] = (username, password)
     return OpenSearch(
-        hosts=[{"host": parsed_url.hostname, "port": resolved_port, "scheme": parsed_url.scheme}],
-        http_auth=(username, password),
+        **connection_kwargs,
         **os_kwargs,
     )
 

--- a/providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py
+++ b/providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py
@@ -844,7 +844,7 @@ class TestOpensearchRemoteLogIO:
             assert "http_auth" in transport_args
             assert transport_args["http_auth"] == (username, password)
         else:
-            assert "http_auth" not in handler.client.transport.kwargs
+            assert "http_auth" not in opensearch_io.client.transport.kwargs
 
 
 class TestOpensearchRemoteLogIOFromConfig:

--- a/providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py
+++ b/providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py
@@ -46,6 +46,7 @@ from airflow.providers.opensearch.log.os_task_handler import (
 )
 from airflow.utils.log.file_task_handler import FileTaskHandler
 from airflow.utils.state import DagRunState, TaskInstanceState
+
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_dags, clear_db_runs
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS

--- a/providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py
+++ b/providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py
@@ -289,14 +289,14 @@ class TestOpensearchTaskHandler:
         assert handler.index_patterns == patterns
 
     @pytest.mark.parametrize(
-        ("username", "password"),
+        ("username", "password", "expect_http_auth"),
         [
-            ("admin", "secret"),
-            ("admin", ""),
-            ("", "secret"),
+            ("admin", "secret", True),
+            ("admin", "", True),
+            ("", "secret", True),
         ],
     )
-    def test_client_with_auth(self, username, password):
+    def test_client_with_auth(self, username, password, expect_http_auth):
         """If either username or password are provided, the handler should pass http_auth to the client."""
         handler = OpensearchTaskHandler(
             base_log_folder=self.local_log_location,
@@ -313,26 +313,11 @@ class TestOpensearchTaskHandler:
         )
 
         transport_args = handler.client.transport.kwargs
-        assert "http_auth" in transport_args
-        assert transport_args["http_auth"] == (username, password)
-
-    def test_client_no_auth(self):
-        """If both username and password are empty, the handler should _not_ pass http_auth to the client."""
-        handler = OpensearchTaskHandler(
-            base_log_folder=self.local_log_location,
-            end_of_log_mark=self.end_of_log_mark,
-            write_stdout=self.write_stdout,
-            host="localhost",
-            port=9200,
-            username="",
-            password="",
-            json_format=self.json_format,
-            json_fields=self.json_fields,
-            host_field=self.host_field,
-            offset_field=self.offset_field,
-        )
-
-        assert "http_auth" not in handler.client.transport.kwargs
+        if expect_http_auth:
+            assert "http_auth" in transport_args
+            assert transport_args["http_auth"] == (username, password)
+        else:
+            assert "http_auth" not in handler.client.transport.kwargs
 
     @pytest.mark.db_test
     @pytest.mark.parametrize("metadata_mode", ["provided", "none", "empty"])
@@ -833,14 +818,14 @@ class TestOpensearchRemoteLogIO:
         self.opensearch_io.upload(log_file, ti=None)
 
     @pytest.mark.parametrize(
-        ("username", "password"),
+        ("username", "password", "expect_http_auth"),
         [
-            ("admin", "secret"),
-            ("admin", ""),
-            ("", "secret"),
+            ("admin", "secret", True),
+            ("admin", "", True),
+            ("", "secret", True),
         ],
     )
-    def test_client_with_auth(self, username, password):
+    def test_client_with_auth(self, username, password, expect_http_auth):
         """If either username or password are provided, the IO should pass http_auth to the client."""
         opensearch_io = OpensearchRemoteLogIO(
             write_to_opensearch=True,
@@ -854,25 +839,12 @@ class TestOpensearchRemoteLogIO:
             log_id_template="{dag_id}-{task_id}-{run_id}-{map_index}-{try_number}",
         )
 
-        transport_args = opensearch_io.client.transport.kwargs
-        assert "http_auth" in transport_args
-        assert transport_args["http_auth"] == (username, password)
-
-    def test_client_no_auth(self):
-        """If both username and password are empty, the IO should _not_ pass http_auth to the client."""
-        opensearch_io = OpensearchRemoteLogIO(
-            write_to_opensearch=True,
-            write_stdout=True,
-            delete_local_copy=True,
-            host="localhost",
-            port=9200,
-            username="",
-            password="",
-            base_log_folder=self.opensearch_io.base_log_folder,
-            log_id_template="{dag_id}-{task_id}-{run_id}-{map_index}-{try_number}",
-        )
-
-        assert "http_auth" not in opensearch_io.client.transport.kwargs
+        transport_args = handler.client.transport.kwargs
+        if expect_http_auth:
+            assert "http_auth" in transport_args
+            assert transport_args["http_auth"] == (username, password)
+        else:
+            assert "http_auth" not in handler.client.transport.kwargs
 
 
 class TestOpensearchRemoteLogIOFromConfig:

--- a/providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py
+++ b/providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py
@@ -46,7 +46,6 @@ from airflow.providers.opensearch.log.os_task_handler import (
 )
 from airflow.utils.log.file_task_handler import FileTaskHandler
 from airflow.utils.state import DagRunState, TaskInstanceState
-
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_dags, clear_db_runs
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
@@ -288,7 +287,36 @@ class TestOpensearchTaskHandler:
         )
         assert handler.index_patterns == patterns
 
+    @pytest.mark.parametrize(
+        ("username", "password"),
+        [
+            ("admin", "secret"),
+            ("admin", ""),
+            ("", "secret"),
+        ],
+    )
+    def test_client_with_auth(self, username, password):
+        """If either username or password are provided, the handler should pass http_auth to the client."""
+        handler = OpensearchTaskHandler(
+            base_log_folder=self.local_log_location,
+            end_of_log_mark=self.end_of_log_mark,
+            write_stdout=self.write_stdout,
+            host="localhost",
+            port=9200,
+            username=username,
+            password=password,
+            json_format=self.json_format,
+            json_fields=self.json_fields,
+            host_field=self.host_field,
+            offset_field=self.offset_field,
+        )
+
+        transport_args = handler.client.transport.kwargs
+        assert "http_auth" in transport_args
+        assert transport_args["http_auth"] == (username, password)
+
     def test_client_no_auth(self):
+        """If both username and password are empty, the handler should _not_ pass http_auth to the client."""
         handler = OpensearchTaskHandler(
             base_log_folder=self.local_log_location,
             end_of_log_mark=self.end_of_log_mark,
@@ -302,6 +330,7 @@ class TestOpensearchTaskHandler:
             host_field=self.host_field,
             offset_field=self.offset_field,
         )
+
         assert "http_auth" not in handler.client.transport.kwargs
 
     @pytest.mark.db_test

--- a/providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py
+++ b/providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py
@@ -831,7 +831,34 @@ class TestOpensearchRemoteLogIO:
         log_file.write_text('{"message": "test"}\n')
         self.opensearch_io.upload(log_file, ti=None)
 
+    @pytest.mark.parametrize(
+        ("username", "password"),
+        [
+            ("admin", "secret"),
+            ("admin", ""),
+            ("", "secret"),
+        ],
+    )
+    def test_client_with_auth(self, username, password):
+        """If either username or password are provided, the IO should pass http_auth to the client."""
+        opensearch_io = OpensearchRemoteLogIO(
+            write_to_opensearch=True,
+            write_stdout=True,
+            delete_local_copy=True,
+            host="localhost",
+            port=9200,
+            username=username,
+            password=password,
+            base_log_folder=self.opensearch_io.base_log_folder,
+            log_id_template="{dag_id}-{task_id}-{run_id}-{map_index}-{try_number}",
+        )
+
+        transport_args = opensearch_io.client.transport.kwargs
+        assert "http_auth" in transport_args
+        assert transport_args["http_auth"] == (username, password)
+
     def test_client_no_auth(self):
+        """If both username and password are empty, the IO should _not_ pass http_auth to the client."""
         opensearch_io = OpensearchRemoteLogIO(
             write_to_opensearch=True,
             write_stdout=True,
@@ -843,6 +870,7 @@ class TestOpensearchRemoteLogIO:
             base_log_folder=self.opensearch_io.base_log_folder,
             log_id_template="{dag_id}-{task_id}-{run_id}-{map_index}-{try_number}",
         )
+
         assert "http_auth" not in opensearch_io.client.transport.kwargs
 
 

--- a/providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py
+++ b/providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py
@@ -288,6 +288,22 @@ class TestOpensearchTaskHandler:
         )
         assert handler.index_patterns == patterns
 
+    def test_client_no_auth(self):
+        handler = OpensearchTaskHandler(
+            base_log_folder=self.local_log_location,
+            end_of_log_mark=self.end_of_log_mark,
+            write_stdout=self.write_stdout,
+            host="localhost",
+            port=9200,
+            username="",
+            password="",
+            json_format=self.json_format,
+            json_fields=self.json_fields,
+            host_field=self.host_field,
+            offset_field=self.offset_field,
+        )
+        assert "http_auth" not in handler.client.transport.kwargs
+
     @pytest.mark.db_test
     @pytest.mark.parametrize("metadata_mode", ["provided", "none", "empty"])
     def test_read(self, ti, metadata_mode):
@@ -785,6 +801,20 @@ class TestOpensearchRemoteLogIO:
         log_file = tmp_path / "1.log"
         log_file.write_text('{"message": "test"}\n')
         self.opensearch_io.upload(log_file, ti=None)
+
+    def test_client_no_auth(self):
+        opensearch_io = OpensearchRemoteLogIO(
+            write_to_opensearch=True,
+            write_stdout=True,
+            delete_local_copy=True,
+            host="localhost",
+            port=9200,
+            username="",
+            password="",
+            base_log_folder=self.opensearch_io.base_log_folder,
+            log_id_template="{dag_id}-{task_id}-{run_id}-{map_index}-{try_number}",
+        )
+        assert "http_auth" not in opensearch_io.client.transport.kwargs
 
 
 class TestOpensearchRemoteLogIOFromConfig:

--- a/providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py
+++ b/providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py
@@ -839,7 +839,7 @@ class TestOpensearchRemoteLogIO:
             log_id_template="{dag_id}-{task_id}-{run_id}-{map_index}-{try_number}",
         )
 
-        transport_args = handler.client.transport.kwargs
+        transport_args = opensearch_io.client.transport.kwargs
         if expect_http_auth:
             assert "http_auth" in transport_args
             assert transport_args["http_auth"] == (username, password)


### PR DESCRIPTION
This change allows `OpensearchTaskHandler` and `OpensearchRemoteLogIO` to utilize Opensearch connections without user/password authentication.

**Current Behavior**
These classes pass their `username` and `password` attributes to the `OpenSearch` client constructor. In the event these attributes are empty or null, the client attempts to connect to the host using an auth string of `":"` or `"None:None"`.

**Proposed Behavior**
`os_task_handler._create_opensearch_client()` passes the `http_auth` tuple to the `OpenSearch()` client constructor only if both `username` and `password` are truthy (i.e., they are non-empty strings).

**Rationale**
Several use cases take advantage of a non-authenticated endpoint. Opensearch instances are sometimes deployed without authentication for testing purposes, and production instances can be operated inside of a VPC where networking rules rather than credentials control access from other services in the cluster.

Additionally, this non-authenticated capability is already in place in the `OpenSearchHook`.

---
##### Was generative AI tooling used to co-author this PR?
- [ ] Yes (please specify the tool below)
---
