### PR TITLE
Stop sending GitHub Actions job notifications to the jobs mailing list

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -138,7 +138,6 @@ github:
     - kacpermuda
 
 notifications:
-  jobs: jobs@airflow.apache.org
   commits: commits@airflow.apache.org
   issues: commits@airflow.apache.org
   pullrequests: commits@airflow.apache.org


### PR DESCRIPTION
Removes the `notifications.jobs` entry from `.asf.yaml`, so GitHub Actions
workflow-run notifications are no longer emailed to jobs@airflow.apache.org.

Those notifications are not really useful — nobody acts on them, so routing
them to a mailing list only adds noise.

The `commits` / `issues` / `pullrequests` / `discussions` notification targets
are unchanged.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
