### PR TITLE
Reject non-string prompts in LLMFileAnalysisOperator before reading files

### DIFF
--- a/providers/common/ai/src/airflow/providers/common/ai/operators/llm_file_analysis.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/llm_file_analysis.py
@@ -105,6 +105,9 @@ class LLMFileAnalysisOperator(LLMOperator):
         self.sample_rows = sample_rows
 
     def execute(self, context: Context) -> Any:
+        if self.require_approval:
+            self.validate_approval_prompt()  # type: ignore[misc]
+
         request = build_file_analysis_request(
             file_path=self.file_path,
             file_conn_id=self.file_conn_id,

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/llm_file_analysis.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/llm_file_analysis.py
@@ -105,8 +105,11 @@ class LLMFileAnalysisOperator(LLMOperator):
         self.sample_rows = sample_rows
 
     def execute(self, context: Context) -> Any:
-        if self.require_approval:
-            self.validate_approval_prompt()  # type: ignore[misc]
+        if not isinstance(self.prompt, str):
+            raise TypeError(
+                f"{type(self).__name__} requires a string prompt (got {type(self.prompt).__name__}). "
+                "Supply images or PDFs via file_path with multi_modal=True instead."
+            )
 
         request = build_file_analysis_request(
             file_path=self.file_path,

--- a/providers/common/ai/tests/unit/common/ai/operators/test_llm_file_analysis.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_llm_file_analysis.py
@@ -346,3 +346,35 @@ class TestLLMFileAnalysisOperatorApproval:
             op.execute(context=_make_context())
 
         assert exc_info.value.timeout == timeout
+
+
+@pytest.mark.skipif(
+    not AIRFLOW_V_3_1_PLUS, reason="Human in the loop is only compatible with Airflow >= 3.1.0"
+)
+class TestLLMFileAnalysisOperatorMultimodalPromptGuard:
+    """LLMFileAnalysisOperator.execute raises before build_file_analysis_request/agent.run_sync
+    when require_approval is True and self.prompt is not a string -- covering the native template
+    rendering escape (where a string template renders to a Sequence)."""
+
+    @patch("airflow.providers.common.ai.operators.llm.PydanticAIHook", autospec=True)
+    @patch(
+        "airflow.providers.common.ai.operators.llm_file_analysis.build_file_analysis_request", autospec=True
+    )
+    def test_execute_rejects_sequence_prompt_with_require_approval(self, mock_build_request, mock_hook_cls):
+        mock_agent = MagicMock(spec=["run_sync"])
+        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+
+        op = LLMFileAnalysisOperator(
+            task_id="t",
+            prompt="placeholder",
+            llm_conn_id="c",
+            file_path="/tmp/app.log",
+            require_approval=True,
+        )
+        op.prompt = ["x", object()]  # simulate post-template-render value
+
+        with pytest.raises(TypeError, match="require_approval=True"):
+            op.execute(context=_make_context())
+
+        mock_build_request.assert_not_called()
+        mock_agent.run_sync.assert_not_called()

--- a/providers/common/ai/tests/unit/common/ai/operators/test_llm_file_analysis.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_llm_file_analysis.py
@@ -348,33 +348,24 @@ class TestLLMFileAnalysisOperatorApproval:
         assert exc_info.value.timeout == timeout
 
 
-@pytest.mark.skipif(
-    not AIRFLOW_V_3_1_PLUS, reason="Human in the loop is only compatible with Airflow >= 3.1.0"
-)
-class TestLLMFileAnalysisOperatorMultimodalPromptGuard:
-    """LLMFileAnalysisOperator.execute raises before build_file_analysis_request/agent.run_sync
-    when require_approval is True and self.prompt is not a string -- covering the native template
-    rendering escape (where a string template renders to a Sequence)."""
-
-    @patch("airflow.providers.common.ai.operators.llm.PydanticAIHook", autospec=True)
+class TestLLMFileAnalysisOperatorPromptTypeGuard:
+    @pytest.mark.parametrize("require_approval", [True, False])
     @patch(
         "airflow.providers.common.ai.operators.llm_file_analysis.build_file_analysis_request", autospec=True
     )
-    def test_execute_rejects_sequence_prompt_with_require_approval(self, mock_build_request, mock_hook_cls):
-        mock_agent = MagicMock(spec=["run_sync"])
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
-
+    def test_execute_rejects_non_string_prompt_before_reading_files(
+        self, mock_build_request, require_approval
+    ):
         op = LLMFileAnalysisOperator(
             task_id="t",
             prompt="placeholder",
             llm_conn_id="c",
             file_path="/tmp/app.log",
-            require_approval=True,
+            require_approval=require_approval,
         )
-        op.prompt = ["x", object()]  # simulate post-template-render value
+        op.prompt = ["x", object()]  # simulate a native-templating render to a Sequence
 
-        with pytest.raises(TypeError, match="require_approval=True"):
+        with pytest.raises(TypeError, match="requires a string prompt"):
             op.execute(context=_make_context())
 
         mock_build_request.assert_not_called()
-        mock_agent.run_sync.assert_not_called()


### PR DESCRIPTION
### Summary

`LLMFileAnalysisOperator` embeds `prompt` in a text preamble alongside the normalized file content, so the prompt must be a `str` whether or not `require_approval` is set. A non-string prompt -- e.g. a native-templating render that resolves to a list - was only rejected after every target file had already been resolved and read from storage, and then surfaced as an opaque `TypeError: sequence item 1: expected str instance, list found`.

The operator now rejects a non-string prompt at the start of `execute()`, before any storage access, with an error that names the operator and points to `multi_modal=True` for attaching images/PDFs. This matches the `@task.llm_file_analysis` decorator, which already rejects non-string return values regardless of `require_approval`.

### Why this change

This PR's gain is skipping the storage reads plus a clearer error message.

---

##### Was generative AI tooling used to co-author this PR?

- [] Yes (please specify the tool below)
