### PR TITLE
UI: Avoid 404 links for tasks outside run dates

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Graph/TaskLink.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Graph/TaskLink.test.tsx
@@ -46,4 +46,23 @@ describe("TaskLink", () => {
       "/dags/test_dag/runs/test_run/tasks/one_try?log_level=error",
     );
   });
+
+  it("links to the task overview when the run has no task instance", () => {
+    render(
+      <MemoryRouter initialEntries={["/dags/test_dag/runs/test_run/tasks/other_task"]}>
+        <Routes>
+          <Route
+            element={<TaskLink hasTaskInstance={false} id="missing_task" label="missing_task" />}
+            path="/dags/:dagId/runs/:runId/tasks/:taskId"
+          />
+        </Routes>
+      </MemoryRouter>,
+      { wrapper: BaseWrapper },
+    );
+
+    expect(screen.getByRole("link", { name: "missing_task" })).toHaveAttribute(
+      "href",
+      "/dags/test_dag/tasks/missing_task",
+    );
+  });
 });

--- a/airflow-core/src/airflow/ui/src/components/Graph/TaskLink.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Graph/TaskLink.tsx
@@ -25,44 +25,50 @@ import { taskNodeSeparator } from "src/utils/assetGraph";
 
 type Props = {
   readonly dagId?: string;
+  readonly hasTaskInstance?: boolean;
   readonly id: string;
 } & TaskNameProps;
 
-export const TaskLink = forwardRef<HTMLAnchorElement, Props>(({ id, isGroup, isMapped, ...rest }, ref) => {
-  const { dagId: urlDagId = "", groupId, runId, taskId: urlTaskId } = useParams();
-  const [searchParams] = useSearchParams();
+export const TaskLink = forwardRef<HTMLAnchorElement, Props>(
+  ({ hasTaskInstance = true, id, isGroup, isMapped, ...rest }, ref) => {
+    const { dagId: urlDagId = "", groupId, runId, taskId: urlTaskId } = useParams();
+    const [searchParams] = useSearchParams();
 
-  // Extract dagId and taskId from composite ID
-  const parseCompositeId = (compositeId: string) => {
-    const match = new RegExp(`^task:(?<dagId>.*?)${taskNodeSeparator}(?<taskId>.+)$`, "u").exec(compositeId);
+    // Extract dagId and taskId from composite ID
+    const parseCompositeId = (compositeId: string) => {
+      const match = new RegExp(`^task:(?<dagId>.*?)${taskNodeSeparator}(?<taskId>.+)$`, "u").exec(
+        compositeId,
+      );
 
-    if (match) {
-      return { dagId: match[1], taskId: match[2] };
-    }
+      if (match) {
+        return { dagId: match[1], taskId: match[2] };
+      }
 
-    return { dagId: undefined, taskId: undefined };
-  };
+      return { dagId: undefined, taskId: undefined };
+    };
 
-  const { dagId: extractedDagId, taskId: extractedTaskId } = parseCompositeId(id);
-  const dagId = extractedDagId ?? urlDagId;
-  const taskId = extractedTaskId ?? id;
+    const { dagId: extractedDagId, taskId: extractedTaskId } = parseCompositeId(id);
+    const dagId = extractedDagId ?? urlDagId;
+    const taskId = extractedTaskId ?? id;
 
-  const basePath = `/dags/${dagId}${runId === undefined ? "" : `/runs/${runId}`}`;
-  const taskPath = isGroup
-    ? groupId === taskId
-      ? ""
-      : `/tasks/group/${taskId}`
-    : urlTaskId === taskId
-      ? ""
-      : `/tasks/${taskId}${isMapped && urlTaskId !== taskId && runId !== undefined ? "/mapped" : ""}`;
+    const includeRun = runId !== undefined && hasTaskInstance;
+    const basePath = `/dags/${dagId}${includeRun ? `/runs/${runId}` : ""}`;
+    const taskPath = isGroup
+      ? includeRun && groupId === taskId
+        ? ""
+        : `/tasks/group/${taskId}`
+      : includeRun && urlTaskId === taskId
+        ? ""
+        : `/tasks/${taskId}${isMapped && urlTaskId !== taskId && includeRun ? "/mapped" : ""}`;
 
-  const targetSearchParams = new URLSearchParams(searchParams);
+    const targetSearchParams = new URLSearchParams(searchParams);
 
-  targetSearchParams.delete(SearchParamsKeys.TRY_NUMBER);
+    targetSearchParams.delete(SearchParamsKeys.TRY_NUMBER);
 
-  return (
-    <RouterLink ref={ref} to={{ pathname: basePath + taskPath, search: targetSearchParams.toString() }}>
-      <TaskName isGroup={isGroup} isMapped={isMapped} {...rest} />
-    </RouterLink>
-  );
-});
+    return (
+      <RouterLink ref={ref} to={{ pathname: basePath + taskPath, search: targetSearchParams.toString() }}>
+        <TaskName isGroup={isGroup} isMapped={isMapped} {...rest} />
+      </RouterLink>
+    );
+  },
+);

--- a/airflow-core/src/airflow/ui/src/components/Graph/TaskNode.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Graph/TaskNode.test.tsx
@@ -16,12 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { ReactFlowProvider } from "@xyflow/react";
 import type { ComponentProps, ReactNode } from "react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 
-import { Wrapper } from "src/utils/Wrapper";
+import type { LightGridTaskInstanceSummary } from "openapi/requests/types.gen";
+import { BaseWrapper, Wrapper } from "src/utils/Wrapper";
 
 import { TaskNode } from "./TaskNode";
 import { readableTextForFill } from "./nodeColors";
@@ -81,6 +83,44 @@ describe("TaskNode operator colors", () => {
   it("alternates the group fill shade by nesting depth so nested groups stay distinct", () => {
     expect(renderHtml({ depth: 0, isGroup: true, isOpen: true, uiColor: "blue.500" })).not.toBe(
       renderHtml({ depth: 1, isGroup: true, isOpen: true, uiColor: "blue.500" }),
+    );
+  });
+});
+
+describe("TaskNode links", () => {
+  it("links to the task overview when the run has no task instance", () => {
+    render(
+      <ReactFlowProvider>
+        <TaskNode
+          {...({
+            data: {
+              height: 80,
+              id: "missing_task",
+              label: "missing_task",
+              taskInstance: { dag_version_number: null } as LightGridTaskInstanceSummary,
+              type: "task",
+              width: 200,
+            },
+            id: "missing_task",
+          } as unknown as ComponentProps<typeof TaskNode>)}
+        />
+      </ReactFlowProvider>,
+      {
+        wrapper: ({ children }: { readonly children: ReactNode }) => (
+          <BaseWrapper>
+            <MemoryRouter initialEntries={["/dags/test_dag/runs/test_run"]}>
+              <Routes>
+                <Route element={children} path="/dags/:dagId/runs/:runId" />
+              </Routes>
+            </MemoryRouter>
+          </BaseWrapper>
+        ),
+      },
+    );
+
+    expect(screen.getByRole("link", { name: "missing_task" })).toHaveAttribute(
+      "href",
+      "/dags/test_dag/tasks/missing_task",
     );
   });
 });

--- a/airflow-core/src/airflow/ui/src/components/Graph/TaskNode.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Graph/TaskNode.tsx
@@ -95,6 +95,9 @@ export const TaskNode = ({
   const thisChildCount = Object.entries(taskInstance?.child_states ?? {})
     .map(([_state, count]) => count)
     .reduce((sum, val) => sum + val, 0);
+  const hasTaskInstance = isGroup
+    ? true
+    : taskInstance?.dag_version_number !== null && taskInstance?.dag_version_number !== undefined;
 
   // Custom colors can mess up the readability of the text, so we calculate a readable foreground color for the node based on the background color.
   // Pass the resolved color so Chakra tokens are measured by their hex rather than skipped.
@@ -146,6 +149,7 @@ export const TaskNode = ({
               <LinkOverlay asChild>
                 <TaskLink
                   childCount={thisChildCount}
+                  hasTaskInstance={hasTaskInstance}
                   id={id}
                   isGroup={isGroup}
                   isMapped={isMapped}

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.test.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.test.tsx
@@ -36,6 +36,7 @@ vi.mock("src/context/colorMode", () => ({
 
 const taskInstance: LightGridTaskInstanceSummary = {
   child_states: null,
+  dag_version_number: 1,
   max_end_date: null,
   min_start_date: null,
   state: "success",
@@ -45,7 +46,16 @@ const taskInstance: LightGridTaskInstanceSummary = {
 
 const SELECTED_RUN_ID = "manual__2026-04-21T00:00:00+00:00";
 
-const renderGridTI = (route: string, taskId = "selected_task", runId = SELECTED_RUN_ID) =>
+type RenderGridTIOptions = {
+  readonly instance?: LightGridTaskInstanceSummary;
+  readonly runId?: string;
+  readonly taskId?: string;
+};
+
+const renderGridTI = (
+  route: string,
+  { instance = taskInstance, runId = SELECTED_RUN_ID, taskId = "selected_task" }: RenderGridTIOptions = {},
+) =>
   render(
     <BaseWrapper>
       <TimezoneProvider>
@@ -55,7 +65,7 @@ const renderGridTI = (route: string, taskId = "selected_task", runId = SELECTED_
               element={
                 <GridTI
                   dagId="example_dag"
-                  instance={{ ...taskInstance, task_id: taskId }}
+                  instance={{ ...instance, task_id: taskId }}
                   label={taskId}
                   runId={runId}
                   taskId={taskId}
@@ -89,7 +99,9 @@ describe("GridTI", () => {
   });
 
   it("does not mark another task square as selected", () => {
-    renderGridTI(`/dags/example_dag/runs/${SELECTED_RUN_ID}/tasks/selected_task`, "other_task");
+    renderGridTI(`/dags/example_dag/runs/${SELECTED_RUN_ID}/tasks/selected_task`, {
+      taskId: "other_task",
+    });
 
     expect(screen.getByTestId("task-state-badge")).not.toHaveAttribute("data-selected");
     expect(screen.getByTestId("task-state-badge").closest("[data-task-id='other_task']")).toHaveAttribute(
@@ -99,16 +111,24 @@ describe("GridTI", () => {
   });
 
   it("keeps the task row selected without marking the same task square in another Dag run as selected", () => {
-    renderGridTI(
-      `/dags/example_dag/runs/${SELECTED_RUN_ID}/tasks/selected_task`,
-      "selected_task",
-      "other_run",
-    );
+    renderGridTI(`/dags/example_dag/runs/${SELECTED_RUN_ID}/tasks/selected_task`, { runId: "other_run" });
 
     expect(screen.getByTestId("task-state-badge")).not.toHaveAttribute("data-selected");
     expect(screen.getByTestId("task-state-badge").closest("[data-task-id='selected_task']")).toHaveAttribute(
       "data-selected",
       "true",
+    );
+  });
+
+  it("links to the task overview when the run has no task instance", () => {
+    renderGridTI(`/dags/example_dag/runs/${SELECTED_RUN_ID}/tasks/selected_task`, {
+      instance: { ...taskInstance, dag_version_number: null },
+      taskId: "missing_task",
+    });
+
+    expect(screen.getByTestId(`grid-${SELECTED_RUN_ID}-missing_task`)).toHaveAttribute(
+      "href",
+      "/dags/example_dag/tasks/missing_task",
     );
   });
 });

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
@@ -55,14 +55,17 @@ export const GridTI = ({
 
   const [searchParams] = useSearchParams();
 
-  const taskUrl = buildTaskInstanceUrl({
-    currentPathname: location.pathname,
-    dagId,
-    isGroup,
-    isMapped: Boolean(isMapped),
-    runId,
-    taskId,
-  });
+  const hasTaskInstance = instance.dag_version_number !== null && instance.dag_version_number !== undefined;
+  const taskUrl = hasTaskInstance
+    ? buildTaskInstanceUrl({
+        currentPathname: location.pathname,
+        dagId,
+        isGroup,
+        isMapped: Boolean(isMapped),
+        runId,
+        taskId,
+      })
+    : `/dags/${dagId}/tasks/${isGroup ? "group/" : ""}${taskId}`;
 
   // Remove try_number query param when navigating to reset to the
   // latest try of the task instance and avoid issues with invalid try numbers:


### PR DESCRIPTION
Tasks excluded from a Dag run by their start or end date still appear as placeholders in the Grid and Graph views, but no TaskInstance exists for them. Route those placeholders to the task overview instead of a run-level TaskInstance endpoint that returns 404.

Regression coverage verifies placeholder navigation in the link component, Graph nodes, and Grid cells.

closes: #71761

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — OpenAI Codex

Generated-by: OpenAI Codex following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
