### PR TITLE
Halve external vault API lookup requests per airflow secret lookup

### DIFF
--- a/providers/hashicorp/src/airflow/providers/hashicorp/_internal_client/vault_client.py
+++ b/providers/hashicorp/src/airflow/providers/hashicorp/_internal_client/vault_client.py
@@ -17,11 +17,13 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Callable
 from functools import cached_property
+from typing import TypeVar
 
 import hvac
 from hvac.api.auth_methods import Kubernetes
-from hvac.exceptions import InvalidPath, VaultError
+from hvac.exceptions import Forbidden, InvalidPath, VaultError
 from requests import Response, Session
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
@@ -30,6 +32,8 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 DEFAULT_KUBERNETES_JWT_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 DEFAULT_KV_ENGINE_VERSION = 2
+
+T = TypeVar("T")
 
 
 VALID_KV_VERSIONS: list[int] = [1, 2]
@@ -204,15 +208,42 @@ class _VaultClient(LoggingMixin):
     @property
     def client(self):
         """
-        Checks that it is still authenticated to Vault and invalidates the cache if this is not the case.
+        Return the client, authenticating on first use.
+
+        The token is not validated here. Vault answers 403 for an expired token and for a path the
+        token may not read, so a probe before every request costs a round trip that cannot tell the
+        two apart. Callers go through :meth:`_run_with_reauth`, which authenticates again and retries
+        once when Vault rejects the token.
 
         :return: Vault Client
         """
-        if not self._client.is_authenticated():
-            # Invalidate the cache:
-            # https://github.com/pydanny/cached-property#invalidating-the-cache
-            self.__dict__.pop("_client", None)
         return self._client
+
+    def _invalidate_client(self) -> None:
+        """Drop the cached client so that the next access authenticates again."""
+        self.__dict__.pop("_client", None)
+
+    def _run_with_reauth(self, operation: Callable[[hvac.Client], T]) -> T:
+        """
+        Run a Vault request, authenticating again and retrying it once if the token is rejected.
+
+        Only ``Forbidden`` is treated as a rejected token. ``InvalidPath`` means the secret is
+        absent and callers turn it into ``None``, and ``InvalidRequest`` covers request-level
+        failures conflicting on a write. Neither is fixed by authenticating again, so both are
+        left to propagate to the caller that knows what they mean.
+
+        :param operation: Callable issuing a single request against the client it is given.
+        :return: Whatever ``operation`` returns.
+        """
+        try:
+            return operation(self.client)
+        except Forbidden:
+            self.log.debug("Vault rejected the token. Authenticating again and retrying once.")
+            self._invalidate_client()
+            try:
+                return operation(self.client)
+            except Forbidden as retry_error:
+                raise VaultError("Vault Authentication Error!") from retry_error
 
     @cached_property
     def _client(self) -> hvac.Client:
@@ -268,9 +299,12 @@ class _VaultClient(LoggingMixin):
         else:
             raise VaultError(f"Authentication type '{self.auth_type}' not supported")
 
-        if _client.is_authenticated():
-            return _client
-        raise VaultError("Vault Authentication Error!")
+        # The login response above already carries the token, so asking Vault to confirm it would be
+        # a wasted round trip. Only the free half of hvac's is_authenticated() is kept, catching an
+        # auth method that never produced a token before the first request goes out.
+        if not _client.token:
+            raise VaultError("Vault Authentication Error!")
+        return _client
 
     def _auth_userpass(self, _client: hvac.Client) -> None:
         if self.auth_mount_point:
@@ -495,13 +529,17 @@ class _VaultClient(LoggingMixin):
             if self.kv_engine_version == 1:
                 if secret_version:
                     raise VaultError("Secret version can only be used with version 2 of the KV engine")
-                response = self.client.secrets.kv.v1.read_secret(path=secret_path, mount_point=mount_point)
+                response = self._run_with_reauth(
+                    lambda client: client.secrets.kv.v1.read_secret(path=secret_path, mount_point=mount_point)
+                )
             else:
-                response = self.client.secrets.kv.v2.read_secret_version(
-                    path=secret_path,
-                    mount_point=mount_point,
-                    version=secret_version,
-                    raise_on_deleted_version=True,
+                response = self._run_with_reauth(
+                    lambda client: client.secrets.kv.v2.read_secret_version(
+                        path=secret_path,
+                        mount_point=mount_point,
+                        version=secret_version,
+                        raise_on_deleted_version=True,
+                    )
                 )
         except InvalidPath:
             self.log.debug("Secret not found %s with mount point %s", secret_path, mount_point)
@@ -525,7 +563,11 @@ class _VaultClient(LoggingMixin):
         mount_point = None
         try:
             mount_point, secret_path = self._parse_secret_path(secret_path)
-            return self.client.secrets.kv.v2.read_secret_metadata(path=secret_path, mount_point=mount_point)
+            return self._run_with_reauth(
+                lambda client: client.secrets.kv.v2.read_secret_metadata(
+                    path=secret_path, mount_point=mount_point
+                )
+            )
         except InvalidPath:
             self.log.debug("Secret not found %s with mount point %s", secret_path, mount_point)
             return None
@@ -549,11 +591,13 @@ class _VaultClient(LoggingMixin):
         mount_point = None
         try:
             mount_point, secret_path = self._parse_secret_path(secret_path)
-            return self.client.secrets.kv.v2.read_secret_version(
-                path=secret_path,
-                mount_point=mount_point,
-                version=secret_version,
-                raise_on_deleted_version=True,
+            return self._run_with_reauth(
+                lambda client: client.secrets.kv.v2.read_secret_version(
+                    path=secret_path,
+                    mount_point=mount_point,
+                    version=secret_version,
+                    raise_on_deleted_version=True,
+                )
             )
         except InvalidPath:
             self.log.debug(
@@ -591,11 +635,15 @@ class _VaultClient(LoggingMixin):
             raise VaultError("The cas parameter is only valid for version 2")
         mount_point, secret_path = self._parse_secret_path(secret_path)
         if self.kv_engine_version == 1:
-            response = self.client.secrets.kv.v1.create_or_update_secret(
-                path=secret_path, secret=secret, mount_point=mount_point, method=method
+            response = self._run_with_reauth(
+                lambda client: client.secrets.kv.v1.create_or_update_secret(
+                    path=secret_path, secret=secret, mount_point=mount_point, method=method
+                )
             )
         else:
-            response = self.client.secrets.kv.v2.create_or_update_secret(
-                path=secret_path, secret=secret, mount_point=mount_point, cas=cas
+            response = self._run_with_reauth(
+                lambda client: client.secrets.kv.v2.create_or_update_secret(
+                    path=secret_path, secret=secret, mount_point=mount_point, cas=cas
+                )
             )
         return response

--- a/providers/hashicorp/src/airflow/providers/hashicorp/hooks/vault.py
+++ b/providers/hashicorp/src/airflow/providers/hashicorp/hooks/vault.py
@@ -314,6 +314,8 @@ class VaultHook(BaseHook):
 
         :return: connection used.
         """
+        if not self.vault_client.client.is_authenticated():
+            self.vault_client._invalidate_client()
         return self.vault_client.client
 
     def get_secret(self, secret_path: str, secret_version: int | None = None) -> dict | None:
@@ -436,7 +438,9 @@ class VaultHook(BaseHook):
     def test_connection(self) -> tuple[bool, str]:
         """Test Vault connectivity from UI."""
         try:
-            self.get_conn()
+            # get_conn() rebuilds a dead client but does not itself fail, so check explicitly for authentication.
+            if not self.get_conn().is_authenticated():
+                return False, "Vault Authentication Error!"
             return True, "Connection successfully tested"
         except Exception as e:
             return False, str(e)

--- a/providers/hashicorp/tests/unit/hashicorp/_internal_client/test_vault_client.py
+++ b/providers/hashicorp/tests/unit/hashicorp/_internal_client/test_vault_client.py
@@ -21,7 +21,7 @@ from unittest import mock
 from unittest.mock import call, mock_open, patch
 
 import pytest
-from hvac.exceptions import InvalidPath, VaultError
+from hvac.exceptions import Forbidden, InvalidPath, VaultError
 from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
@@ -83,7 +83,6 @@ class TestVaultClient:
         client = vault_client.client
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.approle.login.assert_called_with(role_id="role", secret_id="pass")
-        client.is_authenticated.assert_called_with()
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -101,7 +100,6 @@ class TestVaultClient:
         client = vault_client.client
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.approle.login.assert_called_with(role_id="role", secret_id="pass", mount_point="other")
-        client.is_authenticated.assert_called_with()
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -130,7 +128,6 @@ class TestVaultClient:
             secret_key="pass",
             role="role",
         )
-        client.is_authenticated.assert_called_with()
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -151,7 +148,6 @@ class TestVaultClient:
         client.auth.aws.iam_login.assert_called_with(
             access_key="user", secret_key="pass", role="role", mount_point="other"
         )
-        client.is_authenticated.assert_called_with()
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -175,7 +171,6 @@ class TestVaultClient:
             role="role",
             region="us-east-2",
         )
-        client.is_authenticated.assert_called_with()
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -199,7 +194,6 @@ class TestVaultClient:
             client_id="user",
             client_secret="pass",
         )
-        client.is_authenticated.assert_called_with()
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -225,7 +219,6 @@ class TestVaultClient:
             client_secret="pass",
             mount_point="other",
         )
-        client.is_authenticated.assert_called_with()
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -309,7 +302,6 @@ class TestVaultClient:
         assert payload["sub"] == "service_account_email"
 
         client.auth.gcp.login.assert_called_with(role="role", jwt="mocked_jwt")
-        client.is_authenticated.assert_called_with()
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.google.cloud.utils.credentials_provider._get_scopes")
@@ -363,7 +355,6 @@ class TestVaultClient:
         assert payload["sub"] == "service_account_email"
 
         client.auth.gcp.login.assert_called_with(role="role", jwt="mocked_jwt")
-        client.is_authenticated.assert_called_with()
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.google.cloud.utils.credentials_provider._get_scopes")
@@ -418,7 +409,6 @@ class TestVaultClient:
         assert payload["sub"] == "service_account_email"
 
         client.auth.gcp.login.assert_called_with(role="role", jwt="mocked_jwt")
-        client.is_authenticated.assert_called_with()
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.google.cloud.utils.credentials_provider._get_scopes")
@@ -480,7 +470,6 @@ class TestVaultClient:
         assert payload["sub"] == "service_account_email"
 
         client.auth.gcp.login.assert_called_with(role="role", jwt="mocked_jwt", mount_point="other")
-        client.is_authenticated.assert_called_with()
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.google.cloud.utils.credentials_provider._get_scopes")
@@ -536,7 +525,6 @@ class TestVaultClient:
         assert payload["sub"] == "service_account_email"
 
         client.auth.gcp.login.assert_called_with(role="role", jwt="mocked_jwt")
-        client.is_authenticated.assert_called_with()
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.google.cloud.utils.credentials_provider._get_scopes")
@@ -572,7 +560,6 @@ class TestVaultClient:
         client = vault_client.client
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.github.login.assert_called_with(token="s.7AU0I51yv1Q1lxOIg1F3ZRAS")
-        client.is_authenticated.assert_called_with()
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -589,7 +576,6 @@ class TestVaultClient:
         client = vault_client.client
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.github.login.assert_called_with(token="s.7AU0I51yv1Q1lxOIg1F3ZRAS", mount_point="other")
-        client.is_authenticated.assert_called_with()
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -608,12 +594,11 @@ class TestVaultClient:
             auth_type="kubernetes", kubernetes_role="kube_role", url="http://localhost:8180", session=None
         )
         with patch("builtins.open", mock_open(read_data="data")) as mock_file:
-            client = vault_client.client
+            vault_client.client
         mock_file.assert_called_with("/var/run/secrets/kubernetes.io/serviceaccount/token")
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         mock_kubernetes.assert_called_with(mock_client.adapter)
         mock_kubernetes.return_value.login.assert_called_with(role="kube_role", jwt="data")
-        client.is_authenticated.assert_called_with()
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -629,12 +614,11 @@ class TestVaultClient:
             session=None,
         )
         with patch("builtins.open", mock_open(read_data="data")) as mock_file:
-            client = vault_client.client
+            vault_client.client
         mock_file.assert_called_with("path")
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         mock_kubernetes.assert_called_with(mock_client.adapter)
         mock_kubernetes.return_value.login.assert_called_with(role="kube_role", jwt="data")
-        client.is_authenticated.assert_called_with()
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -651,14 +635,13 @@ class TestVaultClient:
             session=None,
         )
         with patch("builtins.open", mock_open(read_data="data")) as mock_file:
-            client = vault_client.client
+            vault_client.client
         mock_file.assert_called_with("path")
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         mock_kubernetes.assert_called_with(mock_client.adapter)
         mock_kubernetes.return_value.login.assert_called_with(
             role="kube_role", jwt="data", mount_point="other"
         )
-        client.is_authenticated.assert_called_with()
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -696,7 +679,6 @@ class TestVaultClient:
         assert client.auth.jwt.jwt_login.call_args_list == [
             call(role="my-role", jwt="eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test")
         ]
-        assert client.is_authenticated.call_args_list == [call(), call()]
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -717,7 +699,6 @@ class TestVaultClient:
         assert client.auth.jwt.jwt_login.call_args_list == [
             call(role="my-role", jwt="eyJhbGciOiJSUzI1NiJ9.jwt-from-file")
         ]
-        assert client.is_authenticated.call_args_list == [call(), call()]
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -751,7 +732,6 @@ class TestVaultClient:
         assert client.auth.jwt.jwt_login.call_args_list == [
             call(role="my-role", jwt="eyJhbGciOiJSUzI1NiJ9.test", path="custom-jwt")
         ]
-        assert client.is_authenticated.call_args_list == [call(), call()]
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -787,7 +767,6 @@ class TestVaultClient:
         client = vault_client.client
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.ldap.login.assert_called_with(username="user", password="pass")
-        client.is_authenticated.assert_called_with()
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -805,7 +784,6 @@ class TestVaultClient:
         client = vault_client.client
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.ldap.login.assert_called_with(username="user", password="pass", mount_point="other")
-        client.is_authenticated.assert_called_with()
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -836,7 +814,6 @@ class TestVaultClient:
         client = vault_client.client
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.radius.configure.assert_called_with(host="radhost", secret="pass", port=None)
-        client.is_authenticated.assert_called_with()
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -856,7 +833,6 @@ class TestVaultClient:
         client.auth.radius.configure.assert_called_with(
             host="radhost", secret="pass", port=None, mount_point="other"
         )
-        client.is_authenticated.assert_called_with()
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -874,7 +850,6 @@ class TestVaultClient:
         client = vault_client.client
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.radius.configure.assert_called_with(host="radhost", secret="pass", port=8110)
-        client.is_authenticated.assert_called_with()
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -893,7 +868,6 @@ class TestVaultClient:
         )
         client = vault_client.client
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
-        client.is_authenticated.assert_called_with()
         assert client.token == "s.7AU0I51yv1Q1lxOIg1F3ZRAS"
         assert vault_client.kv_engine_version == 2
         assert vault_client.mount_point == "secret"
@@ -906,7 +880,6 @@ class TestVaultClient:
         vault_client = _VaultClient(auth_type="token", url="http://localhost:8180", session=None)
         client = vault_client.client
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
-        client.is_authenticated.assert_called_with()
         assert client.token == "s.7AU0I51yv1Q1lxOIg1F3ZRAS"
         assert vault_client.kv_engine_version == 2
         assert vault_client.mount_point == "secret"
@@ -922,7 +895,6 @@ class TestVaultClient:
         )
         client = vault_client.client
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
-        client.is_authenticated.assert_called_with()
         assert client.token == "s.7AU0I51yv1Q1lxOIg1F3ZRAS"
         assert vault_client.kv_engine_version == 2
         assert vault_client.mount_point == "secret"
@@ -938,7 +910,6 @@ class TestVaultClient:
         )
         client = vault_client.client
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
-        client.is_authenticated.assert_called_with()
         assert client.token == "s.7AU0I51yv1Q1lxOIg1F3ZRAS"
         assert vault_client.kv_engine_version == 2
         assert vault_client.mount_point == "secret"
@@ -952,7 +923,6 @@ class TestVaultClient:
         )
         client = vault_client.client
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
-        client.is_authenticated.assert_called_with()
         assert client.token == "s.7AU0I51yv1Q1lxOIg1F3ZRAS"
         assert vault_client.auth_type == "token"
         assert vault_client.kv_engine_version == 2
@@ -968,7 +938,6 @@ class TestVaultClient:
         client = vault_client.client
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.userpass.login.assert_called_with(username="user", password="pass")
-        client.is_authenticated.assert_called_with()
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -986,7 +955,6 @@ class TestVaultClient:
         client = vault_client.client
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         client.auth.userpass.login.assert_called_with(username="user", password="pass", mount_point="other")
-        client.is_authenticated.assert_called_with()
         assert vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -1629,29 +1597,74 @@ class TestVaultClient:
             mount_point="secret", path="path", secret={"key": "value"}, method="post"
         )
 
-    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
-    def test_cached_property_invalidates_on_auth_failure(self, mock_hvac):
-        mock_client = mock.MagicMock()
-        mock_hvac.Client.return_value = mock_client
-
-        vault_client = _VaultClient(
+    @staticmethod
+    def _radius_client(kv_engine_version=1):
+        return _VaultClient(
             auth_type="radius",
             radius_host="radhost",
             radius_port=8110,
             radius_secret="pass",
-            kv_engine_version=1,
+            kv_engine_version=kv_engine_version,
             url="http://localhost:8180",
         )
 
-        # Assert that the original mock_client is returned
+    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
+    def test_client_is_cached_and_never_probed(self, mock_hvac):
+        mock_client = mock.MagicMock()
+        mock_hvac.Client.return_value = mock_client
+
+        vault_client = self._radius_client()
         assert vault_client.client == mock_client
 
-        # Prove that the mock_client is cached by changing the return
-        # value, but still receive the original mock client
-        mock_client_2 = mock.MagicMock()
-        mock_hvac.Client.return_value = mock_client_2
+        mock_hvac.Client.return_value = mock.MagicMock()
         assert vault_client.client == mock_client
-        mock_client.is_authenticated.return_value = False
-        # assert that when the client is not authenticated the cache
-        # is invalidated, therefore returning the second client
-        assert vault_client.client == mock_client_2
+
+        vault_client.get_secret(secret_path="path")
+        mock_client.is_authenticated.assert_not_called()
+
+    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
+    def test_get_secret_reauthenticates_and_retries_once_when_token_rejected(self, mock_hvac):
+        rejecting_client = mock.MagicMock()
+        rejecting_client.secrets.kv.v1.read_secret.side_effect = Forbidden("permission denied")
+        fresh_client = mock.MagicMock()
+        fresh_client.secrets.kv.v1.read_secret.return_value = {"data": {"secret_key": "secret_value"}}
+        mock_hvac.Client.side_effect = [rejecting_client, fresh_client]
+
+        assert self._radius_client().get_secret(secret_path="path") == {"secret_key": "secret_value"}
+
+        assert mock_hvac.Client.call_count == 2
+        rejecting_client.secrets.kv.v1.read_secret.assert_called_once_with(path="path", mount_point="secret")
+        fresh_client.secrets.kv.v1.read_secret.assert_called_once_with(path="path", mount_point="secret")
+
+    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
+    def test_get_secret_raises_vault_error_when_retry_is_also_rejected(self, mock_hvac):
+        mock_client = mock.MagicMock()
+        mock_client.secrets.kv.v1.read_secret.side_effect = Forbidden("permission denied")
+        mock_hvac.Client.return_value = mock_client
+
+        with pytest.raises(VaultError, match="Vault Authentication Error!"):
+            self._radius_client().get_secret(secret_path="path")
+
+        assert mock_client.secrets.kv.v1.read_secret.call_count == 2
+
+    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
+    def test_create_or_update_secret_reauthenticates_and_retries_once(self, mock_hvac):
+        rejecting_client = mock.MagicMock()
+        rejecting_client.secrets.kv.v1.create_or_update_secret.side_effect = Forbidden("permission denied")
+        fresh_client = mock.MagicMock()
+        mock_hvac.Client.side_effect = [rejecting_client, fresh_client]
+
+        self._radius_client().create_or_update_secret(secret_path="path", secret={"key": "value"})
+
+        fresh_client.secrets.kv.v1.create_or_update_secret.assert_called_once_with(
+            path="path", secret={"key": "value"}, mount_point="secret", method=None
+        )
+
+    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
+    def test_auth_method_producing_no_token_raises_error(self, mock_hvac):
+        mock_client = mock.MagicMock()
+        mock_client.token = None
+        mock_hvac.Client.return_value = mock_client
+
+        with pytest.raises(VaultError, match="Vault Authentication Error!"):
+            _ = self._radius_client().client

--- a/providers/hashicorp/tests/unit/hashicorp/hooks/test_vault.py
+++ b/providers/hashicorp/tests/unit/hashicorp/hooks/test_vault.py
@@ -191,7 +191,6 @@ class TestVaultHook:
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url=expected_url, session=None)
         test_client.auth.approle.login.assert_called_with(role_id="user", secret_id="pass")
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @pytest.mark.parametrize(
@@ -226,7 +225,6 @@ class TestVaultHook:
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url=expected_url, session=None)
         test_client.auth.approle.login.assert_called_with(role_id="user", secret_id="pass")
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
@@ -252,7 +250,6 @@ class TestVaultHook:
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.approle.login.assert_called_with(role_id="user", secret_id="pass")
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
@@ -276,7 +273,6 @@ class TestVaultHook:
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.approle.login.assert_called_with(role_id="user", secret_id="pass")
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
@@ -289,7 +285,6 @@ class TestVaultHook:
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url="https://vault.example.com", session=None)
         test_client.auth.approle.login.assert_called_with(role_id="role", secret_id="secret")
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
@@ -318,7 +313,6 @@ class TestVaultHook:
         test_client.auth.aws.iam_login.assert_called_with(
             access_key="user", secret_key="pass", role="role", region="us-east-2"
         )
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
@@ -361,7 +355,6 @@ class TestVaultHook:
         test_client.auth.aws.iam_login.assert_called_with(
             access_key="login", secret_key="pass", role="role", region="us-east-2"
         )
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
@@ -393,7 +386,6 @@ class TestVaultHook:
             client_id="user",
             client_secret="pass",
         )
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
@@ -426,7 +418,6 @@ class TestVaultHook:
             client_id="user",
             client_secret="pass",
         )
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.google.cloud.utils.credentials_provider._get_scopes")
@@ -479,7 +470,6 @@ class TestVaultHook:
         )
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.gcp.login.assert_called_with(role="role", jwt="mocked_jwt")
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.google.cloud.utils.credentials_provider._get_scopes")
@@ -534,7 +524,6 @@ class TestVaultHook:
         )
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.gcp.login.assert_called_with(role="role", jwt="mocked_jwt")
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.google.cloud.utils.credentials_provider._get_scopes")
@@ -588,7 +577,6 @@ class TestVaultHook:
         )
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.gcp.login.assert_called_with(role="role", jwt="mocked_jwt")
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
@@ -613,7 +601,6 @@ class TestVaultHook:
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.github.login.assert_called_with(token="pass")
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
@@ -639,7 +626,6 @@ class TestVaultHook:
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.github.login.assert_called_with(token="pass")
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
@@ -663,13 +649,12 @@ class TestVaultHook:
 
         with patch("builtins.open", mock_open(read_data="data")) as mock_file:
             test_hook = VaultHook(**kwargs)
-            test_client = test_hook.get_conn()
+            test_hook.get_conn()
         mock_get_connection.assert_called_with("vault_conn_id")
         mock_file.assert_called_with("/var/run/secrets/kubernetes.io/serviceaccount/token")
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         mock_kubernetes.assert_called_with(mock_client.adapter)
         mock_kubernetes.return_value.login.assert_called_with(role="kube_role", jwt="data")
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
@@ -694,13 +679,12 @@ class TestVaultHook:
         }
         with patch("builtins.open", mock_open(read_data="data")) as mock_file:
             test_hook = VaultHook(**kwargs)
-            test_client = test_hook.get_conn()
+            test_hook.get_conn()
         mock_get_connection.assert_called_with("vault_conn_id")
         mock_file.assert_called_with("path")
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         mock_kubernetes.assert_called_with(mock_client.adapter)
         mock_kubernetes.return_value.login.assert_called_with(role="kube_role", jwt="data")
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
@@ -724,13 +708,12 @@ class TestVaultHook:
         }
         with patch("builtins.open", mock_open(read_data="data")) as mock_file:
             test_hook = VaultHook(**kwargs)
-            test_client = test_hook.get_conn()
+            test_hook.get_conn()
         mock_get_connection.assert_called_with("vault_conn_id")
         mock_file.assert_called_with("path")
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         mock_kubernetes.assert_called_with(mock_client.adapter)
         mock_kubernetes.return_value.login.assert_called_with(role="kube_role", jwt="data")
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
@@ -755,7 +738,6 @@ class TestVaultHook:
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.jwt.jwt_login.assert_called_with(role="my-role", jwt="eyJhbGciOiJSUzI1NiJ9.test")
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
@@ -781,7 +763,6 @@ class TestVaultHook:
         test_client.auth.jwt.jwt_login.assert_called_with(
             role="my-role", jwt="eyJhbGciOiJSUzI1NiJ9.dejson-test"
         )
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
@@ -809,7 +790,6 @@ class TestVaultHook:
         test_client.auth.jwt.jwt_login.assert_called_with(
             role="my-role", jwt="eyJhbGciOiJSUzI1NiJ9.from-file"
         )
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
@@ -831,7 +811,7 @@ class TestVaultHook:
         mock_connection.extra_dejson.get.side_effect = connection_dict.get
         kwargs = {"vault_conn_id": "vault_conn_id", "generic_arg": "generic_val0", "session": None}
         test_hook = VaultHook(**kwargs)
-        test_client = test_hook.get_conn()
+        test_hook.get_conn()
         mock_get_connection.assert_called_with("vault_conn_id")
         mock_hvac.Client.assert_called_with(
             url="http://localhost:8180",
@@ -840,7 +820,6 @@ class TestVaultHook:
             generic_arg="generic_val0",
             session=None,
         )
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
@@ -865,7 +844,6 @@ class TestVaultHook:
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.ldap.login.assert_called_with(username="user", password="pass")
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
@@ -891,7 +869,6 @@ class TestVaultHook:
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.ldap.login.assert_called_with(username="user", password="pass")
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
@@ -917,7 +894,6 @@ class TestVaultHook:
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.radius.configure.assert_called_with(host="radhost", secret="pass", port=None)
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
@@ -944,7 +920,6 @@ class TestVaultHook:
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.radius.configure.assert_called_with(host="radhost", secret="pass", port=8123)
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
@@ -972,7 +947,6 @@ class TestVaultHook:
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.radius.configure.assert_called_with(host="radhost", secret="pass", port=8123)
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
@@ -1016,7 +990,6 @@ class TestVaultHook:
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
-        test_client.is_authenticated.assert_called_with()
         assert test_client.token == "pass"
         assert test_hook.vault_client.kv_engine_version == 2
         assert test_hook.vault_client.mount_point == "secret"
@@ -1043,7 +1016,6 @@ class TestVaultHook:
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
-        test_client.is_authenticated.assert_called_with()
         assert test_client.token == "pass"
         assert test_hook.vault_client.kv_engine_version == 2
 
@@ -1070,7 +1042,6 @@ class TestVaultHook:
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.userpass.login.assert_called_with(username="user", password="pass")
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
@@ -1096,7 +1067,6 @@ class TestVaultHook:
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
         test_client.auth.userpass.login.assert_called_with(username="user", password="pass")
-        test_client.is_authenticated.assert_called_with()
         assert test_hook.vault_client.kv_engine_version == 2
 
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
@@ -1385,6 +1355,64 @@ class TestVaultHook:
         mock_client.secrets.kv.v1.create_or_update_secret.assert_called_once_with(
             mount_point="secret", path="path", secret={"key": "value"}, method=expected_method
         )
+
+    @pytest.mark.parametrize(
+        ("authenticated", "expected"),
+        [
+            (True, (True, "Connection successfully tested")),
+            (False, (False, "Vault Authentication Error!")),
+        ],
+    )
+    @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
+    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
+    def test_test_connection(self, mock_hvac, mock_get_connection, authenticated, expected):
+        mock_connection = self.get_mock_connection()
+        mock_get_connection.return_value = mock_connection
+        mock_client = mock.MagicMock()
+        mock_client.is_authenticated.return_value = authenticated
+        mock_hvac.Client.return_value = mock_client
+
+        connection_dict = {}
+        mock_connection.extra_dejson.get.side_effect = connection_dict.get
+
+        test_hook = VaultHook(vault_conn_id="vault_conn_id", auth_type="token", kv_engine_version=2)
+
+        assert test_hook.test_connection() == expected
+
+    @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
+    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
+    def test_get_conn_rebuilds_the_client_when_the_token_is_dead(self, mock_hvac, mock_get_connection):
+        mock_connection = self.get_mock_connection()
+        mock_get_connection.return_value = mock_connection
+        connection_dict = {}
+        mock_connection.extra_dejson.get.side_effect = connection_dict.get
+
+        stale_client = mock.MagicMock()
+        stale_client.is_authenticated.return_value = False
+        fresh_client = mock.MagicMock()
+        fresh_client.is_authenticated.return_value = True
+        mock_hvac.Client.side_effect = [stale_client, fresh_client]
+
+        test_hook = VaultHook(vault_conn_id="vault_conn_id", auth_type="token", kv_engine_version=2)
+
+        assert test_hook.get_conn() == fresh_client
+
+    @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
+    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
+    def test_get_conn_keeps_a_live_client(self, mock_hvac, mock_get_connection):
+        mock_connection = self.get_mock_connection()
+        mock_get_connection.return_value = mock_connection
+        connection_dict = {}
+        mock_connection.extra_dejson.get.side_effect = connection_dict.get
+
+        mock_client = mock.MagicMock()
+        mock_client.is_authenticated.return_value = True
+        mock_hvac.Client.return_value = mock_client
+
+        test_hook = VaultHook(vault_conn_id="vault_conn_id", auth_type="token", kv_engine_version=2)
+
+        assert test_hook.get_conn() == mock_client
+        assert mock_hvac.Client.call_count == 1
 
 
 class TestConfigurationFromSecrets:

--- a/providers/hashicorp/tests/unit/hashicorp/secrets/test_vault.py
+++ b/providers/hashicorp/tests/unit/hashicorp/secrets/test_vault.py
@@ -20,7 +20,7 @@ import json
 from unittest import mock
 
 import pytest
-from hvac.exceptions import InvalidPath, VaultError
+from hvac.exceptions import Forbidden, InvalidPath, VaultError
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.hashicorp.secrets.vault import VaultBackend
@@ -587,7 +587,7 @@ class TestVaultSecrets:
     def test_auth_failure_raises_error(self, mock_hvac):
         mock_client = mock.MagicMock()
         mock_hvac.Client.return_value = mock_client
-        mock_client.is_authenticated.return_value = False
+        mock_client.secrets.kv.v2.read_secret_version.side_effect = Forbidden("permission denied")
 
         kwargs = {
             "connections_path": "connections",


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

## What and Why

When `VaultBackend` is configured as a secrets backend for airflow, fetching one secret from Vault costs four HTTP requests today. Only one of them reads the secret.

| Request | Source |
|---|---|
| `POST auth/approle/login` | `_VaultClient._client` |
| `GET auth/token/lookup-self` | post-login check in `_client` |
| `GET auth/token/lookup-self` | staleness check in the `client` property |
| `GET <mount>/data/<path>` | the read |

Neither validation is local. `hvac.Client.is_authenticated()` calls `lookup_token()`, which issues `auth/token/lookup-self` over the network every time it is asked.

The first check runs immediately after a successful login, against a token whose login response has already been received. The second guards a cached client against expiry, which is reasonable in isolation, but the secrets
backend is rebuilt on every lookup so that client never lives long enough to need guarding.

This replaces both with reactive validation instead. Issue the request, and if Vault rejects the token with a 403, authenticate again and retry once. Vault answers 403 for both an expired token and an unreadable path, so a single retry is the only way to tell them apart without paying a round trip before every request.

## Improvements

Set up airflow with a running hashicorp vault docker image by confuguring these envs:
```shell
AIRFLOW__SECRETS__BACKEND=airflow.providers.hashicorp.secrets.vault.VaultBackend
AIRFLOW__SECRETS__BACKEND_KWARGS='{"url":"http://vault-test:8200","auth_type":"approle","role_id":"blahblah","secret_id":"blahblah","mount_point":"secret","variables_path":"variables","connections_path":null,"config_path":null}'

```

Enabled audit logs on vault using: `vault audit enable file file_path=/vault/logs/audit.log`

Placed two variables on vault using:
```shell
vault kv put -mount=secret variables/demo value=hello
vault kv put -mount=secret variables/demo2 value=world
```

### One variable lookup

Before and after changes run on `airflow variables get demo`:

Before:

```shell
amoghrajesh.desai  …/airflow   vault-login-cost-reduction $!?    orbstack  ♥ 12:30  docker exec vault-test cat /vault/logs/audit.log \
  | jq -r 'select(.type=="request") | .request.path' | sort | uniq -c
   1 auth/approle/login
   2 auth/token/lookup-self
   1 secret/data/variables/demo
```

After:

```shell
amoghrajesh.desai  …/airflow   vault-login-cost-reduction $!?    orbstack  ♥ 12:26  docker exec vault-test cat /vault/logs/audit.log \
  | jq -r 'select(.type=="request") | .request.path' | sort | uniq -c
   1 auth/approle/login
   1 secret/data/variables/demo
```


### Two variable lookup

Before and after changes, ran: `airflow variables get demo` and then `airflow variables get demo2` in same session

Before:
```shell
amoghrajesh.desai  …/airflow   vault-login-cost-reduction $!?    orbstack  ♥ 12:31  docker exec vault-test cat /vault/logs/audit.log \
  | jq -r 'select(.type=="request") | .request.path' | sort | uniq -c
   2 auth/approle/login
   4 auth/token/lookup-self
   1 secret/data/variables/demo
   1 secret/data/variables/demo2
```

After:
```shell
amoghrajesh.desai  …/airflow   vault-login-cost-reduction $!?    orbstack  ♥ 12:32  docker exec vault-test cat /vault/logs/audit.log \
  | jq -r 'select(.type=="request") | .request.path' | sort | uniq -c                                                                                                                                                     2 auth/approle/login
   1 secret/data/variables/demo
   1 secret/data/variables/demo2
```

### Summary

<img width="589" height="135" alt="image" src="https://github.com/user-attachments/assets/5cb77e03-d7ce-46c2-9454-fdac93a8015c" />


**Scales linearly. Two variables fetched in one process: 8 requests before, 4 after.**

## Behaviour / Backcompat

`VaultHook.get_conn()` hands the raw client to callers who then issue their own requests, so they cannot benefit from the retry the wrapped methods use. It keeps validating and rebuilding exactly as before, which preserves transparent
re-authentication for that public entry point. The secrets backend never goes through `get_conn()`, so its hot path stays probe free and gets the full reduction.

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
