### PR TITLE
Ignore the magpie snapshot symlink in git worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -312,8 +312,12 @@ dev/registry/modules.json
 dev/registry/providers.json
 
 # apache-magpie — gitignored snapshot of the framework, refreshed
-# by /magpie-setup upgrade. Build artefact, not source.
-/.apache-magpie/
+# by /magpie-setup upgrade. Build artefact, not source. No trailing
+# slash: in the main checkout this is a directory, but
+# /magpie-setup worktree-init makes it a symlink to the main's
+# snapshot, and a directory-only pattern would leave every worktree
+# showing it as untracked.
+/.apache-magpie
 
 # Per-machine local-pin file. Records what THIS machine fetched and
 # when. Compared against the committed .apache-magpie.lock to


### PR DESCRIPTION
`.gitignore` covers the magpie snapshot with `/.apache-magpie/` — a directory-only pattern. Only the main checkout has a directory there.

`/magpie-setup worktree-init` deliberately makes `.apache-magpie` a **symlink** to the main checkout's snapshot, so every worktree shares one framework state and picks up `/magpie-setup upgrade` automatically. A trailing-slash pattern never matches a symlink, so `.apache-magpie` shows as untracked in every worktree — noise in `git status`, and one careless `git add -A` away from committing a machine-local absolute-path symlink.

Dropping the trailing slash matches the directory, its contents, and the symlink alike, so the main checkout is unaffected.

Verified in a scratch repo with the new pattern:

```
dir  -> IGNORED      # main checkout
file -> IGNORED      # .apache-magpie/skills/a.md
link -> IGNORED      # worktree
```

and in this worktree, where `git status` no longer reports `?? .apache-magpie`.

No newsfragment: repo tooling, no user-facing behaviour change.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
