### PR TITLE
Allow Hussein Awala to publish provider docs to S3

### DIFF
--- a/.github/workflows/publish-docs-to-s3.yml
+++ b/.github/workflows/publish-docs-to-s3.yml
@@ -117,6 +117,7 @@ jobs:
       "bugraoz93",
       "eladkal",
       "ephraimbuddy",
+      "hussein-awala",
       "jedcunningham",
       "jscheffl",
       "kaxil",


### PR DESCRIPTION
Add `hussein-awala` to the dispatcher allowlist in `publish-docs-to-s3.yml`.

The workflow gates its `build-info` job on `github.event.sender.login`, and every other job
depends on `build-info` — so when a committer outside the list dispatches it, the run is
created but every job is skipped. There is no error, which makes it easy to mistake for a
successful publish.

Hit while publishing staging docs for the 2026-08-18 provider wave (#71794): the dispatch
returned no error, the run appeared, and all six jobs reported `skipped`.

Note this does not affect dispatches against an already-cut release tag, since the allowlist
is read from the workflow file at the dispatched ref.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
