### PR TITLE
Add airflowctl tasks logs command for retrieving task instance logs

### DIFF
--- a/airflow-ctl-tests/tests/airflowctl_tests/test_airflowctl_commands.py
+++ b/airflow-ctl-tests/tests/airflowctl_tests/test_airflowctl_commands.py
@@ -101,6 +101,8 @@ TEST_COMMANDS = [
     'tasks failed-deps example_bash_operator runme_0 --logical-date "{date_param}"',
     'tasks states-for-dag-run example_bash_operator "manual__{date_param}"',
     'tasks states-for-dag-run example_bash_operator --logical-date "{date_param}"',
+    'tasks logs example_bash_operator "manual__{date_param}" runme_0',
+    'tasks logs example_bash_operator "manual__{date_param}" runme_0 --try-number 1',
     'tasks clear example_bash_operator --dag-run-id "manual__{date_param}" --task-ids runme_0 -o json',
     # Task Instances commands
     'taskinstances get example_bash_operator "manual__{date_param}" runme_0',

--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -72,6 +72,7 @@ from airflowctl.api.datamodels.generated import (
     TaskDependencyCollectionResponse,
     TaskInstanceCollectionResponse,
     TaskInstanceResponse,
+    TaskInstancesLogResponse,
     TriggerDAGRunPostBody,
     VariableBody,
     VariableCollectionResponse,
@@ -712,6 +713,28 @@ class TaskInstancesOperations(BaseOperations):
             extensions={"airflowctl_suppress_error_log": suppress_error_log},
         )
         return TaskDependencyCollectionResponse.model_validate_json(self.response.content)
+
+    def logs(
+        self,
+        dag_id: str,
+        dag_run_id: str,
+        task_id: str,
+        try_number: int,
+        map_index: int | None = None,
+        *,
+        suppress_error_log: bool = False,
+    ) -> TaskInstancesLogResponse | ServerResponseError:
+        """Get the logs of a task instance for a given try number."""
+        path = _build_task_instance_path(
+            dag_id=dag_id, dag_run_id=dag_run_id, task_id=task_id, map_index=None
+        )
+        params = {"map_index": map_index} if map_index is not None and map_index >= 0 else None
+        self.response = self.client.get(
+            f"{path}/logs/{try_number}",
+            params=params,
+            extensions={"airflowctl_suppress_error_log": suppress_error_log},
+        )
+        return TaskInstancesLogResponse.model_validate_json(self.response.content)
 
     def list(self, dag_id: str, dag_run_id: str) -> TaskInstanceCollectionResponse | ServerResponseError:
         """List task instances for a Dag run."""

--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -346,6 +346,20 @@ ARG_MAP_INDEX = Arg(
     help="Mapped task index",
 )
 
+# Task logs command args. Required primitive parameters stay positional per the
+# airflowctl parameter style consensus (#66768).
+ARG_TASKS_LOGS_DAG_RUN_ID = Arg(
+    flags=("dag_run_id",),
+    type=str,
+    help="The run ID of the Dag run",
+)
+ARG_TRY_NUMBER = Arg(
+    flags=("--try-number",),
+    type=int,
+    default=-1,
+    help="The try number of the task instance logs to fetch; -1 fetches the latest attempt",
+)
+
 ARG_ACTION_ON_EXISTING_KEY = Arg(
     flags=("-a", "--action-on-existing-key"),
     type=str,
@@ -1212,6 +1226,22 @@ TASK_COMMANDS = (
             ARG_RUN_ID,
             ARG_LOGICAL_DATE,
             ARG_OUTPUT,
+        ),
+    ),
+    ActionCommand(
+        name="logs",
+        help="Get the logs of a task instance",
+        description=(
+            "Get the logs of a task instance for a given try number. "
+            "The latest attempt is fetched when --try-number is not provided."
+        ),
+        func=lazy_load_command("airflowctl.ctl.commands.task_command.logs"),
+        args=(
+            ARG_DAG_ID,
+            ARG_TASKS_LOGS_DAG_RUN_ID,
+            ARG_TASK_ID,
+            ARG_MAP_INDEX,
+            ARG_TRY_NUMBER,
         ),
     ),
 )

--- a/airflow-ctl/src/airflowctl/ctl/commands/task_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/task_command.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING
 import rich
 
 from airflowctl.api.client import NEW_API_CLIENT, ClientKind, ServerResponseError, provide_api_client
-from airflowctl.api.datamodels.generated import TaskInstanceState
+from airflowctl.api.datamodels.generated import StructuredLogMessage, TaskInstanceState
 from airflowctl.ctl.console_formatting import AirflowConsole
 
 if TYPE_CHECKING:
@@ -149,3 +149,29 @@ def states_for_dag_run(args, api_client=NEW_API_CLIENT) -> None:
         data=[_format_task_instance(ti, has_mapped_instances) for ti in task_instances],
         output=args.output,
     )
+
+
+@provide_api_client(kind=ClientKind.CLI)
+def logs(args, api_client=NEW_API_CLIENT) -> None:
+    """Get the logs of a task instance for a given try."""
+    try:
+        response = api_client.task_instances.logs(
+            dag_id=args.dag_id,
+            dag_run_id=args.dag_run_id,
+            task_id=args.task_id,
+            try_number=args.try_number,
+            map_index=args.map_index,
+            suppress_error_log=True,
+        )
+    except ServerResponseError as e:
+        if e.response.status_code == 404:
+            map_index_part = f" with map index {args.map_index}" if args.map_index >= 0 else ""
+            rich.print(
+                f"[red]Task instance for task {args.task_id!r}{map_index_part} in Dag run "
+                f"{args.dag_run_id!r} of Dag {args.dag_id!r} not found[/red]"
+            )
+            sys.exit(1)
+        raise
+
+    for entry in response.content:
+        print(entry.event if isinstance(entry, StructuredLogMessage) else entry)

--- a/airflow-ctl/tests/airflow_ctl/ctl/commands/test_task_command.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/commands/test_task_command.py
@@ -24,10 +24,12 @@ import httpx
 import pytest
 
 from airflowctl.api.datamodels.generated import (
+    StructuredLogMessage,
     TaskDependencyCollectionResponse,
     TaskDependencyResponse,
     TaskInstanceCollectionResponse,
     TaskInstanceResponse,
+    TaskInstancesLogResponse,
     TaskInstanceState,
 )
 from airflowctl.api.operations import ServerResponseError
@@ -631,3 +633,109 @@ class TestStatesForDagRun:
             task_command.states_for_dag_run(self.parser.parse_args(argv), api_client=api_client)
 
         assert ctx.value is error
+
+
+class TestLogs:
+    parser = cli_parser.get_parser()
+    dag_id = "test_dag"
+    run_id = "test_run"
+    task_id = "test_task"
+
+    def _make_log_response(self, content: list[StructuredLogMessage] | list[str]) -> TaskInstancesLogResponse:
+        return TaskInstancesLogResponse(content=content, continuation_token=None)
+
+    def _make_structured_content(self) -> list[StructuredLogMessage]:
+        return [
+            StructuredLogMessage(
+                timestamp=datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc),
+                event="INFO - hello",
+            ),
+            StructuredLogMessage(
+                timestamp=datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc),
+                event="plain line",
+            ),
+        ]
+
+    def test_logs_defaults_to_latest_attempt(self, capsys):
+        api_client = mock.MagicMock()
+        api_client.task_instances.logs.return_value = self._make_log_response(self._make_structured_content())
+
+        task_command.logs(
+            self.parser.parse_args(["tasks", "logs", self.dag_id, self.run_id, self.task_id]),
+            api_client=api_client,
+        )
+
+        api_client.task_instances.logs.assert_called_once_with(
+            dag_id=self.dag_id,
+            dag_run_id=self.run_id,
+            task_id=self.task_id,
+            try_number=-1,
+            map_index=-1,
+            suppress_error_log=True,
+        )
+        assert capsys.readouterr().out == "INFO - hello\nplain line\n"
+
+    def test_logs_prints_plain_string_entries(self, capsys):
+        api_client = mock.MagicMock()
+        api_client.task_instances.logs.return_value = self._make_log_response(["plain line"])
+
+        task_command.logs(
+            self.parser.parse_args(["tasks", "logs", self.dag_id, self.run_id, self.task_id]),
+            api_client=api_client,
+        )
+
+        assert capsys.readouterr().out == "plain line\n"
+
+    def test_logs_with_explicit_try_number_and_map_index(self, capsys):
+        api_client = mock.MagicMock()
+        api_client.task_instances.logs.return_value = self._make_log_response(self._make_structured_content())
+
+        task_command.logs(
+            self.parser.parse_args(
+                [
+                    "tasks",
+                    "logs",
+                    self.dag_id,
+                    self.run_id,
+                    self.task_id,
+                    "--try-number",
+                    "2",
+                    "--map-index",
+                    "3",
+                ]
+            ),
+            api_client=api_client,
+        )
+
+        api_client.task_instances.logs.assert_called_once_with(
+            dag_id=self.dag_id,
+            dag_run_id=self.run_id,
+            task_id=self.task_id,
+            try_number=2,
+            map_index=3,
+            suppress_error_log=True,
+        )
+
+    def test_logs_task_instance_not_found(self, capsys):
+        api_client = mock.MagicMock()
+        api_client.task_instances.logs.side_effect = _make_server_error(404)
+
+        with pytest.raises(SystemExit, match="1"):
+            task_command.logs(
+                self.parser.parse_args(["tasks", "logs", self.dag_id, self.run_id, self.task_id]),
+                api_client=api_client,
+            )
+
+        assert _normalize_rich_output(capsys.readouterr().out) == (
+            "Task instance for task 'test_task' in Dag run 'test_run' of Dag 'test_dag' not found"
+        )
+
+    def test_logs_reraises_non_404_error(self):
+        api_client = mock.MagicMock()
+        api_client.task_instances.logs.side_effect = _make_server_error(500)
+
+        with pytest.raises(ServerResponseError):
+            task_command.logs(
+                self.parser.parse_args(["tasks", "logs", self.dag_id, self.run_id, self.task_id]),
+                api_client=api_client,
+            )


### PR DESCRIPTION
﻿﻿Summary
Add the `airflowctl tasks logs` command to fetch a task instance's logs for a given try through the existing REST endpoint.

Changes
- Add `TaskInstancesOperations.logs()` calling `GET /api/v2/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}/logs/{try_number}`.
- Register the `tasks logs` command: `airflowctl tasks logs DAG_ID DAG_RUN_ID TASK_ID [--map-index N] [--try-number N]`; `--try-number` defaults to the latest attempt, matching the webserver UI.
- Keep required parameters positional per the airflowctl parameter style consensus (#66768); the issue's suggested `--dag-id`/`--dag-run-id`/`--task-id` flag form was dropped to comply with that convention.
- Limit scope to the primary logs endpoint; `externalLogUrl` handling is left for a follow-up.

Testing
Added unit tests covering the command: default latest attempt, explicit try number and map index, structured and plain-text log output, 404 handling, and non-404 error propagation. All 35 tests in `test_task_command.py` pass. Added `tasks logs` lines to the integration test command list. `ruff format` and `ruff check` pass on all changed files.

closes: #69947

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — DeepSeek V4 Pro

Generated-by: DeepSeek V4 Pro following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)，I also conducted local testing, and no issues were found.

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

