### PR TITLE
Add tests for BaseConfigKeys iteration

### DIFF
--- a/airflow-core/tests/unit/always/test_project_structure.py
+++ b/airflow-core/tests/unit/always/test_project_structure.py
@@ -68,7 +68,6 @@ class TestProjectStructure:
             "providers/amazon/tests/unit/amazon/aws/executors/ecs/test_ecs_executor_config.py",
             "providers/amazon/tests/unit/amazon/aws/executors/aws_lambda/test_utils.py",
             "providers/amazon/tests/unit/amazon/aws/executors/aws_lambda/docker/test_app.py",
-            "providers/amazon/tests/unit/amazon/aws/executors/utils/test_base_config_keys.py",
             "providers/amazon/tests/unit/amazon/aws/operators/test_emr.py",
             "providers/amazon/tests/unit/amazon/aws/operators/test_sagemaker.py",
             "providers/amazon/tests/unit/amazon/aws/sensors/test_emr.py",

--- a/providers/amazon/tests/unit/amazon/aws/executors/utils/test_base_config_keys.py
+++ b/providers/amazon/tests/unit/amazon/aws/executors/utils/test_base_config_keys.py
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from airflow.providers.amazon.aws.executors.utils.base_config_keys import BaseConfigKeys
+
+
+class _ConfigKeys(BaseConfigKeys):
+    FIRST = "first"
+    SECOND = "second"
+
+
+def test_iter_returns_non_dunder_attribute_values():
+    assert set(_ConfigKeys()) == {"first", "second"}


### PR DESCRIPTION
Add a dedicated unit test for `BaseConfigKeys.__iter__` and remove the matching `OVERLOOKED_TESTS` entry. This follows the provider test-module coverage work tracked in #35442.

No runtime behavior changes.

related: #35442

## Testing

- `breeze run pytest providers/amazon/tests/unit/amazon/aws/executors/utils/test_base_config_keys.py airflow-core/tests/unit/always/test_project_structure.py::TestProjectStructure::test_providers_modules_should_have_tests -xvs` (`2 passed`)
- `breeze run mypy providers/amazon/tests/unit/amazon/aws/executors/utils/test_base_config_keys.py`
- `prek run --from-ref upstream/main --stage pre-commit`
- `breeze testing providers-tests --test-type "Providers[amazon]"` (`4737 passed`, `9 skipped`)
- `breeze testing core-tests --test-type Always` (`2020 passed`, `66 skipped`, `1 xfailed`; one unrelated Azure Batch SDK import failure)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5.6 Sol)

Generated-by: Codex (GPT-5.6 Sol) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

---
Drafted-by: Codex (GPT-5.6 Sol); reviewed by @lbbc-lh before posting