### PR TITLE
Avoid duplicate Iceberg asset runs after a triggerer restart

### DIFF
--- a/providers/apache/iceberg/src/airflow/providers/apache/iceberg/triggers/iceberg.py
+++ b/providers/apache/iceberg/src/airflow/providers/apache/iceberg/triggers/iceberg.py
@@ -37,6 +37,8 @@ if TYPE_CHECKING:
 
 DEFAULT_BRANCH = "main"
 WATERMARK_KEY = "snapshot_id"
+# Raised by AssetStateStoreAccessors when the trigger is watched by more than one asset.
+_MULTI_ASSET_ERROR = "concrete inlets and outlets"
 
 
 class IcebergTableSnapshotTrigger(BaseEventTrigger):
@@ -131,9 +133,25 @@ class IcebergTableSnapshotTrigger(BaseEventTrigger):
         try:
             return list(store)
         except TypeError:
-            # Airflow older than the release that made the accessors iterable. It can still be
-            # addressed directly when a single asset watches the trigger.
-            return [store] if store is not None else []
+            pass
+        # Airflow older than the release that made the accessors iterable. It addresses one
+        # asset directly and refuses to guess when several watch the trigger, and it cannot be
+        # asked how many there are, so find out by reading and drop the watermark if it refuses.
+        try:
+            store.get(WATERMARK_KEY)
+        except ValueError as err:
+            # A state store backend can raise ValueError too, and swallowing that would
+            # disable the watermark without saying so.
+            if _MULTI_ASSET_ERROR not in str(err):
+                raise
+            self.log.warning(
+                "%s is watched by more than one asset, and this Airflow version cannot address "
+                "them separately; not persisting a snapshot watermark, so a triggerer restart "
+                "may re-emit the current head.",
+                self.table,
+            )
+            return []
+        return [store]
 
     async def run(self) -> AsyncIterator[TriggerEvent]:
         # serialize() is captured once when the trigger row is created, so a value mutated on

--- a/providers/apache/iceberg/src/airflow/providers/apache/iceberg/triggers/iceberg.py
+++ b/providers/apache/iceberg/src/airflow/providers/apache/iceberg/triggers/iceberg.py
@@ -37,8 +37,6 @@ if TYPE_CHECKING:
 
 DEFAULT_BRANCH = "main"
 WATERMARK_KEY = "snapshot_id"
-# Raised by AssetStateStoreAccessors when the trigger is watched by more than one asset.
-_MULTI_ASSET_ERROR = "concrete inlets and outlets"
 
 
 class IcebergTableSnapshotTrigger(BaseEventTrigger):
@@ -123,42 +121,42 @@ class IcebergTableSnapshotTrigger(BaseEventTrigger):
             return ref.snapshot_id
         return None
 
+    def _watermark_accessors(self) -> list[Any]:
+        """Return one state store accessor per asset watching this trigger."""
+        # asset_state_store postdates the Airflow versions this provider supports, and the
+        # triggerer only sets it for a trigger that watches assets.
+        store = getattr(self, "asset_state_store", None)
+        if store is None:
+            return []
+        try:
+            return list(store)
+        except TypeError:
+            # Airflow older than the release that made the accessors iterable. It can still be
+            # addressed directly when a single asset watches the trigger.
+            return [store] if store is not None else []
+
     async def run(self) -> AsyncIterator[TriggerEvent]:
         # serialize() is captured once when the trigger row is created, so a value mutated on
         # self is lost when the triggerer restarts and the current head would be re-emitted as
         # a new commit. The watermark survives that; the kwarg only seeds the first run.
-        # It postdates the Airflow versions this provider supports and is absent when several
-        # assets share the trigger, so polling carries on without it, losing only that cursor.
-        store = getattr(self, "asset_state_store", None)
-        if store is not None:
-            try:
-                stored = await asyncio.to_thread(store.get, WATERMARK_KEY)
-            except ValueError as err:
-                # The accessor serves one asset at a time, so it refuses to guess when this
-                # trigger is watched by several. That happens because triggers are deduplicated
-                # by hash(classpath, kwargs) while asset_watcher is many-to-many, so two assets
-                # watching this table with the same arguments share one trigger. There is then
-                # no single cursor to keep. A state store backend can raise ValueError too, and
-                # swallowing that would disable the watermark without saying so.
-                if _MULTI_ASSET_ERROR not in str(err):
-                    raise
-                self.log.warning(
-                    "%s is watched by more than one asset; not persisting a snapshot watermark, "
-                    "so a triggerer restart may re-emit the current head.",
-                    self.table,
-                )
-                store = None
-            else:
-                if stored is not None:
-                    self.last_seen_snapshot_id = int(stored)
+        accessors = await asyncio.to_thread(self._watermark_accessors)
+        if accessors:
+            # Triggers are deduplicated by hash(classpath, kwargs) while asset_watcher is
+            # many-to-many, so several assets can watch one trigger. Resume from the oldest of
+            # their watermarks, so a write that reached only some of them repeats a snapshot
+            # rather than skipping one.
+            stored = [await asyncio.to_thread(a.get, WATERMARK_KEY) for a in accessors]
+            seen = [int(v) for v in stored if v is not None]
+            if len(seen) == len(accessors):
+                self.last_seen_snapshot_id = min(seen)
 
         while True:
             # pyiceberg is synchronous, so keep the catalog call off the event loop.
             head = await asyncio.to_thread(self._head_snapshot_id)
             if head is not None and head != self.last_seen_snapshot_id:
                 previous, self.last_seen_snapshot_id = self.last_seen_snapshot_id, head
-                if store is not None:
-                    await asyncio.to_thread(store.set, WATERMARK_KEY, head)
+                for accessor in accessors:
+                    await asyncio.to_thread(accessor.set, WATERMARK_KEY, head)
                 yield TriggerEvent(
                     {
                         "table": self.table,

--- a/providers/apache/iceberg/tests/unit/apache/iceberg/triggers/test_iceberg.py
+++ b/providers/apache/iceberg/tests/unit/apache/iceberg/triggers/test_iceberg.py
@@ -255,6 +255,72 @@ async def test_a_state_store_failure_is_not_swallowed():
             await _collect(trigger, 1)
 
 
+class _LegacyAccessors:
+    """An asset_state_store from before the accessors became iterable.
+
+    It is not iterable and cannot be counted, so the only way to learn that several assets
+    watch the trigger is to read and be refused.
+    """
+
+    def __init__(self, asset_count, stored=None):
+        self._asset_count = asset_count
+        self.stored = stored
+
+    def __getitem__(self, key):
+        raise TypeError(f"Expected Asset, AssetNameRef, or AssetUriRef; got {type(key).__name__}")
+
+    def _check(self):
+        if self._asset_count != 1:
+            raise ValueError(
+                f"Task has {self._asset_count} concrete inlets and outlets — "
+                "use context['asset_state_store'][MY_ASSET] to specify which"
+            )
+
+    def get(self, key, default=None):
+        self._check()
+        return self.stored if self.stored is not None else default
+
+    def set(self, key, value):
+        self._check()
+        self.stored = value
+
+
+@pytest.mark.asyncio
+async def test_keeps_the_watermark_on_airflow_without_iterable_accessors():
+    """One asset on an older Airflow still resumes, addressing the store directly."""
+    store = _LegacyAccessors(asset_count=1, stored=222)
+    trigger = IcebergTableSnapshotTrigger(table="db.tbl", poll_interval=0.01, last_seen_snapshot_id=111)
+    trigger.asset_state_store = store
+
+    with patch(LOAD_TABLE, return_value=_table_at(222)):
+        assert await _collect(trigger, 1, timeout=0.2) == []
+
+
+@pytest.mark.asyncio
+async def test_degrades_on_airflow_without_iterable_accessors():
+    """Several assets on an older Airflow cannot be addressed, so polling carries on unwatermarked."""
+    trigger = IcebergTableSnapshotTrigger(table="db.tbl", poll_interval=0.01)
+    trigger.asset_state_store = _LegacyAccessors(asset_count=2)
+
+    with patch(LOAD_TABLE, return_value=_table_at(111)):
+        payloads = await _collect(trigger, 1)
+
+    assert [p["snapshot_id"] for p in payloads] == [111]
+
+
+@pytest.mark.asyncio
+async def test_a_legacy_state_store_failure_is_not_swallowed():
+    """The legacy path must degrade only on the refusal, not on a backend failure."""
+    store = _LegacyAccessors(asset_count=1)
+    store.get = MagicMock(side_effect=ValueError("could not decode the stored reference"))
+    trigger = IcebergTableSnapshotTrigger(table="db.tbl", poll_interval=0.01)
+    trigger.asset_state_store = store
+
+    with patch(LOAD_TABLE, return_value=_table_at(111)):
+        with pytest.raises(ValueError, match="could not decode"):
+            await _collect(trigger, 1)
+
+
 @pytest.mark.asyncio
 async def test_runs_on_airflow_without_an_asset_state_store():
     """``asset_state_store`` postdates the oldest Airflow this provider supports."""

--- a/providers/apache/iceberg/tests/unit/apache/iceberg/triggers/test_iceberg.py
+++ b/providers/apache/iceberg/tests/unit/apache/iceberg/triggers/test_iceberg.py
@@ -161,6 +161,32 @@ async def test_watches_the_requested_branch():
     assert payloads[0]["snapshot_id"] == 999
 
 
+class _Accessor:
+    """One asset's slice of the state store."""
+
+    def __init__(self, stored=None):
+        self.stored = stored
+
+    def get(self, key, default=None):
+        return self.stored if self.stored is not None else default
+
+    def set(self, key, value):
+        self.stored = value
+
+
+class _Accessors:
+    """Stands in for AssetStateStoreAccessors, which yields one accessor per watched asset."""
+
+    def __init__(self, *accessors):
+        self._accessors = list(accessors)
+
+    def __len__(self):
+        return len(self._accessors)
+
+    def __iter__(self):
+        return iter(self._accessors)
+
+
 @pytest.mark.asyncio
 async def test_resumes_from_the_stored_watermark():
     """A restarted triggerer must not re-emit a snapshot it already reported.
@@ -168,58 +194,61 @@ async def test_resumes_from_the_stored_watermark():
     ``serialize()`` is captured once, so the kwarg still holds the value from when the trigger
     row was written; only the stored watermark reflects what was actually emitted.
     """
-    store = MagicMock()
-    store.get.return_value = 222
-
     trigger = IcebergTableSnapshotTrigger(table="db.tbl", poll_interval=0.01, last_seen_snapshot_id=111)
-    trigger.asset_state_store = store
+    trigger.asset_state_store = _Accessors(_Accessor(222))
 
     with patch(LOAD_TABLE, return_value=_table_at(222)):
         payloads = await _collect(trigger, 1, timeout=0.2)
 
     assert payloads == []
-    store.get.assert_called_once_with("snapshot_id")
 
 
 @pytest.mark.asyncio
 async def test_persists_the_watermark_on_each_event():
-    store = MagicMock()
-    store.get.return_value = None
-
+    accessor = _Accessor()
     trigger = IcebergTableSnapshotTrigger(table="db.tbl", poll_interval=0.01)
-    trigger.asset_state_store = store
+    trigger.asset_state_store = _Accessors(accessor)
 
     with patch(LOAD_TABLE, side_effect=[_table_at(111), _table_at(222), _table_at(222)]):
         payloads = await _collect(trigger, 2)
 
     assert [p["snapshot_id"] for p in payloads] == [111, 222]
-    assert [c.args for c in store.set.call_args_list] == [("snapshot_id", 111), ("snapshot_id", 222)]
+    assert accessor.stored == 222
 
 
 @pytest.mark.asyncio
-async def test_runs_without_a_watermark_when_several_assets_watch_it():
-    """More than one watched asset leaves no single cursor, so it degrades instead of raising."""
-    store = MagicMock()
-    store.get.side_effect = ValueError("Task has 2 concrete inlets and outlets")
-
+async def test_keeps_a_watermark_for_every_asset_watching_it():
+    """Triggers are deduplicated, so several assets can watch one and each needs its own cursor."""
+    raw, curated = _Accessor(), _Accessor()
     trigger = IcebergTableSnapshotTrigger(table="db.tbl", poll_interval=0.01)
-    trigger.asset_state_store = store
+    trigger.asset_state_store = _Accessors(raw, curated)
 
     with patch(LOAD_TABLE, return_value=_table_at(111)):
         payloads = await _collect(trigger, 1)
 
     assert [p["snapshot_id"] for p in payloads] == [111]
-    store.set.assert_not_called()
+    assert (raw.stored, curated.stored) == (111, 111)
 
 
 @pytest.mark.asyncio
-async def test_a_state_store_failure_is_not_mistaken_for_several_assets():
-    """A pluggable backend can raise ValueError too, and hiding it would disable the watermark."""
-    store = MagicMock()
-    store.get.side_effect = ValueError("could not decode the stored reference")
-
+async def test_resumes_several_assets_from_the_oldest_watermark():
+    """A write that reached only some assets must repeat a snapshot rather than skip one."""
     trigger = IcebergTableSnapshotTrigger(table="db.tbl", poll_interval=0.01)
-    trigger.asset_state_store = store
+    trigger.asset_state_store = _Accessors(_Accessor(222), _Accessor(111))
+
+    with patch(LOAD_TABLE, return_value=_table_at(222)):
+        payloads = await _collect(trigger, 1)
+
+    assert [p["snapshot_id"] for p in payloads] == [222]
+
+
+@pytest.mark.asyncio
+async def test_a_state_store_failure_is_not_swallowed():
+    """Hiding a backend failure would disable the watermark without saying so."""
+    accessor = _Accessor()
+    accessor.get = MagicMock(side_effect=ValueError("could not decode the stored reference"))
+    trigger = IcebergTableSnapshotTrigger(table="db.tbl", poll_interval=0.01)
+    trigger.asset_state_store = _Accessors(accessor)
 
     with patch(LOAD_TABLE, return_value=_table_at(111)):
         with pytest.raises(ValueError, match="could not decode"):


### PR DESCRIPTION
# Rationale for this change

Two assets watch one Iceberg table through one trigger. Restart the triggerer for a deploy and both fire again for a commit already reported, so every DAG watching that table gets a duplicate run.

The watermark stops that, and the trigger drops it here. It also detects the case by matching an exception's text against `"concrete inlets and outlets"`, wording from a private helper that nobody promised, so a reword turns the guard into a re-raise. #71460 makes the accessors iterable, so the trigger writes to each asset.

# What changes are included in this PR?

One cursor per asset, not one or none:

```python
stored = [a.get(WATERMARK_KEY) for a in accessors]   # oldest wins, so a partial
...                        # write repeats a snapshot rather than skipping one
for accessor in accessors:
    accessor.set(WATERMARK_KEY, head)
```

A state store failure now propagates, no longer read as the several-assets case. Before #71460 the accessors are neither iterable nor countable, so the trigger reads once to see if it can address them, polling unwatermarked if not.

# Are these changes tested?

Live, on Postgres with a real Iceberg catalog and two assets on one trigger row.
<details><summary>Restart with no new commit, before and after</summary>

```console
# append a row to sales.orders via pyiceberg, then:
$ kill $(pgrep -f "airflow triggerer") && airflow triggerer &  # no new commit
$ psql -c "SELECT e.timestamp, e.extra::json->'payload'->>'snapshot_id' snap,
  e.extra::json->'payload'->>'previous_snapshot_id' prev FROM asset_event e
  JOIN asset a ON a.id=e.asset_id WHERE a.name='orders_raw' ORDER BY 1"

--- on main ---   (orders_reporting identical)
 00:08:58 | 9203870129439515238 | 5620644195193149555  # the commit
 00:10:08 | 9203870129439515238 |                      # RESTART: again

--- with this change ---
 00:11:56 | 9203870129439515238 |     # RESTART after this: no event
 00:14:18 | 9209950183446620906 | 9203870129439515238

$ pytest providers/apache/iceberg/tests/unit/apache/iceberg/triggers/ -q
5 failed, 18 passed  # on main
23 passed            # with this change
```

That last `prev` proves the watermark survived. A stand-in for the pre-#71460 accessors covers the older path.

</details>

# Are there any user-facing changes?

A table watched by several assets keeps its watermark, so restarting the triggerer no longer fires a duplicate run for a handled commit. One asset behaves as before. Stacked on #71460.
