### PR TITLE
Check the pod uid on KubernetesPodOperator durable reattach

### DIFF
--- a/providers/cncf/kubernetes/docs/operators.rst
+++ b/providers/cncf/kubernetes/docs/operators.rst
@@ -206,7 +206,10 @@ If no identity has been persisted yet to the task state store - either because t
 worker crashed in the narrow window after the pod was created but before its identity could be
 persisted, the operator falls back to the same label search ``reattach_on_restart`` has always
 used, so a running pod from a prior attempt is still found and reattached to rather than
-duplicated. Once an identity is persisted, subsequent retries skip the label search entirely.
+duplicated. The label search is used again whenever the persisted identity cannot be trusted: the
+pod is gone, its uid no longer matches, a prior attempt already checked it, or the identity was
+written by a provider version that did not record a uid yet. A pod found that way is persisted
+again together with its uid.
 
 To always create a fresh pod on retry rather than reattaching, set ``durable=False``:
 

--- a/providers/cncf/kubernetes/docs/operators.rst
+++ b/providers/cncf/kubernetes/docs/operators.rst
@@ -195,10 +195,12 @@ worker is preempted or crashes) and the task is retried, the operator can reatta
 that is already running instead of creating a duplicate. This is controlled by the ``durable``
 parameter, which defaults to ``True``.
 
-On Airflow 3.3+, ``durable=True`` persists the running pod's identity (name, namespace) to
+On Airflow 3.3+, ``durable=True`` persists the running pod's identity (name, namespace, uid) to
 :doc:`task state store <apache-airflow:core-concepts/task-state-store>` before the operator starts
 waiting on it. On retry, the operator reads this identity back and reconnects directly to that
-specific pod -- the reconnect step uses this persisted identity instead of a label search.
+specific pod -- the reconnect step uses this persisted identity instead of a label search. The uid is
+compared on reconnect, so a name that an unrelated pod took over after the recorded one was deleted
+is treated as a pod that no longer exists rather than reattached to.
 
 If no identity has been persisted yet to the task state store - either because this is the first attempt, or because the
 worker crashed in the narrow window after the pod was created but before its identity could be

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -668,35 +668,36 @@ class KubernetesPodOperator(BaseOperator):
         self.log.info("`try_number` of task_instance: %s", context["ti"].try_number)
         self.log.info("`try_number` of pod: %s", pod.metadata.labels["try_number"])
 
-    def _get_pod_from_task_state_store(self, context: Context) -> k8s.V1Pod | None:
+    def _get_pod_from_task_state_store(self, context: Context) -> tuple[k8s.V1Pod | None, str | None]:
+        """
+        Return the pod recorded for this task instance, with the namespace it was recorded in.
+
+        The namespace comes back even when the pod does not, so that a caller falling back to the
+        label search looks where the pod was submitted instead of where this try would put it.
+        """
         task_state_store = context.get("task_state_store")
         if task_state_store is None:
-            return None
+            return None, None
         stored = task_state_store.get(POD_IDENTIFIER_STATE_KEY)
         if not isinstance(stored, dict):
-            return None
+            return None, None
         name, namespace = stored.get("name"), stored.get("namespace")
         if not isinstance(name, str) or not name or not isinstance(namespace, str) or not namespace:
             self.log.warning(
                 "Pod identity stored in task state store is malformed (%s), falling back to label search.",
                 stored,
             )
-            return None
+            return None, None
         uid = stored.get("uid")
         if uid is None:
             # Written before the uid was recorded. The name on its own cannot tell this pod from one
-            # that took its name, so identify it by label, in the namespace it was submitted to
-            # rather than the one rendered for this attempt, and record the uid for later retries.
+            # that took its name, so leave it to the label search.
             self.log.info(
-                "Pod identity stored in task state store for %s/%s has no uid, "
-                "resolving it by label search instead.",
+                "Pod identity stored in task state store for %s/%s has no uid, falling back to label search.",
                 namespace,
                 name,
             )
-            pod = self.find_pod(namespace, context=context)
-            if pod is not None:
-                self._persist_pod_identity_to_task_state_store(context, pod)
-            return pod
+            return None, namespace
         if not isinstance(uid, str) or not uid:
             self.log.warning(
                 "Pod identity stored in task state store for %s/%s has an invalid uid (%r), "
@@ -705,7 +706,7 @@ class KubernetesPodOperator(BaseOperator):
                 name,
                 uid,
             )
-            return None
+            return None, namespace
         try:
             pod = self.hook.get_pod(name, namespace)
         except ApiException as e:
@@ -716,7 +717,7 @@ class KubernetesPodOperator(BaseOperator):
                 namespace,
                 name,
             )
-            return None
+            return None, namespace
         # Names are reusable, uids are not: this is a different pod under the recorded name.
         if pod.metadata.uid != uid:
             self.log.warning(
@@ -727,7 +728,7 @@ class KubernetesPodOperator(BaseOperator):
                 uid,
                 pod.metadata.uid,
             )
-            return None
+            return None, namespace
         if (pod.metadata.labels or {}).get(self.POD_CHECKED_KEY) == "True":
             # A prior attempt already fully processed this pod, it belongs to a previous
             # try_number, not one to reattach to. Fall through to fresh pod creation.
@@ -737,12 +738,12 @@ class KubernetesPodOperator(BaseOperator):
                 namespace,
                 name,
             )
-            return None
+            return None, namespace
         self.log.info(
             "Reconnecting to pod %s/%s via identity persisted in task state store.", namespace, name
         )
         self.log_matching_pod(pod=pod, context=context)
-        return pod
+        return pod, namespace
 
     def _persist_pod_identity_to_task_state_store(self, context: Context, pod: k8s.V1Pod) -> None:
         task_state_store = context.get("task_state_store")
@@ -759,9 +760,10 @@ class KubernetesPodOperator(BaseOperator):
 
     def get_or_create_pod(self, pod_request_obj: k8s.V1Pod, context: Context) -> k8s.V1Pod:
         if self.reattach_on_restart:
-            pod = self._get_pod_from_task_state_store(context)
+            pod, stored_namespace = self._get_pod_from_task_state_store(context)
             if pod is None:
-                pod = self.find_pod(pod_request_obj.metadata.namespace, context=context)
+                namespace = stored_namespace or pod_request_obj.metadata.namespace
+                pod = self.find_pod(namespace, context=context)
                 if pod is not None:
                     self._persist_pod_identity_to_task_state_store(context, pod)
             if pod:

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -693,6 +693,19 @@ class KubernetesPodOperator(BaseOperator):
                 name,
             )
             return None
+        # Names are reusable, uids are not: once the recorded pod is deleted an unrelated pod can
+        # take its name. Identities persisted before uids were stored have nothing to compare.
+        uid = stored.get("uid")
+        if uid is not None and pod.metadata.uid != uid:
+            self.log.warning(
+                "Pod %s/%s from task state store is a different pod now "
+                "(recorded uid %s, found %s), falling back to label search.",
+                namespace,
+                name,
+                uid,
+                pod.metadata.uid,
+            )
+            return None
         if (pod.metadata.labels or {}).get(self.POD_CHECKED_KEY) == "True":
             # A prior attempt already fully processed this pod, it belongs to a previous
             # try_number, not one to reattach to. Fall through to fresh pod creation.
@@ -715,7 +728,11 @@ class KubernetesPodOperator(BaseOperator):
             return
         task_state_store.set(
             POD_IDENTIFIER_STATE_KEY,
-            {"name": pod.metadata.name, "namespace": pod.metadata.namespace},
+            {
+                "name": pod.metadata.name,
+                "namespace": pod.metadata.namespace,
+                "uid": pod.metadata.uid,
+            },
         )
 
     def get_or_create_pod(self, pod_request_obj: k8s.V1Pod, context: Context) -> k8s.V1Pod:

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -682,6 +682,16 @@ class KubernetesPodOperator(BaseOperator):
                 stored,
             )
             return None
+        uid = stored.get("uid")
+        if not isinstance(uid, str) or not uid:
+            # Written before the uid was recorded. A name on its own cannot tell the recorded pod
+            # from one that took its name, so let the run scoped label search identify it instead.
+            self.log.info(
+                "Pod identity stored in task state store for %s/%s has no uid, falling back to label search.",
+                namespace,
+                name,
+            )
+            return None
         try:
             pod = self.hook.get_pod(name, namespace)
         except ApiException as e:
@@ -693,10 +703,8 @@ class KubernetesPodOperator(BaseOperator):
                 name,
             )
             return None
-        # Names are reusable, uids are not: once the recorded pod is deleted an unrelated pod can
-        # take its name. Identities persisted before uids were stored have nothing to compare.
-        uid = stored.get("uid")
-        if uid is not None and pod.metadata.uid != uid:
+        # Names are reusable, uids are not: this is a different pod under the recorded name.
+        if pod.metadata.uid != uid:
             self.log.warning(
                 "Pod %s/%s from task state store is a different pod now "
                 "(recorded uid %s, found %s), falling back to label search.",

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -182,8 +182,9 @@ class KubernetesPodOperator(BaseOperator):
         ``durable`` has no effect there.
     :param durable: if the worker dies while the pod is running, reattach and monitor during the next
         try instead of creating a duplicate pod. If False, always create a new pod for each try.
-        Supersedes ``reattach_on_restart`` on Airflow 3.3+, where the reconnection uses a persisted
-        pod identity in task state store instead of a label search. Defaults to ``True`` on Airflow
+        Supersedes ``reattach_on_restart`` on Airflow 3.3+, where the reconnection uses a pod
+        identity persisted in task state store, falling back to the label search when that identity
+        no longer resolves to the pod it recorded. Defaults to ``True`` on Airflow
         3.3+. Below 3.3, ``durable`` has no effect -- setting it explicitly only emits a warning --
         and ``reattach_on_restart`` (default ``True``) is the only lever, using the same
         label-search reattach mechanism it always has.
@@ -718,7 +719,8 @@ class KubernetesPodOperator(BaseOperator):
                 name,
             )
             return None, namespace
-        # Names are reusable, uids are not: this is a different pod under the recorded name.
+        # Names are reusable, uids are not: this is a different pod under the recorded name. Only
+        # this lookup is fenced; https://github.com/apache/airflow/issues/71748 covers the rest.
         if pod.metadata.uid != uid:
             self.log.warning(
                 "Pod %s/%s from task state store is a different pod now "

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -676,20 +676,34 @@ class KubernetesPodOperator(BaseOperator):
         if not isinstance(stored, dict):
             return None
         name, namespace = stored.get("name"), stored.get("namespace")
-        if not isinstance(name, str) or not isinstance(namespace, str):
+        if not isinstance(name, str) or not name or not isinstance(namespace, str) or not namespace:
             self.log.warning(
                 "Pod identity stored in task state store is malformed (%s), falling back to label search.",
                 stored,
             )
             return None
         uid = stored.get("uid")
-        if not isinstance(uid, str) or not uid:
-            # Written before the uid was recorded. A name on its own cannot tell the recorded pod
-            # from one that took its name, so let the run scoped label search identify it instead.
+        if uid is None:
+            # Written before the uid was recorded. The name on its own cannot tell this pod from one
+            # that took its name, so identify it by label, in the namespace it was submitted to
+            # rather than the one rendered for this attempt, and record the uid for later retries.
             self.log.info(
-                "Pod identity stored in task state store for %s/%s has no uid, falling back to label search.",
+                "Pod identity stored in task state store for %s/%s has no uid, "
+                "resolving it by label search instead.",
                 namespace,
                 name,
+            )
+            pod = self.find_pod(namespace, context=context)
+            if pod is not None:
+                self._persist_pod_identity_to_task_state_store(context, pod)
+            return pod
+        if not isinstance(uid, str) or not uid:
+            self.log.warning(
+                "Pod identity stored in task state store for %s/%s has an invalid uid (%r), "
+                "falling back to label search.",
+                namespace,
+                name,
+                uid,
             )
             return None
         try:

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -2607,17 +2607,12 @@ class TestKubernetesPodOperatorDurableExecution:
             log_pod_spec_on_failure=False,
         )
         context = create_context(k)
-        task_state_store = MagicMock()
+        task_state_store = MagicMock(spec=["get", "set"])
         task_state_store.get.return_value = None
         context["task_state_store"] = task_state_store
 
-        mock_pod_request_obj = MagicMock()
-        mock_pod_request_obj.to_dict.return_value = {"metadata": {"name": "test-pod"}}
-        created_pod = MagicMock()
-        created_pod.metadata.name = "test-pod"
-        created_pod.metadata.namespace = "default"
-        created_pod.metadata.uid = "test-pod-uid"
-        self.create_mock.return_value = created_pod
+        mock_pod_request_obj = k8s.V1Pod(metadata=k8s.V1ObjectMeta(name="test-pod", namespace="default"))
+        self.create_mock.return_value = self._pod("test-pod", "default", "test-pod-uid")
 
         with patch(f"{KPO_MODULE}.KubernetesPodOperator.find_pod", return_value=None) as mock_find:
             result = k.get_or_create_pod(pod_request_obj=mock_pod_request_obj, context=context)
@@ -2640,7 +2635,7 @@ class TestKubernetesPodOperatorDurableExecution:
             log_pod_spec_on_failure=False,
         )
         context = create_context(k)
-        task_state_store = MagicMock()
+        task_state_store = MagicMock(spec=["get", "set"])
         task_state_store.get.return_value = {
             "name": "prior-pod",
             "namespace": "default",
@@ -2648,15 +2643,10 @@ class TestKubernetesPodOperatorDurableExecution:
         }
         context["task_state_store"] = task_state_store
 
-        running_pod = MagicMock()
-        running_pod.status.phase = "Running"
-        running_pod.status.reason = None
-        running_pod.metadata.name = "prior-pod"
-        running_pod.metadata.uid = "prior-pod-uid"
-        running_pod.metadata.labels = {"try_number": "1"}
+        running_pod = self._pod("prior-pod", "default", "prior-pod-uid")
         k.hook.get_pod = MagicMock(return_value=running_pod)
 
-        mock_pod_request_obj = MagicMock()
+        mock_pod_request_obj = k8s.V1Pod(metadata=k8s.V1ObjectMeta(name="prior-pod", namespace="default"))
 
         with patch(f"{KPO_MODULE}.KubernetesPodOperator.find_pod") as mock_find:
             result = k.get_or_create_pod(pod_request_obj=mock_pod_request_obj, context=context)
@@ -2680,7 +2670,7 @@ class TestKubernetesPodOperatorDurableExecution:
             log_pod_spec_on_failure=False,
         )
         context = create_context(k)
-        task_state_store = MagicMock()
+        task_state_store = MagicMock(spec=["get", "set"])
         task_state_store.get.return_value = {
             "name": "prior-pod",
             "namespace": "default",
@@ -2688,17 +2678,11 @@ class TestKubernetesPodOperatorDurableExecution:
         }
         context["task_state_store"] = task_state_store
 
-        terminal_pod = MagicMock()
-        terminal_pod.status.phase = pod_phase
-        terminal_pod.status.reason = None
-        terminal_pod.metadata.name = "prior-pod"
-        terminal_pod.metadata.uid = "prior-pod-uid"
-        terminal_pod.metadata.labels = {"try_number": "1"}
+        terminal_pod = self._pod("prior-pod", "default", "prior-pod-uid", phase=pod_phase)
         k.hook.get_pod = MagicMock(return_value=terminal_pod)
         mock_process_pod_deletion.return_value = True
 
-        mock_pod_request_obj = MagicMock()
-        mock_pod_request_obj.to_dict.return_value = {"metadata": {"name": "new-pod"}}
+        mock_pod_request_obj = k8s.V1Pod(metadata=k8s.V1ObjectMeta(name="new-pod", namespace="default"))
 
         with patch(f"{KPO_MODULE}.KubernetesPodOperator.find_pod") as mock_find:
             result = k.get_or_create_pod(pod_request_obj=mock_pod_request_obj, context=context)
@@ -2719,7 +2703,7 @@ class TestKubernetesPodOperatorDurableExecution:
             on_finish_action="keep_pod",
         )
         context = create_context(k)
-        task_state_store = MagicMock()
+        task_state_store = MagicMock(spec=["get", "set"])
         task_state_store.get.return_value = {
             "name": "prior-pod",
             "namespace": "default",
@@ -2727,22 +2711,17 @@ class TestKubernetesPodOperatorDurableExecution:
         }
         context["task_state_store"] = task_state_store
 
-        stale_pod = MagicMock()
-        stale_pod.status.phase = PodPhase.FAILED
-        stale_pod.status.reason = None
-        stale_pod.metadata.name = "prior-pod"
-        stale_pod.metadata.uid = "prior-pod-uid"
-        stale_pod.metadata.labels = {"try_number": "1", "already_checked": "True"}
+        stale_pod = self._pod(
+            "prior-pod",
+            "default",
+            "prior-pod-uid",
+            phase=PodPhase.FAILED,
+            labels={"already_checked": "True"},
+        )
         k.hook.get_pod = MagicMock(return_value=stale_pod)
+        self.create_mock.return_value = self._pod("new-pod", "default", "new-pod-uid")
 
-        created_pod = MagicMock()
-        created_pod.metadata.name = "new-pod"
-        created_pod.metadata.namespace = "default"
-        created_pod.metadata.uid = "new-pod-uid"
-        self.create_mock.return_value = created_pod
-
-        mock_pod_request_obj = MagicMock()
-        mock_pod_request_obj.to_dict.return_value = {"metadata": {"name": "new-pod"}}
+        mock_pod_request_obj = k8s.V1Pod(metadata=k8s.V1ObjectMeta(name="new-pod", namespace="default"))
 
         with (
             patch(f"{KPO_MODULE}.KubernetesPodOperator.find_pod", return_value=None) as mock_find,
@@ -2771,13 +2750,19 @@ class TestKubernetesPodOperatorDurableExecution:
         )
 
     @staticmethod
-    def _running_pod(name, namespace, uid):
+    def _pod(name, namespace, uid, phase=PodPhase.RUNNING, labels=None):
         return k8s.V1Pod(
-            metadata=k8s.V1ObjectMeta(name=name, namespace=namespace, uid=uid, labels={"try_number": "1"}),
-            status=k8s.V1PodStatus(phase=PodPhase.RUNNING),
+            metadata=k8s.V1ObjectMeta(
+                name=name,
+                namespace=namespace,
+                uid=uid,
+                labels={"try_number": "1", **(labels or {})},
+            ),
+            status=k8s.V1PodStatus(phase=phase),
         )
 
-    def test_durable_reconnect_skips_pod_whose_uid_no_longer_matches(self):
+    @patch(f"{KPO_MODULE}.KubernetesPodOperator.find_pod", return_value=None)
+    def test_durable_reconnect_skips_pod_whose_uid_no_longer_matches(self, mock_find):
         """A pod reusing the persisted name is a different pod and must not be reattached to."""
         k = self._durable_operator()
         context = create_context(k)
@@ -2789,16 +2774,13 @@ class TestKubernetesPodOperatorDurableExecution:
         }
         context["task_state_store"] = task_state_store
 
-        k.hook.get_pod = MagicMock(
-            return_value=self._running_pod("prior-pod", "default", "an-unrelated-pod-uid")
-        )
+        k.hook.get_pod = MagicMock(return_value=self._pod("prior-pod", "default", "an-unrelated-pod-uid"))
         self.create_mock.return_value = k8s.V1Pod(
             metadata=k8s.V1ObjectMeta(name="new-pod", namespace="default", uid="new-pod-uid")
         )
         pod_request_obj = k8s.V1Pod(metadata=k8s.V1ObjectMeta(name="new-pod", namespace="default"))
 
-        with patch(f"{KPO_MODULE}.KubernetesPodOperator.find_pod", return_value=None) as mock_find:
-            result = k.get_or_create_pod(pod_request_obj=pod_request_obj, context=context)
+        result = k.get_or_create_pod(pod_request_obj=pod_request_obj, context=context)
 
         mock_find.assert_called_once_with("default", context=context)
         self.create_mock.assert_called_once_with(pod=pod_request_obj)
@@ -2808,7 +2790,8 @@ class TestKubernetesPodOperatorDurableExecution:
         )
         assert result == pod_request_obj
 
-    def test_durable_reconnect_without_uid_searches_the_namespace_it_stored(self):
+    @patch(f"{KPO_MODULE}.KubernetesPodOperator.find_pod")
+    def test_durable_reconnect_without_uid_searches_the_namespace_it_stored(self, mock_find):
         """A legacy identity is resolved where the pod was submitted, not where this try would go."""
         k = self._durable_operator()
         context = create_context(k)
@@ -2817,11 +2800,12 @@ class TestKubernetesPodOperatorDurableExecution:
         context["task_state_store"] = task_state_store
 
         k.hook.get_pod = MagicMock()
-        running_pod = self._running_pod("prior-pod", "old-ns", "prior-pod-uid")
+        running_pod = self._pod("prior-pod", "old-ns", "prior-pod-uid")
         pod_request_obj = k8s.V1Pod(metadata=k8s.V1ObjectMeta(name="prior-pod", namespace="new-ns"))
 
-        with patch(f"{KPO_MODULE}.KubernetesPodOperator.find_pod", return_value=running_pod) as mock_find:
-            result = k.get_or_create_pod(pod_request_obj=pod_request_obj, context=context)
+        mock_find.return_value = running_pod
+
+        result = k.get_or_create_pod(pod_request_obj=pod_request_obj, context=context)
 
         k.hook.get_pod.assert_not_called()
         mock_find.assert_called_once_with("old-ns", context=context)
@@ -2833,7 +2817,8 @@ class TestKubernetesPodOperatorDurableExecution:
         assert result == running_pod
 
     @pytest.mark.parametrize("stored_uid", ["", 123, False])
-    def test_durable_reconnect_ignores_an_identity_whose_uid_is_invalid(self, stored_uid):
+    @patch(f"{KPO_MODULE}.KubernetesPodOperator.find_pod", return_value=None)
+    def test_durable_reconnect_ignores_an_identity_whose_uid_is_invalid(self, mock_find, stored_uid):
         """A malformed uid is not an older identity, so the pod is not taken by name either."""
         k = self._durable_operator()
         context = create_context(k)
@@ -2851,14 +2836,15 @@ class TestKubernetesPodOperatorDurableExecution:
         )
         pod_request_obj = k8s.V1Pod(metadata=k8s.V1ObjectMeta(name="new-pod", namespace="default"))
 
-        with patch(f"{KPO_MODULE}.KubernetesPodOperator.find_pod", return_value=None) as mock_find:
-            k.get_or_create_pod(pod_request_obj=pod_request_obj, context=context)
+        k.get_or_create_pod(pod_request_obj=pod_request_obj, context=context)
 
         k.hook.get_pod.assert_not_called()
         mock_find.assert_called_once_with("default", context=context)
         self.create_mock.assert_called_once_with(pod=pod_request_obj)
 
-    def test_durable_uid_mismatch_on_fixed_name_fails_closed(self):
+    @patch(f"{KPO_MODULE}.KubernetesPodOperator.process_pod_deletion")
+    @patch(f"{KPO_MODULE}.KubernetesPodOperator.find_pod", return_value=None)
+    def test_durable_uid_mismatch_on_fixed_name_fails_closed(self, mock_find, mock_deletion):
         """With random_name_suffix=False the name is taken, and failing is better than adopting it."""
         k = self._durable_operator(name="my-pod", random_name_suffix=False)
         context = create_context(k)
@@ -2870,16 +2856,12 @@ class TestKubernetesPodOperatorDurableExecution:
         }
         context["task_state_store"] = task_state_store
 
-        k.hook.get_pod = MagicMock(return_value=self._running_pod("my-pod", "default", "run-b-pod-uid"))
+        k.hook.get_pod = MagicMock(return_value=self._pod("my-pod", "default", "run-b-pod-uid"))
         # The other run still holds the fixed name, so the fresh pod cannot be created.
         self.create_mock.side_effect = ApiException(status=409)
         pod_request_obj = k8s.V1Pod(metadata=k8s.V1ObjectMeta(name="my-pod", namespace="default"))
 
-        with (
-            patch(f"{KPO_MODULE}.KubernetesPodOperator.find_pod", return_value=None) as mock_find,
-            patch(f"{KPO_MODULE}.KubernetesPodOperator.process_pod_deletion") as mock_deletion,
-            pytest.raises(ApiException) as exc_info,
-        ):
+        with pytest.raises(ApiException) as exc_info:
             k.get_or_create_pod(pod_request_obj=pod_request_obj, context=context)
 
         assert exc_info.value.status == 409
@@ -2922,7 +2904,7 @@ class TestKubernetesPodOperatorDurableExecution:
             durable=False,
         )
         context = create_context(k)
-        task_state_store = MagicMock()
+        task_state_store = MagicMock(spec=["get", "set"])
         task_state_store.get.return_value = {"name": "prior-pod", "namespace": "default"}
         context["task_state_store"] = task_state_store
 

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -2806,8 +2806,8 @@ class TestKubernetesPodOperatorDurableExecution:
         )
         assert result == mock_pod_request_obj
 
-    def test_durable_reconnect_accepts_identity_persisted_without_uid(self):
-        """An identity written before uids were persisted keeps reconnecting on name alone."""
+    def test_durable_reconnect_migrates_identity_persisted_without_uid(self):
+        """An identity written before uids were recorded is resolved by label search, then upgraded."""
         k = KubernetesPodOperator(
             image="ubuntu:16.04",
             cmds=["bash", "-cx"],
@@ -2832,13 +2832,64 @@ class TestKubernetesPodOperatorDurableExecution:
 
         mock_pod_request_obj = MagicMock()
 
-        with patch(f"{KPO_MODULE}.KubernetesPodOperator.find_pod") as mock_find:
+        with patch(f"{KPO_MODULE}.KubernetesPodOperator.find_pod", return_value=running_pod) as mock_find:
             result = k.get_or_create_pod(pod_request_obj=mock_pod_request_obj, context=context)
 
-        mock_find.assert_not_called()
+        k.hook.get_pod.assert_not_called()
+        mock_find.assert_called_once()
         self.create_mock.assert_not_called()
-        task_state_store.set.assert_not_called()
+        task_state_store.set.assert_called_once_with(
+            POD_IDENTIFIER_STATE_KEY,
+            {"name": "prior-pod", "namespace": "default", "uid": "prior-pod-uid"},
+        )
         assert result == running_pod
+
+    def test_durable_uid_mismatch_on_fixed_name_does_not_touch_the_other_pod(self):
+        """With random_name_suffix=False the name is taken, and failing is better than adopting it."""
+        k = KubernetesPodOperator(
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            task_id="task",
+            name="my-pod",
+            random_name_suffix=False,
+            log_pod_spec_on_failure=False,
+        )
+        context = create_context(k)
+        task_state_store = MagicMock()
+        task_state_store.get.return_value = {
+            "name": "my-pod",
+            "namespace": "default",
+            "uid": "run-a-pod-uid",
+        }
+        context["task_state_store"] = task_state_store
+
+        other_run_pod = MagicMock()
+        other_run_pod.status.phase = "Running"
+        other_run_pod.status.reason = None
+        other_run_pod.metadata.name = "my-pod"
+        other_run_pod.metadata.namespace = "default"
+        other_run_pod.metadata.uid = "run-b-pod-uid"
+        other_run_pod.metadata.labels = {"try_number": "1"}
+        k.hook.get_pod = MagicMock(return_value=other_run_pod)
+
+        # The other run still holds the fixed name, so the fresh pod cannot be created.
+        self.create_mock.side_effect = ApiException(status=409)
+
+        mock_pod_request_obj = MagicMock()
+        mock_pod_request_obj.to_dict.return_value = {"metadata": {"name": "my-pod"}}
+
+        with (
+            patch(f"{KPO_MODULE}.KubernetesPodOperator.find_pod", return_value=None) as mock_find,
+            patch(f"{KPO_MODULE}.KubernetesPodOperator.process_pod_deletion") as mock_deletion,
+            pytest.raises(ApiException) as exc_info,
+        ):
+            k.get_or_create_pod(pod_request_obj=mock_pod_request_obj, context=context)
+
+        assert exc_info.value.status == 409
+        mock_find.assert_called_once()
+        mock_deletion.assert_not_called()
+        task_state_store.set.assert_not_called()
 
     def test_durable_true_without_state_store_fallsback(self):
         """No task_state_store key in context (e.g. Airflow <3.3): unchanged label-search behavior."""

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -2759,18 +2759,29 @@ class TestKubernetesPodOperatorDurableExecution:
         )
         assert result == mock_pod_request_obj
 
-    def test_durable_reconnect_skips_pod_whose_uid_no_longer_matches(self):
-        """A pod reusing the persisted name is a different pod and must not be reattached to."""
-        k = KubernetesPodOperator(
+    def _durable_operator(self, **kwargs):
+        kwargs.setdefault("name", "hello")
+        return KubernetesPodOperator(
             image="ubuntu:16.04",
             cmds=["bash", "-cx"],
             arguments=["echo 10"],
             task_id="task",
-            name="hello",
             log_pod_spec_on_failure=False,
+            **kwargs,
         )
+
+    @staticmethod
+    def _running_pod(name, namespace, uid):
+        return k8s.V1Pod(
+            metadata=k8s.V1ObjectMeta(name=name, namespace=namespace, uid=uid, labels={"try_number": "1"}),
+            status=k8s.V1PodStatus(phase=PodPhase.RUNNING),
+        )
+
+    def test_durable_reconnect_skips_pod_whose_uid_no_longer_matches(self):
+        """A pod reusing the persisted name is a different pod and must not be reattached to."""
+        k = self._durable_operator()
         context = create_context(k)
-        task_state_store = MagicMock()
+        task_state_store = MagicMock(spec=["get", "set"])
         task_state_store.get.return_value = {
             "name": "prior-pod",
             "namespace": "default",
@@ -2778,85 +2789,80 @@ class TestKubernetesPodOperatorDurableExecution:
         }
         context["task_state_store"] = task_state_store
 
-        someone_elses_pod = MagicMock()
-        someone_elses_pod.status.phase = "Running"
-        someone_elses_pod.status.reason = None
-        someone_elses_pod.metadata.name = "prior-pod"
-        someone_elses_pod.metadata.uid = "an-unrelated-pod-uid"
-        someone_elses_pod.metadata.labels = {"try_number": "1"}
-        k.hook.get_pod = MagicMock(return_value=someone_elses_pod)
-
-        created_pod = MagicMock()
-        created_pod.metadata.name = "new-pod"
-        created_pod.metadata.namespace = "default"
-        created_pod.metadata.uid = "new-pod-uid"
-        self.create_mock.return_value = created_pod
-
-        mock_pod_request_obj = MagicMock()
-        mock_pod_request_obj.to_dict.return_value = {"metadata": {"name": "new-pod"}}
+        k.hook.get_pod = MagicMock(
+            return_value=self._running_pod("prior-pod", "default", "an-unrelated-pod-uid")
+        )
+        self.create_mock.return_value = k8s.V1Pod(
+            metadata=k8s.V1ObjectMeta(name="new-pod", namespace="default", uid="new-pod-uid")
+        )
+        pod_request_obj = k8s.V1Pod(metadata=k8s.V1ObjectMeta(name="new-pod", namespace="default"))
 
         with patch(f"{KPO_MODULE}.KubernetesPodOperator.find_pod", return_value=None) as mock_find:
-            result = k.get_or_create_pod(pod_request_obj=mock_pod_request_obj, context=context)
+            result = k.get_or_create_pod(pod_request_obj=pod_request_obj, context=context)
 
-        mock_find.assert_called_once()
-        self.create_mock.assert_called_once_with(pod=mock_pod_request_obj)
+        mock_find.assert_called_once_with("default", context=context)
+        self.create_mock.assert_called_once_with(pod=pod_request_obj)
         task_state_store.set.assert_called_once_with(
             POD_IDENTIFIER_STATE_KEY,
             {"name": "new-pod", "namespace": "default", "uid": "new-pod-uid"},
         )
-        assert result == mock_pod_request_obj
+        assert result == pod_request_obj
 
-    def test_durable_reconnect_migrates_identity_persisted_without_uid(self):
-        """An identity written before uids were recorded is resolved by label search, then upgraded."""
-        k = KubernetesPodOperator(
-            image="ubuntu:16.04",
-            cmds=["bash", "-cx"],
-            arguments=["echo 10"],
-            task_id="task",
-            name="hello",
-            log_pod_spec_on_failure=False,
-        )
+    def test_durable_reconnect_without_uid_searches_the_namespace_it_stored(self):
+        """A legacy identity is resolved where the pod was submitted, not where this try would go."""
+        k = self._durable_operator()
         context = create_context(k)
-        task_state_store = MagicMock()
-        task_state_store.get.return_value = {"name": "prior-pod", "namespace": "default"}
+        task_state_store = MagicMock(spec=["get", "set"])
+        task_state_store.get.return_value = {"name": "prior-pod", "namespace": "old-ns"}
         context["task_state_store"] = task_state_store
 
-        running_pod = MagicMock()
-        running_pod.status.phase = "Running"
-        running_pod.status.reason = None
-        running_pod.metadata.name = "prior-pod"
-        running_pod.metadata.namespace = "default"
-        running_pod.metadata.uid = "prior-pod-uid"
-        running_pod.metadata.labels = {"try_number": "1"}
-        k.hook.get_pod = MagicMock(return_value=running_pod)
-
-        mock_pod_request_obj = MagicMock()
+        k.hook.get_pod = MagicMock()
+        running_pod = self._running_pod("prior-pod", "old-ns", "prior-pod-uid")
+        pod_request_obj = k8s.V1Pod(metadata=k8s.V1ObjectMeta(name="prior-pod", namespace="new-ns"))
 
         with patch(f"{KPO_MODULE}.KubernetesPodOperator.find_pod", return_value=running_pod) as mock_find:
-            result = k.get_or_create_pod(pod_request_obj=mock_pod_request_obj, context=context)
+            result = k.get_or_create_pod(pod_request_obj=pod_request_obj, context=context)
 
         k.hook.get_pod.assert_not_called()
-        mock_find.assert_called_once()
+        mock_find.assert_called_once_with("old-ns", context=context)
         self.create_mock.assert_not_called()
         task_state_store.set.assert_called_once_with(
             POD_IDENTIFIER_STATE_KEY,
-            {"name": "prior-pod", "namespace": "default", "uid": "prior-pod-uid"},
+            {"name": "prior-pod", "namespace": "old-ns", "uid": "prior-pod-uid"},
         )
         assert result == running_pod
 
-    def test_durable_uid_mismatch_on_fixed_name_does_not_touch_the_other_pod(self):
-        """With random_name_suffix=False the name is taken, and failing is better than adopting it."""
-        k = KubernetesPodOperator(
-            image="ubuntu:16.04",
-            cmds=["bash", "-cx"],
-            arguments=["echo 10"],
-            task_id="task",
-            name="my-pod",
-            random_name_suffix=False,
-            log_pod_spec_on_failure=False,
-        )
+    @pytest.mark.parametrize("stored_uid", ["", 123, False])
+    def test_durable_reconnect_ignores_an_identity_whose_uid_is_invalid(self, stored_uid):
+        """A malformed uid is not an older identity, so the pod is not taken by name either."""
+        k = self._durable_operator()
         context = create_context(k)
-        task_state_store = MagicMock()
+        task_state_store = MagicMock(spec=["get", "set"])
+        task_state_store.get.return_value = {
+            "name": "prior-pod",
+            "namespace": "default",
+            "uid": stored_uid,
+        }
+        context["task_state_store"] = task_state_store
+
+        k.hook.get_pod = MagicMock()
+        self.create_mock.return_value = k8s.V1Pod(
+            metadata=k8s.V1ObjectMeta(name="new-pod", namespace="default", uid="new-pod-uid")
+        )
+        pod_request_obj = k8s.V1Pod(metadata=k8s.V1ObjectMeta(name="new-pod", namespace="default"))
+
+        with patch(f"{KPO_MODULE}.KubernetesPodOperator.find_pod", return_value=None) as mock_find:
+            k.get_or_create_pod(pod_request_obj=pod_request_obj, context=context)
+
+        k.hook.get_pod.assert_not_called()
+        mock_find.assert_called_once_with("default", context=context)
+        self.create_mock.assert_called_once_with(pod=pod_request_obj)
+
+    def test_durable_uid_mismatch_on_fixed_name_fails_closed(self):
+        """With random_name_suffix=False the name is taken, and failing is better than adopting it."""
+        k = self._durable_operator(name="my-pod", random_name_suffix=False)
+        context = create_context(k)
+        task_state_store = MagicMock(spec=["get", "set"])
         task_state_store.get.return_value = {
             "name": "my-pod",
             "namespace": "default",
@@ -2864,30 +2870,20 @@ class TestKubernetesPodOperatorDurableExecution:
         }
         context["task_state_store"] = task_state_store
 
-        other_run_pod = MagicMock()
-        other_run_pod.status.phase = "Running"
-        other_run_pod.status.reason = None
-        other_run_pod.metadata.name = "my-pod"
-        other_run_pod.metadata.namespace = "default"
-        other_run_pod.metadata.uid = "run-b-pod-uid"
-        other_run_pod.metadata.labels = {"try_number": "1"}
-        k.hook.get_pod = MagicMock(return_value=other_run_pod)
-
+        k.hook.get_pod = MagicMock(return_value=self._running_pod("my-pod", "default", "run-b-pod-uid"))
         # The other run still holds the fixed name, so the fresh pod cannot be created.
         self.create_mock.side_effect = ApiException(status=409)
-
-        mock_pod_request_obj = MagicMock()
-        mock_pod_request_obj.to_dict.return_value = {"metadata": {"name": "my-pod"}}
+        pod_request_obj = k8s.V1Pod(metadata=k8s.V1ObjectMeta(name="my-pod", namespace="default"))
 
         with (
             patch(f"{KPO_MODULE}.KubernetesPodOperator.find_pod", return_value=None) as mock_find,
             patch(f"{KPO_MODULE}.KubernetesPodOperator.process_pod_deletion") as mock_deletion,
             pytest.raises(ApiException) as exc_info,
         ):
-            k.get_or_create_pod(pod_request_obj=mock_pod_request_obj, context=context)
+            k.get_or_create_pod(pod_request_obj=pod_request_obj, context=context)
 
         assert exc_info.value.status == 409
-        mock_find.assert_called_once()
+        mock_find.assert_called_once_with("default", context=context)
         mock_deletion.assert_not_called()
         task_state_store.set.assert_not_called()
 

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -2616,6 +2616,7 @@ class TestKubernetesPodOperatorDurableExecution:
         created_pod = MagicMock()
         created_pod.metadata.name = "test-pod"
         created_pod.metadata.namespace = "default"
+        created_pod.metadata.uid = "test-pod-uid"
         self.create_mock.return_value = created_pod
 
         with patch(f"{KPO_MODULE}.KubernetesPodOperator.find_pod", return_value=None) as mock_find:
@@ -2625,7 +2626,7 @@ class TestKubernetesPodOperatorDurableExecution:
         self.create_mock.assert_called_once_with(pod=mock_pod_request_obj)
         task_state_store.set.assert_called_once_with(
             POD_IDENTIFIER_STATE_KEY,
-            {"name": "test-pod", "namespace": "default"},
+            {"name": "test-pod", "namespace": "default", "uid": "test-pod-uid"},
         )
         assert result == mock_pod_request_obj
 
@@ -2640,13 +2641,18 @@ class TestKubernetesPodOperatorDurableExecution:
         )
         context = create_context(k)
         task_state_store = MagicMock()
-        task_state_store.get.return_value = {"name": "prior-pod", "namespace": "default"}
+        task_state_store.get.return_value = {
+            "name": "prior-pod",
+            "namespace": "default",
+            "uid": "prior-pod-uid",
+        }
         context["task_state_store"] = task_state_store
 
         running_pod = MagicMock()
         running_pod.status.phase = "Running"
         running_pod.status.reason = None
         running_pod.metadata.name = "prior-pod"
+        running_pod.metadata.uid = "prior-pod-uid"
         running_pod.metadata.labels = {"try_number": "1"}
         k.hook.get_pod = MagicMock(return_value=running_pod)
 
@@ -2675,13 +2681,18 @@ class TestKubernetesPodOperatorDurableExecution:
         )
         context = create_context(k)
         task_state_store = MagicMock()
-        task_state_store.get.return_value = {"name": "prior-pod", "namespace": "default"}
+        task_state_store.get.return_value = {
+            "name": "prior-pod",
+            "namespace": "default",
+            "uid": "prior-pod-uid",
+        }
         context["task_state_store"] = task_state_store
 
         terminal_pod = MagicMock()
         terminal_pod.status.phase = pod_phase
         terminal_pod.status.reason = None
         terminal_pod.metadata.name = "prior-pod"
+        terminal_pod.metadata.uid = "prior-pod-uid"
         terminal_pod.metadata.labels = {"try_number": "1"}
         k.hook.get_pod = MagicMock(return_value=terminal_pod)
         mock_process_pod_deletion.return_value = True
@@ -2709,19 +2720,25 @@ class TestKubernetesPodOperatorDurableExecution:
         )
         context = create_context(k)
         task_state_store = MagicMock()
-        task_state_store.get.return_value = {"name": "prior-pod", "namespace": "default"}
+        task_state_store.get.return_value = {
+            "name": "prior-pod",
+            "namespace": "default",
+            "uid": "prior-pod-uid",
+        }
         context["task_state_store"] = task_state_store
 
         stale_pod = MagicMock()
         stale_pod.status.phase = PodPhase.FAILED
         stale_pod.status.reason = None
         stale_pod.metadata.name = "prior-pod"
+        stale_pod.metadata.uid = "prior-pod-uid"
         stale_pod.metadata.labels = {"try_number": "1", "already_checked": "True"}
         k.hook.get_pod = MagicMock(return_value=stale_pod)
 
         created_pod = MagicMock()
         created_pod.metadata.name = "new-pod"
         created_pod.metadata.namespace = "default"
+        created_pod.metadata.uid = "new-pod-uid"
         self.create_mock.return_value = created_pod
 
         mock_pod_request_obj = MagicMock()
@@ -2738,9 +2755,90 @@ class TestKubernetesPodOperatorDurableExecution:
         self.create_mock.assert_called_once_with(pod=mock_pod_request_obj)
         task_state_store.set.assert_called_once_with(
             POD_IDENTIFIER_STATE_KEY,
-            {"name": "new-pod", "namespace": "default"},
+            {"name": "new-pod", "namespace": "default", "uid": "new-pod-uid"},
         )
         assert result == mock_pod_request_obj
+
+    def test_durable_reconnect_skips_pod_whose_uid_no_longer_matches(self):
+        """A pod reusing the persisted name is a different pod and must not be reattached to."""
+        k = KubernetesPodOperator(
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            task_id="task",
+            name="hello",
+            log_pod_spec_on_failure=False,
+        )
+        context = create_context(k)
+        task_state_store = MagicMock()
+        task_state_store.get.return_value = {
+            "name": "prior-pod",
+            "namespace": "default",
+            "uid": "prior-pod-uid",
+        }
+        context["task_state_store"] = task_state_store
+
+        someone_elses_pod = MagicMock()
+        someone_elses_pod.status.phase = "Running"
+        someone_elses_pod.status.reason = None
+        someone_elses_pod.metadata.name = "prior-pod"
+        someone_elses_pod.metadata.uid = "an-unrelated-pod-uid"
+        someone_elses_pod.metadata.labels = {"try_number": "1"}
+        k.hook.get_pod = MagicMock(return_value=someone_elses_pod)
+
+        created_pod = MagicMock()
+        created_pod.metadata.name = "new-pod"
+        created_pod.metadata.namespace = "default"
+        created_pod.metadata.uid = "new-pod-uid"
+        self.create_mock.return_value = created_pod
+
+        mock_pod_request_obj = MagicMock()
+        mock_pod_request_obj.to_dict.return_value = {"metadata": {"name": "new-pod"}}
+
+        with patch(f"{KPO_MODULE}.KubernetesPodOperator.find_pod", return_value=None) as mock_find:
+            result = k.get_or_create_pod(pod_request_obj=mock_pod_request_obj, context=context)
+
+        mock_find.assert_called_once()
+        self.create_mock.assert_called_once_with(pod=mock_pod_request_obj)
+        task_state_store.set.assert_called_once_with(
+            POD_IDENTIFIER_STATE_KEY,
+            {"name": "new-pod", "namespace": "default", "uid": "new-pod-uid"},
+        )
+        assert result == mock_pod_request_obj
+
+    def test_durable_reconnect_accepts_identity_persisted_without_uid(self):
+        """An identity written before uids were persisted keeps reconnecting on name alone."""
+        k = KubernetesPodOperator(
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            task_id="task",
+            name="hello",
+            log_pod_spec_on_failure=False,
+        )
+        context = create_context(k)
+        task_state_store = MagicMock()
+        task_state_store.get.return_value = {"name": "prior-pod", "namespace": "default"}
+        context["task_state_store"] = task_state_store
+
+        running_pod = MagicMock()
+        running_pod.status.phase = "Running"
+        running_pod.status.reason = None
+        running_pod.metadata.name = "prior-pod"
+        running_pod.metadata.namespace = "default"
+        running_pod.metadata.uid = "prior-pod-uid"
+        running_pod.metadata.labels = {"try_number": "1"}
+        k.hook.get_pod = MagicMock(return_value=running_pod)
+
+        mock_pod_request_obj = MagicMock()
+
+        with patch(f"{KPO_MODULE}.KubernetesPodOperator.find_pod") as mock_find:
+            result = k.get_or_create_pod(pod_request_obj=mock_pod_request_obj, context=context)
+
+        mock_find.assert_not_called()
+        self.create_mock.assert_not_called()
+        task_state_store.set.assert_not_called()
+        assert result == running_pod
 
     def test_durable_true_without_state_store_fallsback(self):
         """No task_state_store key in context (e.g. Airflow <3.3): unchanged label-search behavior."""


### PR DESCRIPTION
closes: #71743

## Why the name alone is not enough

`_persist_pod_identity_to_task_state_store` keep only name and namespace, and on retry `_get_pod_from_task_state_store` do `self.hook.get_pod(name, namespace)`. In Kubernetes a name is only a slot, after a pod is delete another pod can take the same name. So when the pod name can repeat, `random_name_suffix=False` or a fixed name from `pod_template_file` / `full_pod_spec`, the retry can reattach to a pod of another dag run. The real cluster log is in #71743.

The old `find_pod()` path do not have this problem, its label selector carry run_id.

## What this change do

Put the uid back into the persisted identity, and compare it after the pod is read back. If the uid is not the same, log and return None so it fall to the label search, the same way the 404 branch just above it already do.

This is the first of the two option kaxil write in the review of #69914:

> I'd either compare the uid and fall back to label search on mismatch, or drop `uid` from the stored payload so the schema doesn't imply a check that isn't performed.

The second one is take at that time, because a pod name normally carry a random suffix. That is true for the default, but `random_name_suffix=False` is a public parameter and then the name repeat.

## Identity persisted by an older provider version

10.20 and 10.21 write only name and namespace. Such an entry can not tell the recorded pod from a pod which take the same name later, so accepting it by name keep the same bug alive for every retry of a task instance which already have that row.

When the identity have no uid, the pod is look up by label search instead, and what it find is persisted again together with the uid, so the entry stop being uid-less after one retry.

That label search run in the namespace which is inside the stored identity, not the one render for this attempt. `namespace` and `labels` are both template fields, so a render which move between attempt can point to a different namespace, and then a pod still running in the old namespace is miss and a duplicate is submit. The stored namespace is where the pod really go, so it is the right place to look. The helper give that namespace back to `get_or_create_pod()` and the search which is already there do the work, so there is still only one list call, and now every fallback use it, not only the one for old identity.

A uid which exist but is not a usable string is not an old entry, it is broken state, so that one is reject and log as a warning instead.

One thing change for old identity: before, it is read with a direct get, now it go through `find_pod()`, so it can raise `FoundMoreThanOnePodFailure` when two pod match. This is the same as what the operator do before durable execution exist, and it fail closed, but it is a change so I write it here.

## Test

`TestKubernetesPodOperatorDurableExecution` get four new test, and every one of them fail if the change in `pod.py` is revert:

- `test_durable_reconnect_skips_pod_whose_uid_no_longer_matches`
- `test_durable_reconnect_without_uid_searches_the_namespace_it_stored`
- `test_durable_reconnect_ignores_an_identity_whose_uid_is_invalid` (empty string, int, bool)
- `test_durable_uid_mismatch_on_fixed_name_fails_closed`

The last one is the `random_name_suffix=False` case from the issue. The other run still hold the fixed name, so the create get 409 and the task fail. That is on purpose, a failed task is better than a task which monitor, read log from and then delete the pod of another dag run.

All the test in that class now build real `V1Pod` and `V1ObjectMeta` and give the state store mock a spec, and use `@patch` decorator, like `.github/instructions/code-review.instructions.md` and `AGENTS.md` ask. Before this the pod are bare `MagicMock`, so a wrong attribute name on `metadata` is accept without any error.

Four test which are already there also change. The payload have one more key now, and they get the same clean up, but the behaviour they check is the same.

```
26 passed, 235 deselected
```

The whole `test_pod.py` is 249 passed / 2 failed / 10 errors here, and the same 2 failed and 10 errors are already there on `main` without my change (`TestKubernetesPodOperatorAsync` and `TestSuppress`, they want things my local env do not have).

I also run the reproduction from #71743 again on the same real cluster with this branch, k8s v1.37.0-rc.0:

```
STEP 4  dag run A retries -> _get_pod_from_task_state_store()
Pod kpo-uid-test/my-pod from task state store is a different pod now
(recorded uid 8983079c-..., found cdf02d8f-...), falling back to label search.
        returned None -> falls back to label search (SAFE)

STEP 5  the real caller: get_or_create_pod()
        label search finds nothing for run A
        create my-pod -> 409 "pods \"my-pod\" already exists"
        run B's pod is never returned, monitored or deleted
```

## Not in this PR

The uid is check once, when the identity is read back. After that the polling, the log fetch, the trigger and the delete still work by name only. `KubernetesPodTrigger` serialize just `pod_name` and `pod_namespace`, and `PodManager.delete_pod()` send `V1DeleteOptions()` with no `preconditions.uid`. Those need a `pod_uid` on the trigger and a delete precondition, which touch sync, async and cleanup together, so I keep them out of here. I open #71748 for that part.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes - Claude Code

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.
