### PR TITLE
Cache latest-DAG lookups in clear_task_instances

### DIFF
--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -403,6 +403,13 @@ def clear_task_instances(
     from airflow.models.dagbag import DBDagBag
 
     scheduler_dagbag = DBDagBag(load_op_links=False)
+    # Cache per-dag lookups of the latest serialized DAG and DagVersion:
+    # get_latest_version_of_dag deserializes the whole DAG on every call, so
+    # calling it per task instance makes clearing O(n) full-DAG loads. One
+    # lookup per dag_id also keeps the clear consistent if a new version is
+    # serialized while it runs.
+    latest_dags: dict[str, Any] = {}
+    latest_versions: dict[str, DagVersion | None] = {}
     for ti in tis:
         ti.prepare_db_for_next_try(session)
 
@@ -423,7 +430,11 @@ def clear_task_instances(
             # run loop below moves it there.
             use_latest_version = run_on_latest_version or dr.created_dag_version_id is None
             if use_latest_version:
-                ti_dag = scheduler_dagbag.get_latest_version_of_dag(ti.dag_id, session=session)
+                if ti.dag_id not in latest_dags:
+                    latest_dags[ti.dag_id] = scheduler_dagbag.get_latest_version_of_dag(
+                        ti.dag_id, session=session
+                    )
+                ti_dag = latest_dags[ti.dag_id]
             else:
                 ti_dag = scheduler_dagbag.get_dag_for_run(dag_run=dr, session=session)
             if not ti_dag:
@@ -446,7 +457,9 @@ def clear_task_instances(
             ti.clear_next_method_args()
             # Match DagVersion to latest serialized DAG when running on the latest version.
             if use_latest_version:
-                latest_dag_version = DagVersion.get_latest_version(ti.dag_id, session=session)
+                if ti.dag_id not in latest_versions:
+                    latest_versions[ti.dag_id] = DagVersion.get_latest_version(ti.dag_id, session=session)
+                latest_dag_version = latest_versions[ti.dag_id]
                 if latest_dag_version is not None:
                     ti.dag_version_id = latest_dag_version.id
             elif ti.dag_version_id is None:

--- a/airflow-core/tests/unit/models/test_cleartasks.py
+++ b/airflow-core/tests/unit/models/test_cleartasks.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import datetime
 import random
+from unittest import mock
 
 import pytest
 from sqlalchemy import func, select, update
@@ -738,6 +739,67 @@ class TestClearTasks:
             assert TaskInstanceState.REMOVED not in [ti.state for ti in dr.task_instances]
             for ti in dr.task_instances:
                 assert ti.dag_version_id == old_dag_version.id
+
+    def test_clear_task_instances_caches_latest_dag_lookups(self, dag_maker, session):
+        """Latest-version lookups happen once per dag, not once per cleared task instance.
+
+        get_latest_version_of_dag deserializes the whole DAG, so calling it per
+        task instance makes clearing O(n) full-DAG loads -- prohibitive on large
+        DAGs (~1.6s per task instance on a DAG with thousands of tasks).
+        """
+        from airflow.models.dagbag import DBDagBag
+
+        with dag_maker(
+            "test_clear_caches_latest_lookups",
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=10),
+            catchup=True,
+            bundle_version="v1",
+        ):
+            for i in range(4):
+                EmptyOperator(task_id=str(i))
+        dr = dag_maker.create_dagrun(
+            state=State.RUNNING,
+            run_type=DagRunType.SCHEDULED,
+        )
+
+        with dag_maker(
+            "test_clear_caches_latest_lookups",
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=10),
+            catchup=True,
+            bundle_version="v2",
+        ):
+            for i in range(4):
+                EmptyOperator(task_id=str(i))
+        new_dag_version = DagVersion.get_latest_version(dr.dag_id)
+
+        qry = session.scalars(select(TI).where(TI.dag_id == dr.dag_id).order_by(TI.task_id)).all()
+        assert len(qry) == 4
+        with (
+            mock.patch.object(
+                DBDagBag,
+                "get_latest_version_of_dag",
+                autospec=True,
+                side_effect=DBDagBag.get_latest_version_of_dag,
+            ) as mock_latest_dag,
+            mock.patch.object(
+                DagVersion,
+                "get_latest_version",
+                wraps=DagVersion.get_latest_version,
+            ) as mock_latest_version,
+        ):
+            clear_task_instances(qry, session, run_on_latest_version=True)
+        session.commit()
+
+        # One lookup for the whole task-instance loop plus one for the dag-run
+        # update -- not one per task instance.
+        assert mock_latest_dag.call_count == 2
+        assert mock_latest_version.call_count == 2
+        cleared_tis = session.scalars(select(TI).where(TI.dag_id == dr.dag_id)).all()
+        assert len(cleared_tis) == 4
+        for ti in cleared_tis:
+            assert ti.dag_version_id == new_dag_version.id
 
     def test_clear_task_instances_without_dag_version_forces_latest(self, dag_maker, session):
         """A Dag run carried over from Airflow 2 has no version, so clearing must pin it to the latest."""


### PR DESCRIPTION
## Problem

`clear_task_instances` calls `scheduler_dagbag.get_latest_version_of_dag()` and `DagVersion.get_latest_version()` **once per task instance** when clearing on the latest version. `get_latest_version_of_dag` deserializes the entire DAG on every call, so clearing N task instances costs N full-DAG deserializations.

On a production DAG with ~8,400 tasks this measures at **~1.6s per cleared task instance**:

| `run_on_latest_version` | affected TIs | duration |
|---|---|---|
| false | 50 | 5.3s |
| **true** | **50** | **84.7s** |
| true | 1 | 4.0s |
| false | 1 | 4.3s |

(same DAG, same run, same task, cleared via `POST /api/v2/dags/{dag_id}/clearTaskInstances`; the 1-TI cases show the cost is per-TI, not per-request)

The UI pre-selects "run on latest version" whenever the task instance's dag version differs from the latest, so routine clears hit this path. Users read the hung request as "clear did nothing" and retry, producing overlapping clear requests that then fail with conflicts (the loser hits the `task_instance_history` unique constraint → opaque 409).

## Fix

Cache both lookups per `dag_id` for the duration of the call (function-local dicts, nothing outlives the request).

Measured on the same deployment after the fix: **84.7s → 4.4s** for the 50-TI clear; `run_on_latest_version=True` is now indistinguishable from `False`.

Side benefit: the clear is now version-consistent — previously a new version serialized mid-request could pin task instances of the same clear to different versions.

Same shape as #14048, which batched this function's per-row TaskReschedule deletes.

## Test

Added `test_clear_task_instances_caches_latest_dag_lookups`: clears 4 TIs with `run_on_latest_version=True` and asserts each lookup happens twice total (once for the TI loop, once for the dag-run update) instead of once per TI, and that all TIs land on the latest version.

---
^ Add meaningful description above
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
