### PR TITLE
Show the JSON parse-error message on the Variable form warning

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.test.tsx
@@ -55,7 +55,7 @@ describe("VariableForm", () => {
 
     fireEvent.change(screen.getByLabelText(/value/iu), { target: { value: '{"enabled": true,' } });
 
-    await waitFor(() => expect(screen.getByText("variables.form.invalidJson")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/variables\.form\.invalidJson/u)).toBeInTheDocument());
     expect(screen.getByRole("button", { name: /save/iu })).toBeEnabled();
 
     fireEvent.click(screen.getByRole("button", { name: /save/iu }));
@@ -73,7 +73,7 @@ describe("VariableForm", () => {
 
     fireEvent.change(screen.getByLabelText(/value/iu), { target: { value: "[DRAFT] plain string value" } });
 
-    await waitFor(() => expect(screen.getByText("variables.form.invalidJson")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/variables\.form\.invalidJson/u)).toBeInTheDocument());
     expect(screen.getByRole("button", { name: /save/iu })).toBeEnabled();
 
     fireEvent.click(screen.getByRole("button", { name: /save/iu }));
@@ -91,7 +91,7 @@ describe("VariableForm", () => {
 
     fireEvent.change(screen.getByLabelText(/value/iu), { target: { value: "{{ var.value.x }}" } });
 
-    await waitFor(() => expect(screen.getByText("variables.form.invalidJson")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/variables\.form\.invalidJson/u)).toBeInTheDocument());
     expect(screen.getByRole("button", { name: /save/iu })).toBeEnabled();
 
     fireEvent.click(screen.getByRole("button", { name: /save/iu }));

--- a/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.tsx
@@ -33,14 +33,14 @@ export type VariableBody = {
   value: string;
 };
 
-const isJsonString = (string: string) => {
+const getJsonParseError = (string: string): string | undefined => {
   try {
     JSON.parse(string);
-  } catch {
-    return false;
-  }
 
-  return true;
+    return undefined;
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
 };
 
 type VariableFormProps = {
@@ -97,8 +97,10 @@ const VariableForm = ({ error, initialVariable, isPending, manageMutate, setErro
         control={control}
         name="value"
         render={({ field, fieldState }) => {
-          const showJsonWarning =
-            field.value.startsWith("{") || field.value.startsWith("[") ? !isJsonString(field.value) : false;
+          const jsonParseError =
+            field.value.startsWith("{") || field.value.startsWith("[")
+              ? getJsonParseError(field.value)
+              : undefined;
 
           return (
             <Field.Root invalid={Boolean(fieldState.error)} mt={4} required>
@@ -106,11 +108,11 @@ const VariableForm = ({ error, initialVariable, isPending, manageMutate, setErro
                 {translate("columns.value")} <Field.RequiredIndicator />
               </Field.Label>
               <Textarea {...field} size="sm" />
-              {showJsonWarning ? (
+              {jsonParseError === undefined ? undefined : (
                 <Alert mt={2} status="warning">
-                  {translate("variables.form.invalidJson")}
+                  {translate("variables.form.invalidJson")}: {jsonParseError}
                 </Alert>
-              ) : undefined}
+              )}
               {fieldState.error ? <Field.ErrorText>{fieldState.error.message}</Field.ErrorText> : undefined}
             </Field.Root>
           );


### PR DESCRIPTION
The Variables form warns "Invalid JSON" the moment the value looks like it might be JSON but doesn't parse. That warning tells the user something's wrong but not *where*, so a typo halfway through a large value is still a hunt.

The browser's `SyntaxError` from `JSON.parse` already carries the position (`"Unexpected token ',' at position 42 (line 3 column 12)"` on V8; similar on Firefox / Safari). Surface it alongside the localized label so users can jump straight to the character that broke the parse.

**Caveat worth naming up front.** The parser message is emitted by the JS engine and is only ever in English — mixing it with a localized label is a compromise. The position info is more valuable than perfect localization here IMO, and no browser offers a localized JSON parse error to begin with. Alternative would be a dependency like `jsonc-parser` for a cross-browser structured error, which is ~30KB and specific code for a UI hint.

Existing test cases (Jinja template `{{ var.value.x }}`, bracket-prefixed plain string `[DRAFT] ...`, malformed object with trailing comma) still hit the same warning path — just with a browser-provided detail message now. Updated the `getByText` assertions to a regex so they don't depend on the exact detail suffix, which varies by browser.

closes: #68262

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)