### PR TITLE
restrict permissions on teradata credential files written for ssh runs

### DIFF
--- a/providers/teradata/src/airflow/providers/teradata/hooks/bteq.py
+++ b/providers/teradata/src/airflow/providers/teradata/hooks/bteq.py
@@ -43,6 +43,7 @@ from airflow.providers.teradata.utils.encryption_utils import (
     generate_encrypted_file_with_openssl,
     generate_random_password,
 )
+from airflow.providers.teradata.utils.tpt_util import set_local_file_permissions
 
 
 class BteqHook(TtuHook):
@@ -131,6 +132,9 @@ class BteqHook(TtuHook):
             file_path = os.path.join(tmp_dir, "bteq_script.txt")
             with open(file_path, "w", encoding=str(temp_file_read_encoding or "UTF-8")) as f:
                 f.write(bteq_script)
+            # The script embeds the `.LOGON` credentials, so restrict it to the owner before
+            # it is encrypted and transferred.
+            set_local_file_permissions(file_path, self.log)
             return self._transfer_to_and_execute_bteq_on_remote(
                 file_path,
                 remote_working_dir,

--- a/providers/teradata/src/airflow/providers/teradata/hooks/tpt.py
+++ b/providers/teradata/src/airflow/providers/teradata/hooks/tpt.py
@@ -124,6 +124,9 @@ class TptHook(TtuHook):
         with self.preferred_temp_directory() as tmp_dir:
             local_script_file = os.path.join(tmp_dir, f"tbuild_script_{uuid.uuid4().hex}.sql")
             write_file(local_script_file, tpt_script_content)
+            # The script embeds the connection password, so restrict it to the owner before
+            # it is encrypted and transferred, matching `_execute_tbuild_locally`.
+            set_local_file_permissions(local_script_file, logging.getLogger(__name__))
             encrypted_file_path = f"{local_script_file}.enc"
             remote_encrypted_script_file = os.path.join(
                 remote_working_dir, os.path.basename(encrypted_file_path)
@@ -293,6 +296,9 @@ class TptHook(TtuHook):
         with self.preferred_temp_directory() as tmp_dir:
             local_job_var_file = os.path.join(tmp_dir, f"tdload_job_var_{uuid.uuid4().hex}.txt")
             write_file(local_job_var_file, job_var_content or "")
+            # The job variable file embeds the connection password, so restrict it to the owner
+            # before it is encrypted and transferred, matching the direct tdload path.
+            set_local_file_permissions(local_job_var_file, logging.getLogger(__name__))
             return self._transfer_to_and_execute_tdload_on_remote(
                 local_job_var_file, remote_working_dir, tdload_options, tdload_job_name
             )

--- a/providers/teradata/tests/unit/teradata/hooks/test_bteq.py
+++ b/providers/teradata/tests/unit/teradata/hooks/test_bteq.py
@@ -228,7 +228,9 @@ def hook_with_ssh(patch_ssh_hook_class):
 @patch(
     "airflow.providers.teradata.hooks.bteq.decrypt_remote_file_to_string", return_value=(0, ["output"], [])
 )
+@patch("airflow.providers.teradata.hooks.bteq.set_local_file_permissions")
 def test_execute_bteq_script_at_remote_success(
+    mock_set_local_permissions,
     mock_decrypt,
     mock_prepare_cmd,
     mock_transfer,
@@ -273,6 +275,10 @@ def test_execute_bteq_script_at_remote_success(
     mock_transfer.assert_called_once()
     mock_prepare_cmd.assert_called_once()
     mock_decrypt.assert_called_once()
+
+    # The script embeds the `.LOGON` credentials, so it must be restricted to the owner
+    mock_set_local_permissions.assert_called_once()
+    assert mock_set_local_permissions.call_args.args[0].endswith("bteq_script.txt")
 
     # Assert the return code is what decrypt_remote_file_to_string returns (0 here)
     assert ret_code == 0

--- a/providers/teradata/tests/unit/teradata/hooks/test_tpt.py
+++ b/providers/teradata/tests/unit/teradata/hooks/test_tpt.py
@@ -125,6 +125,23 @@ class TestTptHook:
         mock_ssh.assert_called_once()
 
     @patch("airflow.providers.teradata.hooks.tpt.SSHHook")
+    @patch("airflow.providers.teradata.hooks.tpt.TptHook._transfer_to_and_execute_tdload_on_remote")
+    @patch("airflow.providers.teradata.hooks.tpt.set_local_file_permissions")
+    @patch("airflow.providers.teradata.hooks.tpt.write_file")
+    def test_execute_tdload_via_ssh_sets_local_file_permissions(
+        self, mock_write_file, mock_set_local_permissions, mock_transfer, mock_ssh_hook
+    ):
+        mock_transfer.return_value = 0
+        hook = TptHook(ssh_conn_id="ssh_default")
+        hook.ssh_hook = MagicMock()
+
+        result = hook._execute_tdload_via_ssh("/tmp", "job var content", None, None)
+
+        assert result == 0
+        mock_write_file.assert_called_once()
+        mock_set_local_permissions.assert_called_once()
+
+    @patch("airflow.providers.teradata.hooks.tpt.SSHHook")
     @patch("airflow.providers.teradata.hooks.tpt.execute_remote_command")
     @patch("airflow.providers.teradata.hooks.tpt.remote_secure_delete")
     @patch("airflow.providers.teradata.hooks.tpt.secure_delete")
@@ -135,8 +152,10 @@ class TestTptHook:
     @patch("airflow.providers.teradata.hooks.tpt.generate_random_password")
     @patch("airflow.providers.teradata.hooks.tpt.verify_tpt_utility_on_remote_host")
     @patch("airflow.providers.teradata.hooks.tpt.write_file")
+    @patch("airflow.providers.teradata.hooks.tpt.set_local_file_permissions")
     def test_execute_tbuild_via_ssh_success(
         self,
+        mock_set_local_permissions,
         mock_write_file,
         mock_verify_tpt,
         mock_gen_password,
@@ -173,6 +192,7 @@ class TestTptHook:
             mock_ssh_client, "tbuild", logging.getLogger("airflow.providers.teradata.hooks.tpt")
         )
         mock_write_file.assert_called_once()
+        mock_set_local_permissions.assert_called_once()
         mock_gen_password.assert_called_once()
         mock_encrypt_file.assert_called_once()
         mock_transfer_file.assert_called_once()
@@ -193,8 +213,10 @@ class TestTptHook:
     @patch("airflow.providers.teradata.hooks.tpt.generate_random_password")
     @patch("airflow.providers.teradata.hooks.tpt.verify_tpt_utility_on_remote_host")
     @patch("airflow.providers.teradata.hooks.tpt.write_file")
+    @patch("airflow.providers.teradata.hooks.tpt.set_local_file_permissions")
     def test_execute_tbuild_via_ssh_failure(
         self,
+        mock_set_local_permissions,
         mock_write_file,
         mock_verify_tpt,
         mock_gen_password,
@@ -226,6 +248,8 @@ class TestTptHook:
         with pytest.raises(RuntimeError, match="tbuild command failed with exit code 1"):
             hook._execute_tbuild_via_ssh("CREATE TABLE test (id INT);", "/tmp")
 
+        # The credential-bearing script is restricted before the remote command runs
+        mock_set_local_permissions.assert_called_once()
         # Verify cleanup was called even on failure
         mock_remote_secure_delete.assert_called_once()
         mock_secure_delete.assert_called()


### PR DESCRIPTION
The Teradata remote-execution paths write the tbuild script, the tdload job-variable file, and the BTEQ script to a local temp file before encrypting and transferring them, and each of those embeds the connection password (`UserPassword`/`TargetUserPassword` for TPT, `.LOGON <host>/<user>,<password>` for BTEQ). The local-execution siblings already restrict those files to the owner through `set_local_file_permissions`, but the three SSH paths left them at the process umask, so under a common umask the credential files are group- and world-readable on disk before transfer. This applies the same owner-only restriction at the three remote-execution sites and adds regression tests.

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.