### PR TITLE
Ignore shadow-gradle-plugin and jsonschema2pojo bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -99,10 +99,14 @@ updates:
       - dependency-name: "*"
         update-types:
           - version-update:semver-major
-      # Pinned to the last shadow-gradle-plugin release that supports Java 11
-      # (see java-sdk/plugin/build.gradle.kts). Ignore minor/patch bumps too,
-      # not just majors, until the SDK's Java 11 support requirement is dropped.
+      # Pinned to the last release that supports Java 11. Ignore minor/patch
+      # bumps too, not just majors, until the SDK's Java 11 support requirement
+      # is dropped. See also: java-sdk/sdk/build.gradle.kts
       - dependency-name: "com.gradleup.shadow:shadow-gradle-plugin"
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-patch
+      - dependency-name: "org.jsonschema2pojo"
         update-types:
           - version-update:semver-minor
           - version-update:semver-patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -99,6 +99,13 @@ updates:
       - dependency-name: "*"
         update-types:
           - version-update:semver-major
+      # Pinned to the last shadow-gradle-plugin release that supports Java 11
+      # (see java-sdk/plugin/build.gradle.kts). Ignore minor/patch bumps too,
+      # not just majors, until the SDK's Java 11 support requirement is dropped.
+      - dependency-name: "com.gradleup.shadow:shadow-gradle-plugin"
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-patch
 
   - package-ecosystem: npm
     cooldown:


### PR DESCRIPTION
com.gradleup.shadow:shadow-gradle-plugin is pinned to 9.1.0 as the last release supporting Java 11. The existing ignore rule only skips major bumps, so Dependabot kept proposing 9.2+ minor/patch upgrades. Ignore those too until the Java version requirement is dropped.