### PR TITLE
Improve DAG authorization filtering performance

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/base_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/base_auth_manager.py
@@ -22,6 +22,7 @@ import logging
 import warnings
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from functools import cache, cached_property
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
@@ -692,7 +693,13 @@ class BaseAuthManager(Generic[T], LoggingMixin, metaclass=ABCMeta):
                 method=method, details=DagDetails(id=dag_id, team_name=team_name), user=user
             )
 
-        return {dag_id for dag_id in dag_ids if _is_authorized_dag_id(dag_id)}
+        if not dag_ids:
+            return set()
+
+        with ThreadPoolExecutor() as executor:
+            results = executor.map(_is_authorized_dag_id, dag_ids)
+
+        return {dag_id for dag_id, authorized in zip(dag_ids, results) if authorized}
 
     @provide_session
     def get_authorized_pools(


### PR DESCRIPTION
Improve the performance of DAG authorization filtering by evaluating DAG authorization checks concurrently using a ThreadPoolExecutor.

Changes
Added ThreadPoolExecutor to BaseAuthManager.filter_authorized_dag_ids.
Execute individual is_authorized_dag checks concurrently instead of sequentially.
Return an empty set immediately when no DAG IDs are provided.
Preserve the existing authorization behavior and return only authorized DAG IDs.
Motivation

filter_authorized_dag_ids previously checked each DAG authorization sequentially, which could become a performance bottleneck when many DAGs need to be authorized. Running the checks concurrently reduces the time spent waiting on individual authorization calls.

Testing

Tests were not run locally.