### PR TITLE
Fix InfluxDB hook methods failing when called before get_conn

### DIFF
--- a/providers/influxdb/src/airflow/providers/influxdb/hooks/influxdb.py
+++ b/providers/influxdb/src/airflow/providers/influxdb/hooks/influxdb.py
@@ -84,7 +84,10 @@ class InfluxDBHook(BaseHook):
     def get_uri(self, conn: Connection):
         """Add additional parameters to the URI based on InfluxDB host requirements."""
         conn_scheme = "https" if conn.schema is None else conn.schema
-        conn_port = 7687 if conn.port is None else conn.port
+        if conn.port is None:
+            conn_port = 443 if conn_scheme == "https" else 8086
+        else:
+            conn_port = conn.port
         return f"{conn_scheme}://{conn.host}:{conn_port}"
 
     def get_conn(self) -> InfluxDBClient:
@@ -136,11 +139,13 @@ class InfluxDBHook(BaseHook):
 
         Example: ``Point("my_measurement").tag("location", "Prague").field("temperature", 25.3)``
         """
+        client = self.get_conn()
+
         # By defaults its Batching
         if synchronous:
-            write_api = self.client.write_api(write_options=SYNCHRONOUS)
+            write_api = client.write_api(write_options=SYNCHRONOUS)
         else:
-            write_api = self.client.write_api()
+            write_api = client.write_api()
 
         p = Point(point_name).tag(tag_name, tag_value).field(field_name, field_value)
 
@@ -148,25 +153,29 @@ class InfluxDBHook(BaseHook):
 
     def create_organization(self, name):
         """Create a new organization."""
-        return self.client.organizations_api().create_organization(name=name)
+        return self.get_conn().organizations_api().create_organization(name=name)
 
     def delete_organization(self, org_id):
         """Delete an organization by ID."""
-        return self.client.organizations_api().delete_organization(org_id=org_id)
+        return self.get_conn().organizations_api().delete_organization(org_id=org_id)
 
     def create_bucket(self, bucket_name, description, org_id, retention_rules=None):
         """Create a bucket for an organization."""
-        return self.client.buckets_api().create_bucket(
-            bucket_name=bucket_name, description=description, org_id=org_id, retention_rules=None
+        buckets_api = self.get_conn().buckets_api()
+        return buckets_api.create_bucket(
+            bucket_name=bucket_name,
+            description=description,
+            org_id=org_id,
+            retention_rules=retention_rules,
         )
 
     def find_bucket_id_by_name(self, bucket_name):
         """Get bucket ID by name."""
-        bucket = self.client.buckets_api().find_bucket_by_name(bucket_name)
+        bucket = self.get_conn().buckets_api().find_bucket_by_name(bucket_name)
 
         return "" if bucket is None else bucket.id
 
     def delete_bucket(self, bucket_name):
         """Delete bucket by name."""
         bucket = self.find_bucket_id_by_name(bucket_name)
-        return self.client.buckets_api().delete_bucket(bucket)
+        return self.get_conn().buckets_api().delete_bucket(bucket)

--- a/providers/influxdb/tests/system/influxdb/example_influxdb.py
+++ b/providers/influxdb/tests/system/influxdb/example_influxdb.py
@@ -34,10 +34,13 @@ def test_influxdb_hook():
     influxdb_hook = InfluxDBHook()
     client = influxdb_hook.get_conn()
     print(client)
-    print(f"Organization name {influxdb_hook.org_name}")
+
+    org_name = influxdb_hook.extras["org"]
+    print(f"Organization name {org_name}")
+    org_id = client.organizations_api().find_organizations(org=org_name)[0].id
 
     # Make sure enough permissions to create bucket.
-    influxdb_hook.create_bucket(bucket_name, "Bucket to test influxdb connection", influxdb_hook.org_name)
+    influxdb_hook.create_bucket(bucket_name, "Bucket to test influxdb connection", org_id)
     influxdb_hook.write(bucket_name, "test_point", "location", "Prague", "temperature", 25.3, True)
 
     tables = influxdb_hook.query('from(bucket:"test-influx") |> range(start: -10m)')

--- a/providers/influxdb/tests/unit/influxdb/hooks/test_influxdb.py
+++ b/providers/influxdb/tests/unit/influxdb/hooks/test_influxdb.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
+
 from airflow.models import Connection
 from airflow.providers.influxdb.hooks.influxdb import InfluxDBHook
 
@@ -31,60 +33,103 @@ class TestInfluxDbHook:
         extra["timeout"] = 10000
 
         self.connection = Connection(schema="http", host="localhost", extra=extra)
+        # Every hook method resolves the Airflow connection before touching the
+        # client, so stub it once rather than in each test.
+        self.influxdb_hook.get_connection = mock.Mock(return_value=self.connection)
 
     @mock.patch("airflow.providers.influxdb.hooks.influxdb.InfluxDBClient")
     def test_get_conn(self, influx_db_client):
-        self.influxdb_hook.get_connection = mock.Mock()
-        self.influxdb_hook.get_connection.return_value = self.connection
-
         self.influxdb_hook.get_conn()
 
-        assert self.influxdb_hook.uri == "http://localhost:7687"
+        assert self.influxdb_hook.uri == "http://localhost:8086"
 
         assert self.influxdb_hook.get_connection.return_value.schema == "http"
         assert self.influxdb_hook.get_connection.return_value.host == "localhost"
         influx_db_client.assert_called_once_with(
-            url="http://localhost:7687", token="123456789", org="test", timeout=10000
+            url="http://localhost:8086", token="123456789", org="test", timeout=10000
         )
 
         assert self.influxdb_hook.get_client is not None
 
-    def test_query(self):
-        self.influxdb_hook.get_conn = mock.Mock()
+    @pytest.mark.parametrize(
+        ("schema", "port", "expected_uri"),
+        [
+            pytest.param("http", None, "http://localhost:8086", id="http-defaults-to-8086"),
+            pytest.param("https", None, "https://localhost:443", id="https-defaults-to-443"),
+            pytest.param(None, None, "https://localhost:443", id="no-scheme-defaults-to-https-443"),
+            pytest.param("http", 9999, "http://localhost:9999", id="explicit-port-wins"),
+        ],
+    )
+    def test_get_uri(self, schema, port, expected_uri):
+        conn = Connection(schema=schema, host="localhost", port=port)
 
+        assert self.influxdb_hook.get_uri(conn) == expected_uri
+
+    @mock.patch("airflow.providers.influxdb.hooks.influxdb.InfluxDBClient")
+    def test_write_opens_connection(self, influx_db_client):
+        self.influxdb_hook.write("bucket", "point", "location", "Prague", "temperature", 25.3, True)
+
+        write_api = influx_db_client.return_value.write_api.return_value
+        write_api.write.assert_called_once()
+
+    @mock.patch("airflow.providers.influxdb.hooks.influxdb.InfluxDBClient")
+    def test_create_organization_opens_connection(self, influx_db_client):
+        self.influxdb_hook.create_organization("my-org")
+
+        organizations_api = influx_db_client.return_value.organizations_api.return_value
+        organizations_api.create_organization.assert_called_once_with(name="my-org")
+
+    @mock.patch("airflow.providers.influxdb.hooks.influxdb.InfluxDBClient")
+    def test_delete_organization_opens_connection(self, influx_db_client):
+        self.influxdb_hook.delete_organization("org-id")
+
+        organizations_api = influx_db_client.return_value.organizations_api.return_value
+        organizations_api.delete_organization.assert_called_once_with(org_id="org-id")
+
+    @mock.patch("airflow.providers.influxdb.hooks.influxdb.InfluxDBClient")
+    def test_create_bucket_forwards_retention_rules(self, influx_db_client):
+        retention_rules = mock.sentinel.retention_rules
+
+        self.influxdb_hook.create_bucket("bucket", "description", "org-id", retention_rules)
+
+        buckets_api = influx_db_client.return_value.buckets_api.return_value
+        buckets_api.create_bucket.assert_called_once_with(
+            bucket_name="bucket",
+            description="description",
+            org_id="org-id",
+            retention_rules=retention_rules,
+        )
+
+    @mock.patch("airflow.providers.influxdb.hooks.influxdb.InfluxDBClient")
+    def test_find_bucket_id_by_name_opens_connection(self, influx_db_client):
+        buckets_api = influx_db_client.return_value.buckets_api.return_value
+        buckets_api.find_bucket_by_name.return_value = mock.Mock(id="bucket-id")
+
+        assert self.influxdb_hook.find_bucket_id_by_name("bucket") == "bucket-id"
+
+    @mock.patch("airflow.providers.influxdb.hooks.influxdb.InfluxDBClient")
+    def test_delete_bucket_opens_connection(self, influx_db_client):
+        buckets_api = influx_db_client.return_value.buckets_api.return_value
+        buckets_api.find_bucket_by_name.return_value = mock.Mock(id="bucket-id")
+
+        self.influxdb_hook.delete_bucket("bucket")
+
+        buckets_api.delete_bucket.assert_called_once_with("bucket-id")
+
+    @mock.patch("airflow.providers.influxdb.hooks.influxdb.InfluxDBClient")
+    def test_query(self, influx_db_client):
         influxdb_query = 'SELECT "duration" FROM "pyexample"'
+
         self.influxdb_hook.query(influxdb_query)
 
-        self.influxdb_hook.get_conn.assert_called()
+        query_api = influx_db_client.return_value.query_api.return_value
+        query_api.query.assert_called_once_with(influxdb_query)
 
-    def test_query_to_df(self):
-        self.influxdb_hook.get_conn = mock.Mock()
-
-        self.influxdb_hook.write = mock.Mock()
+    @mock.patch("airflow.providers.influxdb.hooks.influxdb.InfluxDBClient")
+    def test_query_to_df(self, influx_db_client):
         influxdb_query = 'SELECT "duration" FROM "pyexample"'
+
         self.influxdb_hook.query_to_df(influxdb_query)
 
-        self.influxdb_hook.get_conn.assert_called()
-
-    def test_write(self):
-        self.influxdb_hook.get_connection = mock.Mock()
-        self.influxdb_hook.get_connection.return_value = self.connection
-
-        self.influxdb_hook.get_conn = mock.Mock()
-        self.influxdb_hook.client = mock.Mock()
-        self.influxdb_hook.client.write_api = mock.Mock()
-
-        self.influxdb_hook.write("test_bucket", "test_point", "location", "Prague", "temperature", 25.3, True)
-
-        self.influxdb_hook.client.write_api.assert_called()
-
-    def test_find_bucket_by_id(self):
-        self.influxdb_hook.get_connection = mock.Mock()
-        self.influxdb_hook.get_connection.return_value = self.connection
-
-        self.influxdb_hook.client = mock.Mock()
-        self.influxdb_hook.client.buckets_api = mock.Mock()
-
-        self.influxdb_hook.find_bucket_id_by_name("test")
-
-        self.influxdb_hook.client.buckets_api.assert_called()
+        query_api = influx_db_client.return_value.query_api.return_value
+        query_api.query_data_frame.assert_called_once_with(influxdb_query)


### PR DESCRIPTION

`InfluxDBHook.write()` and the five bucket/organization methods read `self.client` directly, but that attribute stays `None` until something calls `get_conn()`. Any Dag that calls them on a fresh hook fails with `AttributeError: 'NoneType' object has no attribute 'write_api'`. 
They now take the client from `self.get_conn()`, which is what `query()` and `query_to_df()` in the same class have always done. `get_conn()` already returns a cached client, so this opens no additional connections.

Three further defects in the same hook are fixed alongside it:

- `get_uri()` fell back to port 7687 — Neo4j's Bolt port — when the connection carried no explicit port, so a connection created without one pointed at an unreachable address. It now defaults to 8086 for `http` and 443 for `https`, matching `InfluxDB3Hook.get_uri()` in the same provider.
- `create_bucket()` accepts a `retention_rules` argument and then passed a hardcoded `None` to the client, silently discarding whatever the caller supplied.
- The system Dag reads `influxdb_hook.org_name`, which has not existed since the constructor moved to `self.extras`. It also passed an organization *name* into `create_bucket()`'s `org_id` parameter, so it now resolves the name to an
  ID first.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)