### PR TITLE
UI: Show an empty object for object params with no value

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldObject.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldObject.test.tsx
@@ -1,0 +1,88 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import { Wrapper } from "src/utils/Wrapper";
+
+import { FieldObject } from "./FieldObject";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockParamsDict: Record<string, any> = {};
+const mockSetParamsDict = vi.fn();
+
+vi.mock("src/queries/useParamStore", () => ({
+  paramPlaceholder: {
+    schema: {},
+    value: null,
+  },
+  useParamStore: () => ({
+    disabled: false,
+    paramsDict: mockParamsDict,
+    setParamsDict: mockSetParamsDict,
+  }),
+}));
+
+vi.mock("src/components/MonacoEditor", () => ({
+  default: ({
+    onChange,
+    value,
+  }: {
+    readonly onChange?: (value: string | undefined) => void;
+    readonly value?: string;
+  }) => (
+    <textarea aria-label="JSON editor" onChange={(event) => onChange?.(event.target.value)} value={value} />
+  ),
+}));
+
+vi.mock("src/context/colorMode", () => ({
+  useMonacoTheme: () => ({ beforeMount: vi.fn(), theme: "airflow-light" }),
+}));
+
+describe("FieldObject", () => {
+  beforeEach(() => {
+    Object.keys(mockParamsDict).forEach((key) => {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete mockParamsDict[key];
+    });
+  });
+
+  it("renders an empty object for an object param with no value", () => {
+    mockParamsDict.test_param = {
+      schema: { type: ["object", "null"] },
+      value: null,
+    };
+
+    render(<FieldObject name="test_param" onUpdate={vi.fn()} />, { wrapper: Wrapper });
+
+    expect(screen.getByLabelText("JSON editor")).toHaveValue("{}");
+  });
+
+  it("renders the existing value for an object param that has one", () => {
+    mockParamsDict.test_param = {
+      schema: { type: "object" },
+      value: { key: "value" },
+    };
+
+    render(<FieldObject name="test_param" onUpdate={vi.fn()} />, { wrapper: Wrapper });
+
+    expect(screen.getByLabelText("JSON editor")).toHaveValue(JSON.stringify({ key: "value" }, undefined, 2));
+  });
+});

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldObject.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldObject.tsx
@@ -46,7 +46,7 @@ export const FieldObject = ({ name, namespace = "default", onUpdate }: FlexibleF
       editable={!disabled}
       id={`element_${name}`}
       onChange={handleChange}
-      value={JSON.stringify(param.value ?? [], undefined, 2)}
+      value={JSON.stringify(param.value ?? {}, undefined, 2)}
     />
   );
 };


### PR DESCRIPTION

`FieldObject` renders the JSON editor for params whose declared type is `object` — `FieldSelector` routes arrays to `FieldStringArray`, `FieldAdvancedArray` and `FieldMultiSelect`, so an array never reaches it. It nonetheless falls back to an empty **array** when the param has no value:

```tsx
value={JSON.stringify(param.value ?? [], undefined, 2)}
```

So a param declared as an object but left unset opens the trigger form's editor showing `[]`, and anyone editing it starts from the wrong JSON literal for the field's declared type.

The submitted `conf` is built from `param.value` rather than the editor text, so an untouched field still submits `null` — this is about what the user is shown and edits from, not about the value sent when the field is left alone.

related: #55213

### Tests

Adds `FieldObject.test.tsx` covering both branches of the fallback — a param with no value, and one with an existing value. The first fails before this change (`Expected {} / Received []`) and passes after.

`pnpm lint` (eslint + tsc) is clean and the full `ui` suite passes — 935 tests across 121 files.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
