### PR TITLE
Keep sync-perm going when a Dag has bad access_control

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -1008,7 +1008,14 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
                         self._merge_perm(action_name, dag_resource_name)
 
             if dag.access_control is not None:
-                self.sync_perm_for_dag(dag.dag_id, dag.access_control)
+                try:
+                    self.sync_perm_for_dag(dag.dag_id, dag.access_control)
+                except FabException:
+                    self.log.exception(
+                        "Failed to sync permissions for DAG '%s'; skipping it and continuing with "
+                        "the remaining DAGs. Fix its access_control configuration and re-run sync-perm.",
+                        dag.dag_id,
+                    )
 
     def sync_perm_for_dag(
         self,

--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -983,7 +983,14 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
                         self._merge_perm(action_name, dag_resource_name)
 
             if dag.access_control is not None:
-                self.sync_perm_for_dag(dag.dag_id, dag.access_control)
+                try:
+                    self.sync_perm_for_dag(dag.dag_id, dag.access_control)
+                except FabException:
+                    self.log.exception(
+                        "Failed to sync permissions for DAG '%s'; skipping it and continuing with "
+                        "the remaining DAGs. Fix its access_control configuration and re-run sync-perm.",
+                        dag.dag_id,
+                    )
 
     def sync_perm_for_dag(
         self,

--- a/providers/fab/tests/unit/fab/auth_manager/test_security.py
+++ b/providers/fab/tests/unit/fab/auth_manager/test_security.py
@@ -1055,7 +1055,28 @@ def test_create_dag_specific_permissions_airflow3(session, security_manager, mon
         security_manager.create_dag_specific_permissions()
 
 
-def test_get_all_permissions(security_manager):
+def test_create_dag_specific_permissions_skips_dag_with_bad_access_control(security_manager, monkeypatch):
+    """A single DAG with an invalid access_control must not abort syncing the remaining DAGs."""
+    bad_dag = DAG("bad_access_control", schedule=None, access_control={"NonExistentRole": {ACTION_CAN_READ}})
+    good_dag = DAG("good_access_control", schedule=None, access_control={"Public": {ACTION_CAN_READ}})
+
+    import airflow.providers.fab.auth_manager.security_manager
+
+    _iter_dags_mock = mock.Mock(return_value=[bad_dag, good_dag])
+    monkeypatch.setitem(
+        airflow.providers.fab.auth_manager.security_manager.override.__dict__, "_iter_dags", _iter_dags_mock
+    )
+
+    try:
+        security_manager.create_dag_specific_permissions()
+
+        good_perms = security_manager.get_all_permissions()
+        good_resource_name = _resource_name(good_dag.dag_id, permissions.RESOURCE_DAG)
+        assert (ACTION_CAN_READ, good_resource_name) in good_perms
+    finally:
+        _delete_dag_permissions(bad_dag.dag_id, security_manager)
+        _delete_dag_permissions(good_dag.dag_id, security_manager)
+
     with assert_queries_count(1):
         perms = security_manager.get_all_permissions()
 


### PR DESCRIPTION
`airflow sync-perm --include-dags` iterates every Dag and syncs its `access_control`. A single Dag referencing a non-existent role (or an invalid resource/action) raised `FabException` mid-loop, aborting the whole run and leaving every remaining Dag without its permissions synced.

This catches `FabException` per-Dag in `create_dag_specific_permissions`, logs the misconfigured Dag, and continues with the rest — so one bad Dag can no longer block permission sync for all the good ones. The per-Dag parse path (`_sync_dag_perms` in `collection.py`) is deliberately left untouched, so a bad `access_control` still surfaces as that Dag's import error.

closes: #71795

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes 

Generated-by: an AI coding assistant following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)