### PR TITLE
Add test_connection support to LangChainHook and LlamaIndexHook

### DIFF
--- a/providers/common/ai/src/airflow/providers/common/ai/hooks/langchain.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/hooks/langchain.py
@@ -171,3 +171,18 @@ class LangChainHook(BaseHook):
             kind="embedding",
         )
         return init_embeddings(model_id, **self._connection_kwargs(conn))
+
+    def test_connection(self) -> tuple[bool, str]:
+        """
+        Test connection by resolving the chat model.
+
+        Validates that the model identifier is valid and the provider can be
+        instantiated with the supplied credentials. Does NOT make an LLM API
+        call -- that would be expensive and fail for reasons unrelated to
+        connectivity (quotas, billing, rate limits).
+        """
+        try:
+            self.get_chat_model()
+            return True, "Model resolved successfully."
+        except Exception as e:
+            return False, str(e)

--- a/providers/common/ai/src/airflow/providers/common/ai/hooks/llamaindex.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/hooks/llamaindex.py
@@ -187,3 +187,18 @@ class LlamaIndexHook(BaseHook):
             kind="llm",
         )
         return OpenAI(model=model_id, **self._connection_kwargs(conn))
+
+    def test_connection(self) -> tuple[bool, str]:
+        """
+        Test connection by resolving the LLM.
+
+        Validates that the model identifier is valid and the provider can be
+        instantiated with the supplied credentials. Does NOT make an LLM API
+        call -- that would be expensive and fail for reasons unrelated to
+        connectivity (quotas, billing, rate limits).
+        """
+        try:
+            self.get_llm()
+            return True, "Model resolved successfully."
+        except Exception as e:
+            return False, str(e)

--- a/providers/common/ai/tests/unit/common/ai/hooks/test_langchain.py
+++ b/providers/common/ai/tests/unit/common/ai/hooks/test_langchain.py
@@ -271,6 +271,41 @@ class TestGetEmbeddingModel:
         mock_init_embeddings.assert_called_once_with("openai:text-embedding-3-small")
 
 
+class TestConnectionTest:
+    @patch("langchain.chat_models.init_chat_model")
+    @patch.object(LangChainHook, "get_connection")
+    def test_successful_connection(self, mock_get_conn, mock_init_chat_model):
+        mock_get_conn.return_value = _conn(password="sk-test", extra={"model": "openai:gpt-4o"})
+
+        hook = LangChainHook()
+        success, message = hook.test_connection()
+
+        assert success is True
+        assert message == "Model resolved successfully."
+
+    @patch("langchain.chat_models.init_chat_model")
+    @patch.object(LangChainHook, "get_connection")
+    def test_failed_connection(self, mock_get_conn, mock_init_chat_model):
+        mock_get_conn.return_value = _conn(password="sk-test", extra={"model": "openai:gpt-4o"})
+        mock_init_chat_model.side_effect = ValueError("Unknown provider 'badprovider'")
+
+        hook = LangChainHook()
+        success, message = hook.test_connection()
+
+        assert success is False
+        assert "Unknown provider" in message
+
+    @patch.object(LangChainHook, "get_connection")
+    def test_failed_connection_no_model(self, mock_get_conn):
+        mock_get_conn.return_value = _conn()
+
+        hook = LangChainHook()
+        success, message = hook.test_connection()
+
+        assert success is False
+        assert "No chat model identifier set" in message
+
+
 class TestSameHookForBoth:
     """A single hook instance must serve both chat and embedding calls."""
 

--- a/providers/common/ai/tests/unit/common/ai/hooks/test_llamaindex.py
+++ b/providers/common/ai/tests/unit/common/ai/hooks/test_llamaindex.py
@@ -168,3 +168,38 @@ class TestGetLlm:
 
         with pytest.raises(ValueError, match="No llm model identifier set"):
             hook.get_llm()
+
+
+class TestConnectionTest:
+    @patch("llama_index.llms.openai.OpenAI")
+    @patch.object(LlamaIndexHook, "get_connection")
+    def test_successful_connection(self, mock_get_conn, mock_cls):
+        mock_get_conn.return_value = _conn(password="sk-test", extra={"llm_model": "gpt-4o"})
+
+        hook = LlamaIndexHook()
+        success, message = hook.test_connection()
+
+        assert success is True
+        assert message == "Model resolved successfully."
+
+    @patch("llama_index.llms.openai.OpenAI")
+    @patch.object(LlamaIndexHook, "get_connection")
+    def test_failed_connection(self, mock_get_conn, mock_cls):
+        mock_get_conn.return_value = _conn(password="sk-test", extra={"llm_model": "gpt-4o"})
+        mock_cls.side_effect = ValueError("Invalid API key")
+
+        hook = LlamaIndexHook()
+        success, message = hook.test_connection()
+
+        assert success is False
+        assert "Invalid API key" in message
+
+    @patch.object(LlamaIndexHook, "get_connection")
+    def test_failed_connection_no_model(self, mock_get_conn):
+        mock_get_conn.return_value = _conn()
+
+        hook = LlamaIndexHook()
+        success, message = hook.test_connection()
+
+        assert success is False
+        assert "No llm model identifier set" in message


### PR DESCRIPTION
## Summary

`LangChainHook` and `LlamaIndexHook` are two of the four selectable connection types in the `common.ai` provider, but neither implemented `test_connection()`.

Clicking "Test" on a connection of either type in the UI always returned:
> Hook LangChainHook doesn't implement or inherit test_connection method

<img width="1925" height="906" alt="image" src="https://github.com/user-attachments/assets/d3ff1d23-4597-4b4b-8466-13e4ff41dae0" />


`PydanticAIHook` and `MCPHook` — the other two connection types in this provider already implement it, resolving the model/config without making a real API call. 

### Changes

This PR adds the same pattern to the two missing hooks:

- `LangChainHook.test_connection()` resolves the chat model via `get_chat_model()`.
- `LlamaIndexHook.test_connection()` resolves the LLM via `get_llm()`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5) for writing test.