### PR TITLE
Fix flaky Iceberg snapshot trigger tests under CI thread-pool latency

### DIFF
--- a/providers/apache/iceberg/tests/unit/apache/iceberg/triggers/test_iceberg.py
+++ b/providers/apache/iceberg/tests/unit/apache/iceberg/triggers/test_iceberg.py
@@ -135,7 +135,9 @@ async def test_emits_once_per_new_snapshot():
     """Each commit produces exactly one event carrying the snapshot it replaced."""
     with patch(LOAD_TABLE, side_effect=[_table_at(111), _table_at(222), _table_at(222), _table_at(333)]):
         trigger = IcebergTableSnapshotTrigger(table="db.tbl", poll_interval=0.01, last_seen_snapshot_id=111)
-        payloads = await _collect(trigger, 2)
+        # Gathering 2 events takes 4 polling rounds, each with a real asyncio.to_thread call;
+        # the default 1s budget is too tight under CI thread-pool scheduling latency.
+        payloads = await _collect(trigger, 2, timeout=3.0)
 
     assert [(p["previous_snapshot_id"], p["snapshot_id"]) for p in payloads] == [(111, 222), (222, 333)]
 
@@ -190,7 +192,9 @@ async def test_persists_the_watermark_on_each_event():
     trigger.asset_state_store = store
 
     with patch(LOAD_TABLE, side_effect=[_table_at(111), _table_at(222), _table_at(222)]):
-        payloads = await _collect(trigger, 2)
+        # Gathering 2 events runs several real asyncio.to_thread calls (head lookup + store
+        # get/set); the default 1s budget is too tight under CI thread-pool scheduling latency.
+        payloads = await _collect(trigger, 2, timeout=3.0)
 
     assert [p["snapshot_id"] for p in payloads] == [111, 222]
     assert [c.args for c in store.set.call_args_list] == [("snapshot_id", 111), ("snapshot_id", 222)]


### PR DESCRIPTION
## Why

Two tests for the newly added `IcebergTableSnapshotTrigger` (#71387) collect 2 events via `_collect(trigger, 2)`, whose default 1s wall-clock budget is too tight given the real `asyncio.to_thread` scheduling each polling round performs (head-snapshot lookup, plus asset-state-store get/set). Under CI's constrained/parallel runners, thread-pool scheduling latency occasionally pushes the total past 1s, so the collector times out before both events
arrive and the assertion fails on an incomplete payload list.

Observed failing on unrelated PRs:
- https://github.com/apache/airflow/actions/runs/32140762877/job/95763173856 (`test_persists_the_watermark_on_each_event`)
- https://github.com/apache/airflow/actions/runs/32140762877/job/95763173984 (`test_emits_once_per_new_snapshot`)


## What
Widens the collection timeout to 3s for just these two tests. The trigger
implementation itself is correct — a single sequential loop with no
concurrency, so the emitted order is deterministic; this is purely a test
budget issue.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)

Generated-by: Claude Code (Sonnet 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)