### PR TITLE
Fix incorrect documented defaults for MwaaTriggerDagRunOperator waiter params

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/mwaa.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/mwaa.py
@@ -55,8 +55,8 @@ class MwaaTriggerDagRunOperator(AwsBaseOperator[MwaaHook]):
             This parameter is only used if the local web token method is used to call Airflow API. (templated)
 
     :param wait_for_completion: Whether to wait for Dag run to stop. (default: False)
-    :param waiter_delay: Time in seconds to wait between status checks. (default: 120)
-    :param waiter_max_attempts: Maximum number of attempts to check for Dag run completion. (default: 720)
+    :param waiter_delay: Time in seconds to wait between status checks. (default: 60)
+    :param waiter_max_attempts: Maximum number of attempts to check for Dag run completion. (default: 20)
     :param deferrable: If True, the operator will wait asynchronously for the Dag run to stop.
         This implies waiting for completion. This mode requires aiobotocore module to be installed.
         (default: False)


### PR DESCRIPTION
The class docstring for `MwaaTriggerDagRunOperator` (`providers/amazon/aws/operators/mwaa.py`) documents `waiter_delay` and `waiter_max_attempts` defaults that no longer match the constructor:

| param | docstring says | constructor default |
|---|---|---|
| `waiter_delay` | `120` | `60` |
| `waiter_max_attempts` | `720` | `20` |

The code defaults were lowered in a previous change, but the docstring was not updated. This aligns the docstring with the actual defaults (the sibling `triggers/mwaa.py` already documents `60` for the delay). Documentation-only; no behavior change.

---
> [!NOTE]
> This change was prepared with AI assistance; the fix was reviewed and verified against the constructor signature.