### PR TITLE
Fix FAB SSO guide's non-working OAuth configuration instructions

### DIFF
--- a/providers/fab/docs/auth-manager/sso.rst
+++ b/providers/fab/docs/auth-manager/sso.rst
@@ -54,7 +54,7 @@ Configuration Steps
 
    .. code-block:: ini
 
-      [webserver]
+      [core]
       auth_manager = airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager
 
    This replaces the default ``SimpleAuthManager``.
@@ -99,48 +99,27 @@ Configuration Steps
 
 4. **Configure OAuth2 Provider**
 
-   FAB Auth Manager reads provider configuration from the ``[fab]`` section
-   of ``airflow.cfg`` or from environment variables.
+   Define ``OAUTH_PROVIDERS`` in the same ``webserver_config.py`` file as ``AUTH_TYPE``.
+   This is a Flask AppBuilder setting read from that file, not an Airflow configuration
+   option, so it cannot be set in ``airflow.cfg`` or through an ``AIRFLOW__FAB__``
+   environment variable.
 
-   **Option A: Environment Variables (Recommended)**
+   .. code-block:: python
 
-   .. code-block:: bash
-
-      export AIRFLOW__FAB__OAUTH_PROVIDERS='[{
-         "name": "generic",
-         "icon": "fa-circle",
-         "token_key": "access_token",
-         "remote_app": {
-           "client_id": "your-client-id",
-           "client_secret": "your-client-secret",
-           "api_base_url": "https://provider.com/oauth/",
-           "request_token_url": null,
-           "access_token_url": "https://provider.com/oauth/token",
-           "authorize_url": "https://provider.com/oauth/authorize"
-         }
-      }]'
-
-   **Option B: Configuration File**
-
-   Add to your ``airflow.cfg``:
-
-   .. code-block:: ini
-
-      [fab]
-      oauth_providers = [
-        {
-          "name": "generic",
-          "icon": "fa-circle",
-          "token_key": "access_token",
-          "remote_app": {
-            "client_id": "your-client-id",
-            "client_secret": "your-client-secret",
-            "api_base_url": "https://provider.com/oauth/",
-            "request_token_url": null,
-            "access_token_url": "https://provider.com/oauth/token",
-            "authorize_url": "https://provider.com/oauth/authorize"
+      OAUTH_PROVIDERS = [
+          {
+              "name": "generic",
+              "icon": "fa-circle",
+              "token_key": "access_token",
+              "remote_app": {
+                  "client_id": "your-client-id",
+                  "client_secret": "your-client-secret",
+                  "api_base_url": "https://provider.com/oauth/",
+                  "request_token_url": None,
+                  "access_token_url": "https://provider.com/oauth/token",
+                  "authorize_url": "https://provider.com/oauth/authorize",
+              },
           }
-        }
       ]
 
    Adjust these values according to your provider's documentation.
@@ -160,45 +139,47 @@ Provider Examples
 
 **Okta**
 
-.. code-block:: bash
+.. code-block:: python
 
-   export AIRFLOW__FAB__OAUTH_PROVIDERS='[{
-      "name": "okta",
-      "icon": "fa-circle",
-      "token_key": "access_token",
-      "remote_app": {
-        "client_id": "your-client-id",
-        "client_secret": "your-client-secret",
-        "api_base_url": "https://your-org.okta.com/oauth2/default",
-        "request_token_url": null,
-        "access_token_url": "https://your-org.okta.com/oauth2/default/v1/token",
-        "authorize_url": "https://your-org.okta.com/oauth2/default/v1/authorize"
-      }
-   }]'
+   OAUTH_PROVIDERS = [
+       {
+           "name": "okta",
+           "icon": "fa-circle",
+           "token_key": "access_token",
+           "remote_app": {
+               "client_id": "your-client-id",
+               "client_secret": "your-client-secret",
+               "api_base_url": "https://your-org.okta.com/oauth2/default",
+               "request_token_url": None,
+               "access_token_url": "https://your-org.okta.com/oauth2/default/v1/token",
+               "authorize_url": "https://your-org.okta.com/oauth2/default/v1/authorize",
+           },
+       }
+   ]
 
 .. seealso::
    For detailed Okta setup instructions, see the `Okta OAuth2 documentation <https://developer.okta.com/docs/guides/implement-oauth/>`_.
 
 **Azure Entra ID (Azure AD)**
 
-.. code-block:: bash
+.. code-block:: python
 
-   export AIRFLOW__FAB__OAUTH_PROVIDERS='[{
-      "name": "azure",
-      "icon": "fa-circle",
-      "token_key": "access_token",
-      "remote_app": {
-        "client_id": "your-client-id",
-        "client_secret": "your-client-secret",
-        "api_base_url": "https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/",
-        "request_token_url": null,
-        "access_token_url": "https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token",
-        "authorize_url": "https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/authorize",
-        "client_kwargs": {
-          "scope": "openid email profile"
-        }
-      }
-   }]'
+   OAUTH_PROVIDERS = [
+       {
+           "name": "azure",
+           "icon": "fa-circle",
+           "token_key": "access_token",
+           "remote_app": {
+               "client_id": "your-client-id",
+               "client_secret": "your-client-secret",
+               "api_base_url": "https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/",
+               "request_token_url": None,
+               "access_token_url": "https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token",
+               "authorize_url": "https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/authorize",
+               "client_kwargs": {"scope": "openid email profile"},
+           },
+       }
+   ]
 
 .. seealso::
    For Azure app registration and OAuth setup, see :doc:`apache-airflow-providers-microsoft-azure:connections/azure`
@@ -265,24 +246,24 @@ Provider Examples
 
 **Google OAuth2**
 
-.. code-block:: bash
+.. code-block:: python
 
-   export AIRFLOW__FAB__OAUTH_PROVIDERS='[{
-      "name": "google",
-      "icon": "fa-google",
-      "token_key": "access_token",
-      "remote_app": {
-        "client_id": "your-client-id.googleusercontent.com",
-        "client_secret": "your-client-secret",
-        "api_base_url": "https://www.googleapis.com/oauth2/v2/",
-        "request_token_url": null,
-        "access_token_url": "https://oauth2.googleapis.com/token",
-        "authorize_url": "https://accounts.google.com/o/oauth2/auth",
-        "client_kwargs": {
-          "scope": "openid email profile"
-        }
-      }
-   }]'
+   OAUTH_PROVIDERS = [
+       {
+           "name": "google",
+           "icon": "fa-google",
+           "token_key": "access_token",
+           "remote_app": {
+               "client_id": "your-client-id.googleusercontent.com",
+               "client_secret": "your-client-secret",
+               "api_base_url": "https://www.googleapis.com/oauth2/v2/",
+               "request_token_url": None,
+               "access_token_url": "https://oauth2.googleapis.com/token",
+               "authorize_url": "https://accounts.google.com/o/oauth2/auth",
+               "client_kwargs": {"scope": "openid email profile"},
+           },
+       }
+   ]
 
 .. seealso::
    For Google OAuth setup and credential configuration, see :doc:`apache-airflow-providers-google:connections/gcp`


### PR DESCRIPTION
Following the FAB SSO guide as written does not produce a working SSO setup.

- Step 1 puts `auth_manager` in `[webserver]`. Airflow reads it from `[core]`, and there is no deprecation mapping for the `[webserver]` spelling, so the setting is silently ignored and the deployment stays on `SimpleAuthManager`.
- Step 4 offers `AIRFLOW__FAB__OAUTH_PROVIDERS` and `[fab] oauth_providers`. Neither exists. The provider declares no `oauth_providers` option, and `FabAirflowSecurityManagerOverride.oauth_providers` returns `current_app.config["OAUTH_PROVIDERS"]`, which is populated from `webserver_config.py`. With `AUTH_TYPE = AUTH_OAUTH` set and the providers configured the way the guide describes, the API server refuses to start with `KeyError: 'OAUTH_PROVIDERS'`.
- The Okta, Azure and Google examples all use the same non-functional environment variable. The Azure group-authorization example further down already used the correct `webserver_config.py` form, so the guide contradicted itself.

Verified on Airflow 3.3.1 with `apache-airflow-providers-fab==3.8.1rc1`. Following the corrected guide verbatim against a fresh `AIRFLOW_HOME`, the API server starts, the provider appears on the login page, and `/auth/login/google` redirects to the IdP with `redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fauth%2Foauth-authorized%2Fgoogle`.

Found while verifying #71624 for the RC round in #71847.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
