### PR TITLE
Document that clear_on_success also removes the KPO pod identity

### DIFF
--- a/providers/cncf/kubernetes/docs/operators.rst
+++ b/providers/cncf/kubernetes/docs/operators.rst
@@ -222,8 +222,10 @@ ignored either way. The deprecated ``reattach_on_restart`` parameter (default ``
 only lever there, and it falls back to the same label-search reattach behavior this operator has
 always used -- unchanged from before this feature existed.
 
-The pod identity persisted in task state store isn't deleted automatically, that only happens
-when someone runs ``airflow state-store clean``. If a task's ``retry_delay`` is longer than
+The pod identity persisted in task state store is deleted when someone runs
+``airflow state-store clean``, and also as soon as the task instance succeeds if
+``[state_store] clear_on_success`` is turned on, which it is not by default.
+If a task's ``retry_delay`` is longer than
 ``[state_store] default_retention_days`` (30 days by default) and cleanup runs in between, the
 pod identity won't be there for the next retry, and the operator falls back to the label-search
 bootstrap path instead of reconnecting directly. This isn't necessarily a duplicate, the label


### PR DESCRIPTION
## What is wrong

The durable execution section of the KubernetesPodOperator doc say:

> The pod identity persisted in task state store isn't deleted automatically, that only happens
> when someone runs ``airflow state-store clean``.

But `[state_store] clear_on_success` delete it too. When a task instance reach SUCCESS, the execution API clear the whole task scope from the state store:

```python
if updated_state == TaskInstanceState.SUCCESS:
    if conf.getboolean("state_store", "clear_on_success"):
        scope = TaskScope(...)
        get_state_backend().clear(scope, session=session)
```

The default is `False`, so most people never see it. But someone who turn it on read this sentence and think the pod identity still stay, and then the next retry go to the label search instead of the direct reconnect, and they do not know why.

## What I change

Only that one sentence. The rest of the paragraph, the part about `retry_delay` and `default_retention_days`, I do not touch.

I find this while working on #71743, sorry for the small PR. Thank you for reading it.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes - Claude Code

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.
