### PR TITLE
Shut down the replaced MeterProvider in get_otel_logger()

### DIFF
--- a/airflow-core/newsfragments/71800.bugfix.rst
+++ b/airflow-core/newsfragments/71800.bugfix.rst
@@ -1,0 +1,7 @@
+``get_otel_logger()`` now shuts down the ``MeterProvider`` it replaces.
+
+Re-initialising the OTel metrics pipeline in a long-lived process previously left the
+previous provider's ``PeriodicExportingMetricReader`` thread running. The abandoned reader
+kept exporting instruments that were no longer being recorded to, publishing frozen
+cumulative totals under a second ``start_time_unix_nano`` and conflicting with the live
+stream for the same series.

--- a/shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
@@ -510,6 +510,23 @@ def get_otel_logger(
         )
         readers.append(export_to_console)
 
+    # Shut down the pipeline we are about to replace. Resetting the Once() guard below makes
+    # set_meter_provider() genuinely swap the global provider, but the outgoing provider owns a
+    # PeriodicExportingMetricReader whose constructor started a daemon export thread, and
+    # shutdown_on_exit=False means nothing ever reaps it. Left running it keeps exporting on its
+    # own interval while its instruments are no longer recorded to, so its cumulative totals
+    # freeze and are republished indefinitely under the same resource with a different
+    # start_time_unix_nano. Downstream that arrives as a second, conflicting stream for the same
+    # series. shutdown() force-flushes first, so the final datapoints are not lost.
+    previous_provider = metrics.get_meter_provider()
+    # Checked by capability rather than type: only the SDK provider can be shut down, while the
+    # API's no-op and proxy providers have no shutdown() to call.
+    if callable(getattr(previous_provider, "shutdown", None)):
+        try:
+            previous_provider.shutdown()
+        except Exception:
+            log.warning("Could not shut down the previous MeterProvider", exc_info=True)
+
     # Reset the OTel SDK's Once() guard so set_meter_provider() can succeed.
     # This is necessary when get_otel_logger() is called after a process fork:
     # the parent's _METER_PROVIDER_SET_ONCE._done = True is inherited by the child,

--- a/shared/observability/tests/observability/metrics/test_otel_logger.py
+++ b/shared/observability/tests/observability/metrics/test_otel_logger.py
@@ -618,6 +618,37 @@ class TestOtelMetrics:
         )
 
 
+    def test_reinit_does_not_leak_exporter_threads(self):
+        """Re-initialising must replace the previous pipeline, not run alongside it.
+
+        The replaced provider owns a ``PeriodicExportingMetricReader`` whose constructor already
+        started a daemon export thread, and it is built with ``shutdown_on_exit=False``, so
+        without an explicit shutdown it keeps exporting after its instruments stop being recorded
+        to. Its cumulative totals freeze and are republished under the same resource with a
+        different ``start_time_unix_nano``, colliding with the live stream for the same series.
+        """
+        test_module_name = "tests.observability.metrics.test_otel_logger"
+        function_call_str = f"import {test_module_name} as m; m.mock_service_run_reinit_readers()"
+
+        proc = subprocess.run(
+            [sys.executable, "-c", function_call_str],
+            check=False,
+            env=os.environ.copy(),
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+
+        assert proc.returncode == 0, f"Process failed\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+
+        assert "leaked_readers=0" in proc.stdout, (
+            "Re-initialisation left the replaced pipeline exporting, so the process now has two "
+            "readers publishing the same series.\n"
+            f"stdout:\n{proc.stdout}\n"
+            f"stderr:\n{proc.stderr}"
+        )
+
+
 def mock_service_run():
     logger = get_otel_logger(debug=True)
     logger.incr("my_test_stat")
@@ -636,3 +667,23 @@ def mock_service_run_reinit():
     # Second init — simulates post-fork re-initialization
     logger = get_otel_logger(debug=True)
     logger.incr("post_fork_stat")
+
+
+def mock_service_run_reinit_readers():
+    """Re-initialise the OTel pipeline twice and report whether an exporter thread leaked.
+
+    Every ``get_otel_logger()`` call builds a ``PeriodicExportingMetricReader``, and the reader's
+    constructor starts a daemon thread that exports on an interval. Replacing the provider must
+    stop the old reader; otherwise it keeps publishing instruments that nothing records to.
+    """
+    import threading
+
+    def live_readers() -> int:
+        return sum(1 for t in threading.enumerate() if t.name == "OtelPeriodicExportingMetricReader")
+
+    get_otel_logger()
+    after_first = live_readers()
+    get_otel_logger()
+    after_second = live_readers()
+
+    print(f"leaked_readers={after_second - after_first}")


### PR DESCRIPTION
Re-initialising the OTel metrics pipeline inside a long-lived process leaves the previous
pipeline running and exporting.

#64703 resets the SDK's `Once()` guard so that `set_meter_provider()` genuinely succeeds on a
second call. That fixed metrics being silently dropped in forked children (#64690). What it does
not do is shut down the provider it replaces.

The outgoing provider owns a `PeriodicExportingMetricReader`, and that reader's constructor has
already started a daemon thread which exports on its own interval. The provider is built with
`shutdown_on_exit=False`, so nothing ever reaps it. The abandoned reader therefore keeps
exporting, but its instruments are no longer recorded to, so its cumulative totals freeze. It
republishes those frozen totals indefinitely, under the same resource, with a different
`start_time_unix_nano`.

A consumer then receives two conflicting cumulative streams for one series: one climbing
correctly, one stuck at whatever the value was when the pipeline was replaced. Backends that must
collapse them to a single series alternate between the two, which reads as a large spurious rate
spike; backends that reject out-of-order samples can drop the counter entirely.

This is invisible under delta temporality, because the abandoned reader honestly reports "nothing
new" forever. It only surfaces once counters are reported as cumulative.

### Reproduction

Against `opentelemetry-sdk==1.42.1`, mimicking `get_otel_logger()`: build a provider, record 48 to
a counter, reset the `Once()` guard, install a second provider, record 1000 to the counter.

Before:

```
A-first-init     batches=  9  last_value=   48  start_time=1787084407400194000
B-second-init    batches=  5  last_value= 1000  start_time=1787084408103536000

A exports occurring AFTER B came online: 5
  same metric name: True   different start_time: True
live reader threads: ['OtelPeriodicExportingMetricReader', 'OtelPeriodicExportingMetricReader']
```

After:

```
A exports occurring AFTER B came online: 0
live reader threads: ['OtelPeriodicExportingMetricReader']
```

The new test in `test_otel_logger.py` asserts the process does not accumulate exporter threads
across a re-initialisation. It fails without this change (`leaked_readers=1`) and passes with it.

### Fix

Shut down the outgoing provider before installing the replacement. `MeterProvider.shutdown()`
force-flushes first, so the final datapoints are not lost, which keeps the guarantee #64703 was
written to restore.

---

- [x] Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst)
- [x] Tests added (`shared/observability/tests/observability/metrics/test_otel_logger.py`)
- [x] Newsfragment added

**Was generative AI tooling used to co-author this PR?**

- [x] Yes (please specify the tool below)

Claude Code (Opus)
