### PR TITLE
i18n(Ko): add missing translations in assets.json (Aug 18)

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/assets.json
@@ -1,5 +1,8 @@
 {
   "additional_data": "추가 데이터",
+  "alias_one": "별칭",
+  "alias_other": "별칭",
+  "aliases": "별칭",
   "asset_many": "에셋들",
   "asset_one": "에셋",
   "assetStateStore": {
@@ -13,6 +16,8 @@
     "deleteWarning": "에셋이 저장된 상태 저장소 항목을 잃게 됩니다.",
     "edit": "에셋 상태 저장소 편집",
     "emptyState": "에셋 상태 저장소는 에셋 식별자 범위로 지정된 값을 저장하며, 모든 Dag 실행에서 공유됩니다. 워커는 Task SDK를 통해 에셋 상태 저장소에 값을 기록할 수 있습니다.",
+    "entry_one": "항목",
+    "entry_other": "항목",
     "lastUpdatedBy": "마지막 수정자",
     "lastUpdatedByApi": "API",
     "lastUpdatedByWatcher": "Watcher",
@@ -53,5 +58,8 @@
   "scheduledDags": "스케줄 된 Dags",
   "scheduling": "스케줄링",
   "searchPlaceholder": "에셋 검색",
-  "taskDependencies": "태스크 종속성"
+  "taskDependencies": "태스크 종속성",
+  "watcher_one": "Watcher",
+  "watcher_other": "Watcher",
+  "watchers": "Watcher"
 }


### PR DESCRIPTION
add missing translations in assets.json

## Before
<img width="598" height="423" alt="image" src="https://github.com/user-attachments/assets/1db51ef0-c310-4c5e-98e4-4ec13e8c5e8f" />

## After
<img width="598" height="408" alt="image" src="https://github.com/user-attachments/assets/f6fdf2b9-ddd4-4f7d-bf85-4c5a1588bd9b" />

### Description
* alias_one: "별칭" 추가
* alias_other: "별칭" 추가
* aliases: "별칭" 추가
* entry_one: "항목" 추가
* entry_other: "항목" 추가
* watcher_one: "Watcher" 추가
* watcher_other: "Watcher" 추가
* watchers: "Watcher" 추가

Please review this translation.
/cc @onestn @noeunkim