### PR TITLE
Fix dag processor crash when a killed parsing subprocess still has buffered logs

### DIFF
--- a/airflow-core/newsfragments/71811.bugfix.rst
+++ b/airflow-core/newsfragments/71811.bugfix.rst
@@ -1,0 +1,1 @@
+Fix dag processor crash with ``ValueError: write to closed file`` when a killed parsing subprocess still had buffered log output.

--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -752,6 +752,14 @@ class DagFileProcessorProcess(WatchedSubprocess, LoggingMixin):
         raise NotImplementedError(f"Don't call wait on {type(self).__name__} objects")
 
     def close(self):
+        # If the subprocess was killed, we may never have read EOF from its sockets, so they can
+        # still be registered in the shared selector. Unregister and close them before closing the
+        # log file handle, otherwise a later select() delivers stale events whose callbacks write
+        # to the closed handle and crash the whole dag processor job.
+        for sock in list(self._open_sockets):
+            self._on_socket_closed(sock)
+            with contextlib.suppress(OSError):
+                sock.close()
         try:
             self.logger_filehandle.close()
         except OSError:

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -624,6 +624,7 @@ class TestDagFileProcessorManager:
         versioned_file = _get_versioned_file_info("callbacks.py")
         processor, _ = self.mock_processor()
         stale_sock, _keep_alive = socketpair()
+        stale_sock_fd = stale_sock.fileno()
         processor.selector.register(
             stale_sock, selectors.EVENT_READ, (lambda sock: False, lambda sock: None)
         )
@@ -639,8 +640,7 @@ class TestDagFileProcessorManager:
 
         assert manager._processors == {}
         assert stale_sock not in processor._open_sockets
-        with pytest.raises(KeyError):
-            processor.selector.get_key(stale_sock)
+        assert stale_sock_fd not in processor.selector.get_map()
         processor.logger_filehandle.close.assert_called_once()
 
     def test_remove_orphaned_file_stats_keeps_versioned_callback_stats_when_unversioned_file_is_present(self):

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -23,6 +23,7 @@ import logging
 import os
 import random
 import re
+import selectors
 import shutil
 import signal
 import textwrap
@@ -611,6 +612,36 @@ class TestDagFileProcessorManager:
             manager.terminate_orphan_processes(present=set())
 
         assert manager._processors == {}
+
+    def test_terminate_orphan_processes_unregisters_stale_sockets_on_close(self):
+        """A killed processor may still have sockets registered in the shared selector.
+
+        kill() can return before EOF was read from the subprocess sockets. If close() left them
+        registered, a later select() would deliver stale events that write to the already closed
+        log file handle and crash the whole dag processor job.
+        """
+        manager = DagFileProcessorManager(max_runs=1)
+        versioned_file = _get_versioned_file_info("callbacks.py")
+        processor, _ = self.mock_processor()
+        stale_sock, _keep_alive = socketpair()
+        processor.selector.register(
+            stale_sock, selectors.EVENT_READ, (lambda sock: False, lambda sock: None)
+        )
+        processor._open_sockets[stale_sock] = "logs"
+
+        manager._processors[versioned_file] = processor
+
+        with (
+            mock.patch.object(type(processor), "kill"),
+            mock.patch("airflow.dag_processing.manager.stats.decr"),
+        ):
+            manager.terminate_orphan_processes(present=set())
+
+        assert manager._processors == {}
+        assert stale_sock not in processor._open_sockets
+        with pytest.raises(KeyError):
+            processor.selector.get_key(stale_sock)
+        processor.logger_filehandle.close.assert_called_once()
 
     def test_remove_orphaned_file_stats_keeps_versioned_callback_stats_when_unversioned_file_is_present(self):
         manager = DagFileProcessorManager(max_runs=1)

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -625,9 +625,7 @@ class TestDagFileProcessorManager:
         processor, _ = self.mock_processor()
         stale_sock, _keep_alive = socketpair()
         stale_sock_fd = stale_sock.fileno()
-        processor.selector.register(
-            stale_sock, selectors.EVENT_READ, (lambda sock: False, lambda sock: None)
-        )
+        processor.selector.register(stale_sock, selectors.EVENT_READ, (lambda sock: False, lambda sock: None))
         processor._open_sockets[stale_sock] = "logs"
 
         manager._processors[versioned_file] = processor

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -2425,9 +2425,12 @@ def process_log_messages_from_subprocess(
             for target in loggers:
                 try:
                     target.log(level, msg, **event)
-                except ValueError:
+                except ValueError as e:
                     # The log file handle can already be closed while we drain buffered output of
-                    # a killed subprocess. Drop the leftover line instead of crashing the job.
+                    # a killed subprocess. Drop the leftover line instead of crashing the job, but
+                    # let any unrelated ValueError propagate.
+                    if "closed file" not in str(e):
+                        raise
                     continue
 
 

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -2423,7 +2423,12 @@ def process_log_messages_from_subprocess(
         if level := NAME_TO_LEVEL.get(event.pop("level")):
             msg = event.pop("event", None)
             for target in loggers:
-                target.log(level, msg, **event)
+                try:
+                    target.log(level, msg, **event)
+                except ValueError:
+                    # The log file handle can already be closed while we drain buffered output of
+                    # a killed subprocess. Drop the leftover line instead of crashing the job.
+                    continue
 
 
 def forward_to_log(

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -4306,6 +4306,32 @@ def test_process_log_messages_from_subprocess_tolerates_closed_log_file():
     gen.send(b'{"level": "error", "event": "log line after the subprocess was killed"}\n')
 
 
+def test_process_log_messages_from_subprocess_reraises_unrelated_value_error():
+    """Only closed file write errors are dropped; any other ValueError still propagates."""
+    import io
+
+    from airflow.sdk.log import logging_processors
+
+    class ExplodingFile(io.RawIOBase):
+        def writable(self):
+            return True
+
+        def write(self, data):
+            raise ValueError("boom")
+
+    broken_log = structlog.wrap_logger(
+        structlog.BytesLogger(ExplodingFile()),
+        processors=logging_processors(json_output=True),
+        logger_name="processor",
+    ).bind()
+
+    gen = process_log_messages_from_subprocess(loggers=(broken_log,))
+    next(gen)
+
+    with pytest.raises(ValueError, match="boom"):
+        gen.send(b'{"level": "error", "event": "some log line"}\n')
+
+
 def test_reinit_supervisor_comms(monkeypatch, client_with_ti_start, caplog):
     def subprocess_main():
         # This is run in the subprocess!

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -4281,6 +4281,31 @@ def test_process_log_messages_from_subprocess(monkeypatch, caplog):
     ]
 
 
+def test_process_log_messages_from_subprocess_tolerates_closed_log_file():
+    """Late log lines from a killed subprocess must not crash the supervisor.
+
+    The manager can kill a parsing subprocess and close its log file handle before all buffered
+    log output was drained from the socket. Writing the leftover lines used to raise
+    ``ValueError: write to closed file`` and take down the whole dag processor job.
+    """
+    import io
+
+    from airflow.sdk.log import logging_processors
+
+    filehandle = io.BytesIO()
+    filehandle.close()
+    closed_file_log = structlog.wrap_logger(
+        structlog.BytesLogger(filehandle),
+        processors=logging_processors(json_output=True),
+        logger_name="processor",
+    ).bind()
+
+    gen = process_log_messages_from_subprocess(loggers=(closed_file_log,))
+    next(gen)
+
+    gen.send(b'{"level": "error", "event": "log line after the subprocess was killed"}\n')
+
+
 def test_reinit_supervisor_comms(monkeypatch, client_with_ti_start, caplog):
     def subprocess_main():
         # This is run in the subprocess!


### PR DESCRIPTION
Closes #64959

When `terminate_orphan_processes` kills a parsing subprocess, `kill()` returns as soon as the exit code is known, which can be before EOF was read from the subprocess sockets. Those sockets stay registered in the shared selector, so a later `select()` delivers stale events whose callbacks write to the log file handle that `close()` has already closed. The `ValueError: write to closed file` then propagates out of the parsing loop and crashes the whole DagProcessorJob.

Two changes:

* `DagFileProcessorProcess.close()` now unregisters and closes any sockets that never reported EOF before it closes the log file handle, so no stale selector events can fire afterwards.
* `process_log_messages_from_subprocess()` drops leftover log lines when the target file handle is already closed instead of letting the `ValueError` escape, as a second layer of protection for the supervisor.

Added a unit test on each side: one that verifies close() drains sockets a killed processor left registered, and one that feeds a log line into the forwarder after the log file was closed.
