### PR TITLE
Keep scheduling remaining tasks when a running Dag is paused

### DIFF
--- a/airflow-core/docs/core-concepts/dags.rst
+++ b/airflow-core/docs/core-concepts/dags.rst
@@ -804,12 +804,12 @@ and finally all metadata for the Dag can be deleted.
 
 Dag can be paused via UI when it is present in the ``DAGS_FOLDER``, and scheduler stored it in
 the database, but the user chose to disable it via the UI. The "pause" and "unpause" actions are available
-via UI and API. Paused Dags are not scheduled by the Scheduler, but you can trigger them via UI for
+via UI and API. Paused Dags are not given new Dag runs by the Scheduler, but you can trigger them via UI for
 manual runs. In the UI, you can see paused Dags (in ``Paused`` tab). The Dags that are un-paused
-can be found in the ``Active`` tab. When a Dag is paused, any running tasks are allowed to complete and all
-downstream tasks are put in to a state of "Scheduled". When the Dag is unpaused, any "scheduled" tasks will
-begin running according to the Dag logic. Dags with no "scheduled" tasks will begin running according to
-their schedule.
+can be found in the ``Active`` tab. When a Dag is paused, Dag runs that have not started yet stay
+queued until the Dag is unpaused. A Dag run that is already running continues: remaining tasks are
+still scheduled and queued, and the run can reach a terminal state. After unpause, new Dag runs
+begin according to the Dag's schedule.
 
 Dags can be deactivated (do not confuse it with ``Active`` tag in the UI) by removing them from the
 ``DAGS_FOLDER``. When scheduler parses the ``DAGS_FOLDER`` and misses the Dag that it had seen

--- a/airflow-core/newsfragments/71765.bugfix.rst
+++ b/airflow-core/newsfragments/71765.bugfix.rst
@@ -1,0 +1,1 @@
+Pausing a Dag no longer freezes an already-running Dag run; remaining tasks still schedule and the run can finish. New Dag runs are still not created.

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -52,7 +52,6 @@ from sqlalchemy import (
 )
 from sqlalchemy.exc import DBAPIError, OperationalError
 from sqlalchemy.orm import joinedload, lazyload, load_only, make_transient, selectinload
-from sqlalchemy.sql import expression
 
 from airflow import settings
 from airflow._shared.observability.metrics import stats
@@ -726,7 +725,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 .join(TI.dag_run)
                 .where(DR.state == DagRunState.RUNNING)
                 .join(TI.dag_model)
-                .where(~DM.is_paused)
                 .where(TI.state == TaskInstanceState.SCHEDULED)
                 .where(DM.bundle_name.is_not(None))
                 .join(
@@ -1736,34 +1734,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             self.log.info("Exited execute loop")
         return None
 
-    @provide_session
-    def _update_dag_run_state_for_paused_dags(self, *, session: Session = NEW_SESSION) -> None:
-        try:
-            paused_runs = list(
-                session.scalars(
-                    select(DagRun)
-                    .join(DagRun.dag_model)
-                    .join(TI)
-                    .where(
-                        DagModel.is_paused == expression.true(),
-                        DagRun.state == DagRunState.RUNNING,
-                    )
-                    .having(DagRun.last_scheduling_decision <= func.max(TI.updated_at))
-                    .group_by(DagRun)
-                )
-            )
-            # Team name should be added before listeners are called in update_state()
-            self._stamp_team_names(paused_runs, session)
-            for dag_run in paused_runs:
-                dag = self.scheduler_dag_bag.get_dag_for_run(dag_run=dag_run, session=session)
-                if dag is not None:
-                    dag_run.dag = dag
-                    _, callback_to_run = dag_run.update_state(execute_callbacks=False, session=session)
-                    if callback_to_run:
-                        self._send_dag_callbacks_to_processor(dag, callback_to_run)
-        except Exception as e:  # should not fail the scheduler
-            self.log.exception("Failed to update dag run state for paused dags due to %s", e)
-
     def _run_scheduler_loop(self) -> None:
         """
         Harvest DAG parsing results, queue tasks, and perform executor heartbeat; the actual scheduler loop.
@@ -1827,8 +1797,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             conf.getfloat("scheduler", "task_instance_heartbeat_timeout_detection_interval", fallback=10.0),
             self._find_and_purge_task_instances_without_heartbeats,
         )
-
-        timers.call_regular_interval(60.0, self._update_dag_run_state_for_paused_dags)
 
         timers.call_regular_interval(
             conf.getfloat("scheduler", "task_queued_timeout_check_interval"),

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -766,7 +766,6 @@ class DagRun(Base, LoggingMixin):
             .join(DagModel, DagModel.dag_id == cls.dag_id)
             .join(BackfillDagRun, BackfillDagRun.dag_run_id == DagRun.id, isouter=True)
             .where(
-                DagModel.is_paused == false(),
                 DagModel.is_stale == false(),
             )
             .order_by(

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -135,7 +135,6 @@ from airflow.sdk import (
 )
 from airflow.sdk.definitions.callback import AsyncCallback, SyncCallback
 from airflow.sdk.definitions.timetables.assets import PartitionedAssetTimetable
-from airflow.serialization.definitions.dag import SerializedDAG
 from airflow.serialization.encoders import ensure_serialized_asset
 from airflow.serialization.serialized_objects import LazyDeserializedDAG
 from airflow.timetables.base import DagRunInfo, DataInterval, compute_rollup_fingerprint
@@ -177,6 +176,8 @@ from unit.models import TEST_DAGS_FOLDER
 
 if TYPE_CHECKING:
     from sqlalchemy.orm.session import Session
+
+    from airflow.serialization.definitions.dag import SerializedDAG
 
     from tests_common.pytest_plugin import DagMaker
 
@@ -1196,24 +1197,28 @@ class TestSchedulerJob:
         assert events[0].asset is not None
         assert events[0].source_aliases is not None
 
-    def test_execute_task_instances_is_paused_wont_execute(self, session, dag_maker):
-        dag_id = "SchedulerJobTest.test_execute_task_instances_is_paused_wont_execute"
-        task_id_1 = "dummy_task"
+    def test_execute_task_instances_paused_running_dag_still_enqueues(self, session, dag_maker):
+        dag_id = "SchedulerJobTest.test_execute_task_instances_paused_running_dag_still_enqueues"
 
-        with dag_maker(dag_id=dag_id, session=session) as dag:
-            EmptyOperator(task_id=task_id_1)
-        assert isinstance(dag, SerializedDAG)
+        with dag_maker(dag_id=dag_id, session=session):
+            EmptyOperator(task_id="dummy_task")
 
         scheduler_job = Job()
         self.job_runner = SchedulerJobRunner(job=scheduler_job)
-        dr1 = dag_maker.create_dagrun(run_type=DagRunType.BACKFILL_JOB)
+        dr1 = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED)
+        assert dr1.state == State.RUNNING
+
+        dag_model = session.get(DagModel, dag_id)
+        dag_model.is_paused = True
+
         (ti1,) = dr1.task_instances
         ti1.state = State.SCHEDULED
+        session.flush()
 
         self.job_runner._critical_section_enqueue_task_instances(session)
         session.flush()
         ti1.refresh_from_db(session=session)
-        assert ti1.state == State.SCHEDULED
+        assert ti1.state == TaskInstanceState.QUEUED
         session.rollback()
 
     @pytest.mark.usefixtures("testing_dag_bundle")
@@ -8714,16 +8719,15 @@ class TestSchedulerJob:
             )
         ) > (timezone.utcnow() - timedelta(days=2))
 
-    def test_update_dagrun_state_for_paused_dag(self, dag_maker, session):
-        """Test that _update_dagrun_state_for_paused_dag puts DagRuns in terminal states"""
-        with dag_maker("testdag") as dag:
+    def test_paused_running_dag_run_reaches_terminal_state(self, dag_maker, session):
+        """Test that a paused running dag run reaches a terminal state"""
+        with dag_maker(dag_id="test_paused_running_dag_run_terminal_state") as dag:
             EmptyOperator(task_id="task1")
 
         scheduled_run = dag_maker.create_dagrun(
             logical_date=datetime.datetime(2022, 1, 1),
             run_type=DagRunType.SCHEDULED,
         )
-        scheduled_run.last_scheduling_decision = datetime.datetime.now(timezone.utc) - timedelta(minutes=1)
         ti = scheduled_run.get_task_instances(session=session)[0]
         ti.set_state(TaskInstanceState.RUNNING)
         dm = DagModel.get_dagmodel(dag.dag_id, session=session)
@@ -8731,56 +8735,91 @@ class TestSchedulerJob:
         session.flush()
 
         assert scheduled_run.state == State.RUNNING
+        examined_run_ids = {
+            dr.id
+            for dr in DagRun.get_running_dag_runs_to_examine(session=session, eagerly_load_dag_tags=False)
+        }
+        assert scheduled_run.id in examined_run_ids
 
         scheduler_job = Job()
         self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
 
-        self.job_runner._update_dag_run_state_for_paused_dags(session=session)
+        self.job_runner._schedule_dag_run(scheduled_run, session)
         session.flush()
 
-        # TI still running, DagRun left in running
         (scheduled_run,) = DagRun.find(dag_id=dag.dag_id, run_type=DagRunType.SCHEDULED, session=session)
         assert scheduled_run.state == State.RUNNING
-        prior_last_scheduling_decision = scheduled_run.last_scheduling_decision
 
-        # Make sure we don't constantly try dagruns over and over
-        self.job_runner._update_dag_run_state_for_paused_dags(session=session)
-        (scheduled_run,) = DagRun.find(dag_id=dag.dag_id, run_type=DagRunType.SCHEDULED, session=session)
-        assert scheduled_run.state == State.RUNNING
-        # last_scheduling_decision is bumped by update_state, so check that to determine if we tried again
-        assert prior_last_scheduling_decision == scheduled_run.last_scheduling_decision
-
-        # Once the TI is in a terminal state though, DagRun goes to success
         ti.set_state(TaskInstanceState.SUCCESS, session=session)
+        self.job_runner._schedule_dag_run(scheduled_run, session)
+        session.flush()
 
-        self.job_runner._update_dag_run_state_for_paused_dags(session=session)
         (scheduled_run,) = DagRun.find(dag_id=dag.dag_id, run_type=DagRunType.SCHEDULED, session=session)
         assert scheduled_run.state == State.SUCCESS
 
-    def test_update_dagrun_state_for_paused_dag_not_for_backfill(self, dag_maker, session):
-        """Test that the _update_dagrun_state_for_paused_dag does not affect backfilled dagruns"""
-        with dag_maker("testdag") as dag:
-            EmptyOperator(task_id="task1")
+    def test_paused_running_dag_still_schedules_and_enqueues_downstream(self, dag_maker, session):
+        """Test that a paused running dag still schedules and enqueues downstream"""
+        with dag_maker(dag_id="test_paused_running_dag_downstream_tasks") as dag:
+            task_a = BashOperator(task_id="a", bash_command="true")
+            task_b = BashOperator(task_id="b", bash_command="true")
+            task_a >> task_b
 
-        # Backfill run
-        backfill_run = dag_maker.create_dagrun(run_type=DagRunType.BACKFILL_JOB)
-        backfill_run.last_scheduling_decision = datetime.datetime.now(timezone.utc) - timedelta(minutes=1)
-        ti = backfill_run.get_task_instances(session=session)[0]
-        ti.set_state(TaskInstanceState.SUCCESS, session=session)
+        dr = dag_maker.create_dagrun(
+            logical_date=datetime.datetime(2022, 1, 1),
+            run_type=DagRunType.SCHEDULED,
+        )
+        ti_a = dr.get_task_instance(task_id="a", session=session)
+        ti_b = dr.get_task_instance(task_id="b", session=session)
+        ti_a.set_state(TaskInstanceState.RUNNING, session=session)
         dm = DagModel.get_dagmodel(dag.dag_id, session=session)
         dm.is_paused = True
         session.flush()
 
-        assert backfill_run.state == State.RUNNING
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
+
+        self.job_runner._schedule_dag_run(dr, session)
+        session.flush()
+        ti_b.refresh_from_db(session=session)
+        assert ti_b.state is None
+
+        ti_a.set_state(TaskInstanceState.SUCCESS, session=session)
+        self.job_runner._schedule_dag_run(dr, session)
+        session.flush()
+        ti_b.refresh_from_db(session=session)
+        assert ti_b.state == TaskInstanceState.SCHEDULED
+
+        self.job_runner._critical_section_enqueue_task_instances(session)
+        session.flush()
+        ti_b.refresh_from_db(session=session)
+        assert ti_b.state == TaskInstanceState.QUEUED
+
+    def test_paused_queued_dag_run_stays_queued_until_unpause(self, dag_maker, session):
+        """Test that a paused queued DAG run stays queued until unpause"""
+        with dag_maker(dag_id="test_paused_queued_dag_run") as dag:
+            EmptyOperator(task_id="task")
+
+        dr = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED, state=State.QUEUED, session=session)
+        dm = DagModel.get_dagmodel(dag.dag_id, session=session)
+        dm.is_paused = True
+        session.flush()
 
         scheduler_job = Job()
         self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
 
-        self.job_runner._update_dag_run_state_for_paused_dags(session=session)
+        self.job_runner._do_scheduling(session)
+        dr = session.merge(dr)
+        session.refresh(dr)
+        assert dr.state == State.QUEUED
+
+        dm = session.get(DagModel, dag.dag_id)
+        dm.is_paused = False
         session.flush()
 
-        (backfill_run,) = DagRun.find(dag_id=dag.dag_id, run_type=DagRunType.BACKFILL_JOB, session=session)
-        assert backfill_run.state == State.SUCCESS
+        self.job_runner._do_scheduling(session)
+        dr = session.merge(dr)
+        session.refresh(dr)
+        assert dr.state == State.RUNNING
 
     @staticmethod
     def _find_assets_activation(session) -> tuple[list[AssetModel], list[AssetModel]]:

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -1049,11 +1049,19 @@ class TestDagRun:
         schedulable_tis = [ti.task_id for ti in decision.schedulable_tis]
         assert (upstream.task_id in schedulable_tis) == is_ti_schedulable
 
-    @pytest.mark.parametrize("state", [DagRunState.QUEUED, DagRunState.RUNNING])
-    def test_next_dagruns_to_examine_only_unpaused(self, session, state, testing_dag_bundle):
+    @pytest.mark.parametrize(
+        ("state", "examined_while_paused"),
+        [
+            pytest.param(DagRunState.QUEUED, False, id="queued-not-started"),
+            pytest.param(DagRunState.RUNNING, True, id="running-still-examined"),
+        ],
+    )
+    def test_next_dagruns_to_examine_paused(self, session, state, examined_while_paused, testing_dag_bundle):
         """
-        Check that "next_dagruns_to_examine" ignores runs from paused/inactive DAGs
-        and gets running/queued dagruns
+        Pause does not start queued Dag runs.
+
+        A Dag run that is already running is still examined so remaining tasks can
+        be scheduled and the run can reach a terminal state.
         """
         dag = DAG(dag_id="test_dags", schedule=datetime.timedelta(days=1), start_date=DEFAULT_DATE)
         EmptyOperator(task_id="dummy", dag=dag, owner="airflow")
@@ -1100,7 +1108,10 @@ class TestDagRun:
         session.commit()
 
         runs = fetch().all()
-        assert runs == []
+        if examined_while_paused:
+            assert runs == [dr]
+        else:
+            assert runs == []
 
     @mock.patch("airflow._shared.observability.metrics.stats.timing")
     def test_no_scheduling_delay_for_nonscheduled_runs(self, stats_mock, session, testing_dag_bundle):


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

### 1. Problem

Pausing a Dag stopped the scheduler from examining already-running Dag runs and from enqueueing remaining `scheduled` tasks. In-flight work froze until unpaused, even though running tasks were allowed to finish. As a result, 
a running Dag could remain running indefinitely because its downstream tasks would never be queued.

closes: #71381

### 2. Solution

- A Dag run that is already running continues while the Dag is paused: remaining tasks are still scheduled and queued, and the run can reach a terminal state.
- Queued Dag runs stay queued until unpause.
- New Dag runs are not created.
- Pause is not the way to stop in-flight work. If you need a running Dag run to stop, mark the run or its tasks as failed.

### Cleanup

- Removed `_update_dag_run_state_for_paused_dags` (and its 60s timer). Paused running Dag runs are now examined in the main scheduler loop, so a separate `update_state` pass was redundant.

### Tests

```bash
uv run --project airflow-core pytest \
  airflow-core/tests/unit/models/test_dagrun.py::TestDagRun::test_next_dagruns_to_examine_paused \
  airflow-core/tests/unit/jobs/test_scheduler_job.py::TestSchedulerJob::test_execute_task_instances_paused_running_dag_still_enqueues \
  airflow-core/tests/unit/jobs/test_scheduler_job.py::TestSchedulerJob::test_paused_running_dag_run_reaches_terminal_state \
  airflow-core/tests/unit/jobs/test_scheduler_job.py::TestSchedulerJob::test_paused_running_dag_still_schedules_and_enqueues_downstream \
  airflow-core/tests/unit/jobs/test_scheduler_job.py::TestSchedulerJob::test_paused_queued_dag_run_stays_queued_until_unpause \
  -xvs
```

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Cursor Grok 4.6

Generated-by: Cursor Grok 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.