### PR TITLE
CLI: Add --limit flag to airflow dags list-runs

### DIFF
--- a/airflow-core/newsfragments/71729.improvement.rst
+++ b/airflow-core/newsfragments/71729.improvement.rst
@@ -1,0 +1,1 @@
+Add ``--limit`` option to ``airflow dags list-runs`` to cap output to the N most recent Dag runs after filters and sorting are applied, mirroring ``airflow dags list-jobs --limit``.

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -291,6 +291,11 @@ ARG_DR_STATE = Arg(
     metavar=", ".join(dagrun_states),
     choices=dagrun_states,
 )
+ARG_DR_LIMIT = Arg(
+    ("--limit",),
+    type=positive_int(allow_zero=False),
+    help="Return a limited number of Dag runs, ordered by most recent run_after first",
+)
 
 # list_jobs
 ARG_DAG_ID_OPT = Arg(("-d", "--dag-id"), help="The id of the dag")
@@ -1250,13 +1255,15 @@ DAGS_COMMANDS = (
             "dagruns with the given state. If no_backfill option is given, it will filter out all "
             "backfill dagruns for given dag id. If start_date is given, it will filter out all the "
             "dagruns that were executed before this date. If end_date is given, it will filter out "
-            "all the dagruns that were executed after this date. "
+            "all the dagruns that were executed after this date. If limit is given, it will return "
+            "only the most recent N runs after filters and sorting are applied."
         ),
         func=lazy_load_command("airflow.cli.commands.dag_command.dag_list_dag_runs"),
         args=(
             ARG_DAG_ID,
             ARG_NO_BACKFILL,
             ARG_DR_STATE,
+            ARG_DR_LIMIT,
             ARG_OUTPUT,
             ARG_VERBOSE,
             ARG_START_DATE,

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -791,6 +791,10 @@ def dag_list_dag_runs(args, dag: DAG | None = None, *, session: Session = NEW_SE
         session=session,
     )
     dag_runs.sort(key=operator.attrgetter("run_after"), reverse=True)
+    # Slice after sorting so `--limit` reliably returns the most recent runs,
+    # independent of insertion order in DagRun.find().
+    if getattr(args, "limit", None):
+        dag_runs = dag_runs[: args.limit]
 
     def _render_dagrun(dr: DagRun) -> dict[str, str]:
         return {

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -540,6 +540,44 @@ class TestCliDags:
         )
         dag_command.dag_list_dag_runs(args)
 
+    @pytest.mark.parametrize(
+        ("limit", "expected_count"),
+        [
+            (None, 3),
+            (1, 1),
+            (2, 2),
+            (5, 3),
+        ],
+    )
+    @mock.patch("airflow.cli.commands.dag_command.AirflowConsole")
+    def test_cli_list_dag_runs_limit(self, mock_console, limit, expected_count):
+        """`--limit N` caps output to the N most recent runs; without it, all runs are returned."""
+        for i in range(3):
+            dag_command.dag_trigger(
+                self.parser.parse_args(
+                    ["dags", "trigger", "example_bash_operator", "--run-id", f"cli_limit_test_{i}"]
+                )
+            )
+
+        argv = ["dags", "list-runs", "example_bash_operator"]
+        if limit is not None:
+            argv += ["--limit", str(limit)]
+        args = self.parser.parse_args(argv)
+        dag_command.dag_list_dag_runs(args)
+
+        printed = mock_console.return_value.print_as.call_args.kwargs["data"]
+        assert len(printed) == expected_count
+        # Slicing happens after the run_after DESC sort, so the returned rows must
+        # remain monotonically non-increasing on run_after.
+        run_afters = [dr.run_after for dr in printed]
+        assert run_afters == sorted(run_afters, reverse=True)
+
+    @pytest.mark.parametrize("bad_value", ["0", "-1", "abc"])
+    def test_cli_list_dag_runs_limit_rejects_invalid(self, bad_value):
+        """`--limit` must be a positive int; argparse rejects invalid inputs before the command runs."""
+        with pytest.raises(SystemExit):
+            self.parser.parse_args(["dags", "list-runs", "example_bash_operator", "--limit", bad_value])
+
     def test_cli_list_jobs_with_args(self):
         args = self.parser.parse_args(
             [


### PR DESCRIPTION
## Summary

`airflow dags list-jobs` accepts `--limit`, but the sibling `airflow dags list-runs` command does not — on busy DAGs the command dumps every run since the start of time (subject to date filters). This PR closes that asymmetry with a small, additive flag.

## Details

- New `ARG_DR_LIMIT` typed as `positive_int(allow_zero=False)` — argparse rejects `0`, negative numbers, and non-numeric input up-front.
- Applied in `dag_list_dag_runs` **after** the existing `run_after` DESC sort, so `--limit N` reliably returns the N most recent runs regardless of insertion order in `DagRun.find`.
- Default behaviour when the flag is absent is unchanged (all rows returned).

## Test plan

- [X] `ruff format` and `ruff check` clean.
- [X] Parser smoke test: `--limit 3` parses to `int(3)`; `--limit 0`, `--limit -1`, `--limit abc` all rejected by argparse; `--limit` shows in `dags list-runs --help`.
- `uv run --project airflow-core pytest airflow-core/tests/unit/cli/commands/test_dag_command.py::TestCliDags::test_cli_list_dag_runs airflow-core/tests/unit/cli/commands/test_dag_command.py::TestCliDags::test_cli_list_dag_runs_limit airflow-core/tests/unit/cli/commands/test_dag_command.py::TestCliDags::test_cli_list_dag_runs_limit_rejects_invalid -xvs`
- [ ] `prek run --from-ref main --stage pre-commit`

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Cursor