### PR TITLE
Build pgbouncer-exporter image from a pinned commit rather than a tag

### DIFF
--- a/chart/dockerfiles/pgbouncer-exporter/Dockerfile
+++ b/chart/dockerfiles/pgbouncer-exporter/Dockerfile
@@ -21,12 +21,16 @@ ARG GO_VERSION="1.23.7"
 FROM golang:${GO_VERSION} AS builder
 
 ARG PGBOUNCER_EXPORTER_VERSION
+ARG PGBOUNCER_EXPORTER_COMMIT_SHA
 
 WORKDIR /usr/src/myapp
 
 SHELL ["/bin/bash", "-o", "pipefail", "-e", "-u", "-x", "-c"]
 
-RUN URL="https://github.com/jbub/pgbouncer_exporter/archive/v${PGBOUNCER_EXPORTER_VERSION}.tar.gz" \
+# Fetch the source by commit id rather than by tag. Git tags are mutable: `vX.Y.Z` on the
+# upstream repository can be moved to different content without anything in this image's
+# build inputs changing, so a tag alone does not identify what we build. A commit id does.
+RUN URL="https://github.com/jbub/pgbouncer_exporter/archive/${PGBOUNCER_EXPORTER_COMMIT_SHA}.tar.gz" \
     && curl -L "${URL}" | tar -zx --strip-components 1 \
     && PLATFORM=$([ "$(uname -m)" = "aarch64" ] && echo "arm64" || echo "amd64" )\
     && GOOS=linux GOARCH="${PLATFORM}" CGO_ENABLED=0 go build -v
@@ -41,12 +45,14 @@ RUN apk --no-cache add libressl libressl-dev openssl
 COPY --from=builder /usr/src/myapp/pgbouncer_exporter /bin
 
 ARG PGBOUNCER_EXPORTER_VERSION
+ARG PGBOUNCER_EXPORTER_COMMIT_SHA
 ARG AIRFLOW_PGBOUNCER_EXPORTER_VERSION
 ARG GO_VERSION
 ARG COMMIT_SHA
 
 LABEL org.apache.airflow.component="pgbouncer-exporter" \
     org.apache.airflow.pgbouncer-exporter.version="${PGBOUNCER_EXPORTER_VERSION}" \
+    org.apache.airflow.pgbouncer-exporter.commit-sha="${PGBOUNCER_EXPORTER_COMMIT_SHA}" \
     org.apache.airflow.go.version="${GO_VERSION}" \
     org.apache.airflow.airflow-pgbouncer-exporter.version="${AIRFLOW_PGBOUNCER_EXPORTER_VERSION}" \
     org.apache.airflow.commit-sha="${COMMIT_SHA}" \

--- a/chart/dockerfiles/pgbouncer-exporter/build_and_push.sh
+++ b/chart/dockerfiles/pgbouncer-exporter/build_and_push.sh
@@ -23,6 +23,12 @@ readonly DOCKERHUB_REPO
 
 PGBOUNCER_EXPORTER_VERSION="0.18.0"
 readonly PGBOUNCER_EXPORTER_VERSION
+# The commit that PGBOUNCER_EXPORTER_VERSION's tag pointed at when it was reviewed. The image
+# is built from this commit, not from the tag: tags on the upstream repository are mutable and
+# can be moved to different content without this file changing. Update both together, and
+# re-check the diff upstream when you do.
+PGBOUNCER_EXPORTER_COMMIT_SHA="1b1faecd80fdeb0f4d8baa0d423e8b58e4ab9aa5"
+readonly PGBOUNCER_EXPORTER_COMMIT_SHA
 
 AIRFLOW_PGBOUNCER_EXPORTER_VERSION="2026.04.17"
 readonly AIRFLOW_PGBOUNCER_EXPORTER_VERSION
@@ -58,6 +64,7 @@ docker buildx build . \
     --pull \
     --push \
     --build-arg "PGBOUNCER_EXPORTER_VERSION=${PGBOUNCER_EXPORTER_VERSION}" \
+    --build-arg "PGBOUNCER_EXPORTER_COMMIT_SHA=${PGBOUNCER_EXPORTER_COMMIT_SHA}" \
     --build-arg "AIRFLOW_PGBOUNCER_EXPORTER_VERSION=${AIRFLOW_PGBOUNCER_EXPORTER_VERSION}"\
     --build-arg "COMMIT_SHA=${COMMIT_SHA}" \
     --build-arg "GO_VERSION=${EXPECTED_GO_VERSION}" \


### PR DESCRIPTION
The `airflow-pgbouncer-exporter` image builds upstream source fetched from a mutable git tag:

```dockerfile
RUN URL="https://github.com/jbub/pgbouncer_exporter/archive/v${PGBOUNCER_EXPORTER_VERSION}.tar.gz" \
    && curl -L "${URL}" | tar -zx --strip-components 1 \
```

`v0.18.0` is a **lightweight tag** — it points straight at a commit and can be force-moved to different content. `build_and_push.sh` pins only the version string (`0.18.0`), so if that tag were ever moved upstream, the next image rebuild would inherit the change with nothing in this repository differing. The tarball is also piped straight into `tar`, so it never lands on disk where it could be checked.

The exporter container runs in the pgbouncer pod, which is mounted with the metadata-DB stats credentials and sits on the connection path to the metadata database, so it is worth being able to say exactly what went into it.

### Change

Build from the commit the reviewed tag points at, rather than from the tag:

```dockerfile
RUN URL="https://github.com/jbub/pgbouncer_exporter/archive/${PGBOUNCER_EXPORTER_COMMIT_SHA}.tar.gz" \
```

`PGBOUNCER_EXPORTER_COMMIT_SHA` sits next to `PGBOUNCER_EXPORTER_VERSION` in `build_and_push.sh` with a comment saying the two are updated together. The commit is also recorded as an image label, so a published image states which source it was built from.

### Why not a checksum

The obvious move is to copy the sibling `pgbouncer` image, which does pin one:

```dockerfile
RUN wget ... && echo "${PGBOUNCER_SHA256}  pgbouncer-${VERSION}.tar.gz" | sha256sum -c -
```

That works there because it downloads an **uploaded release asset**, which is a stable file. This image downloads a GitHub **auto-generated archive**, and those are not guaranteed to be byte-stable — GitHub has changed archive generation before, which broke pinned checksums across the ecosystem. A sha256 here could fail the build without the source having changed.

Pinning the commit gives the property actually wanted — the build no longer depends on a tag continuing to mean what it meant when reviewed — without that failure mode. If you would rather carry a checksum as well, it can go on top; I did not want to add a maintenance burden with a known false-positive mode without asking.

### Verification

- Confirmed `v0.18.0` is a lightweight tag pointing at `1b1faecd80fdeb0f4d8baa0d423e8b58e4ab9aa5` (2024-10-10).
- Confirmed the commit-pinned reference yields the **same 34-file set** as the tag, so this is not a content change.
- Confirmed the archive still has a single top-level directory, so the existing `--strip-components 1` continues to apply.

Not build-tested locally — building requires `docker buildx` with the multi-platform setup this script uses. The change is to the source URL and one build arg, so CI's image build is the real check.

`lint-helm-chart` and `kubeconform` were skipped at commit time: both need a local `helm` binary that is not installed here, and both trigger on any `chart/**` path even though this change touches only `chart/dockerfiles/` and no chart templates.

---

Generated-by: Claude Opus 5 (1M context) following the guidelines at
https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
