### PR TITLE
Fix scheduler DBDagBag unbounded cache

### DIFF
--- a/airflow-core/newsfragments/71704.bugfix.rst
+++ b/airflow-core/newsfragments/71704.bugfix.rst
@@ -1,0 +1,1 @@
+The scheduler's Dag cache is now a bounded LRU of 512 versions, so scheduler memory no longer grows with every Dag version the process has ever seen.

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -155,6 +155,18 @@ DM = DagModel
 TASK_STUCK_IN_QUEUED_RESCHEDULE_EVENT = "stuck in queued reschedule"
 """:meta private:"""
 
+SCHEDULER_DAG_CACHE_SIZE = 512
+"""
+Max deserialized Dag versions the scheduler keeps in memory.
+
+The scheduler reaches its DagBag through the Dag version of each active Dag run, so an
+unbounded cache retains every version the process has ever seen and grows for the life of
+the process. Sized to sit above the versions-with-runs-in-flight working set of a typical
+deployment, so eviction costs a re-fetch only where that working set is genuinely larger.
+
+:meta private:
+"""
+
 # Per-tick cap on pending AssetPartitionDagRun rows the scheduler evaluates.
 # Bounds the per-tick transaction so executor heartbeats and regular scheduling
 # aren't starved; remaining APDRs drain across subsequent ticks.
@@ -370,7 +382,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         if log:
             self._log = log
 
-        self.scheduler_dag_bag = DBDagBag(load_op_links=False)
+        self.scheduler_dag_bag = DBDagBag(load_op_links=False, cache_size=SCHEDULER_DAG_CACHE_SIZE)
 
         # Set of (dag_id, asset_name, asset_uri) tuples for trigger policies that
         # are permanently unreachable for the rollup window's cardinality — the

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -64,7 +64,7 @@ from airflow.executors.executor_loader import ExecutorLoader
 from airflow.executors.executor_utils import ExecutorName
 from airflow.executors.local_executor import LocalExecutor
 from airflow.jobs.job import Job, run_job
-from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
+from airflow.jobs.scheduler_job_runner import SCHEDULER_DAG_CACHE_SIZE, SchedulerJobRunner
 from airflow.models.asset import (
     AssetActive,
     AssetAliasModel,
@@ -413,6 +413,15 @@ class TestSchedulerJob:
 
         assert scheduler_job.executor == mock_local_executor
         assert scheduler_job.executors == [mock_local_executor]
+
+    def test_scheduler_dag_bag_is_bounded(self):
+        """The scheduler's Dag cache must evict, or it retains every version it has ever seen."""
+        from cachetools import LRUCache
+
+        job_runner = SchedulerJobRunner(Job())
+
+        assert isinstance(job_runner.scheduler_dag_bag._dags, LRUCache)
+        assert job_runner.scheduler_dag_bag._dags.maxsize == SCHEDULER_DAG_CACHE_SIZE
 
     @pytest.mark.parametrize(
         "heartrate",


### PR DESCRIPTION
- closes: #69001
- supersedes: #69774, #69007
- deferred work: #71814, #71815, #71816

## Why

The scheduler kept every Dag version it deserialized in a mapping that never evicted, so a long-running scheduler grew with the number of versions it had ever seen until it was restarted or OOM killed. Deployments that redeploy Dags frequently accumulate versions fastest and hit this soonest.

## How

One line. `DBDagBag` already builds a bounded LRU cache when given a `cache_size`; the scheduler simply never passed one.

```python
-        self.scheduler_dag_bag = DBDagBag(load_op_links=False)
+        self.scheduler_dag_bag = DBDagBag(load_op_links=False, cache_size=SCHEDULER_DAG_CACHE_SIZE)
```

No changes to `DBDagBag`, to the API server, or to configuration — deliberately, so this cherry-picks cleanly.

## Why a size cap rather than a TTL

A least-recently-used cap is the only thing that bounds the cache outright. An idle timeout would not: `_get_dag` re-checks an entry on each lookup, and cachetools re-arms expiry on assignment, so a TTL reclaims a version only once its runs finish and it stops being requested. That leaves memory a function of the concurrently active set rather than a fixed ceiling.

Where the working set exceeds the cap, the evicted version is re-fetched and deserialized on the next loop. Correctness is unaffected — a cache miss is a re-read, never a wrong Dag.

## Known limitation

Enabling the cache also enables `DBDagBag`'s metrics, which are currently hard-coded to `api_server.dag_bag.*`. Those counters therefore now include scheduler traffic. Giving each component its own namespace requires a `DBDagBag` API change, deferred to #71815. Making the cap configurable is #71816, and #71814 fixes `[api] dag_cache_size = 0` silently ignoring `[api] dag_cache_ttl`.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

