### PR TITLE
Fix Variable.set rewriting team_name of existing variables

### DIFF
--- a/airflow-core/src/airflow/models/variable.py
+++ b/airflow-core/src/airflow/models/variable.py
@@ -287,7 +287,6 @@ class Variable(Base, LoggingMixin):
                 val=val,
                 description=description,
                 is_encrypted=is_encrypted,
-                team_name=team_name,
             )
             stmt = build_upsert_stmt(
                 get_dialect_name(session), Variable, ["key"], upsert_values, update_fields

--- a/airflow-core/tests/unit/models/test_variable.py
+++ b/airflow-core/tests/unit/models/test_variable.py
@@ -374,7 +374,7 @@ class TestVariable:
         Variable.set(key="k", value="v1", session=session)
 
         Variable.set(key="k", value="v2", team_name=testing_team.name, session=session)
-        
+
         assert Variable.get("k") == "v2"
 
     @mock.patch("airflow.models.variable.ensure_secrets_loaded")

--- a/airflow-core/tests/unit/models/test_variable.py
+++ b/airflow-core/tests/unit/models/test_variable.py
@@ -369,6 +369,14 @@ class TestVariable:
         finally:
             session.rollback()
 
+    @conf_vars({("core", "multi_team"): "True"})
+    def test_variable_set_does_not_change_team_name_on_update(self, testing_team, session):
+        Variable.set(key="k", value="v1", session=session)
+
+        Variable.set(key="k", value="v2", team_name=testing_team.name, session=session)
+        
+        assert Variable.get("k") == "v2"
+
     @mock.patch("airflow.models.variable.ensure_secrets_loaded")
     def test_caching_caches(self, mock_ensure_secrets: mock.Mock):
         mock_backend = mock.Mock()


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

When `core.multi_team = True`, calling `Variable.set(key="k", value="v2", team_name="team_a")` on an existing variable rewrites `team_name` to `"team_a"` in the `ON CONFLICT (key) DO UPDATE` clause.
This overwrites the original ownership of existing global variables (or variables belonging to other teams), causing subsequent global lookups (e.g. `Variable.get("k")` without `team_name`, as done during DAG parsing) to fail with `KeyError`.
This PR removes `team_name` from `update_fields` in `Variable.set()`, preserving the original `team_name` ownership of existing variables during value updates.
closes: #71810

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes 

Generated-by: Claude following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
