### PR TITLE
Add LLMSchemaCompareOperator to the common-ai operator index table

### DIFF
--- a/providers/common/ai/docs/operators/index.rst
+++ b/providers/common/ai/docs/operators/index.rst
@@ -43,6 +43,9 @@ to pick the one that fits your use case:
    * - Natural-language → SQL generation (no execution)
      - :class:`~airflow.providers.common.ai.operators.llm_sql.LLMSQLQueryOperator`
      - ``@task.llm_sql``
+   * - Compare schemas across data sources and detect drift
+     - :class:`~airflow.providers.common.ai.operators.llm_schema_compare.LLMSchemaCompareOperator`
+     - ``@task.llm_schema_compare``
    * - Multi-turn reasoning with tools (DB queries, API calls, etc.)
      - :class:`~airflow.providers.common.ai.operators.agent.AgentOperator`
      - ``@task.agent``


### PR DESCRIPTION
### Sumarry

The table in `providers/common/ai/docs/operators/index.rst` lists every operator in the provider except `LLMSchemaCompareOperator`, even though it has its own fully-documented operator guide (`docs/operators/llm_schema_compare.rst`). 

### Changes

Add a row for `LLMSchemaCompareOperator` / `@task.llm_schema_compare`, next to the other SQL/schema-introspection operators.

No any behavior be changed.
