### PR TITLE
Keep the HTTPError when a Dataprep error body is not JSON

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/hooks/dataprep.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/dataprep.py
@@ -219,8 +219,21 @@ class GoogleDataprepHook(BaseHook):
         try:
             response.raise_for_status()
         except HTTPError:
-            self.log.error(response.json().get("exception"))
+            self.log.error(self._error_message(response))
             raise
+
+    @staticmethod
+    def _error_message(response: requests.models.Response) -> Any:
+        """Return the error detail from the response, falling back to its raw body.
+
+        An error response does not always carry a JSON object: a proxy or gateway
+        can answer with HTML or an empty payload, and parsing that here would
+        replace the HTTPError we are about to re-raise.
+        """
+        try:
+            return response.json().get("exception")
+        except (ValueError, AttributeError):
+            return response.text
 
     @retry(stop=stop_after_attempt(5), wait=wait_exponential(multiplier=1, max=10))
     def create_imported_dataset(self, *, body_request: dict) -> dict:

--- a/providers/google/tests/unit/google/cloud/hooks/test_dataprep.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_dataprep.py
@@ -24,6 +24,7 @@ from unittest.mock import patch
 
 import pytest
 from requests import HTTPError
+from requests.exceptions import JSONDecodeError
 from tenacity import RetryError
 
 from airflow.providers.google.cloud.hooks.dataprep import GoogleDataprepHook
@@ -852,3 +853,53 @@ class TestGoogleDataprepFlowPathHooks:
             )
         assert "HTTPError" in str(ctx.value)
         assert mock_get_request.call_count == 5
+
+
+class TestGoogleDataprepHookRaiseForStatus:
+    """`_raise_for_status` must always re-raise the HTTPError.
+
+    The error body is only used to log a detail, so it must not be able to
+    replace the exception being reported.
+    """
+
+    def setup_method(self):
+        with mock.patch(f"{BASEHOOK_PATCH_PATH}.get_connection") as conn:
+            conn.return_value.extra_dejson = EXTRA
+            self.hook = GoogleDataprepHook(dataprep_conn_id="dataprep_default")
+
+    @staticmethod
+    def _failing_response(**kwargs):
+        response = mock.MagicMock()
+        response.raise_for_status.side_effect = HTTPError()
+        for key, value in kwargs.items():
+            setattr(response, key, value)
+        return response
+
+    def test_raises_http_error_for_json_body(self):
+        response = self._failing_response()
+        response.json.return_value = {"exception": {"message": "boom"}}
+
+        with pytest.raises(HTTPError):
+            self.hook._raise_for_status(response)
+
+    def test_raises_http_error_when_body_is_not_json(self):
+        """A gateway can answer with HTML, which used to raise JSONDecodeError."""
+        response = self._failing_response(text="<html>502 Bad Gateway</html>")
+        response.json.side_effect = JSONDecodeError("Expecting value", "", 0)
+
+        with pytest.raises(HTTPError):
+            self.hook._raise_for_status(response)
+
+    def test_raises_http_error_when_body_is_not_an_object(self):
+        """A JSON array has no `get`, which used to raise AttributeError."""
+        response = self._failing_response(text='["boom"]')
+        response.json.return_value = ["boom"]
+
+        with pytest.raises(HTTPError):
+            self.hook._raise_for_status(response)
+
+    def test_does_not_raise_for_a_successful_response(self):
+        response = mock.MagicMock()
+        response.raise_for_status.return_value = None
+
+        assert self.hook._raise_for_status(response) is None


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.
-->

`GoogleDataprepHook._raise_for_status` logs a detail from the error body before re-raising,
but it parses that body inside the handler with no guard:

```python
def _raise_for_status(self, response: requests.models.Response) -> None:
    try:
        response.raise_for_status()
    except HTTPError:
        self.log.error(response.json().get("exception"))
        raise
```

When the body is not a JSON object, `response.json()` raises and replaces the `HTTPError`, so
the `raise` on the next line never runs and the caller loses the real status. `.get()` also
assumes the parsed body is a dict.

Behaviour before and after, for the same failing response:

| error body | before | after |
|---|---|---|
| `{"exception": {...}}` | `HTTPError` | `HTTPError` |
| `<html>502 Bad Gateway</html>` | `JSONDecodeError` | `HTTPError` |
| empty | `JSONDecodeError` | `HTTPError` |
| `["boom"]` | `AttributeError` | `HTTPError` |

A proxy or load balancer in front of Dataprep answering 502 with an HTML page, or an empty
401 or 504, is enough to trigger it.

This matters beyond one call site: every Dataprep API method on the hook funnels through
`_raise_for_status`, so the masking applies to all of them.

The fix reads the detail through a small helper that falls back to `response.text`, so the
`HTTPError` is always what propagates. The successful path is unchanged.

### Tests

Four cases added covering a well-formed JSON body, a non-JSON body, a JSON array body, and a
successful response, each asserting that the `HTTPError` is what surfaces.

I was not able to run the provider suite locally, since Airflow is not installed in this
environment. The before and after table above comes from exercising the handler's logic
directly with the same four bodies.

---

<!-- Please keep an empty line above the dashes. -->
^ Add meaningful description above
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improyments+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
