### PR TITLE
Document the API pagination limit in OpenAPI

### DIFF
--- a/airflow-core/docs/security/api.rst
+++ b/airflow-core/docs/security/api.rst
@@ -107,9 +107,10 @@ response that does so, so a wildcard origin would simply break every cross-origi
 Page size limit
 ---------------
 
-To protect against requests that may lead to application instability, the stable API has a limit of items in response.
-The default is 100 items, but you can change it using ``maximum_page_limit``  option in ``[api]``
-section in the ``airflow.cfg`` file.
+To protect against requests that may lead to application instability, the stable API limits the number of items in
+each response. The default maximum is 100 items, but you can change it using the ``maximum_page_limit`` option in the
+``[api]`` section of the ``airflow.cfg`` file. Requests with a ``limit`` greater than this value return the maximum
+number of items instead.
 
 Request Payload Considerations
 ------------------------------

--- a/airflow-core/src/airflow/api_fastapi/common/parameters.py
+++ b/airflow-core/src/airflow/api_fastapi/common/parameters.py
@@ -85,6 +85,7 @@ if TYPE_CHECKING:
 
 T = TypeVar("T")
 
+_MAXIMUM_PAGE_LIMIT: int = conf.getint("api", "maximum_page_limit")
 _FALLBACK_PAGE_LIMIT: int = conf.getint("api", "fallback_page_limit")
 
 
@@ -154,8 +155,17 @@ class LimitFilter(BaseParam[NonNegativeInt]):
         return select.limit(self.value)
 
     @classmethod
-    def depends(cls, limit: NonNegativeInt = _FALLBACK_PAGE_LIMIT) -> LimitFilter:
-        return cls().set_value(min(limit, conf.getint("api", "maximum_page_limit")))
+    def depends(
+        cls,
+        limit: Annotated[
+            NonNegativeInt,
+            Query(
+                description="Maximum number of items to return in the response. Larger values are clamped.",
+                json_schema_extra={"maximum": _MAXIMUM_PAGE_LIMIT},
+            ),
+        ] = _FALLBACK_PAGE_LIMIT,
+    ) -> LimitFilter:
+        return cls().set_value(min(limit, _MAXIMUM_PAGE_LIMIT))
 
 
 class OffsetFilter(BaseParam[NonNegativeInt]):

--- a/airflow-core/tests/unit/api_fastapi/common/test_parameters.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_parameters.py
@@ -25,11 +25,13 @@ from unittest import mock
 
 import pytest
 from fastapi import Depends, FastAPI, HTTPException
+from fastapi.testclient import TestClient
 from sqlalchemy import select
 
 from airflow.api_fastapi.common.parameters import (
     FilterParam,
     NullableDatetimeRangeFilter,
+    QueryLimit,
     RangeFilter,
     SortParam,
     _AssetDependencyFilter,
@@ -44,6 +46,7 @@ from airflow.api_fastapi.common.parameters import (
     filter_param_factory,
     regex_param_factory,
 )
+from airflow.configuration import conf
 from airflow.models import DagModel, DagRun, Log
 from airflow.models.asset import AssetEvent
 from airflow.models.errors import ParseImportError
@@ -109,6 +112,25 @@ class TestFilterParam:
                 assert param["description"] == expected_description, (
                     f"Expected description '{expected_description}', got '{param['description']}'"
                 )
+
+
+class TestLimitFilter:
+    def test_limit_maximum_is_documented_and_enforced(self):
+        app = FastAPI()
+
+        @app.get("/test")
+        def test_route(limit: QueryLimit):
+            return {"limit": limit.value}
+
+        maximum_page_limit = conf.getint("api", "maximum_page_limit")
+        parameter = app.openapi()["paths"]["/test"]["get"]["parameters"][0]
+        assert parameter["schema"]["maximum"] == maximum_page_limit
+
+        client = TestClient(app)
+        assert client.get("/test", params={"limit": maximum_page_limit}).status_code == 200
+        response = client.get("/test", params={"limit": maximum_page_limit + 1})
+        assert response.status_code == 200
+        assert response.json() == {"limit": maximum_page_limit}
 
 
 class TestSortParam:


### PR DESCRIPTION
Document the configured API pagination limit in the generated OpenAPI schema while preserving the existing runtime behavior that clamps oversized limits.

The change:
- Exposes `maximum_page_limit` as the OpenAPI `maximum` for the `limit` query parameter.
- Clarifies the clamping behavior in the API documentation.
- Adds a regression test covering both the schema and runtime behavior.

Tests:
- `uv run --project airflow-core pytest airflow-core/tests/unit/api_fastapi/common/test_parameters.py -q`
- Result: 54 passed

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (OpenAI Codex, GPT-5)

Generated-by: OpenAI Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.

---
Drafted-by: OpenAI Codex (GPT-5) (no human review before posting)