### PR TITLE
Fix Task subprocess deadlock on Linux when fork inherits a held OpenSSL lock

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -514,7 +514,9 @@ See: https://github.com/python/cpython/issues/105912
 
 def _should_use_exec() -> bool:
     """Whether forked children should ``exec`` a fresh interpreter on this platform."""
-    return sys.platform in _FORK_EXEC_PLATFORMS
+    if sys.platform in _FORK_EXEC_PLATFORMS:
+        return True
+    return conf.getboolean("core", "execute_tasks_new_python_interpreter", fallback=False)
 
 
 def _resolve_child_target(dotted: str) -> Callable[[], None]:

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -4478,6 +4478,22 @@ def test_api_client_clears_dag_bag_override_when_dag_is_none():
     finally:
         in_process_api_server.cache_clear()
 
+class TestShouldUseExec:
+    @pytest.mark.parametrize(
+        "platform, config_val, expected",
+        [
+            ("darwin", False, True),
+            ("darwin", True, True),
+            ("linux", False, False),
+            ("linux", True, True),
+        ]
+    )
+    def test_should_use_exec(self, monkeypatch, platform, config_val, expected):
+        from airflow.sdk.execution_time import supervisor
+        monkeypatch.setattr(supervisor.sys, "platform", platform)
+        with conf_vars({("core", "execute_tasks_new_python_interpreter"): str(config_val)}):
+            assert supervisor._should_use_exec() is expected
+
 
 class TestResolveChildTarget:
     """Test rehydrating the exec'd child's entry point from _AIRFLOW_CHILD_TARGET."""


### PR DESCRIPTION
Resolves #71707.

### Problem
On Linux, `ActivitySubprocess.start()` previously used a bare `os.fork()`. If a background thread in the supervisor process (e.g. OTel exporter, google-auth refresh) held a C-level lock like OpenSSL's at the exact instant of the fork, the child inherited that lock in a perpetually locked state (since the thread holding it didn't survive the fork). Any subsequent attempt by the child to acquire the lock would deadlock indefinitely, causing tasks to hang.

### Solution
This PR allows tasks to avoid the bare `os.fork()` on Linux by opting into the fork+exec path. It reuses the existing `core.execute_tasks_new_python_interpreter` configuration option.

By setting `AIRFLOW__CORE__EXECUTE_TASKS_NEW_PYTHON_INTERPRETER=True`, `_should_use_exec()` will return `True` and execute tasks using a fresh interpreter that doesn't inherit the corrupted lock state. The default remains `False` to preserve existing performance where this issue is not encountered.

Included an automated unit test asserting that `_should_use_exec()` correctly respects this configuration on Linux.