### PR TITLE
Validate issuer and audience of Azure AD id_tokens in FAB auth manager

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -24,6 +24,7 @@ import importlib
 import itertools
 import json
 import logging
+import re
 import uuid
 from collections.abc import Collection, Iterable, Mapping
 from typing import TYPE_CHECKING, Any
@@ -69,6 +70,7 @@ from sqlalchemy.exc import IntegrityError, MultipleResultsFound
 from sqlalchemy.orm import joinedload
 from werkzeug.security import check_password_hash, generate_password_hash
 
+from airflow.exceptions import AirflowConfigException
 from airflow.providers.common.compat.sdk import conf
 from airflow.providers.fab.auth_manager.models import (
     Action,
@@ -2425,13 +2427,69 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
 
         return requests.get(MICROSOFT_KEY_SET_URL, timeout=30).json()
 
+    def _get_azure_tenant_id(self) -> str | None:
+        """
+        Resolve the Azure AD tenant the deployment is configured against.
+
+        Prefers an explicit ``tenant_id`` in ``client_kwargs``; otherwise derives it from
+        the tenant segment of the configured Azure endpoints, which is where the documented
+        configuration puts it (``https://login.microsoftonline.com/<tenant-id>/...``).
+
+        Returns ``None`` when the configuration is tenant-agnostic (the ``common`` or
+        ``organizations`` endpoints), because there is then no single issuer to pin to.
+        """
+        azure = self.oauth_remotes["azure"]
+
+        tenant_id = azure.client_kwargs.get("tenant_id")
+        if tenant_id:
+            return tenant_id
+
+        for url in (
+            getattr(azure, "api_base_url", None),
+            getattr(azure, "access_token_url", None),
+            getattr(azure, "authorize_url", None),
+        ):
+            if not isinstance(url, str):
+                continue
+            match = re.search(r"login\.microsoftonline\.com/([^/]+)/", url)
+            if match and match.group(1) not in ("common", "organizations", "consumers"):
+                return match.group(1)
+
+        return None
+
     def _decode_and_validate_azure_jwt(self, id_token: str) -> dict[str, str]:
         verify_signature = self.oauth_remotes["azure"].client_kwargs.get("verify_signature", True)
         if verify_signature:
             from authlib.jose import JsonWebKey, jwt as authlib_jwt
 
+            tenant_id = self._get_azure_tenant_id()
+            if not tenant_id:
+                raise AirflowConfigException(
+                    "Azure AD tenant could not be determined from the OAuth configuration. "
+                    "The Microsoft key set used to verify id_token signatures serves keys for "
+                    "every tenant, so without a tenant the issuer of the token cannot be "
+                    "checked. Configure the tenant-specific endpoints "
+                    "(https://login.microsoftonline.com/<tenant-id>/...) or set 'tenant_id' "
+                    "in the azure provider's client_kwargs."
+                )
+
+            claims_options = {
+                # The token must have been issued by the configured tenant. Both the v1.0 and
+                # v2.0 issuer forms are accepted because either may be returned depending on
+                # which endpoints the deployment is configured against.
+                "iss": {
+                    "essential": True,
+                    "values": [
+                        f"https://login.microsoftonline.com/{tenant_id}/v2.0",
+                        f"https://sts.windows.net/{tenant_id}/",
+                    ],
+                },
+                # The token must have been minted for this application.
+                "aud": {"essential": True, "value": self.oauth_remotes["azure"].client_id},
+            }
+
             keyset = JsonWebKey.import_key_set(self._get_microsoft_jwks())  # type: ignore
-            claims = authlib_jwt.decode(id_token, keyset)
+            claims = authlib_jwt.decode(id_token, keyset, claims_options=claims_options)
             claims.validate()
             return claims
 

--- a/providers/fab/tests/unit/fab/auth_manager/security_manager/test_override.py
+++ b/providers/fab/tests/unit/fab/auth_manager/security_manager/test_override.py
@@ -475,8 +475,15 @@ class TestFabAirflowSecurityManagerOverride:
     def test_decode_and_validate_azure_jwt_verifies_signature_by_default(self):
         """Azure AD id_token signatures are verified by default (verify_signature defaults to True)."""
         sm = EmptySecurityManager()
-        # client_kwargs does not set verify_signature -> it must default to verifying
-        sm.oauth_remotes = {"azure": Mock(client_kwargs={})}
+        # client_kwargs does not set verify_signature -> it must default to verifying.
+        # A resolvable tenant is required before the key set is fetched, so the mock
+        # carries the tenant-specific endpoint the documented configuration uses.
+        sm.oauth_remotes = {
+            "azure": Mock(
+                client_kwargs={},
+                api_base_url="https://login.microsoftonline.com/tenant-abc/oauth2/v2.0/",
+            )
+        }
 
         with mock.patch.object(
             EmptySecurityManager, "_get_microsoft_jwks", side_effect=RuntimeError("verify-branch-reached")
@@ -503,6 +510,88 @@ class TestFabAirflowSecurityManagerOverride:
 
         mock_jwks.assert_not_called()
         assert result == {"oid": "user-1"}
+
+    @pytest.mark.parametrize(
+        ("remote_kwargs", "expected"),
+        [
+            pytest.param(
+                {"client_kwargs": {"tenant_id": "explicit-tenant"}}, "explicit-tenant", id="explicit"
+            ),
+            pytest.param(
+                {
+                    "client_kwargs": {},
+                    "api_base_url": "https://login.microsoftonline.com/tenant-from-url/oauth2/v2.0/",
+                },
+                "tenant-from-url",
+                id="from-api-base-url",
+            ),
+            pytest.param(
+                {
+                    "client_kwargs": {},
+                    "api_base_url": None,
+                    "access_token_url": "https://login.microsoftonline.com/tenant-from-token-url/oauth2/v2.0/token",
+                },
+                "tenant-from-token-url",
+                id="from-access-token-url",
+            ),
+        ],
+    )
+    def test_get_azure_tenant_id_resolves_configured_tenant(self, remote_kwargs, expected):
+        """The tenant is taken from client_kwargs when set, otherwise from the configured endpoints."""
+        sm = EmptySecurityManager()
+        sm.oauth_remotes = {"azure": Mock(**remote_kwargs)}
+
+        assert sm._get_azure_tenant_id() == expected
+
+    @pytest.mark.parametrize("multi_tenant_segment", ["common", "organizations", "consumers"])
+    def test_get_azure_tenant_id_returns_none_for_tenant_agnostic_endpoints(self, multi_tenant_segment):
+        """The shared endpoints identify no single tenant, so no issuer can be pinned."""
+        sm = EmptySecurityManager()
+        sm.oauth_remotes = {
+            "azure": Mock(
+                client_kwargs={},
+                api_base_url=f"https://login.microsoftonline.com/{multi_tenant_segment}/oauth2/v2.0/",
+                access_token_url=None,
+                authorize_url=None,
+            )
+        }
+
+        assert sm._get_azure_tenant_id() is None
+
+    def test_decode_and_validate_azure_jwt_requires_a_resolvable_tenant(self):
+        """Without a tenant there is no issuer to check, so the token is not accepted."""
+        from airflow.exceptions import AirflowConfigException
+
+        sm = EmptySecurityManager()
+        sm.oauth_remotes = {
+            "azure": Mock(
+                client_kwargs={},
+                api_base_url="https://login.microsoftonline.com/common/oauth2/v2.0/",
+                access_token_url=None,
+                authorize_url=None,
+            )
+        }
+
+        with pytest.raises(AirflowConfigException, match="tenant could not be determined"):
+            sm._decode_and_validate_azure_jwt("header.payload.signature")
+
+    def test_decode_and_validate_azure_jwt_pins_issuer_and_audience(self):
+        """The decode call constrains both the issuer and the audience of the token."""
+        sm = EmptySecurityManager()
+        sm.oauth_remotes = {"azure": Mock(client_kwargs={"tenant_id": "tenant-abc"}, client_id="app-xyz")}
+
+        with mock.patch.object(EmptySecurityManager, "_get_microsoft_jwks", return_value={"keys": []}):
+            with mock.patch("authlib.jose.JsonWebKey.import_key_set"):
+                with mock.patch("authlib.jose.jwt.decode") as mock_decode:
+                    sm._decode_and_validate_azure_jwt("header.payload.signature")
+
+        claims_options = mock_decode.call_args.kwargs["claims_options"]
+        assert claims_options["aud"] == {"essential": True, "value": "app-xyz"}
+        assert claims_options["iss"]["essential"] is True
+        assert claims_options["iss"]["values"] == [
+            "https://login.microsoftonline.com/tenant-abc/v2.0",
+            "https://sts.windows.net/tenant-abc/",
+        ]
 
 
 def test_ldap_search_escapes_username_and_validates_filter():


### PR DESCRIPTION
The Azure `id_token` signature is verified against Microsoft's key set, but the decode call passes no `claims_options`, so authlib's `claims.validate()` enforces neither the **issuer** nor the **audience**.

The key set in use is the multi-tenant one — `login.microsoftonline.com/common/discovery/keys` — which serves signing keys for every Azure tenant. A correctly-signed token from *any* tenant therefore satisfies the signature check, and `get_oauth_user_info()` then reads the login identity (`oid`, `email`, `roles`) straight out of it.

### What this changes

Both claims are now pinned:

* `iss` must be the configured tenant, accepting the v1.0 (`sts.windows.net/<tenant>/`) and v2.0 (`login.microsoftonline.com/<tenant>/v2.0`) issuer forms, since either may be returned depending on which endpoints are configured.
* `aud` must be this application's `client_id`.

The tenant is resolved from an explicit `tenant_id` in `client_kwargs` when set, and otherwise from the tenant segment of the configured endpoints — which is where the [documented configuration](https://github.com/apache/airflow/blob/main/providers/fab/docs/auth-manager/sso.rst) already puts it:

```python
"api_base_url": "https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/",
```

**Deployments following the documented setup need no configuration change.**

### Behaviour change worth reviewing

A configuration that identifies no single tenant — the `common`, `organizations` or `consumers` endpoints — now raises `AirflowConfigException` rather than accepting tokens whose issuer it cannot check. Those deployments must set `tenant_id` explicitly.

I chose fail-closed deliberately: a silent fallback would leave exactly the behaviour this PR is removing. But it is a startup-time break for multi-tenant configurations, so it is the main thing I would like a second opinion on. The alternative is to log loudly and continue, which I think is worse but is a defensible call.

### Three things I would like your view on

1. **Fail-closed vs. warn-and-continue** for the tenant-less case, as above.
2. **Where `tenant_id` comes from.** I added it as an optional `client_kwargs` key and fall back to parsing the endpoints. Parsing-only would mean no new config surface at all; explicit-only would be cleaner but breaks every existing deployment. The current shape tries to get both.
3. **Both issuer forms.** I accept v1.0 and v2.0. If Airflow only ever requests v2.0 tokens, the `sts.windows.net` entry should go.

### Also worth noting

`_validate_jwt()` (the Authentik path, same file) has the identical `authlib_jwt.decode(id_token, keyset)` shape with no `claims_options`. Its blast radius is smaller because the Authentik JWKS is deployment-specific rather than multi-tenant, so there is no cross-issuer concern — but `aud` is still unchecked there. I left it out to keep this diff reviewable; happy to fold it in here or do it separately, whichever you prefer.

### Testing

Added coverage for tenant resolution (explicit, from `api_base_url`, from `access_token_url`, and the tenant-agnostic endpoints), for the fail-closed path, and for the claim options actually passed to `decode`. The existing `test_decode_and_validate_azure_jwt_verifies_signature_by_default` needed updating: tenant resolution now happens before the key set is fetched, so the mock had to grow a tenant-bearing endpoint.

All 42 tests in `test_override.py` pass locally.

---

Generated-by: Claude Opus 5 (1M context) following the guidelines at
https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
