### PR TITLE
Authenticate only once per task process to external secrets backends

### DIFF
--- a/task-sdk/src/airflow/sdk/configuration.py
+++ b/task-sdk/src/airflow/sdk/configuration.py
@@ -304,22 +304,32 @@ def initialize_secrets_backends(
     return backend_list
 
 
+_secrets_backend_cache: dict[tuple[str, ...], list] = {}
+
+
+def clear_secrets_backends_cache() -> None:
+    """Drop the memoised backends so the next load rebuilds them from the current config."""
+    _secrets_backend_cache.clear()
+
+
 def ensure_secrets_loaded(
     default_backends: list[str] = _SERVER_DEFAULT_SECRETS_SEARCH_PATH,
 ) -> list:
     """
-    Ensure that all secrets backends are loaded.
+    Return the secrets backends for the given search path, building them once per process.
 
-    If the secrets_backend_list contains only 2 default backends, reload it.
+    A backend holds an authenticated client, so rebuilding one per lookup makes every secret
+    fetch authenticate again against the remote store. Nothing is memoised until a custom
+    backend is configured, so one appearing after the first lookup is still picked up.
     """
-    # Check if the secrets_backend_list contains only 2 default backends.
-
-    # Check if we are loading the backends for worker too by checking if the default_backends is equal
-    # to _SERVER_DEFAULT_SECRETS_SEARCH_PATH.
-    secrets_backend_list = initialize_secrets_backends()
-    if len(secrets_backend_list) == 2 or default_backends != _SERVER_DEFAULT_SECRETS_SEARCH_PATH:
-        return initialize_secrets_backends(default_backends=default_backends)
-    return secrets_backend_list
+    key = tuple(default_backends)
+    if key not in _secrets_backend_cache:
+        backends = initialize_secrets_backends(default_backends=default_backends)
+        # Equal lengths mean nothing was prepended, so no custom backend is configured yet.
+        if len(backends) == len(default_backends):
+            return backends
+        _secrets_backend_cache[key] = backends
+    return _secrets_backend_cache[key]
 
 
 def initialize_config() -> AirflowSDKConfigParser:

--- a/task-sdk/tests/conftest.py
+++ b/task-sdk/tests/conftest.py
@@ -175,6 +175,16 @@ def _disable_ol_plugin():
 
 
 @pytest.fixture(autouse=True)
+def _clear_secrets_backends_cache():
+    """Keep memoised backends from leaking config between tests."""
+    from airflow.sdk.configuration import clear_secrets_backends_cache
+
+    clear_secrets_backends_cache()
+    yield
+    clear_secrets_backends_cache()
+
+
+@pytest.fixture(autouse=True)
 def _cleanup_async_resources(request):
     """
     Clean up async resources that can cause Python 3.12 fork warnings.

--- a/task-sdk/tests/task_sdk/execution_time/test_secrets.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_secrets.py
@@ -20,8 +20,13 @@ from __future__ import annotations
 import pytest
 
 from airflow.sdk.api.datamodels._generated import ConnectionResponse
+from airflow.sdk.configuration import clear_secrets_backends_cache, ensure_secrets_loaded
 from airflow.sdk.exceptions import AirflowSecretsBackendAccessDenied, ErrorType
 from airflow.sdk.execution_time.comms import ConnectionResult, ErrorResponse, VariableResult
+from airflow.sdk.execution_time.secrets import (
+    _SERVER_DEFAULT_SECRETS_SEARCH_PATH,
+    DEFAULT_SECRETS_SEARCH_PATH_WORKERS,
+)
 from airflow.sdk.execution_time.secrets.execution_api import ExecutionAPISecretsBackend
 
 
@@ -302,3 +307,36 @@ class TestContextDetection:
         assert "EnvironmentVariablesBackend" in backend_classes
         assert "MetastoreBackend" not in backend_classes
         assert "ExecutionAPISecretsBackend" not in backend_classes
+
+
+class TestSecretsBackendMemoisation:
+    BACKEND = "airflow.secrets.environment_variables.EnvironmentVariablesBackend"
+
+    def test_nothing_is_memoised_until_a_custom_backend_is_configured(self):
+        first = ensure_secrets_loaded(default_backends=_SERVER_DEFAULT_SECRETS_SEARCH_PATH)
+
+        assert ensure_secrets_loaded(default_backends=_SERVER_DEFAULT_SECRETS_SEARCH_PATH) is not first
+
+    def test_backends_are_built_once_with_a_custom_backend(self, monkeypatch):
+        monkeypatch.setenv("AIRFLOW__SECRETS__BACKEND", self.BACKEND)
+
+        first = ensure_secrets_loaded(default_backends=_SERVER_DEFAULT_SECRETS_SEARCH_PATH)
+
+        assert ensure_secrets_loaded(default_backends=_SERVER_DEFAULT_SECRETS_SEARCH_PATH) is first
+
+    def test_worker_chain_is_memoised_separately_from_the_server_chain(self, monkeypatch):
+        monkeypatch.setenv("AIRFLOW__SECRETS__BACKEND", self.BACKEND)
+
+        server = ensure_secrets_loaded(default_backends=_SERVER_DEFAULT_SECRETS_SEARCH_PATH)
+        worker = ensure_secrets_loaded(default_backends=DEFAULT_SECRETS_SEARCH_PATH_WORKERS)
+
+        assert server is not worker
+        assert ensure_secrets_loaded(default_backends=DEFAULT_SECRETS_SEARCH_PATH_WORKERS) is worker
+
+    def test_clearing_the_cache_rebuilds_backends(self, monkeypatch):
+        monkeypatch.setenv("AIRFLOW__SECRETS__BACKEND", self.BACKEND)
+
+        first = ensure_secrets_loaded(default_backends=_SERVER_DEFAULT_SECRETS_SEARCH_PATH)
+        clear_secrets_backends_cache()
+
+        assert ensure_secrets_loaded(default_backends=_SERVER_DEFAULT_SECRETS_SEARCH_PATH) is not first


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->


Follow-up to https://github.com/apache/airflow/pull/71701 but for generic secrets backends, which removed the two token validation calls the HashiCorp provider made per secret. This removes the repeated authentication underneath them.

## The problem

`_get_connection` and `_get_variable` call `ensure_secrets_backend_loaded()` inside the
lookup itself. That reaches `sdk/configuration.py` and ends at a bare `secrets_backend_cls(**backend_kwargs)` in the shared config parser, so every lookup gets a new backend, a new client, and a cold `cached_property`. For Vault that means a fresh AppRole login per secret.

Measured against a real Vault: two variables fetched in one process produced **two** AppRole logins.

The SDK function is inspired was copied from `airflow.configuration`. One line differs:

```python
# airflow-core
secrets_backend_list                                   # module global, built once

# task-sdk, before this change
secrets_backend_list = initialize_secrets_backends()   # local, rebuilt every call
```

The copy turned a reference to a cached global into a fresh call to build one. Everything downstream follows from that substitution, which is why core never showed the problem and the SDK always did.

## Why not simply mirror core

Core keeps one module-level list and returns it only when the requested search path is the
server default. Any other path takes the rebuild branch. The task runner always asks for `DEFAULT_SECRETS_SEARCH_PATH_WORKERS`, which is not the server default, so a faithful copy of
core would leave worker lookups rebuilding exactly as they do today.

Caching per search path is what makes both chains cacheable. The SDK also defers config initialisation deliberately via `__getattr__`, so populating at import the way core does would regress that.

## Preserved behaviour

Core's `len(secrets_backend_list) == 2` check exists so that a custom backend configured after
startup is still picked up. That is kept, expressed as `len(backends) == len(default_backends)`
so it holds for the worker chain too rather than hardcoding the server chain's length. When no
custom backend is found nothing is stored and every call rebuilds, exactly as before.

I traced the old and new implementations across every combination. Chain contents are identical
in all eight:

| `[workers]` / `[secrets]` | chain | backends | cached |
|---|---|---|---|
| set / unset | server | env, metastore | no |
| set / unset | worker | **metastore**, env, execapi | yes |
| set / set | server | **env**, env, metastore | yes |
| set / set | worker | **metastore**, env, execapi | yes |
| unset / set | server | **env**, env, metastore | yes |
| unset / set | worker | **env**, env, execapi | yes |
| unset / unset | server | env, metastore | no |
| unset / unset | worker | env, execapi | no |

Bold is the custom backend prepended by `initialize_secrets_backends`. Caching engages only
where one exists for the chain being requested.

## One behaviour difference

The old code always built the server chain first and discarded it, even when the worker chain
was requested. That discarded construction could raise:

```
[secrets] backend         = VaultBackend (misconfigured)
[workers] secrets_backend = MetastoreBackend (fine)
requesting the worker chain:

before: VaultError: The 'token' authentication type requires 'token' or 'token_path'
after:  ['MetastoreBackend', 'EnvironmentVariablesBackend', 'ExecutionAPISecretsBackend']
```

A worker with a valid backend no longer fails because of an unrelated server-side
misconfiguration it never uses. It needs `[workers] secrets_backend` set to something different
and `[secrets] backend` broken enough to raise on construction; with `[workers]` unset the
worker falls back to `[secrets] backend` and both versions raise identically.

## Credential expiry across backends

Holding an instance for the life of a process means an expiring credential has to refresh. All seven external backends were checked:

| Backend | Auth state held | Refreshes? |
|---|---|---|
| amazon (secrets manager, SSM) | boto3 session | yes, botocore credential resolver |
| google | google-auth credentials | yes |
| microsoft/azure | azure-identity credentials | yes |
| akeyless | own `_cached_token` with `_token_expiry`, TTL 600s | yes, itself |
| yandex | `yandexcloud.SDK` from OAuth token or SA key | SA key path refreshes; OAuth tokens are long-lived |
| hashicorp | static hvac token | yes, via the 403 retry added in #<FIX_A_PR> |
| cncf/kubernetes | `load_incluster_config()` in a `cached_property` | **no** |

The kubernetes backend reads the projected service account token from disk once. Bound tokens
expire and kubelet rotates the file, and the Python client does not re-read it.

That gap is not introduced here. Core has cached backend instances for the life of the process
on the server path for years, so the same defect already exists in the API server, scheduler and
Dag processor. This change makes it reachable in a worker whose task outlives the token. It is
worth fixing separately, with the same shape used for Vault: catch the 401, drop the cached
client, retry once.

## Improvements

Setup breeze with `VaultBackend` and create 5 variables:

```shell
alias v='docker exec -e VAULT_ADDR=http://127.0.0.1:8200 -e VAULT_TOKEN=root vault-test vault'

v write auth/approle/role/airflow token_policies=airflow token_type=batch
for i in 1 2 3 4 5; do v kv put -mount=secret variables/var$i value=value-$i; done
```

Use this dag:
```python
from __future__ import annotations

from datetime import datetime

from airflow.sdk import DAG, Variable, task

with DAG("five_vars", schedule=None, start_date=datetime(2024, 1, 1), catchup=False):

    @task
    def read_five():
        return [Variable.get(f"var{i}") for i in range(1, 6)]

    read_five()

```

### Before the changes

From audit file:
```shell
amoghrajesh.desai  …/airflow   main $?    orbstack  ♥ 10:27  docker exec vault-test cat /vault/logs/audit.log \
  | jq -r 'select(.type=="request") | .request.path' | sort | uniq -c                                                                                                                                                     5 auth/approle/login
   1 secret/data/variables/var1
   1 secret/data/variables/var2
   1 secret/data/variables/var3
   1 secret/data/variables/var4
   1 secret/data/variables/var5
```

### After the changes:

<img width="2560" height="509" alt="image" src="https://github.com/user-attachments/assets/e52f5b9f-c9c6-4001-8101-738af8f0de72" />


From audit file:

```shell
amoghrajesh.desai  …/airflow   vault-login-cost-reduction-part-2 $?    orbstack  ♥ 10:32  docker exec vault-test cat /vault/logs/audit.log \
  | jq -r 'select(.type=="request") | .request.path' | sort | uniq -c                                                                                                                                                     1 auth/approle/login
   1 secret/data/variables/var1
   1 secret/data/variables/var2
   1 secret/data/variables/var3
   1 secret/data/variables/var4
   1 secret/data/variables/var5
```

One Airflow task reading five distinct variables, counted from Vault's own file audit device.

| Path | main | this PR |
|---|---|---|
| `auth/approle/login` | 5 | **1** |
| `secret/data/variables/var1` … `var5` | 5 | 5 |
| **total** | **10** | **6** |

Cumulative across both changes, same workload:

| | logins | `lookup-self` | reads | total |
|---|---|---|---|---|
| Before either change | 5 | 10 | 5 | 20 |
| #71701 | 5 | 0 | 5 | 10 |
| This PR | 1 | 0 | 5 | 6 |

Six is the floor for five distinct secrets: one authentication plus one read each. Reads do not
drop because the secrets backend interface fetches one key at a time and there is no bulk read.


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
