### PR TITLE
Fix Logs tab scroll view

### DIFF
--- a/airflow/www/static/js/dag/Main.tsx
+++ b/airflow/www/static/js/dag/Main.tsx
@@ -190,9 +190,15 @@ const Main = () => {
       height={`${mainHeight}px`}
       overflow="hidden"
       position="relative"
-      minHeight="750px"
+      display="flex"
+      flexDirection="column"
     >
-      <Accordion allowToggle index={accordionIndexes} borderTopWidth={0}>
+      <Accordion
+        allowToggle
+        index={accordionIndexes}
+        borderTopWidth={0}
+        flexShrink={0}
+      >
         <AccordionItem
           sx={{
             // Override chakra-collapse so our dropdowns still work
@@ -211,7 +217,7 @@ const Main = () => {
           </AccordionPanel>
         </AccordionItem>
       </Accordion>
-      <Flex height="100%">
+      <Flex flex={1} minHeight={0}>
         {isLoading || isEmpty(groups) ? (
           <Spinner />
         ) : (

--- a/airflow/www/static/js/dag/details/EventLog.tsx
+++ b/airflow/www/static/js/dag/details/EventLog.tsx
@@ -19,7 +19,7 @@
 
 /* global moment */
 
-import React, { useMemo, useRef, useState } from "react";
+import React, { useMemo, useState } from "react";
 import {
   Box,
   Flex,
@@ -43,7 +43,7 @@ import {
 } from "chakra-react-select";
 
 import { useEventLogs } from "src/api";
-import { getMetaValue, useContentHeight } from "src/utils";
+import { getMetaValue } from "src/utils";
 import type { DagRun } from "src/types";
 import LinkButton from "src/components/LinkButton";
 import type { EventLog as EventLogType } from "src/types/api-generated";
@@ -74,8 +74,6 @@ const dagId = getMetaValue("dag_id") || undefined;
 const columnHelper = createColumnHelper<EventLogType>();
 
 const EventLog = ({ taskId, run, showMapped }: Props) => {
-  const logRef = useRef<HTMLDivElement>(null);
-  const contentHeight = useContentHeight(logRef);
   const { tableURLState, setTableURLState } = useTableURLState({
     sorting: [{ id: "when", desc: true }],
   });
@@ -214,12 +212,7 @@ const EventLog = ({ taskId, run, showMapped }: Props) => {
   });
 
   return (
-    <Box
-      height="100%"
-      maxHeight={`${contentHeight}px`}
-      ref={logRef}
-      overflowY="auto"
-    >
+    <Box flex={1} minHeight={0} overflowY="auto">
       <Flex justifyContent="right" mb={2}>
         <IconButton
           aria-label="Refresh"

--- a/airflow/www/static/js/dag/details/dag/Dag.tsx
+++ b/airflow/www/static/js/dag/details/dag/Dag.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { useRef, ReactNode } from "react";
+import React, { ReactNode } from "react";
 import {
   Table,
   Tbody,
@@ -41,7 +41,6 @@ import {
   getMetaValue,
   getTaskSummary,
   toSentenceCase,
-  useContentHeight,
 } from "src/utils";
 import { useGridData, useDagDetails } from "src/api";
 import Time from "src/components/Time";
@@ -60,8 +59,6 @@ const Dag = () => {
   const {
     data: { dagRuns, groups },
   } = useGridData();
-  const detailsRef = useRef<HTMLDivElement>(null);
-  const contentHeight = useContentHeight(detailsRef);
 
   const { data: dagDetailsData, isLoading: isLoadingDagDetails } =
     useDagDetails();
@@ -158,12 +155,7 @@ const Dag = () => {
   );
 
   return (
-    <Box
-      height="100%"
-      maxHeight={`${contentHeight}px`}
-      ref={detailsRef}
-      overflowY="auto"
-    >
+    <Box flex={1} minHeight={0} overflowY="auto">
       <Table variant="striped">
         <Tbody>
           {durations.length > 0 && (

--- a/airflow/www/static/js/dag/details/dagCode/CodeBlock.tsx
+++ b/airflow/www/static/js/dag/details/dagCode/CodeBlock.tsx
@@ -37,7 +37,8 @@ export default function CodeBlock({ code }: Props) {
 
   return (
     <Box
-      height="calc(100% - 10px)"
+      flex={1}
+      minHeight={0}
       borderWidth={2}
       borderColor="gray:100"
       position="relative"

--- a/airflow/www/static/js/dag/details/dagCode/index.tsx
+++ b/airflow/www/static/js/dag/details/dagCode/index.tsx
@@ -17,10 +17,9 @@
  * under the License.
  */
 
-import React, { useRef } from "react";
+import React from "react";
 import { Box, Heading, Spinner } from "@chakra-ui/react";
 
-import { useContentHeight } from "src/utils";
 import Time from "src/components/Time";
 import { useDag, useDagCode } from "src/api";
 import ErrorAlert from "src/components/ErrorAlert";
@@ -28,8 +27,6 @@ import ErrorAlert from "src/components/ErrorAlert";
 import CodeBlock from "./CodeBlock";
 
 const DagCode = () => {
-  const dagCodeRef = useRef<HTMLDivElement>(null);
-  const contentHeight = useContentHeight(dagCodeRef);
   const { data: dagData, isLoading: isLoadingDag, error: dagError } = useDag();
   const {
     data: codeSource = "",
@@ -41,9 +38,15 @@ const DagCode = () => {
   const error = codeError || dagError;
 
   return (
-    <Box ref={dagCodeRef} height={`${contentHeight}px`}>
+    <Box flex={1} minHeight={0} display="flex" flexDirection="column">
       {dagData?.lastParsedTime && (
-        <Heading as="h4" size="md" paddingBottom="10px" fontSize="14px">
+        <Heading
+          as="h4"
+          size="md"
+          paddingBottom="10px"
+          fontSize="14px"
+          flexShrink={0}
+        >
           Parsed at: <Time dateTime={dagData.lastParsedTime} />
         </Heading>
       )}

--- a/airflow/www/static/js/dag/details/dagRun/index.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/index.tsx
@@ -16,11 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { useRef } from "react";
+import React from "react";
 import { Box } from "@chakra-ui/react";
 
 import { useGridData } from "src/api";
-import { getMetaValue, useContentHeight } from "src/utils";
+import { getMetaValue } from "src/utils";
 import type { DagRun as DagRunType } from "src/types";
 import NotesAccordion from "src/dag/details/NotesAccordion";
 
@@ -37,8 +37,6 @@ const DagRun = ({ runId }: Props) => {
   const {
     data: { dagRuns },
   } = useGridData();
-  const detailsRef = useRef<HTMLDivElement>(null);
-  const contentHeight = useContentHeight(detailsRef);
 
   const run = dagRuns.find((dr) => dr.runId === runId);
 
@@ -46,12 +44,7 @@ const DagRun = ({ runId }: Props) => {
   const { runType, note } = run;
 
   return (
-    <Box
-      maxHeight={`${contentHeight}px`}
-      ref={detailsRef}
-      overflowY="auto"
-      pb={4}
-    >
+    <Box flex={1} minHeight={0} overflowY="auto" pb={4}>
       <NotesAccordion
         dagId={dagId}
         runId={runId}

--- a/airflow/www/static/js/dag/details/gantt/index.tsx
+++ b/airflow/www/static/js/dag/details/gantt/index.tsx
@@ -154,7 +154,13 @@ const Gantt = ({
   const intervals = runDuration / numBars;
 
   return (
-    <Box ref={ganttRef} position="relative" height="100%" overflow="hidden">
+    <Box
+      ref={ganttRef}
+      position="relative"
+      flex={1}
+      minHeight={0}
+      overflow="hidden"
+    >
       {!runId && (
         <Alert status="warning" position="absolute" top={2}>
           <AlertIcon />

--- a/airflow/www/static/js/dag/details/graph/index.tsx
+++ b/airflow/www/static/js/dag/details/graph/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { useRef, useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { Box, useTheme, Select, Text, Switch, Flex } from "@chakra-ui/react";
 import ReactFlow, {
   ReactFlowProvider,
@@ -39,7 +39,7 @@ import {
   useUpstreamDatasetEvents,
 } from "src/api";
 import useSelection from "src/dag/useSelection";
-import { getMetaValue, getTask, useContentHeight } from "src/utils";
+import { getMetaValue, getTask } from "src/utils";
 import { useGraphLayout } from "src/utils/graph";
 import Edge from "src/components/Graph/Edge";
 import type { DepNode, WebserverEdge } from "src/types";
@@ -132,7 +132,6 @@ const getUpstreamDatasets = (
 };
 
 const Graph = ({ openGroupIds, onToggleGroups, hoveredTaskState }: Props) => {
-  const graphRef = useRef(null);
   const { data } = useGraphData();
   const [arrange, setArrange] = useState(data?.arrange || "LR");
   const [hasRendered, setHasRendered] = useState(false);
@@ -244,7 +243,6 @@ const Graph = ({ openGroupIds, onToggleGroups, hoveredTaskState }: Props) => {
   const { colors } = useTheme();
   const { getZoom, fitView } = useReactFlow();
   const latestDagRunId = dagRuns[dagRuns.length - 1]?.runId;
-  const contentHeight = useContentHeight(graphRef);
 
   useOnViewportChange({
     onEnd: (viewport: Viewport) => {
@@ -310,68 +308,61 @@ const Graph = ({ openGroupIds, onToggleGroups, hoveredTaskState }: Props) => {
   });
 
   return (
-    <Box
-      ref={graphRef}
-      height={`${contentHeight}px`}
-      borderWidth={1}
-      borderColor="gray.200"
-    >
-      {!!contentHeight && (
-        <ReactFlow
-          nodes={nodes}
-          edges={edges}
-          nodesDraggable={false}
-          nodeTypes={nodeTypes}
-          edgeTypes={edgeTypes}
-          minZoom={0.25}
-          maxZoom={1}
-          onlyRenderVisibleElements
-          defaultEdgeOptions={{ zIndex: 1 }}
-          // Fit view to selected task or the whole graph on render
-          fitView
-          fitViewOptions={{
-            nodes: selected.taskId ? [{ id: selected.taskId }] : undefined,
-          }}
-        >
-          <Panel position="top-right">
-            <Box bg={colors.whiteAlpha[800]} p={1}>
-              {!!datasetsCollection?.datasets?.length && (
-                <Flex display="flex" alignItems="center">
-                  <Text fontSize="sm" mr={1}>
-                    Show datasets:
-                  </Text>
-                  <Switch
-                    id="show-datasets"
-                    isChecked={showDatasets}
-                    onChange={() => setShowDatasets(!showDatasets)}
-                  />
-                </Flex>
-              )}
-              <Text fontSize="sm">Layout:</Text>
-              <Select
-                value={arrange}
-                onChange={(e) => setArrange(e.target.value)}
-                fontSize="sm"
-                size="sm"
-              >
-                <option value="LR">Left -&gt; Right</option>
-                <option value="RL">Right -&gt; Left</option>
-                <option value="TB">Top -&gt; Bottom</option>
-                <option value="BT">Bottom -&gt; Top</option>
-              </Select>
-            </Box>
-          </Panel>
-          <Background />
-          <Controls showInteractive={false} />
-          <MiniMap
-            nodeStrokeWidth={15}
-            nodeStrokeColor={(props) => nodeStrokeColor(props, colors)}
-            nodeColor={nodeColor}
-            zoomable
-            pannable
-          />
-        </ReactFlow>
-      )}
+    <Box flex={1} minHeight={0} borderWidth={1} borderColor="gray.200">
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodesDraggable={false}
+        nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
+        minZoom={0.25}
+        maxZoom={1}
+        onlyRenderVisibleElements
+        defaultEdgeOptions={{ zIndex: 1 }}
+        // Fit view to selected task or the whole graph on render
+        fitView
+        fitViewOptions={{
+          nodes: selected.taskId ? [{ id: selected.taskId }] : undefined,
+        }}
+      >
+        <Panel position="top-right">
+          <Box bg={colors.whiteAlpha[800]} p={1}>
+            {!!datasetsCollection?.datasets?.length && (
+              <Flex display="flex" alignItems="center">
+                <Text fontSize="sm" mr={1}>
+                  Show datasets:
+                </Text>
+                <Switch
+                  id="show-datasets"
+                  isChecked={showDatasets}
+                  onChange={() => setShowDatasets(!showDatasets)}
+                />
+              </Flex>
+            )}
+            <Text fontSize="sm">Layout:</Text>
+            <Select
+              value={arrange}
+              onChange={(e) => setArrange(e.target.value)}
+              fontSize="sm"
+              size="sm"
+            >
+              <option value="LR">Left -&gt; Right</option>
+              <option value="RL">Right -&gt; Left</option>
+              <option value="TB">Top -&gt; Bottom</option>
+              <option value="BT">Bottom -&gt; Top</option>
+            </Select>
+          </Box>
+        </Panel>
+        <Background />
+        <Controls showInteractive={false} />
+        <MiniMap
+          nodeStrokeWidth={15}
+          nodeStrokeColor={(props) => nodeStrokeColor(props, colors)}
+          nodeColor={nodeColor}
+          zoomable
+          pannable
+        />
+      </ReactFlow>
     </Box>
   );
 };

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -156,6 +156,16 @@ const indexToTab = (
 
 export const TAB_PARAM = "tab";
 
+// Each panel fills the tab area and lays its content out as a column, so a single child can claim
+// the leftover space and scroll on its own rather than pushing the page past the viewport.
+// `overflowY` is a safety net for content that does not opt into that sizing.
+const panelProps = {
+  height: "100%",
+  display: "flex",
+  flexDirection: "column",
+  overflowY: "auto",
+} as const;
+
 const Details = ({
   openGroupIds,
   onToggleGroups,
@@ -260,8 +270,13 @@ const Details = ({
       : group?.instances.find((ti) => ti.runId === runId);
 
   return (
-    <Flex flexDirection="column" height="100%">
-      <Flex alignItems="center" justifyContent="space-between" flexWrap="wrap">
+    <Flex flexDirection="column" height="100%" overflow="hidden">
+      <Flex
+        alignItems="center"
+        justifyContent="space-between"
+        flexWrap="wrap"
+        flexShrink={0}
+      >
         <Header
           mapIndex={
             mappedTaskInstance?.renderedMapIndex || mappedTaskInstance?.mapIndex
@@ -305,16 +320,19 @@ const Details = ({
           <FilterTasks taskId={taskId} />
         </Flex>
       </Flex>
-      <Divider my={2} />
+      <Divider my={2} flexShrink={0} />
       <Tabs
         size="lg"
         isLazy
         lazyBehavior="keepMounted"
-        height="100%"
+        display="flex"
+        flexDirection="column"
+        flex={1}
+        minHeight={0}
         index={tabIndex}
         onChange={onChangeTab}
       >
-        <TabList>
+        <TabList flexShrink={0}>
           <Tab>
             <MdDetails size={16} />
             <Text as="strong" ml={1}>
@@ -426,8 +444,8 @@ const Details = ({
             </Button>
           )}
         </TabList>
-        <TabPanels height="100%">
-          <TabPanel height="100%">
+        <TabPanels flex={1} minHeight={0}>
+          <TabPanel {...panelProps}>
             {isDag && <DagContent />}
             {isDagRun && <DagRunContent runId={runId} />}
             {!!runId && !!taskId && (
@@ -445,14 +463,14 @@ const Details = ({
             )}
             {showTaskDetails && <TaskDetails />}
           </TabPanel>
-          <TabPanel p={0} height="100%">
+          <TabPanel {...panelProps} p={0}>
             <Graph
               openGroupIds={openGroupIds}
               onToggleGroups={onToggleGroups}
               hoveredTaskState={hoveredTaskState}
             />
           </TabPanel>
-          <TabPanel p={0} height="100%">
+          <TabPanel {...panelProps} p={0}>
             <Gantt
               openGroupIds={openGroupIds}
               gridScrollRef={gridScrollRef}
@@ -461,10 +479,10 @@ const Details = ({
               runId={runId}
             />
           </TabPanel>
-          <TabPanel height="100%">
+          <TabPanel {...panelProps}>
             <DagCode />
           </TabPanel>
-          <TabPanel height="100%">
+          <TabPanel {...panelProps}>
             <EventLog
               taskId={isGroup || !taskId ? undefined : taskId}
               showMapped={isMapped || !taskId}
@@ -472,12 +490,12 @@ const Details = ({
             />
           </TabPanel>
           {isDag && (
-            <TabPanel height="100%">
+            <TabPanel height="100%" overflow="auto">
               <RunDuration />
             </TabPanel>
           )}
           {isDag && (
-            <TabPanel height="80%">
+            <TabPanel height="100%" overflow="auto">
               <Flex justifyContent="right" pr="30px">
                 <Checkbox
                   isChecked={showBar}
@@ -498,8 +516,8 @@ const Details = ({
           )}
           {isTaskInstance && run && (
             <TabPanel
+              {...panelProps}
               pt={mapIndex !== undefined ? "0px" : undefined}
-              height="100%"
             >
               <BackToTaskSummary
                 isMapIndexDefined={mapIndex !== undefined}
@@ -521,7 +539,7 @@ const Details = ({
             </TabPanel>
           )}
           {isMappedTaskSummary && (
-            <TabPanel height="100%">
+            <TabPanel {...panelProps}>
               <MappedInstances
                 dagId={dagId}
                 runId={runId}
@@ -533,7 +551,7 @@ const Details = ({
             </TabPanel>
           )}
           {isTaskInstance && (
-            <TabPanel height="100%">
+            <TabPanel {...panelProps}>
               <XcomCollection
                 dagId={dagId}
                 dagRunId={runId}
@@ -544,7 +562,7 @@ const Details = ({
             </TabPanel>
           )}
           {isTaskInstance && isK8sExecutor && (
-            <TabPanel height="100%">
+            <TabPanel {...panelProps}>
               <RenderedK8s />
             </TabPanel>
           )}

--- a/airflow/www/static/js/dag/details/taskInstance/BackToTaskSummary.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/BackToTaskSummary.tsx
@@ -29,7 +29,7 @@ const BackToTaskSummary = ({ isMapIndexDefined, onClick }: Props) => {
   if (!isMapIndexDefined) return null;
 
   return (
-    <Flex justifyContent="right">
+    <Flex justifyContent="right" flexShrink={0}>
       <Button variant="ghost" colorScheme="blue" onClick={onClick} size="lg">
         Back to Dynamic Task Summary
       </Button>

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
@@ -19,7 +19,6 @@
 
 import React, { useRef, useEffect, useState } from "react";
 import { Code } from "@chakra-ui/react";
-import { useContentHeight } from "src/utils";
 
 interface Props {
   parsedLogs: string;
@@ -37,7 +36,6 @@ const LogBlock = ({
   const [autoScroll, setAutoScroll] = useState(true);
 
   const logBoxRef = useRef<HTMLPreElement>(null);
-  const contentHeight = useContentHeight(logBoxRef);
 
   const scrollToBottom = () => {
     if (logBoxRef.current) {
@@ -47,13 +45,13 @@ const LogBlock = ({
 
   useEffect(() => {
     // Always scroll to bottom when wrap or tryNumber change
-    if (contentHeight) scrollToBottom();
-  }, [wrap, tryNumber, contentHeight]);
+    scrollToBottom();
+  }, [wrap, tryNumber]);
 
   useEffect(() => {
     // When logs change, only scroll if autoScroll is enabled
-    if (autoScroll && contentHeight) scrollToBottom();
-  }, [parsedLogs, autoScroll, contentHeight]);
+    if (autoScroll) scrollToBottom();
+  }, [parsedLogs, autoScroll]);
 
   const onScroll = (e: React.UIEvent<HTMLDivElement>) => {
     if (e.currentTarget) {
@@ -103,7 +101,8 @@ const LogBlock = ({
       ref={logBoxRef}
       onScroll={onScroll}
       onClick={onClick}
-      maxHeight={`${contentHeight}px`}
+      flex={1}
+      minHeight={0}
       overflowY="auto"
       p={3}
       display="block"

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -155,7 +155,7 @@ const Logs = ({
   return (
     <>
       {showExternalLogRedirect && externalLogName && (
-        <Box my={1}>
+        <Box my={1} flexShrink={0}>
           <Text>View Logs in {externalLogName} (by attempts):</Text>
           <Flex flexWrap="wrap">
             {Array.from({ length: finalTryNumber || 1 }, (_, i) => i + 1).map(
@@ -173,7 +173,7 @@ const Logs = ({
           </Flex>
         </Box>
       )}
-      <Box>
+      <Box flexShrink={0}>
         {!!taskInstance && (
           <TrySelector
             taskInstance={taskInstance}
@@ -250,6 +250,7 @@ const Logs = ({
           alignItems="center"
           p={2}
           mb={2}
+          flexShrink={0}
         >
           <Icon as={MdWarning} color="yellow.500" mr={2} />
           <Text fontSize="sm">{warning}</Text>
@@ -263,6 +264,7 @@ const Logs = ({
           alignItems="center"
           p={2}
           mb={2}
+          flexShrink={0}
         >
           <Icon as={MdInfo} color="blue.600" mr={2} />
           <Text fontSize="sm">

--- a/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { useState, useMemo, useRef } from "react";
+import React, { useState, useMemo } from "react";
 import { Flex, Box } from "@chakra-ui/react";
 import { snakeCase } from "lodash";
 import type { Row, SortingRule } from "react-table";
@@ -27,7 +27,6 @@ import { useMappedInstances } from "src/api";
 import { StatusWithNotes } from "src/dag/StatusBox";
 import { Table, CellProps } from "src/components/Table";
 import Time from "src/components/Time";
-import { useContentHeight } from "src/utils";
 
 interface Props {
   dagId: string;
@@ -37,8 +36,6 @@ interface Props {
 }
 
 const MappedInstances = ({ dagId, runId, taskId, onRowClicked }: Props) => {
-  const mappedTasksRef = useRef<HTMLDivElement>(null);
-  const contentHeight = useContentHeight(mappedTasksRef);
   const limit = 25;
   const [offset, setOffset] = useState(0);
   const [sortBy, setSortBy] = useState<SortingRule<object>[]>([]);
@@ -125,7 +122,7 @@ const MappedInstances = ({ dagId, runId, taskId, onRowClicked }: Props) => {
   );
 
   return (
-    <Box ref={mappedTasksRef} maxHeight={`${contentHeight}px`} overflowY="auto">
+    <Box flex={1} minHeight={0} overflowY="auto">
       <Table
         data={data}
         columns={columns}

--- a/airflow/www/static/js/dag/details/taskInstance/RenderedK8s.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/RenderedK8s.tsx
@@ -17,11 +17,11 @@
  * under the License.
  */
 
-import React, { useRef } from "react";
+import React from "react";
 import { Code } from "@chakra-ui/react";
 import YAML from "json-to-pretty-yaml";
 
-import { getMetaValue, useContentHeight } from "src/utils";
+import { getMetaValue } from "src/utils";
 
 import useSelection from "src/dag/useSelection";
 import { useRenderedK8s } from "src/api";
@@ -35,13 +35,10 @@ const RenderedK8s = () => {
 
   const { data: renderedK8s } = useRenderedK8s(runId, taskId, mapIndex);
 
-  const k8sRef = useRef<HTMLPreElement>(null);
-  const contentHeight = useContentHeight(k8sRef);
-
   if (!isK8sExecutor || !runId || !taskId) return null;
 
   return (
-    <Code mt={3} ref={k8sRef} maxHeight={`${contentHeight}px`} overflowY="auto">
+    <Code mt={3} flex={1} minHeight={0} overflowY="auto">
       <pre>{YAML.stringify(renderedK8s)}</pre>
     </Code>
   );

--- a/airflow/www/static/js/dag/details/taskInstance/Xcom/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Xcom/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { useRef } from "react";
+import React from "react";
 import {
   Table,
   Text,
@@ -31,7 +31,6 @@ import {
 
 import type { Dag, DagRun, TaskInstance } from "src/types";
 import { useTaskXcomCollection } from "src/api";
-import { useContentHeight } from "src/utils";
 import ErrorAlert from "src/components/ErrorAlert";
 
 import XcomEntry from "./XcomEntry";
@@ -51,9 +50,6 @@ const XcomCollection = ({
   mapIndex,
   tryNumber,
 }: Props) => {
-  const taskXcomRef = useRef<HTMLDivElement>(null);
-  const contentHeight = useContentHeight(taskXcomRef);
-
   const {
     data: xcomCollection,
     isLoading,
@@ -67,12 +63,7 @@ const XcomCollection = ({
   });
 
   return (
-    <Box
-      ref={taskXcomRef}
-      height="100%"
-      maxHeight={`${contentHeight}px`}
-      overflowY="auto"
-    >
+    <Box flex={1} minHeight={0} overflowY="auto">
       {isLoading && <Spinner size="xl" thickness="4px" speed="0.65s" />}
       <ErrorAlert error={error} />
       {xcomCollection &&

--- a/airflow/www/static/js/dag/details/taskInstance/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/index.tsx
@@ -17,11 +17,11 @@
  * under the License.
  */
 
-import React, { useRef } from "react";
+import React from "react";
 import { Box } from "@chakra-ui/react";
 
 import { useGridData, useTaskInstance } from "src/api";
-import { getMetaValue, getTask, useContentHeight } from "src/utils";
+import { getMetaValue, getTask } from "src/utils";
 import type { DagRun, TaskInstance as GridTaskInstance } from "src/types";
 import NotesAccordion from "src/dag/details/NotesAccordion";
 
@@ -42,8 +42,6 @@ interface Props {
 }
 
 const TaskInstance = ({ taskId, runId, mapIndex }: Props) => {
-  const taskInstanceRef = useRef<HTMLDivElement>(null);
-  const contentHeight = useContentHeight(taskInstanceRef);
   const isMapIndexDefined = !(mapIndex === undefined);
   const {
     data: { dagRuns, groups },
@@ -77,12 +75,7 @@ const TaskInstance = ({ taskId, runId, mapIndex }: Props) => {
   const gridInstance = group?.instances.find((ti) => ti.runId === runId);
 
   return (
-    <Box
-      py="4px"
-      height={`${contentHeight}px`}
-      ref={taskInstanceRef}
-      overflowY="auto"
-    >
+    <Box py="4px" flex={1} minHeight={0} overflowY="auto">
       {!isGroup && run?.executionDate && (
         <TaskNav
           taskId={taskId}

--- a/airflow/www/static/js/utils/useContentHeight.test.tsx
+++ b/airflow/www/static/js/utils/useContentHeight.test.tsx
@@ -1,0 +1,68 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* global document, window */
+
+import React from "react";
+import { renderHook } from "@testing-library/react";
+
+import useContentHeight from "./useContentHeight";
+
+const viewportHeight = 900;
+const footerReserve = 70;
+
+const refAt = (viewportTop: number) =>
+  ({
+    current: {
+      getBoundingClientRect: () => ({ top: viewportTop }),
+    },
+  }) as unknown as React.RefObject<HTMLElement>;
+
+const scrollTo = (scrollY: number) =>
+  Object.defineProperty(window, "scrollY", { value: scrollY, writable: true });
+
+describe("Test useContentHeight", () => {
+  beforeEach(() => {
+    window.innerHeight = viewportHeight;
+    document.body.style.paddingBottom = `${footerReserve}px`;
+    scrollTo(0);
+  });
+
+  test("Fills the viewport below the element, leaving the footer reserve", () => {
+    const { result } = renderHook(() => useContentHeight(refAt(180)));
+
+    expect(result.current).toBe(viewportHeight - footerReserve - 180);
+  });
+
+  test("Ignores the page scroll position", () => {
+    // Same element, but the page is scrolled down 200px so it sits higher in the viewport.
+    scrollTo(200);
+    const { result } = renderHook(() => useContentHeight(refAt(180 - 200)));
+
+    expect(result.current).toBe(viewportHeight - footerReserve - 180);
+  });
+
+  test("Never returns a negative height", () => {
+    const { result } = renderHook(() =>
+      useContentHeight(refAt(viewportHeight)),
+    );
+
+    expect(result.current).toBe(0);
+  });
+});

--- a/airflow/www/static/js/utils/useContentHeight.ts
+++ b/airflow/www/static/js/utils/useContentHeight.ts
@@ -19,14 +19,11 @@
 
 import React, { useLayoutEffect, useState } from "react";
 
-// Vertical space available to a scroll container, measured down to the bottom of the nearest
-// min-height-constrained ancestor — the grid's Main box, which has a min-height floor. Anchoring to
-// that box (rather than the viewport) lets the content grow to fill the floored area even when the
-// box is taller than the viewport and the page scrolls, instead of shrinking to the fold and
-// leaving a blank strip below. When there is no such ancestor (the Main box measuring itself), it
-// falls back to the viewport minus the body's bottom padding (the Flask footer reserve). Either way
-// this avoids the `height: 100%` cascade, which over-claims because <Tabs>/<TabPanel> have sibling
-// chrome (tab headers) stacked above the panel — that cascade is what truncated the details tabs.
+// Vertical space between the top of an element and the bottom of the viewport, less the body's
+// bottom padding (the Flask footer reserve). The element's position is taken in document
+// coordinates so the result does not change while the page is scrolled — anchoring to the viewport
+// instead would feed the element's own height back into the measurement and grow it on every
+// observer tick.
 const useContentHeight = (contentRef: React.RefObject<HTMLElement>) => {
   const [height, setHeight] = useState(0);
 
@@ -34,19 +31,11 @@ const useContentHeight = (contentRef: React.RefObject<HTMLElement>) => {
     const update = () => {
       const element = contentRef.current;
       if (!element) return;
-      let container = element.parentElement;
-      while (
-        container &&
-        !(parseFloat(getComputedStyle(container).minHeight) > 0)
-      ) {
-        container = container.parentElement;
-      }
-      const bottom = container
-        ? container.getBoundingClientRect().bottom
-        : window.innerHeight -
-          (parseFloat(getComputedStyle(document.body).paddingBottom) || 0);
+      const documentTop = element.getBoundingClientRect().top + window.scrollY;
+      const footerReserve =
+        parseFloat(getComputedStyle(document.body).paddingBottom) || 0;
       const available = Math.max(
-        bottom - element.getBoundingClientRect().top,
+        window.innerHeight - footerReserve - documentTop,
         0,
       );
       // Guard against re-setting the same value (avoids ResizeObserver feedback loops).


### PR DESCRIPTION
Remove per tab height calculation to fix the competing scroll boxes on a large logs page.

<img width="1533" height="1358" alt="Screenshot 2026-08-18 at 2 02 31 PM" src="https://github.com/user-attachments/assets/5e511167-a88c-4176-a36b-376b6c97203a" />

Closes #63934

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
Clause Opus 4.5

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
