### PR TITLE
UI: Mask sensitive connection extra fields in the connection form

### DIFF
--- a/airflow-core/newsfragments/53410.improvement.rst
+++ b/airflow-core/newsfragments/53410.improvement.rst
@@ -1,0 +1,1 @@
+Connection extra fields and Dag params whose key name is sensitive now render as masked inputs with a show/hide toggle in the UI, instead of only the extra fields a provider declares with ``format: "password"``. Set ``[core] hide_sensitive_var_conn_fields = False`` to disable.

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/config.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/config.py
@@ -40,6 +40,7 @@ class ConfigResponse(BaseModel):
     external_log_name: str | None = None
     theme: Theme | None
     multi_team: bool
+    sensitive_field_names: list[str]
     rerun_with_latest_version: bool | None = None
 
     @field_serializer("theme")

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -2681,6 +2681,11 @@ components:
         multi_team:
           type: boolean
           title: Multi Team
+        sensitive_field_names:
+          items:
+            type: string
+          type: array
+          title: Sensitive Field Names
         rerun_with_latest_version:
           anyOf:
           - type: boolean
@@ -2700,6 +2705,7 @@ components:
       - show_external_log_redirect
       - theme
       - multi_team
+      - sensitive_field_names
       title: ConfigResponse
       description: configuration serializer.
     ConnectionHookFieldBehavior:

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/config.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/config.py
@@ -27,7 +27,7 @@ from airflow.api_fastapi.core_api.datamodels.ui.config import ConfigResponse
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
 from airflow.api_fastapi.core_api.security import requires_authenticated
 from airflow.configuration import conf
-from airflow.settings import DASHBOARD_UIALERTS
+from airflow.settings import DASHBOARD_UIALERTS, get_sensitive_variable_fields
 from airflow.utils.log.log_reader import TaskLogReader
 
 config_router = AirflowRouter(tags=["Config"])
@@ -62,6 +62,13 @@ def get_configs() -> ConfigResponse:
         "external_log_name": getattr(task_log_reader.log_handler, "log_name", None),
         "theme": loads(conf.get("api", "theme", fallback="{}")) or None,
         "multi_team": conf.getboolean("core", "multi_team"),
+        # Field *names* only, never values — lets the UI mask connection extra fields and Dag params
+        # whose key is sensitive, matching what the secrets masker hides server-side.
+        "sensitive_field_names": (
+            sorted(get_sensitive_variable_fields())
+            if conf.getboolean("core", "hide_sensitive_var_conn_fields")
+            else []
+        ),
         # Return None when the option isn't explicitly set so the UI hook can apply
         # its own fallback (False for clear/rerun, True for backfills).
         "rerun_with_latest_version": (

--- a/airflow-core/src/airflow/settings.py
+++ b/airflow-core/src/airflow/settings.py
@@ -681,20 +681,26 @@ def configure_adapters():
             )
 
 
-def _configure_secrets_masker():
-    """Configure the secrets masker with values from config."""
-    from airflow._shared.secrets_masker import (
-        DEFAULT_SENSITIVE_FIELDS,
-        _secrets_masker as secrets_masker_core,
-    )
+def get_sensitive_variable_fields() -> frozenset[str]:
+    """Return the default sensitive field names unioned with ``[core] sensitive_var_conn_names``."""
+    from airflow._shared.secrets_masker import DEFAULT_SENSITIVE_FIELDS
     from airflow.configuration import conf
 
-    min_length_to_mask = conf.getint("logging", "min_length_masked_secret", fallback=5)
-    secret_mask_adapter = conf.getimport("logging", "secret_mask_adapter", fallback=None)
     sensitive_fields = DEFAULT_SENSITIVE_FIELDS.copy()
     sensitive_variable_fields = conf.get("core", "sensitive_var_conn_names")
     if sensitive_variable_fields:
         sensitive_fields |= frozenset({field.strip() for field in sensitive_variable_fields.split(",")})
+    return sensitive_fields
+
+
+def _configure_secrets_masker():
+    """Configure the secrets masker with values from config."""
+    from airflow._shared.secrets_masker import _secrets_masker as secrets_masker_core
+    from airflow.configuration import conf
+
+    min_length_to_mask = conf.getint("logging", "min_length_masked_secret", fallback=5)
+    secret_mask_adapter = conf.getimport("logging", "secret_mask_adapter", fallback=None)
+    sensitive_fields = get_sensitive_variable_fields()
 
     hide_sensitive_var_conn_fields = conf.getboolean("core", "hide_sensitive_var_conn_fields")
 

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -8973,6 +8973,13 @@ export const $ConfigResponse = {
             type: 'boolean',
             title: 'Multi Team'
         },
+        sensitive_field_names: {
+            items: {
+                type: 'string'
+            },
+            type: 'array',
+            title: 'Sensitive Field Names'
+        },
         rerun_with_latest_version: {
             anyOf: [
                 {
@@ -8986,7 +8993,7 @@ export const $ConfigResponse = {
         }
     },
     type: 'object',
-    required: ['fallback_page_limit', 'auto_refresh_interval', 'hide_paused_dags_by_default', 'instance_name', 'enable_swagger_ui', 'require_confirmation_dag_change', 'default_wrap', 'test_connection', 'dashboard_alert', 'show_external_log_redirect', 'theme', 'multi_team'],
+    required: ['fallback_page_limit', 'auto_refresh_interval', 'hide_paused_dags_by_default', 'instance_name', 'enable_swagger_ui', 'require_confirmation_dag_change', 'default_wrap', 'test_connection', 'dashboard_alert', 'show_external_log_redirect', 'theme', 'multi_team', 'sensitive_field_names'],
     title: 'ConfigResponse',
     description: 'configuration serializer.'
 } as const;

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -2282,6 +2282,7 @@ export type ConfigResponse = {
     external_log_name?: string | null;
     theme: Theme | null;
     multi_team: boolean;
+    sensitive_field_names: Array<(string)>;
     rerun_with_latest_version?: boolean | null;
 };
 

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldSelector.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldSelector.test.tsx
@@ -1,0 +1,135 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import { Wrapper } from "src/utils/Wrapper";
+
+import { FieldSelector } from "./FieldSelector";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockParamsDict: Record<string, any> = {};
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockInitialParamDict: Record<string, any> = {};
+
+vi.mock("src/queries/useParamStore", () => ({
+  paramPlaceholder: {
+    description: null,
+    schema: {},
+    value: "",
+  },
+  useParamStore: () => ({
+    disabled: false,
+    initialParamDict: mockInitialParamDict,
+    paramsDict: mockParamsDict,
+    setParamsDict: vi.fn(),
+  }),
+}));
+
+let mockSensitiveFieldNames: Array<string> | undefined = [];
+
+vi.mock("src/queries/useConfig", () => ({
+  useConfig: () => mockSensitiveFieldNames,
+}));
+
+// Match on the name attribute — free-form extra keys contain dots and dashes, which are not
+// valid in a `#id` selector.
+const getInputByName = (name: string) => document.querySelector<HTMLInputElement>(`[name="element_${name}"]`);
+
+const clearDict = (dict: Record<string, unknown>) => {
+  Object.keys(dict).forEach((key) => {
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete dict[key];
+  });
+};
+
+const renderField = (name: string) =>
+  render(<FieldSelector name={name} onUpdate={vi.fn()} />, { wrapper: Wrapper });
+
+describe("FieldSelector", () => {
+  beforeEach(() => {
+    mockSensitiveFieldNames = ["access_key", "password", "private_key"];
+    clearDict(mockParamsDict);
+    clearDict(mockInitialParamDict);
+  });
+
+  it("masks a free-form field whose name is sensitive", () => {
+    mockParamsDict.private_key = { schema: {}, value: "-----BEGIN..." };
+
+    renderField("private_key");
+
+    expect(getInputByName("private_key")?.type).toBe("password");
+  });
+
+  it("masks a sensitive free-form field that has no value yet", () => {
+    mockParamsDict.private_key = { schema: {}, value: null };
+
+    renderField("private_key");
+
+    expect(getInputByName("private_key")?.type).toBe("password");
+  });
+
+  it("masks a sensitive name that needs normalization", () => {
+    mockParamsDict["spark.hadoop.fs.s3a.Access-Key"] = { schema: {}, value: "AKIA" };
+
+    renderField("spark.hadoop.fs.s3a.Access-Key");
+
+    expect(getInputByName("spark.hadoop.fs.s3a.Access-Key")?.type).toBe("password");
+  });
+
+  it("leaves a non-sensitive free-form field as plain text", () => {
+    mockParamsDict["spark.executor.memory"] = { schema: {}, value: "2g" };
+
+    renderField("spark.executor.memory");
+
+    expect(getInputByName("spark.executor.memory")?.type).toBe("text");
+  });
+
+  it("leaves sensitive names as plain text when masking is disabled", () => {
+    mockSensitiveFieldNames = [];
+    mockParamsDict.private_key = { schema: {}, value: "-----BEGIN..." };
+
+    renderField("private_key");
+
+    expect(getInputByName("private_key")?.type).toBe("text");
+  });
+
+  it("does not turn a non-string sensitive field into a password input", () => {
+    mockInitialParamDict.use_private_key = { description: null, schema: { type: "boolean" }, value: false };
+    mockParamsDict.use_private_key = { schema: { type: "boolean" }, value: false };
+
+    renderField("use_private_key");
+
+    expect(getInputByName("use_private_key")?.type).toBe("checkbox");
+  });
+
+  it("still masks a declared password-format field", () => {
+    mockInitialParamDict.token_secret = {
+      description: null,
+      schema: { format: "password", type: ["string", "null"] },
+      value: null,
+    };
+    mockParamsDict.token_secret = { schema: { format: "password", type: ["string", "null"] }, value: null };
+    mockSensitiveFieldNames = [];
+
+    renderField("token_secret");
+
+    expect(getInputByName("token_secret")?.type).toBe("password");
+  });
+});

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldSelector.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldSelector.tsx
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { useConfig } from "src/queries/useConfig";
 import type { ParamSchema, ParamSpec } from "src/queries/useDagParams";
 import { paramPlaceholder, useParamStore } from "src/queries/useParamStore";
 
@@ -91,8 +92,19 @@ const isFieldNumber = (fieldType: string) => {
 
 const isFieldObject = (fieldType: string) => fieldType === "object";
 
-const isFieldPassword = (fieldType: string, fieldSchema: ParamSchema) =>
-  fieldType === "string" && fieldSchema.format === "password";
+// Port of SecretsMasker.should_hide_value_for_key: case-insensitive substring match on the
+// normalized key, so `spark.hadoop.fs.s3a.access.key` still matches the `access_key` entry.
+const isSensitiveName = (name: string, sensitiveFieldNames: Array<string>) => {
+  const normalized = name.trim().toLowerCase().replaceAll(/\W+/gu, "_");
+
+  return sensitiveFieldNames.some((field) => normalized.includes(field));
+};
+
+// `null` is included because inferType() returns it for a key with no value yet — an empty
+// free-form extra field is exactly where a secret is about to be typed in plain sight.
+const isFieldPassword = (fieldType: string, fieldSchema: ParamSchema, isSensitive: boolean) =>
+  (fieldType === "string" && fieldSchema.format === "password") ||
+  (isSensitive && (fieldType === "string" || fieldType === "null"));
 
 const isFieldStringArray = (fieldType: string, fieldSchema: ParamSchema) =>
   fieldType === "array" && (fieldSchema.items?.type === undefined || fieldSchema.items.type === "string");
@@ -109,6 +121,7 @@ const isFieldTime = (fieldType: string, fieldSchema: ParamSchema) =>
 export const FieldSelector = ({ name, namespace = "default", onUpdate }: FlexibleFormElementProps) => {
   // FUTURE: Add support for other types as described in AIP-68 via Plugins
   const { initialParamDict, paramsDict } = useParamStore(namespace);
+  const sensitiveFieldNames = useConfig("sensitive_field_names") as Array<string> | undefined;
 
   // Use current paramsDict (which has actual values) for type inference, fall back to initialParamDict for schema
   const currentParam = paramsDict[name];
@@ -152,7 +165,7 @@ export const FieldSelector = ({ name, namespace = "default", onUpdate }: Flexibl
     return <FieldDuration name={name} namespace={namespace} onUpdate={onUpdate} />;
   } else if (isFieldMultilineText(fieldType, param.schema)) {
     return <FieldMultilineText name={name} namespace={namespace} onUpdate={onUpdate} />;
-  } else if (isFieldPassword(fieldType, param.schema)) {
+  } else if (isFieldPassword(fieldType, param.schema, isSensitiveName(name, sensitiveFieldNames ?? []))) {
     return <FieldPassword name={name} namespace={namespace} onUpdate={onUpdate} />;
   } else {
     return <FieldString name={name} namespace={namespace} onUpdate={onUpdate} />;

--- a/airflow-core/src/airflow/ui/src/mocks/handlers/config.ts
+++ b/airflow-core/src/airflow/ui/src/mocks/handlers/config.ts
@@ -29,6 +29,7 @@ export const handlers: Array<HttpHandler> = [
       multi_team: false,
       page_size: 15,
       require_confirmation_dag_change: false,
+      sensitive_field_names: [],
       test_connection: "Disabled",
     }),
   ),

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_config.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_config.py
@@ -20,6 +20,8 @@ import json
 
 import pytest
 
+from airflow._shared.secrets_masker import DEFAULT_SENSITIVE_FIELDS
+
 from tests_common.test_utils.asserts import assert_queries_count
 from tests_common.test_utils.config import conf_vars
 
@@ -69,6 +71,7 @@ expected_config_response = {
     "external_log_name": None,
     "theme": THEME,
     "multi_team": False,
+    "sensitive_field_names": sorted(DEFAULT_SENSITIVE_FIELDS),
     "rerun_with_latest_version": None,
 }
 
@@ -170,6 +173,21 @@ class TestGetConfig:
         response = unauthorized_test_client.get("/config")
         assert response.status_code == 200
         assert response.json() == expected_config_response
+
+    def test_sensitive_field_names_include_configured_names(self, mock_config_data, test_client):
+        with conf_vars({("core", "sensitive_var_conn_names"): "my_custom_key, other_key"}):
+            response = test_client.get("/config")
+
+        assert response.status_code == 200
+        names = response.json()["sensitive_field_names"]
+        assert set(names) == set(DEFAULT_SENSITIVE_FIELDS) | {"my_custom_key", "other_key"}
+
+    def test_sensitive_field_names_empty_when_hiding_disabled(self, mock_config_data, test_client):
+        with conf_vars({("core", "hide_sensitive_var_conn_fields"): "False"}):
+            response = test_client.get("/config")
+
+        assert response.status_code == 200
+        assert response.json()["sensitive_field_names"] == []
 
     def test_should_response_200_with_all_color_tokens(self, mock_config_data_all_colors, test_client):
         """Theme with gray, black, and white tokens (in addition to brand) passes validation and round-trips."""


### PR DESCRIPTION
Extra fields whose key name is sensitive — SSH's `private_key` / `private_key_passphrase`, the
reporter's case in #53410 — are free-form keys that no provider declares in `hook_meta`. They get
no schema, so `FieldSelector` falls back to `paramPlaceholder` and renders them as plain
`FieldString` inputs.

Stored values already come back redacted from the API (#59873), so this is not about the value on
screen at rest — it is about the value being typed. Anything entered into one of those fields was
legible to anyone looking at the screen, which is exactly the scenario this masking is meant to
cover. #70473 fixed this for extra fields a provider declares with `format: "password"`; free-form
keys were explicitly left out there because the UI had no signal to go on.

This adds that signal. The effective sensitive-name list (`DEFAULT_SENSITIVE_FIELDS` unioned with
`[core] sensitive_var_conn_names`) is exposed on the existing `/ui/config` endpoint, and
`FieldSelector`'s password branch now also matches on field name, reusing `FieldPassword` /
`PasswordToggle` from #70473. The name match is a port of `SecretsMasker.should_hide_value_for_key`,
so `spark.hadoop.fs.s3a.access.key` matches `access_key` the same way it does server-side.

The extra JSON blob is deliberately left alone — it stays redacted as #59873 made it.

Notes for review:

- Only field *names* cross the wire, never values, and the list is empty when
  `[core] hide_sensitive_var_conn_fields = False`. `/ui/config` requires authentication; these two
  options are already readable via `/config` when `[api] expose_config` is on.
- `FieldSelector` is shared with the Dag trigger form, so a Dag param named `password` or `token`
  now renders masked too. That seemed right rather than surprising — same threat, same treatment —
  but say the word if you would rather it were scoped to connections only.
- The password branch keeps its position in the dispatch chain, so enum/boolean/number/array fields
  keep their widgets; a checkbox named `use_secret_manager` is not turned into a password box. The
  `"null"` field type is included so an empty free-form field is masked before anything is typed
  into it.

related: #53410

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)