### PR TITLE
Ignore task start_date and end_date on manual runs

### DIFF
--- a/airflow-core/docs/core-concepts/dag-run.rst
+++ b/airflow-core/docs/core-concepts/dag-run.rst
@@ -110,6 +110,9 @@ If your Dag logic needs the user-specified date for a manual run, use
 
 For upgrade guidance, see :ref:`data-interval-manual-triggering`.
 
+A task's ``start_date`` and ``end_date`` are also ignored for manual runs; like
+backfills, they bound only scheduled runs.
+
 Re-run Dag
 ''''''''''
 There can be cases where you will want to execute your Dag again. One such case is when the scheduled

--- a/airflow-core/docs/faq.rst
+++ b/airflow-core/docs/faq.rst
@@ -485,7 +485,8 @@ important to watch DagRun activity status in time when introducing
 new ``depends_on_past=True``, unless you are planning on running a backfill
 for the new task(s).
 
-It is also important to note that the task's ``start_date`` is ignored in backfills.
+It is also important to note that the task's ``start_date`` and ``end_date`` are ignored in
+backfills and in manually triggered runs. They only bound scheduled runs.
 
 Using time zones
 ----------------

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -1850,7 +1850,7 @@ class DagRun(Base, LoggingMixin):
 
         def task_filter(task: Operator) -> bool:
             return task.task_id not in task_ids and (
-                self.run_type == DagRunType.BACKFILL_JOB
+                self.run_type in (DagRunType.BACKFILL_JOB, DagRunType.MANUAL)
                 or (
                     task.start_date is None
                     or self.logical_date is None

--- a/airflow-core/tests/unit/models/test_dag.py
+++ b/airflow-core/tests/unit/models/test_dag.py
@@ -3388,7 +3388,9 @@ class TestQueries:
         for i in range(tasks_count):
             EmptyOperator(task_id=f"dummy_task_{i}", owner="test", dag=dag)
         scheduler_dag = sync_dag_to_db(dag)
-        with assert_queries_count(5):
+        # logical_date is before the Dag's start_date, so this manual run is outside the task
+        # window; it now creates its task instances (one bulk insert) instead of staying empty.
+        with assert_queries_count(6):
             scheduler_dag.create_dagrun(
                 run_id="test_dagrun_query_count",
                 run_type=DagRunType.MANUAL,

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -1579,15 +1579,16 @@ class TestDagRun:
 @pytest.mark.parametrize(
     ("run_type", "expected_tis"),
     [
-        pytest.param(DagRunType.MANUAL, 1, id="manual"),
+        pytest.param(DagRunType.MANUAL, 3, id="manual"),
         pytest.param(DagRunType.BACKFILL_JOB, 3, id="backfill"),
+        pytest.param(DagRunType.SCHEDULED, 1, id="scheduled"),
     ],
 )
 @mock.patch("airflow._shared.observability.metrics.stats._get_backend")
 def test_verify_integrity_task_start_and_end_date(
     mock_get_backend, dag_maker, session, run_type, expected_tis
 ):
-    """Test that tasks with specific dates are only created for backfill runs"""
+    """Test that tasks with specific dates are filtered out only for scheduled runs"""
     mock_stats = mock.MagicMock(spec=StatsLogger)
     mock_get_backend.return_value = mock_stats
 
@@ -1622,6 +1623,42 @@ def test_verify_integrity_task_start_and_end_date(
         count=expected_tis,
         tags={"dag_id": "test", "run_type": run_type, "task_type": "EmptyOperator"},
     )
+
+
+@pytest.mark.parametrize(
+    ("dag_kwargs", "logical_date"),
+    [
+        pytest.param(
+            {"start_date": DEFAULT_DATE + datetime.timedelta(days=365)},
+            DEFAULT_DATE,
+            id="logical-date-before-start-date",
+        ),
+        pytest.param(
+            {"start_date": DEFAULT_DATE, "end_date": DEFAULT_DATE},
+            DEFAULT_DATE + datetime.timedelta(days=365),
+            id="logical-date-after-end-date",
+        ),
+    ],
+)
+def test_manual_run_outside_task_date_window_runs_tasks(dag_maker, session, dag_kwargs, logical_date):
+    """A manual run whose logical date is outside the task date window must still run the tasks.
+
+    Otherwise no task instance is created at all, and the empty run is reported as a success
+    without anything having run.
+    """
+    with dag_maker("test_manual_outside_window", schedule="@daily", catchup=False, **dag_kwargs):
+        EmptyOperator(task_id="task1")
+        EmptyOperator(task_id="task2")
+
+    dag_run = dag_maker.create_dagrun(
+        run_type=DagRunType.MANUAL, logical_date=logical_date, run_after=logical_date
+    )
+
+    assert {ti.task_id for ti in dag_run.task_instances} == {"task1", "task2"}
+
+    dag_run.update_state(session=session)
+    session.flush()
+    assert dag_run.state == DagRunState.RUNNING
 
 
 @pytest.mark.parametrize("is_noop", [True, False])

--- a/task-sdk/src/airflow/sdk/bases/operator.py
+++ b/task-sdk/src/airflow/sdk/bases/operator.py
@@ -704,7 +704,11 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         ``TimeSensor`` and ``TimeDeltaSensor``. We advise against using
         dynamic ``start_date`` and recommend using fixed ones. Read the
         FAQ entry about start_date for more information.
-    :param end_date: if specified, the scheduler won't go beyond this date
+        This date only bounds scheduled runs; it is ignored for manually
+        triggered runs and backfills.
+    :param end_date: if specified, the scheduler won't go beyond this date.
+        Like ``start_date``, it only bounds scheduled runs and is ignored for
+        manually triggered runs and backfills.
     :param depends_on_past: when set to true, task instances will run
         sequentially and only if the previous instance has succeeded or has been skipped.
         The task instance for the start_date is allowed to run.


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

closes: #38513

A manual run whose logical date falls outside a task's `start_date` / `end_date` window creates no task instance for that task. When every task is filtered out this way, the run ends up with no task instances at all and is immediately reported as success, with no error and no failed task to alert on. Manual runs are now exempt from that window, as backfill runs already are.

The issue has been assigned since 2024 with no activity, happy to hand it back.

## Verified in the UI

Using a Dag modelled on the one from the issue, with a `start_date` of 2050 and three chained `@task` functions (`extract` → `transform` → `load`).

### Before


https://github.com/user-attachments/assets/fd8a57c2-c5c9-4ecf-b0ce-65e49f543dc6


### After


https://github.com/user-attachments/assets/eec34244-c5b2-43ad-bfcc-92baeefb613f



---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
  - Opus 5

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
