### PR TITLE
Fix comma-separated selected_fields in BigQuery to SQL transfers

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/transfers/bigquery_to_sql.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/bigquery_to_sql.py
@@ -93,6 +93,8 @@ class BigQueryToSqlBaseOperator(BaseOperator):
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
+        if isinstance(selected_fields, str):
+            selected_fields = [field.strip() for field in selected_fields.split(",") if field.strip()]
         self.selected_fields = selected_fields
         self.gcp_conn_id = gcp_conn_id
         self.database = database
@@ -186,12 +188,7 @@ class BigQueryToSqlBaseOperator(BaseOperator):
             return OperatorLineage()
 
         if self.selected_fields:
-            if isinstance(self.selected_fields, str):
-                transferred_field_names = [
-                    field.strip() for field in self.selected_fields.split(",") if field.strip()
-                ]
-            else:
-                transferred_field_names = list(self.selected_fields)
+            transferred_field_names = list(self.selected_fields)
         else:
             transferred_field_names = [field.name for field in getattr(table_obj, "schema", [])]
 

--- a/providers/google/tests/unit/google/cloud/transfers/test_bigquery_to_mysql.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_bigquery_to_mysql.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 from unittest import mock
 from unittest.mock import MagicMock
 
+import pytest
+
 from airflow.providers.google.cloud.transfers.bigquery_to_mysql import BigQueryToMySqlOperator
 
 TASK_ID = "test-bq-create-table-operator"
@@ -66,6 +68,39 @@ class TestBigQueryToMySqlOperator:
             selected_fields=None,
             start_index=0,
         )
+
+    @pytest.mark.parametrize(
+        ("selected_fields", "expected_fields"),
+        [
+            ("col_1,col_2", ["col_1", "col_2"]),
+            (" col_1 , col_2 , ", ["col_1", "col_2"]),
+            (["col_1", "col_2"], ["col_1", "col_2"]),
+        ],
+    )
+    @mock.patch("airflow.providers.google.cloud.transfers.bigquery_to_sql.bigquery_get_data")
+    @mock.patch("airflow.providers.google.cloud.transfers.bigquery_to_sql.BigQueryHook")
+    @mock.patch("airflow.providers.google.cloud.transfers.bigquery_to_mysql.MySqlHook")
+    def test_execute_passes_selected_fields_as_list_of_columns(
+        self,
+        mock_mysql_hook,
+        mock_bq_hook,
+        mock_bigquery_get_data,
+        selected_fields,
+        expected_fields,
+    ):
+        operator = BigQueryToMySqlOperator(
+            task_id=TASK_ID,
+            dataset_table=f"{TEST_DATASET}.{TEST_TABLE_ID}",
+            target_table_name="table",
+            selected_fields=selected_fields,
+        )
+        mock_bigquery_get_data.return_value = [[("only_row", "val")]]
+
+        operator.execute(None)
+
+        insert_rows = mock_mysql_hook.return_value.insert_rows
+        assert insert_rows.call_args.kwargs["target_fields"] == expected_fields
+        assert mock_bigquery_get_data.call_args.args[-1] == expected_fields
 
     @mock.patch("airflow.providers.google.cloud.transfers.bigquery_to_sql.BigQueryHook")
     @mock.patch("airflow.providers.google.cloud.transfers.bigquery_to_mysql.MySqlHook")

--- a/providers/google/tests/unit/google/cloud/transfers/test_bigquery_to_postgres.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_bigquery_to_postgres.py
@@ -129,6 +129,46 @@ class TestBigQueryToPostgresOperator:
         )
 
     @pytest.mark.parametrize(
+        ("selected_fields", "expected_fields"),
+        [
+            ("col_1,col_2", ["col_1", "col_2"]),
+            (" col_1 , col_2 , ", ["col_1", "col_2"]),
+            (["col_1", "col_2"], ["col_1", "col_2"]),
+        ],
+    )
+    @mock.patch("airflow.providers.google.cloud.transfers.bigquery_to_postgres.bigquery_get_data")
+    @mock.patch.object(BigQueryToPostgresOperator, "bigquery_hook", new_callable=mock.PropertyMock)
+    @mock.patch.object(BigQueryToPostgresOperator, "postgres_hook", new_callable=mock.PropertyMock)
+    def test_execute_passes_selected_fields_as_list_of_columns(
+        self,
+        mock_pg_hook,
+        mock_bq_hook,
+        mock_bigquery_get_data,
+        selected_fields,
+        expected_fields,
+    ):
+        operator = BigQueryToPostgresOperator(
+            task_id=TASK_ID,
+            dataset_table=f"{TEST_DATASET}.{TEST_TABLE_ID}",
+            target_table_name=TEST_DESTINATION_TABLE,
+            replace=True,
+            selected_fields=selected_fields,
+            replace_index=["col_1"],
+        )
+
+        mock_bigquery_get_data.return_value = [[("only_row", "val")]]
+        mock_pg = mock.MagicMock()
+        mock_pg_hook.return_value = mock_pg
+        mock_bq = mock.MagicMock()
+        mock_bq.project_id = TEST_PROJECT
+        mock_bq_hook.return_value = mock_bq
+
+        operator.execute(context=mock.MagicMock())
+
+        assert mock_pg.insert_rows.call_args.kwargs["target_fields"] == expected_fields
+        assert mock_bigquery_get_data.call_args.args[-1] == expected_fields
+
+    @pytest.mark.parametrize(
         ("selected_fields", "replace_index"),
         [(None, None), (["col_1, col_2"], None), (None, ["col_1"])],
     )


### PR DESCRIPTION
## Why

- The docstring says selected_fields is a "List of fields to return (comma-separated)". The operator passes that value to two places: BigQueryHook.list_rows() splits it on commas, but insert_rows(target_fields=...) does not.
- `common.sql` builds the column list with `", ".join(map(escape_word, target_fields))`, so a string is iterated character by character. With `selected_fields="emp_name,salary"`:

  ```sql
  -- before
  INSERT INTO employees (e, m, p, _, n, a, m, e, ",", s, a, l, a, r, y) VALUES (%s, %s)
  -- after
  INSERT INTO employees (emp_name, salary) VALUES (%s, %s)
  ```

## How
* `BigQueryToSqlBaseOperator.__init__` normalises a comma-separated string into `list[str]`, so `BigQueryToPostgres` / `BigQueryToMySql` / `BigQueryToMsSql` all get a real column list on both the BigQuery read and the SQL write side.

## Verification

* `uv run --project providers/google pytest providers/google/tests/unit/google/cloud/transfers/test_bigquery_to_postgres.py providers/google/tests/unit/google/cloud/transfers/test_bigquery_to_mysql.py -v`

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
