### PR TITLE
Probe AOSS index readiness as the Knowledge Base role in Bedrock RAG system test

### DIFF
--- a/providers/amazon/tests/system/amazon/aws/example_bedrock_retrieve_and_generate.py
+++ b/providers/amazon/tests/system/amazon/aws/example_bedrock_retrieve_and_generate.py
@@ -218,13 +218,14 @@ def create_collection(collection_name: str):
 
 
 @task
-def create_vector_index(index_name: str, collection_id: str, region: str):
+def create_vector_index(index_name: str, collection_id: str, region: str, bedrock_role_arn: str):
     """
     Use the OpenSearchPy client to create the vector index for the Amazon Open Search Serverless Collection.
 
     :param index_name: The vector index name to create.
     :param collection_id: ID of the collection to be indexed.
     :param region: Name of the AWS region the collection resides in.
+    :param bedrock_role_arn: Arn of the Bedrock Knowledge Base Execution Role.
     """
     # Build the OpenSearch client
     oss_client = OpenSearch(
@@ -278,6 +279,30 @@ def create_vector_index(index_name: str, collection_id: str, region: str):
     # OpenSearch Serverless materializes it asynchronously and exposes no status API for it.
     # Poll a trivial search as a readiness probe so downstream Bedrock ingestion does not
     # start (and fail) before the index can serve requests.
+    #
+    # The probe authenticates as the Knowledge Base execution role rather than as this task's
+    # own principal. AOSS data access policies propagate per principal, and the Bedrock
+    # ingestion job runs as the Knowledge Base role, so probing with this task's (already
+    # propagated) credentials would not prove the ingestion job can reach the index. Waiting
+    # until the search succeeds as the Knowledge Base role closes the propagation race that
+    # intermittently failed the ingestion job sensor with:
+    #   [security_exception] authentication/authorization failure. Call to Amazon OpenSearch
+    #   Serverless Vector Database did not succeed.
+    assumed = StsHook().conn.assume_role(RoleArn=bedrock_role_arn, RoleSessionName="AossIndexReadinessProbe")
+    kb_role_session = boto3.Session(
+        aws_access_key_id=assumed["Credentials"]["AccessKeyId"],
+        aws_secret_access_key=assumed["Credentials"]["SecretAccessKey"],
+        aws_session_token=assumed["Credentials"]["SessionToken"],
+    )
+    kb_role_oss_client = OpenSearch(
+        hosts=[{"host": f"{collection_id}.{region}.aoss.amazonaws.com", "port": 443}],
+        http_auth=AWSV4SignerAuth(kb_role_session.get_credentials(), region, "aoss"),
+        use_ssl=True,
+        verify_certs=True,
+        connection_class=RequestsHttpConnection,
+        timeout=300,
+    )
+
     @retry(
         retry=retry_if_exception_type(TransportError),
         stop=stop_after_attempt(30),
@@ -286,7 +311,7 @@ def create_vector_index(index_name: str, collection_id: str, region: str):
         reraise=True,
     )
     def _wait_for_index_readiness():
-        oss_client.search(index=index_name, body={"query": {"match_all": {}}, "size": 0})
+        kb_role_oss_client.search(index=index_name, body={"query": {"match_all": {}}, "size": 0})
 
     _wait_for_index_readiness()
     log.info("Index %s is ready.", index_name)
@@ -590,7 +615,12 @@ with DAG(
         opensearch_policies,
         collection,
         await_collection,
-        create_vector_index(index_name=index_name, collection_id=collection, region=region_name),
+        create_vector_index(
+            index_name=index_name,
+            collection_id=collection,
+            region=region_name,
+            bedrock_role_arn=test_context[ROLE_ARN_KEY],
+        ),
         copy_data_to_s3(bucket=bucket_name),
         # TEST BODY
         create_knowledge_base,


### PR DESCRIPTION
The `example_bedrock_retrieve_and_generate` system test intermittently fails in the ingestion job sensor with:

```
Bedrock ingestion job sensor failed. Failure reasons: ["Encountered error: Request failed:
[security_exception] authentication/authorization failure. Call to Amazon OpenSearch
Serverless Vector Database did not succeed."]
```

(This failure reason became visible thanks to #71124.)

OpenSearch Serverless data access policies propagate **per principal**. The existing index readiness probe authenticates as the task's own principal, which proves nothing about the Knowledge Base execution role that actually performs the ingestion. When the collection activates quickly, Bedrock can call AOSS before the access policy has propagated for the Knowledge Base role, and the ingestion job fails. The deferrable path never hits this because its longer runtime provides enough propagation slack.

This PR assumes the Knowledge Base role and runs the readiness probe with its credentials, so the probe only passes once the ingesting principal is authorized. No retry changes are needed: `AuthorizationException` and `AuthenticationException` subclass `TransportError`, so the existing tenacity retry (30 attempts x 5s) already absorbs the interim 403s.

---

^ Add meaningful description above
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).