### PR TITLE
Allow paused Dags to finish running DagRuns

### DIFF
--- a/airflow-core/newsfragments/71697.bugfix.rst
+++ b/airflow-core/newsfragments/71697.bugfix.rst
@@ -1,0 +1,1 @@
+Allow already-running Dag runs to continue scheduling tasks after their Dag is paused.

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -726,7 +726,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 .join(TI.dag_run)
                 .where(DR.state == DagRunState.RUNNING)
                 .join(TI.dag_model)
-                .where(~DM.is_paused)
                 .where(TI.state == TaskInstanceState.SCHEDULED)
                 .where(DM.bundle_name.is_not(None))
                 .join(

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -766,7 +766,6 @@ class DagRun(Base, LoggingMixin):
             .join(DagModel, DagModel.dag_id == cls.dag_id)
             .join(BackfillDagRun, BackfillDagRun.dag_run_id == DagRun.id, isouter=True)
             .where(
-                DagModel.is_paused == false(),
                 DagModel.is_stale == false(),
             )
             .order_by(

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -1196,8 +1196,8 @@ class TestSchedulerJob:
         assert events[0].asset is not None
         assert events[0].source_aliases is not None
 
-    def test_execute_task_instances_is_paused_wont_execute(self, session, dag_maker):
-        dag_id = "SchedulerJobTest.test_execute_task_instances_is_paused_wont_execute"
+    def test_execute_task_instances_for_paused_running_dagrun(self, session, dag_maker):
+        dag_id = "SchedulerJobTest.test_execute_task_instances_for_paused_running_dagrun"
         task_id_1 = "dummy_task"
 
         with dag_maker(dag_id=dag_id, session=session) as dag:
@@ -1206,14 +1206,20 @@ class TestSchedulerJob:
 
         scheduler_job = Job()
         self.job_runner = SchedulerJobRunner(job=scheduler_job)
-        dr1 = dag_maker.create_dagrun(run_type=DagRunType.BACKFILL_JOB)
+        dr1 = dag_maker.create_dagrun(state=DagRunState.RUNNING)
         (ti1,) = dr1.task_instances
         ti1.state = State.SCHEDULED
+        orm_dag = session.get(DagModel, dag_id)
+        assert orm_dag
+        orm_dag.is_paused = True
+        session.merge(ti1)
+        session.flush()
 
-        self.job_runner._critical_section_enqueue_task_instances(session)
+        queued_tis = self.job_runner._executable_task_instances_to_queued(max_tis=32, session=session)
         session.flush()
         ti1.refresh_from_db(session=session)
-        assert ti1.state == State.SCHEDULED
+        assert {queued_ti.key for queued_ti in queued_tis} == {ti1.key}
+        assert ti1.state == State.QUEUED
         session.rollback()
 
     @pytest.mark.usefixtures("testing_dag_bundle")

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -1050,10 +1050,9 @@ class TestDagRun:
         assert (upstream.task_id in schedulable_tis) == is_ti_schedulable
 
     @pytest.mark.parametrize("state", [DagRunState.QUEUED, DagRunState.RUNNING])
-    def test_next_dagruns_to_examine_only_unpaused(self, session, state, testing_dag_bundle):
+    def test_next_dagruns_to_examine_paused_dag(self, session, state, testing_dag_bundle):
         """
-        Check that "next_dagruns_to_examine" ignores runs from paused/inactive DAGs
-        and gets running/queued dagruns
+        Check that pause only blocks queued DagRuns from starting, not already-running DagRuns.
         """
         dag = DAG(dag_id="test_dags", schedule=datetime.timedelta(days=1), start_date=DEFAULT_DATE)
         EmptyOperator(task_id="dummy", dag=dag, owner="airflow")
@@ -1100,7 +1099,10 @@ class TestDagRun:
         session.commit()
 
         runs = fetch().all()
-        assert runs == []
+        if state == DagRunState.RUNNING:
+            assert runs == [dr]
+        else:
+            assert runs == []
 
     @mock.patch("airflow._shared.observability.metrics.stats.timing")
     def test_no_scheduling_delay_for_nonscheduled_runs(self, stats_mock, session, testing_dag_bundle):


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Why
Pausing a Dag currently blocks more than new Dag run creation. If a Dag is paused while a Dag run is already `running`, the scheduler stops examining that run and stops queueing its remaining scheduled task instances.

That leaves the run silently stuck in `running`, with remaining tasks staying in `scheduled` and never reaching the executor. Unpausing fixes the stuck run, but also allows new runs to start, which is not always what the operator intended.

relates: #71381

## Solution
Keep pause behavior for new work, but let already-running Dag runs continue.

Queued Dag runs still require an unpaused Dag before they can move to `running`. The scheduler now only removes the pause gate from paths that operate on Dag runs already in `running` state:

- selecting running Dag runs for scheduler examination
- queueing scheduled task instances that belong to running Dag runs

This preserves pause as "do not start new runs" while allowing in-flight runs to finish.



## Testing

- `uv run ruff check --fix airflow-core/src/airflow/models/dagrun.py airflow-core/src/airflow/jobs/scheduler_job_runner.py airflow-core/tests/unit/models/test_dagrun.py airflow-core/tests/unit/jobs/test_scheduler_job.py`
- `uv run --project airflow-core pytest airflow-core/tests/unit/models/test_dagrun.py::TestDagRun::test_next_dagruns_to_examine_paused_dag airflow-core/tests/unit/jobs/test_scheduler_job.py::TestSchedulerJob::test_execute_task_instances_for_paused_running_dagrun -q`
- `git diff --check`

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- `[X]` Yes (please specify the tool below)


Generated-by: [Codex] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
