### PR TITLE
Require Dag edit to delete asset queued events

### DIFF
--- a/airflow-core/docs/security/api_permissions_ref.rst
+++ b/airflow-core/docs/security/api_permissions_ref.rst
@@ -89,7 +89,7 @@ source code so it stays up to date as endpoints are added or changed.
    * - ``DELETE``
      - ``/api/v2/assets/{asset_id}/queuedEvents``
      - ``DAG``
-     - ``GET``
+     - ``PUT``
    * - ``GET``
      - ``/api/v2/assets/{asset_id}/queuedEvents``
      - ``Asset``
@@ -225,7 +225,7 @@ source code so it stays up to date as endpoints are added or changed.
    * - ``DELETE``
      - ``/api/v2/dags/{dag_id}/assets/queuedEvents``
      - ``DAG``
-     - ``GET``
+     - ``PUT``
    * - ``GET``
      - ``/api/v2/dags/{dag_id}/assets/queuedEvents``
      - ``Asset``
@@ -241,7 +241,7 @@ source code so it stays up to date as endpoints are added or changed.
    * - ``DELETE``
      - ``/api/v2/dags/{dag_id}/assets/{asset_id}/queuedEvents``
      - ``DAG``
-     - ``GET``
+     - ``PUT``
    * - ``GET``
      - ``/api/v2/dags/{dag_id}/assets/{asset_id}/queuedEvents``
      - ``Asset``

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -695,7 +695,7 @@ def get_dag_asset_queued_event(
     responses=create_openapi_http_exception_doc([status.HTTP_404_NOT_FOUND]),
     dependencies=[
         Depends(requires_access_asset(method="DELETE")),
-        Depends(requires_access_dag(method="GET")),
+        Depends(requires_access_dag(method="PUT")),
         Depends(action_logging()),
     ],
 )
@@ -729,7 +729,7 @@ def delete_asset_queued_events(
     ),
     dependencies=[
         Depends(requires_access_asset(method="DELETE")),
-        Depends(requires_access_dag(method="GET")),
+        Depends(requires_access_dag(method="PUT")),
         Depends(action_logging()),
     ],
 )
@@ -761,7 +761,7 @@ def delete_dag_asset_queued_events(
     ),
     dependencies=[
         Depends(requires_access_asset(method="DELETE")),
-        Depends(requires_access_dag(method="GET")),
+        Depends(requires_access_dag(method="PUT")),
         Depends(action_logging()),
     ],
 )

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
@@ -1591,6 +1591,73 @@ class TestGetDagAssetQueuedEvents(TestQueuedEventEndpoint):
         assert response.json() == {"queued_events": [], "total_entries": 0}
 
 
+class TestQueuedEventsDagAxisAuthorization:
+    """The Dag axis of the queued-events routes must match what the route does to the Dag.
+
+    Deleting queued events cancels a Dag's pending asset-triggered scheduling, which is a
+    write to that Dag's scheduling state, so those routes require Dag edit. Reading them
+    requires only Dag read.
+    """
+
+    @staticmethod
+    def _dag_axis_methods(route) -> list[str]:
+        """Return the ``method`` captured by each ``requires_access_dag`` on a route."""
+        from airflow.api_fastapi.core_api.security import requires_access_dag
+
+        module = requires_access_dag.__module__
+        methods = []
+        for dependency in route.dependant.dependencies:
+            call = dependency.call
+            # requires_access_dag returns a closure; the ResourceMethod it was built with
+            # is captured in one of that closure's cells.
+            if getattr(call, "__module__", None) != module or not call.__closure__:
+                continue
+            if call.__qualname__.split(".")[0] != "requires_access_dag":
+                continue
+            for cell in call.__closure__:
+                value = cell.cell_contents
+                if isinstance(value, str) and value in {"GET", "POST", "PUT", "DELETE", "MENU"}:
+                    methods.append(value)
+        return methods
+
+    @pytest.fixture
+    def routes_by_path(self, test_client):
+        return {
+            (r.path, tuple(sorted(r.methods))): r for r in test_client.app.routes if hasattr(r, "dependant")
+        }
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/assets/{asset_id}/queuedEvents",
+            "/dags/{dag_id}/assets/queuedEvents",
+            "/dags/{dag_id}/assets/{asset_id}/queuedEvents",
+        ],
+    )
+    def test_delete_queued_events_requires_dag_edit(self, routes_by_path, path):
+        matches = [
+            r for (p, methods), r in routes_by_path.items() if p.endswith(path) and "DELETE" in methods
+        ]
+        assert matches, f"no DELETE route registered for {path}"
+        for route in matches:
+            assert self._dag_axis_methods(route) == ["PUT"], (
+                f"DELETE {path} must gate the Dag axis on edit, not read"
+            )
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/dags/{dag_id}/assets/queuedEvents",
+            "/dags/{dag_id}/assets/{asset_id}/queuedEvents",
+        ],
+    )
+    def test_get_queued_events_requires_only_dag_read(self, routes_by_path, path):
+        matches = [r for (p, methods), r in routes_by_path.items() if p.endswith(path) and "GET" in methods]
+        assert matches, f"no GET route registered for {path}"
+        for route in matches:
+            assert self._dag_axis_methods(route) == ["GET"]
+
+
 class TestDeleteDagDatasetQueuedEvents(TestQueuedEventEndpoint):
     @pytest.mark.usefixtures("time_freezer")
     def test_should_respond_204(self, test_client, session, create_dummy_dag):

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -463,6 +463,7 @@ deliverability
 deltalake
 denylist
 dep
+dependant
 DependencyMixin
 Deprecations
 deprecations


### PR DESCRIPTION
The three asset queued-events `DELETE` endpoints authorize the Dag axis with `requires_access_dag(method="GET")` — a read-level check — while deleting rows from `AssetDagRunQueue`, which cancels a Dag's pending asset-triggered scheduling.

Every other Dag-scheduling mutation in the API requires Dag edit:

* Dag run clear / patch / delete — `method="PUT"`/`"DELETE"` with `access_entity=RUN`
* task-instance state changes — `method="PUT"`

These three deletes were the only Dag-scheduling-state writes gated on read. A caller holding `can_delete` on the global `Assets` resource plus only `can_read` on a Dag could therefore suppress that Dag's asset-triggered runs.

### Change

The Dag-axis gate on the three routes moves to `method="PUT"`. The paired `requires_access_asset(method="DELETE")` and the `ReadableDagsFilterDep` row filter are unchanged — only the Dag axis moves from read to edit.

The `GET` queued-events routes keep `method="GET"`; reading queued events is a read.

The generated REST API permission reference picked the change up automatically:

```diff
    * - ``DELETE``
      - ``/api/v2/dags/{dag_id}/assets/queuedEvents``
      - ``DAG``
-     - ``GET``
+     - ``PUT``
```

### Compatibility

This is a tightening, so a caller who previously succeeded with only Dag read on these three endpoints will now get a 403. That is the intent, but it is worth a second opinion on whether it needs a release-note callout beyond the permission-reference diff.

### Testing

Added `TestQueuedEventsDagAxisAuthorization`, which introspects the registered routes and asserts the `method` each `requires_access_dag` was built with — `PUT` on the three deletes, `GET` on the two reads. Verified it is not vacuous: reverting the source change makes exactly the three delete assertions fail while the two read assertions still pass.

All 185 tests in `test_assets.py` pass.

`dependant` is added to `docs/spelling_wordlist.txt` — it is FastAPI's own attribute name on a route object, which codespell otherwise flags.

---

Generated-by: Claude Opus 5 (1M context) following the guidelines at
https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
