### PR TITLE
Migrate Execution API responses that older Task SDK clients still read

### DIFF
--- a/airflow-core/newsfragments/71861.bugfix.rst
+++ b/airflow-core/newsfragments/71861.bugfix.rst
@@ -1,0 +1,1 @@
+Task SDK clients older than the API server no longer receive unmigrated Execution API responses. The compat previous-Dag-run route answered with the current response shape, and the asset-events routes failed to serialize when an event had created a Dag run, returning a server error. Both paths now migrate their responses to the client's negotiated API version.

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2025_11_05.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2025_11_05.py
@@ -34,3 +34,10 @@ class AddTriggeringUserNameField(VersionChange):
         """Remove the `triggering_user_name` field from the dag_run object when converting to the previous version."""
         if "dag_run" in response.body and isinstance(response.body["dag_run"], dict):
             response.body["dag_run"].pop("triggering_user_name", None)
+
+    # The compat previous-run route has no response model, so it is addressed by path.
+    @convert_response_to_previous_version_for("/dag-runs/{dag_id}/previous", ["GET"])  # type: ignore[arg-type]
+    def remove_triggering_user_name_from_compat_previous_dag_run(response: ResponseInfo) -> None:  # type: ignore[misc]
+        """Remove the `triggering_user_name` field from the compat previous-run response."""
+        if isinstance(response.body, dict):
+            response.body.pop("triggering_user_name", None)

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_04_06.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_04_06.py
@@ -59,12 +59,24 @@ class AddPartitionKeyField(VersionChange):
                 if isinstance(event, dict):
                     event.pop("partition_key", None)
 
+    # The compat previous-run route has no response model, so it is addressed by path.
+    @convert_response_to_previous_version_for("/dag-runs/{dag_id}/previous", ["GET"])  # type: ignore[arg-type]
+    def remove_partition_key_from_compat_previous_dag_run(response: ResponseInfo) -> None:  # type: ignore[misc]
+        """Remove the `partition_key` field from the compat previous-run response."""
+        if isinstance(response.body, dict):
+            response.body.pop("partition_key", None)
+
     @convert_response_to_previous_version_for(AssetEventsResponse)  # type: ignore[arg-type]
     def remove_partition_key_from_asset_events(response: ResponseInfo) -> None:  # type: ignore[misc]
-        """Remove the `partition_key` field from the dag_run object when converting to the previous version."""
+        """Remove the `partition_key` field from the asset events when converting to the previous version."""
         events = response.body["asset_events"]
         for elem in events:
             elem.pop("partition_key", None)
+            # The nested Dag runs carry the field too, and their previous-version schema forbids
+            # unknown keys, so leaving it here fails response serialization for those clients.
+            for dag_run in elem.get("created_dagruns") or ():
+                if isinstance(dag_run, dict):
+                    dag_run.pop("partition_key", None)
 
 
 class MovePreviousRunEndpoint(VersionChange):
@@ -111,6 +123,13 @@ class MakeDagRunStartDateNullable(VersionChange):
     def ensure_start_date_in_dag_run(response: ResponseInfo) -> None:  # type: ignore[misc]
         """Ensure start_date is never None in direct DagRun responses for previous API versions."""
         if response.body.get("start_date") is None:
+            response.body["start_date"] = response.body.get("run_after")
+
+    # The compat previous-run route has no response model, so it is addressed by path.
+    @convert_response_to_previous_version_for("/dag-runs/{dag_id}/previous", ["GET"])  # type: ignore[arg-type]
+    def ensure_start_date_in_compat_previous_dag_run(response: ResponseInfo) -> None:  # type: ignore[misc]
+        """Ensure start_date is never None in the compat previous-run response."""
+        if isinstance(response.body, dict) and response.body.get("start_date") is None:
             response.body["start_date"] = response.body.get("run_after")
 
 
@@ -185,6 +204,13 @@ class AddNoteField(VersionChange):
         """Remove note field for older API versions."""
         if "dag_run" in response.body and isinstance(response.body["dag_run"], dict):
             response.body["dag_run"].pop("note", None)
+
+    # The compat previous-run route has no response model, so it is addressed by path.
+    @convert_response_to_previous_version_for("/dag-runs/{dag_id}/previous", ["GET"])  # type: ignore[arg-type]
+    def remove_note_from_compat_previous_dag_run(response: ResponseInfo) -> None:  # type: ignore[misc]
+        """Remove the `note` field from the compat previous-run response."""
+        if isinstance(response.body, dict):
+            response.body.pop("note", None)
 
 
 class AddTaskInstanceStartDateField(VersionChange):

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_06_30.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_06_30.py
@@ -113,6 +113,13 @@ class AddTeamNameField(VersionChange):
         if isinstance(response.body, dict):
             response.body.pop("team_name", None)
 
+    # The compat previous-run route needs the same treatment, matched by its own path.
+    @convert_response_to_previous_version_for("/dag-runs/{dag_id}/previous", ["GET"])  # type: ignore[arg-type]
+    def remove_team_name_from_compat_previous_dag_run(response: ResponseInfo) -> None:  # type: ignore[misc]
+        """Strip ``team_name`` from the compat previous-run response."""
+        if isinstance(response.body, dict):
+            response.body.pop("team_name", None)
+
 
 class AddAssetsByAliasEndpoint(VersionChange):
     """Add endpoint to resolve assets from an AssetAlias."""
@@ -166,5 +173,12 @@ class AddPartitionDateField(VersionChange):
     @convert_response_to_previous_version_for("/dag-runs/previous", ["GET"])  # type: ignore[arg-type]
     def remove_partition_date_from_previous_dag_run(response: ResponseInfo) -> None:  # type: ignore[misc]
         """Strip ``partition_date`` from the previous-run response."""
+        if isinstance(response.body, dict):
+            response.body.pop("partition_date", None)
+
+    # The compat previous-run route needs the same treatment, matched by its own path.
+    @convert_response_to_previous_version_for("/dag-runs/{dag_id}/previous", ["GET"])  # type: ignore[arg-type]
+    def remove_partition_date_from_compat_previous_dag_run(response: ResponseInfo) -> None:  # type: ignore[misc]
+        """Strip ``partition_date`` from the compat previous-run response."""
         if isinstance(response.body, dict):
             response.body.pop("partition_date", None)

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2025_11_05/__init__.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2025_11_05/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2025_11_05/test_asset_events_nested.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2025_11_05/test_asset_events_nested.py
@@ -1,0 +1,114 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy import delete
+
+from airflow._shared.timezones import timezone
+from airflow.models.asset import AssetActive, AssetAliasModel, AssetEvent, AssetModel
+from airflow.models.dagrun import DagRun
+from airflow.utils.state import DagRunState
+from airflow.utils.types import DagRunType
+
+pytestmark = pytest.mark.db_test
+
+DEFAULT_DATE = timezone.parse("2021-01-01T00:00:00")
+
+
+@pytest.fixture
+def ver_client(client):
+    """A version older than the one that introduced partition_key on nested Dag runs."""
+    client.headers["Airflow-API-Version"] = "2025-11-05"
+    return client
+
+
+@pytest.fixture
+def asset_event_with_created_dagrun(session):
+    asset = AssetModel(
+        id=1,
+        name="test_asset",
+        uri="s3://bucket/key",
+        group="asset",
+        extra={},
+        created_at=DEFAULT_DATE,
+        updated_at=DEFAULT_DATE,
+    )
+    session.add_all([asset, AssetActive.for_asset(asset)])
+    event = AssetEvent(
+        id=1,
+        asset_id=1,
+        timestamp=datetime(2021, 1, 2, tzinfo=timezone.utc),
+        extra={},
+        source_dag_id="source_dag",
+        source_task_id="source_task",
+        source_run_id="source_run",
+        source_map_index=-1,
+        partition_key=None,
+    )
+    session.add(event)
+    event.created_dagruns.append(
+        DagRun(
+            dag_id="created_dag",
+            run_id="created_run",
+            logical_date=DEFAULT_DATE,
+            state=DagRunState.SUCCESS,
+            run_type=DagRunType.ASSET_TRIGGERED,
+            data_interval=(DEFAULT_DATE, DEFAULT_DATE),
+        )
+    )
+    alias = AssetAliasModel(id=1, name="test_alias")
+    alias.asset_events = [event]
+    alias.assets.append(asset)
+    session.add(alias)
+    session.commit()
+
+    yield asset
+
+    session.execute(delete(AssetEvent))
+    session.execute(delete(DagRun))
+    session.execute(delete(AssetAliasModel))
+    session.execute(delete(AssetActive))
+    session.execute(delete(AssetModel))
+    session.commit()
+
+
+@pytest.mark.usefixtures("asset_event_with_created_dagrun")
+@pytest.mark.parametrize(
+    ("path", "params"),
+    [
+        ("by-asset", {"name": "test_asset", "uri": None}),
+        ("by-asset-alias", {"name": "test_alias"}),
+    ],
+)
+def test_nested_created_dagruns_hide_partition_key(ver_client, path, params):
+    """Nested Dag runs must be migrated too, not only the events that carry them.
+
+    The nested schema for this version forbids unknown keys, so leaving ``partition_key`` on a
+    created Dag run fails response serialization and the client receives a 500.
+    """
+    response = ver_client.get(f"/execution/asset-events/{path}", params=params)
+
+    assert response.status_code == 200
+    events = response.json()["asset_events"]
+    assert events, "fixture must produce at least one event"
+    for event in events:
+        assert "partition_key" not in event
+        for created in event["created_dagruns"]:
+            assert "partition_key" not in created

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2025_11_05/test_dag_runs_compat.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2025_11_05/test_dag_runs_compat.py
@@ -1,0 +1,94 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow._shared.timezones import timezone
+from airflow.utils.state import DagRunState
+
+pytestmark = pytest.mark.db_test
+
+# Fields added to DagRun after each version. Clients of a version forbid unknown keys, so a
+# field must be absent for every version older than the one that introduced it.
+ADDED_AFTER = {
+    "2025-08-10": ("triggering_user_name", "note", "partition_key", "team_name", "partition_date"),
+    "2025-11-05": ("note", "partition_key", "team_name", "partition_date"),
+}
+
+
+@pytest.fixture
+def ver_client(client):
+    client.headers["Airflow-API-Version"] = "2025-11-05"
+    return client
+
+
+@pytest.mark.parametrize("api_version", sorted(ADDED_AFTER))
+def test_compat_previous_dag_run_hides_later_fields(api_version, client, session, dag_maker):
+    """The compat previous-run route must answer in the shape each version defines.
+
+    It has no response model, so the schema-based converters cannot match it and it is
+    addressed by path instead.
+    """
+    client.headers["Airflow-API-Version"] = api_version
+    ver_client = client
+    with dag_maker(dag_id="compat_dag", session=session, serialized=True):
+        pass
+    dag_maker.create_dagrun(
+        state=DagRunState.SUCCESS, logical_date=timezone.datetime(2025, 1, 1), run_id="previous"
+    )
+    dag_maker.create_dagrun(
+        state=DagRunState.SUCCESS, logical_date=timezone.datetime(2025, 1, 10), run_id="current"
+    )
+    session.commit()
+
+    response = ver_client.get(
+        "/execution/dag-runs/compat_dag/previous",
+        params={"logical_date": timezone.datetime(2025, 1, 10).isoformat()},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["run_id"] == "previous"
+    assert [f for f in ADDED_AFTER[api_version] if f in body] == []
+    if api_version == "2025-11-05":
+        # Introduced in this version, so it must still be served here.
+        assert "triggering_user_name" in body
+
+
+def test_compat_previous_dag_run_start_date_is_never_null(ver_client, session, dag_maker):
+    """A queued previous run must still report a non-null start_date at this version."""
+    with dag_maker(dag_id="compat_dag_queued", session=session, serialized=True):
+        pass
+    dag_maker.create_dagrun(
+        state=DagRunState.QUEUED,
+        logical_date=timezone.datetime(2025, 1, 1),
+        run_id="queued_previous",
+        start_date=None,
+    )
+    dag_maker.create_dagrun(
+        state=DagRunState.SUCCESS, logical_date=timezone.datetime(2025, 1, 10), run_id="current"
+    )
+    session.commit()
+
+    response = ver_client.get(
+        "/execution/dag-runs/compat_dag_queued/previous",
+        params={"logical_date": timezone.datetime(2025, 1, 10).isoformat()},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["start_date"] is not None


### PR DESCRIPTION
Two Execution API response paths skip their version migrations, so a Task SDK older than the API server either receives fields it forbids or gets a 500. #70138 fixed this class for `/dag-runs/previous` and direct `DagRun` responses; these are the two paths it did not reach.

### Root cause 1: the compat previous-run route has no response model

`get_previous_dagrun_compat` serves `/dag-runs/{dag_id}/previous` for clients older than `2026-04-06`. It carries no return annotation, so the route has no response model, and schema-based converters are matched against the response model by identity. None of them fire.

The route therefore answers old clients with the current `DagRun` shape. At `2025-08-10` the body carries `triggering_user_name`, `note`, `partition_key`, `team_name` and `partition_date`, and `start_date` is `null` for a queued previous run. The client model forbids unknown keys and requires a non-null `start_date`, so `ti.get_previous_dagrun()` raises and the task fails.

#70138 already documented this identity-matching rule in `v2026_06_30.py` and solved it for the sibling path with path-based converters. This applies the same treatment to the compat path, in each `VersionChange` that touched `DagRun` after the endpoint became compat-only.

### Root cause 2: the asset-events converter stops at the top level

`remove_partition_key_from_asset_events` strips `partition_key` from each event but not from the Dag runs nested inside it. Those nested runs use a strict schema too, so the field is not merely leaked: response serialisation fails and the client receives

```
fastapi.exceptions.ResponseValidationError: 1 validation error:
  {'type': 'extra_forbidden', 'loc': ('response', 'asset_events', 0, 'created_dagruns', 0, 'partition_key')}
```

This is a 500 on both `/asset-events/by-asset` and `/by-asset-alias` for every old client whose events triggered a Dag run, which is the ordinary case in asset-driven pipelines. The sibling converter in the same `VersionChange` already walks nested `consumed_asset_events`, which is why the migration reads as complete.

### Why the existing tests did not catch either

They assert only fields that exist in every version. The compat-route test checks `dag_id`, `run_id` and `state`; the old-version asset-events test builds events with no attached Dag runs, so the nested strict model is never exercised. Both leaks pass CI today.

The new tests assert in both directions: a field must be absent for versions older than the one that introduced it, and still present for the version that added it, so a future change cannot over-strip. They run at `2025-08-10` and `2025-11-05`, and cover both asset-events endpoints.

Beyond the test assertions, the released client model was extracted from git and used to validate the actual response bodies: it rejects the current output and accepts it after this change.

### On the general case

Neither leak is a mistake in the migration machinery; both are missing registrations. Nothing in CI replays a supported version against the model a released SDK actually uses, so this class stays invisible until a mixed-version deployment hits it. A shared contract test that does that replay would close the class, and I am happy to follow up with one if that seems worth having.

related: #70138
related: #71379

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)