### PR TITLE
Make finished TIs more lightweight when scanning task instances for scheduling

### DIFF
--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -23,6 +23,7 @@ import os
 import re
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Sequence
+from dataclasses import dataclass, fields
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar, cast, overload
 from uuid import UUID
@@ -140,14 +141,41 @@ log = structlog.get_logger(__name__)
 tracer = trace.get_tracer(__name__)
 
 
+@dataclass(frozen=True, slots=True, eq=False)
+class FinishedTI:
+    """
+    Immutable view of a task instance in a terminal state.
+
+    Keeps the dag_run rescan lightweight and fast: scheduling only reads these columns
+    off finished task instances, so a fully instrumented TaskInstance per row is
+    unnecessary. ``task`` is attached from the serialized dag rather than the row.
+
+    ``eq=False`` keeps the same identity-based equality and hashing a TaskInstance has.
+
+    Anything needing a full TaskInstance must re-fetch it (see ``_ensure_type_task_instance``).
+    """
+
+    task_id: str
+    map_index: int
+    state: str | None
+    start_date: datetime | None
+    end_date: datetime | None
+    task: Operator | None = None
+
+
+# Get the necessary columns from the FinishedTI fields so that the class stays
+# the single source of truth. For any needed change, add or remove a field there.
+FINISHED_TI_COLUMNS = tuple(getattr(TI, f.name) for f in fields(FinishedTI) if f.name != "task")
+
+
 class TISchedulingDecision(NamedTuple):
     """Type of return for DagRun.task_instance_scheduling_decisions."""
 
-    tis: list[TI]
+    tis: list[TI | FinishedTI]
     schedulable_tis: list[TI]
     changed_tis: bool
     unfinished_tis: list[TI]
-    finished_tis: list[TI]
+    finished_tis: list[TI | FinishedTI]
 
 
 def _default_run_after(ctx):
@@ -1333,7 +1361,7 @@ class DagRun(Base, LoggingMixin):
                 callback = self.produce_dag_callback(
                     dag=dag,
                     success=False,
-                    relevant_ti=ti_causing_failure,
+                    relevant_ti=self._ensure_type_task_instance(ti_causing_failure, session=session),
                     reason="task_failure",
                     execute=execute_callbacks,
                 )
@@ -1355,7 +1383,7 @@ class DagRun(Base, LoggingMixin):
             self.notify_dagrun_state_changed(msg="success")
 
             if dag.has_on_success_callback:
-                last_succeeded_ti: TI | None = max(
+                last_succeeded_ti: TI | FinishedTI | None = max(
                     (ti for ti in tis if ti.state == TaskInstanceState.SUCCESS),
                     key=lambda ti: ti.end_date or timezone.make_aware(datetime.min),
                     default=None,
@@ -1363,7 +1391,7 @@ class DagRun(Base, LoggingMixin):
                 callback = self.produce_dag_callback(
                     dag=dag,
                     success=True,
-                    relevant_ti=last_succeeded_ti,
+                    relevant_ti=self._ensure_type_task_instance(last_succeeded_ti, session=session),
                     reason="success",
                     execute=execute_callbacks,
                 )
@@ -1449,8 +1477,27 @@ class DagRun(Base, LoggingMixin):
 
     @provide_session
     def task_instance_scheduling_decisions(self, *, session: Session = NEW_SESSION) -> TISchedulingDecision:
-        tis = self.get_task_instances(session=session, state=State.task_states)
-        self.log.debug("number of tis tasks for %s: %s task(s)", self, len(tis))
+        # Fetch finished task instances as lightweight read-only rows and only the
+        # unfinished ones as full ORM objects. Finished ones are never mutated during
+        # scheduling, so hydrating them is pure overhead.
+        #
+        # Flush here to avoid task instances ending up in the wrong list or in both,
+        # in case of a pending in-session state change.
+        # The airflow session maker sets autoflush=False (ref settings.configure_orm).
+        session.flush()
+        unfinished_tis = self.get_task_instances(session=session, state=State.unfinished)
+        finished_rows = session.execute(
+            select(*FINISHED_TI_COLUMNS)
+            .where(
+                TI.dag_id == self.dag_id,
+                TI.run_id == self.run_id,
+                TI.state.in_(State.finished),
+            )
+            .order_by(TI.task_id, TI.map_index)
+        ).all()
+        self.log.debug(
+            "number of tis tasks for %s: %s task(s)", self, len(unfinished_tis) + len(finished_rows)
+        )
 
         def _filter_tis_and_exclude_removed(dag: SerializedDAG, tis: list[TI]) -> Iterable[TI]:
             """Populate ``ti.task`` while excluding those missing one, marking them as REMOVED."""
@@ -1465,10 +1512,38 @@ class DagRun(Base, LoggingMixin):
                 else:
                     yield ti
 
-        tis = list(_filter_tis_and_exclude_removed(self.get_dag(), tis))
+        def _build_finished_tis(dag: SerializedDAG, rows) -> list[FinishedTI]:
+            """Attach the serialized task, dropping (and marking REMOVED) rows whose task is gone."""
+            finished: list[FinishedTI] = []
+            orphaned: list[str] = []
+            for row in rows:
+                try:
+                    task = dag.get_task(row.task_id)
+                except TaskNotFound:
+                    if row.state != TaskInstanceState.REMOVED:
+                        orphaned.append(row.task_id)
+                    continue
+                finished.append(FinishedTI(**row._mapping, task=task))
+            if orphaned:
+                self.log.error("Failed to get task for finished tis %s. Marking them as removed.", orphaned)
+                session.execute(
+                    update(TI)
+                    .where(
+                        TI.dag_id == self.dag_id,
+                        TI.run_id == self.run_id,
+                        TI.task_id.in_(orphaned),
+                        TI.state != TaskInstanceState.REMOVED,
+                    )
+                    .values(state=TaskInstanceState.REMOVED)
+                    .execution_options(synchronize_session=False)
+                )
+            return finished
 
-        unfinished_tis = [t for t in tis if t.state in State.unfinished]
-        finished_tis = [t for t in tis if t.state in State.finished]
+        dag = self.get_dag()
+        unfinished_tis = list(_filter_tis_and_exclude_removed(dag, unfinished_tis))
+        finished_tis: list[TI | FinishedTI] = list(_build_finished_tis(dag, finished_rows))
+
+        tis: list[TI | FinishedTI] = [*unfinished_tis, *finished_tis]
         if unfinished_tis:
             schedulable_tis = [ut for ut in unfinished_tis if ut.state in SCHEDULEABLE_STATES]
             self.log.debug("number of scheduleable tasks for %s: %s task(s)", self, len(schedulable_tis))
@@ -1629,7 +1704,7 @@ class DagRun(Base, LoggingMixin):
     def _get_ready_tis(
         self,
         schedulable_tis: list[TI],
-        finished_tis: list[TI],
+        finished_tis: list[TI | FinishedTI],
         session: Session,
     ) -> tuple[list[TI], bool, bool]:
         old_states: dict[TaskInstanceKey, Any] = {}
@@ -1737,10 +1812,28 @@ class DagRun(Base, LoggingMixin):
 
         return ready_tis, changed_tis, expansion_happened
 
+    def _ensure_type_task_instance(self, ti: TI | FinishedTI | None, *, session: Session) -> TI | None:
+        """
+        Return ``ti`` as a full TaskInstance, re-fetching it when it is a FinishedTI view.
+
+        Full instances (and ``None``) pass through unchanged. Only the dag-callback path
+        needs the full row, and only when a dag_run reaches a terminal state, so the
+        re-fetch costs one query per finished dag_run rather than one per loop.
+        """
+        if not isinstance(ti, FinishedTI):
+            return ti
+        return DagRun.fetch_task_instance(
+            dag_id=self.dag_id,
+            dag_run_id=self.run_id,
+            task_id=ti.task_id,
+            map_index=ti.map_index,
+            session=session,
+        )
+
     def _are_premature_tis(
         self,
         unfinished_tis: Sequence[TI],
-        finished_tis: list[TI],
+        finished_tis: list[TI | FinishedTI],
         session: Session,
     ) -> tuple[bool, bool]:
         dep_context = DepContext(
@@ -1756,7 +1849,9 @@ class DagRun(Base, LoggingMixin):
             dep_context.have_changed_ti_states,
         )
 
-    def _emit_true_scheduling_delay_stats_for_finished_state(self, finished_tis: list[TI]) -> None:
+    def _emit_true_scheduling_delay_stats_for_finished_state(
+        self, finished_tis: list[TI | FinishedTI]
+    ) -> None:
         """
         Emit the true scheduling delay stats.
 

--- a/airflow-core/src/airflow/ti_deps/dep_context.py
+++ b/airflow-core/src/airflow/ti_deps/dep_context.py
@@ -28,7 +28,7 @@ from airflow.utils.state import State
 if TYPE_CHECKING:
     from sqlalchemy.orm.session import Session
 
-    from airflow.models.dagrun import DagRun
+    from airflow.models.dagrun import DagRun, FinishedTI
     from airflow.models.taskinstance import TaskInstance
 
 
@@ -79,7 +79,7 @@ class DepContext:
     ignore_task_deps: bool = False
     ignore_ti_state: bool = False
     ignore_unmapped_tasks: bool = False
-    finished_tis: list[TaskInstance] | None = None
+    finished_tis: list[TaskInstance | FinishedTI] | None = None
     description: str | None = None
 
     have_changed_ti_states: bool = False
@@ -107,20 +107,22 @@ class DepContext:
     fresh empty dict, so they would neither read the memo nor warm it for anything else.
     """
 
-    def ensure_finished_tis(self, dag_run: DagRun, session: Session) -> list[TaskInstance]:
+    def ensure_finished_tis(self, dag_run: DagRun, session: Session) -> list[TaskInstance | FinishedTI]:
         """
         Ensure finished_tis is populated if it's currently None, which allows running tasks without dag_run.
 
          :param dag_run: The DagRun for which to find finished tasks
          :return: A list of all the finished tasks of this DAG and logical_date
         """
+        finished_tis: list[TaskInstance | FinishedTI]
         if self.finished_tis is None:
-            finished_tis = dag_run.get_task_instances(state=State.finished, session=session)
-            for ti in finished_tis:
+            fetched = dag_run.get_task_instances(state=State.finished, session=session)
+            for ti in fetched:
                 if getattr(ti, "task", None) is not None or (dag := dag_run.dag) is None:
                     continue
                 with contextlib.suppress(TaskNotFound):
                     ti.task = dag.get_task(ti.task_id)
+            finished_tis = list(fetched)
             self.finished_tis = finished_tis
         else:
             finished_tis = self.finished_tis

--- a/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
     from sqlalchemy.sql import ColumnElement
 
+    from airflow.models.dagrun import FinishedTI
     from airflow.models.taskinstance import TaskInstance
     from airflow.serialization.definitions.mappedoperator import Operator
     from airflow.serialization.definitions.taskgroup import SerializedTaskGroup
@@ -58,7 +59,7 @@ class _UpstreamTIStates(NamedTuple):
     skipped_setup: int
 
     @classmethod
-    def calculate(cls, finished_upstreams: Iterator[TaskInstance]) -> _UpstreamTIStates:
+    def calculate(cls, finished_upstreams: Iterator[TaskInstance | FinishedTI]) -> _UpstreamTIStates:
         """
         Calculate states for a task instance.
 
@@ -206,7 +207,9 @@ class TriggerRuleDep(BaseTIDep):
                 session=session,
             )
 
-        def _is_relevant_upstream(upstream: TaskInstance, relevant_ids: set[str] | KeysView[str]) -> bool:
+        def _is_relevant_upstream(
+            upstream: TaskInstance | FinishedTI, relevant_ids: set[str] | KeysView[str]
+        ) -> bool:
             """
             Whether a task instance is a "relevant upstream" of the current task.
 

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -10975,8 +10975,8 @@ class TestSchedulerJobQueriesCount:
             # 10 DAGs with 10 tasks per DAG file.
             ([10, 10, 10, 10], 10, 10, "1d", "None", "no_structure"),
             ([10, 10, 10, 10], 10, 10, "1d", "None", "linear"),
-            ([218, 69, 69, 69], 10, 10, "1d", "@once", "no_structure"),
-            ([228, 84, 84, 84], 10, 10, "1d", "@once", "linear"),
+            ([218, 97, 89, 89], 10, 10, "1d", "@once", "no_structure"),
+            ([228, 104, 104, 104], 10, 10, "1d", "@once", "linear"),
             ([217, 119, 119, 119], 10, 10, "1d", "30m", "no_structure"),
             ([2227, 145, 145, 145], 10, 10, "1d", "30m", "linear"),
             ([227, 139, 139, 139], 10, 10, "1d", "30m", "binary_tree"),

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -53,7 +53,7 @@ from airflow._shared.timezones import timezone
 from airflow.callbacks.callback_requests import DagCallbackRequest, DagRunContext
 from airflow.models.dag import DagModel, infer_automated_data_interval
 from airflow.models.dag_version import DagVersion
-from airflow.models.dagrun import DagRun, DagRunNote, clear_partition_runs
+from airflow.models.dagrun import DagRun, DagRunNote, FinishedTI, clear_partition_runs
 from airflow.models.deadline import Deadline
 from airflow.models.deadline_alert import DeadlineAlert as DeadlineAlertModel
 from airflow.models.serialized_dag import SerializedDagModel
@@ -471,6 +471,10 @@ class TestDagRun:
         # Make sure the correct TI is passed on success
         call_args = execute_dag_callbacks.call_args
         ti_passed = call_args.kwargs["relevant_ti"]
+        # During scheduling, finished tis are accessed as a minimal FinishedTI view,
+        # and only the ti handed to a dag callback is fetched as a full TaskInstance.
+        # Check that the callback receives a TaskInstance and not a FinishedTI.
+        assert isinstance(ti_passed, TaskInstance)
         assert ti_passed.task_id == "test_state_succeeded2"
 
         assert dag_run.state == DagRunState.SUCCESS
@@ -505,6 +509,10 @@ class TestDagRun:
         # Make sure the correct TI is passed on failure
         call_args = execute_dag_callbacks.call_args
         ti_passed = call_args.kwargs["relevant_ti"]
+        # During scheduling, finished tis are accessed as a minimal FinishedTI view,
+        # and only the ti handed to a dag callback is fetched as a full TaskInstance.
+        # Check that the callback receives a TaskInstance and not a FinishedTI.
+        assert isinstance(ti_passed, TaskInstance)
         assert ti_passed.task_id == "test_state_failed2"
 
         assert dag_run.state == DagRunState.FAILED
@@ -2409,9 +2417,15 @@ def test_ti_scheduling_mapped_zero_length(dag_maker, session):
 
     decision = dr.task_instance_scheduling_decisions(session=session)
 
-    # ti1 finished execution. ti2 goes directly to finished state because it's
-    # expanded against a zero-length XCom.
-    assert decision.finished_tis == [ti1, ti2]
+    # The finished_tis list contains both FinishedTI and TaskInstance types,
+    # so compare by content rather than identity.
+    #
+    # ti1 finished execution (before the decision - FinishedTI). ti2 goes directly to finished state
+    # (during the decision - TaskInstance) because it's expanded against a zero-length XCom.
+    assert [(ti.task_id, ti.state) for ti in decision.finished_tis] == [
+        (ti1.task_id, TaskInstanceState.SUCCESS),
+        (ti2.task_id, TaskInstanceState.SKIPPED),
+    ]
 
     indices = session.execute(
         select(TI.map_index, TI.state)
@@ -3957,6 +3971,29 @@ def test_teardown_and_fail_fast(dag_maker):
         "tg_2.my_teardown": "skipped",
         "tg_2.my_work": "skipped",
     }
+
+
+def test_scheduling_decisions_mark_orphaned_finished_tis_removed(dag_maker, session):
+    """A finished ti whose task no longer exists in the dag is marked REMOVED and excluded."""
+    with dag_maker(session=session):
+        EmptyOperator(task_id="stays")
+        EmptyOperator(task_id="vanishes")
+    dr = dag_maker.create_dagrun()
+    for ti in dr.get_task_instances(session=session):
+        ti.state = TaskInstanceState.SUCCESS
+    session.flush()
+
+    del dr.dag.task_dict["vanishes"]
+    decision = dr.task_instance_scheduling_decisions(session=session)
+
+    assert len(decision.finished_tis) == 1
+    finished_ti = decision.finished_tis[0]
+    assert isinstance(finished_ti, FinishedTI)
+    assert finished_ti.task_id == "stays"
+    assert finished_ti.state == TaskInstanceState.SUCCESS
+    assert finished_ti.task is dr.dag.task_dict["stays"]
+    session.expire_all()
+    assert dr.get_task_instance("vanishes", session=session).state == TaskInstanceState.REMOVED
 
 
 class TestDagRunHandleDagCallback:


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

The goal of this PR is to increase scheduler performance.

## Scheduler investigation

In our production environment, sometimes schedulers become very slow under load.

During my investigation, I added debug spans for every major step of the scheduler's iteration loop to help understand the issue. There is an open PR with the changes

https://github.com/apache/airflow/pull/69809

I ran various tests and with the help of the debug spans from the PR, I was able to identify a possible bottleneck.

When we have multiple dags with a lot of tasks running in parallel, the scheduler spends most of the time scanning the task instances of the active dag runs to decide which can be queued. It actually looks for SCHEDULED tasks that can be moved to QUEUED state.

Once the tasks are moved to QUEUED state, then the worker can pick them up and it's no longer up to the scheduler.

The scan is consisted of 2 parts. The actual DB query that fetches the data and the SQL-alchemy part which hydrates ORM objects with the query results. Basically, it creates `taskinstance` objects and fills them with data from each row that we get back. According to the spans, the query is very fast and the entire time is spent on the object hydration part.

The code distinguishes between finished and unfinished tasks but only after the query. It fetches all of them from the DB and creates objects and then splits them into 2 separate lists.

## Solution

Let's assume that we have a dag run with 1000 tasks. If 100 tasks have finished, then during the scan we hydrate 100 objects for finished tasks and 900 for unfinished. Similarly, if 400 tasks have finished, then we hydrate 400 objects for finished tasks and 600 for unfinished. As the dag run progresses we get more and more finished tasks.

For finished tasks, we don't really need full ORM objects because we only read 5 fields and we never modify them. Instead of creating a full `taskinstance` object, we can hydrate a more lightweight immutable object with only the 5 necessary fields.

Instead of having 1 query that fetches everything, creates objects and then splits them into 2 lists, we can have 2 queries, one for unfinished tasks that hydrates full objects and one for finished tasks that hydrates lightweight read-only objects.

There is a scenario with dag callbacks where we need the actual `taskinstance` object in which case we fetch it from the DB. Still cheaper than the current approach.

## Testing

### Setup

* 1 scheduler
* 3 celery workers × 18 slots = 54 execution slots

### Config

* max_tis_per_query=16 (default)
* max_dagruns_per_loop_to_schedule=20
* parallelism, max_active_tasks_per_dag and default_pool_task_slot_count set to 4096 so that there isn't a limit other than the scheduler itself

### Workload

* 35 identical dag runs all start in parallel
* each dag has a 1st deferrable task and then 9 sequential mapped task stages
* when the deferrable task finishes, it returns a number that determines the number of tasks that each stage expands to

The deferrable task doesn't have any special meaning. It just helps to make sure that most of the mapped tasks are running in parallel.

So for example, if the 1st task returns 10, the 1st stage will expand into 10 tasks. Once these 10 finish, then the 2nd expands into 10 tasks. Once, these finish then the 3rd expands into 10 tasks and so on. And this is running for 35 parallel dags. 

I used 70 for the number of mapped tasks, which translates into 9stages * 70tasks * 35dags = 22050 tasks and another 35 deferred, 22085 in total.

The code from `main` takes 35 minutes to run the 22000 tasks, while the code from this patch took 28 minutes. The more the load, the bigger the difference.

**Here are some gathered metrics during the test. Left is the code from `main` and right is the code from this patch.**

### Time needed for each scan (the PR improvement)

<img width="1980" height="614" alt="image" src="https://github.com/user-attachments/assets/1593966c-285c-45c2-b008-28e3d765240d" />

Before it reached up to 94ms while after it never exceeded 20ms.

### Scheduler loop duration per iteration

<img width="1978" height="608" alt="image" src="https://github.com/user-attachments/assets/d9ad6409-2bb1-4a71-8190-08f883f57fed" />

Iterations became faster.

### Scheduler vs worker vs worker slot utilization

<img width="3966" height="1218" alt="image" src="https://github.com/user-attachments/assets/509bd139-742a-4a6a-a07a-ae0de0d7e29d" />

Scheduler is working at 100% in both cases but before it was spending most of its resources on the ORM hydration and it  wouldn't hand enough tasks to workers.

I've set max slot occupancy to 54. Before the change, at any given moment we would have up to 34% of the 54 slots occupied. After, we reach 100% occupancy and that didn't occur once but for most of the time.

Red line is the worker slot occupancy.

### Time waiting for the scheduler vs workers

<img width="3944" height="614" alt="image" src="https://github.com/user-attachments/assets/f9a521a9-48d3-4f24-b5ff-e33970749cc3" />

At the end, tasks end up waiting for workers instead of the scheduler.

### Increased number of running tasks

<img width="1992" height="624" alt="image" src="https://github.com/user-attachments/assets/64d41d65-7866-423e-a955-9c18b69db2b0" />

### Waiting on the scheduler (SCHEDULED -> QUEUED) vs waiting for the workers (QUEUED -> RUNNING)

<img width="3968" height="1216" alt="image" src="https://github.com/user-attachments/assets/a52846cd-32df-44f0-a294-75dcea3a5267" />

Tasks wait less on the scheduler and more for a worker.

### Same number of tasks, finish faster

<img width="3970" height="624" alt="image" src="https://github.com/user-attachments/assets/740afcdd-2748-4349-81aa-dbcf969af398" />

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Claude code Opus 4.8

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
