### PR TITLE
Keep asset-event Dag run start_date non-null for older Task SDK clients

### DIFF
--- a/airflow-core/newsfragments/71862.bugfix.rst
+++ b/airflow-core/newsfragments/71862.bugfix.rst
@@ -1,0 +1,1 @@
+Task SDK clients no longer fail reading ``inlet_events`` when an asset event created a Dag run that has not started yet. The Execution API returned a null ``start_date`` for such a run at every negotiated API version, which every released Task SDK rejects. Older versions now receive a non-null value again.

--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/asset_event.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/asset_event.py
@@ -32,6 +32,9 @@ class DagRunAssetReference(StrictBaseModel):
     dag_id: str
     logical_date: datetime | None
     start_date: datetime | None
+    # Always set on a Dag run, so clients of versions that require a non-null start_date can be
+    # served this value while the run has not started yet.
+    run_after: datetime
     end_date: datetime | None
     state: str
     data_interval_start: datetime | None

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
@@ -51,11 +51,18 @@ from airflow.api_fastapi.execution_api.versions.v2026_06_30 import (
     AddTeamNameField,
     AddVariableKeysEndpoint,
 )
-from airflow.api_fastapi.execution_api.versions.v2026_10_30 import AddArgBindingsToTIRunContext
+from airflow.api_fastapi.execution_api.versions.v2026_10_30 import (
+    AddArgBindingsToTIRunContext,
+    MakeAssetEventDagRunStartDateNullable,
+)
 
 bundle = VersionBundle(
     HeadVersion(),
-    Version("2026-10-30", AddArgBindingsToTIRunContext),
+    Version(
+        "2026-10-30",
+        AddArgBindingsToTIRunContext,
+        MakeAssetEventDagRunStartDateNullable,
+    ),
     Version(
         "2026-06-30",
         AddVariableKeysEndpoint,

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
@@ -54,11 +54,17 @@ from airflow.api_fastapi.execution_api.versions.v2026_06_30 import (
 from airflow.api_fastapi.execution_api.versions.v2026_10_30 import (
     AddArgBindingsToTIRunContext,
     AddCallbackRunEndpoint,
+    MakeAssetEventDagRunStartDateNullable,
 )
 
 bundle = VersionBundle(
     HeadVersion(),
-    Version("2026-10-30", AddArgBindingsToTIRunContext, AddCallbackRunEndpoint),
+    Version(
+        "2026-10-30",
+        AddArgBindingsToTIRunContext,
+        AddCallbackRunEndpoint,
+        MakeAssetEventDagRunStartDateNullable,
+    ),
     Version(
         "2026-06-30",
         AddVariableKeysEndpoint,

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_10_30.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_10_30.py
@@ -19,11 +19,17 @@ from __future__ import annotations
 
 from cadwyn import (
     ResponseInfo,
+    VersionChange,
     VersionChangeWithSideEffects,
     convert_response_to_previous_version_for,
     schema,
 )
 
+from airflow.api_fastapi.common.types import UtcDateTime
+from airflow.api_fastapi.execution_api.datamodels.asset_event import (
+    AssetEventsResponse,
+    DagRunAssetReference,
+)
 from airflow.api_fastapi.execution_api.datamodels.taskinstance import TIRunContext
 
 
@@ -40,3 +46,33 @@ class AddArgBindingsToTIRunContext(VersionChangeWithSideEffects):
     def remove_arg_bindings_field(response: ResponseInfo) -> None:  # type: ignore[misc]
         """Strip ``arg_bindings`` from the run context for older clients."""
         response.body.pop("arg_bindings", None)
+
+
+class MakeAssetEventDagRunStartDateNullable(VersionChange):
+    """Make DagRunAssetReference.start_date nullable for runs that have not started yet."""
+
+    description = __doc__
+
+    instructions_to_migrate_to_previous_version = (
+        schema(DagRunAssetReference).field("start_date").had(type=UtcDateTime),
+        schema(DagRunAssetReference).field("run_after").didnt_exist,
+    )
+
+    @convert_response_to_previous_version_for(AssetEventsResponse)  # type: ignore[arg-type]
+    def ensure_start_date_in_created_dagruns(response: ResponseInfo) -> None:  # type: ignore[misc]
+        """
+        Keep created_dagruns[*].start_date non-null for previous API versions.
+
+        Clients of those versions declare the field non-nullable and reject the whole response
+        when it is null, which happens while a created Dag run is queued or has been cleared.
+        Fall back to run_after, then drop the field those clients never knew about.
+        """
+        for event in response.body.get("asset_events") or ():
+            if not isinstance(event, dict):
+                continue
+            for dag_run in event.get("created_dagruns") or ():
+                if not isinstance(dag_run, dict):
+                    continue
+                if dag_run.get("start_date") is None:
+                    dag_run["start_date"] = dag_run.get("run_after")
+                dag_run.pop("run_after", None)

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_10_30.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_10_30.py
@@ -26,6 +26,11 @@ from cadwyn import (
     schema,
 )
 
+from airflow.api_fastapi.common.types import UtcDateTime
+from airflow.api_fastapi.execution_api.datamodels.asset_event import (
+    AssetEventsResponse,
+    DagRunAssetReference,
+)
 from airflow.api_fastapi.execution_api.datamodels.taskinstance import TIRunContext
 
 
@@ -52,3 +57,33 @@ class AddCallbackRunEndpoint(VersionChange):
     instructions_to_migrate_to_previous_version = (
         endpoint("/callbacks/{callback_id}/run", ["PATCH"]).didnt_exist,
     )
+
+
+class MakeAssetEventDagRunStartDateNullable(VersionChange):
+    """Make DagRunAssetReference.start_date nullable for runs that have not started yet."""
+
+    description = __doc__
+
+    instructions_to_migrate_to_previous_version = (
+        schema(DagRunAssetReference).field("start_date").had(type=UtcDateTime),
+        schema(DagRunAssetReference).field("run_after").didnt_exist,
+    )
+
+    @convert_response_to_previous_version_for(AssetEventsResponse)  # type: ignore[arg-type]
+    def ensure_start_date_in_created_dagruns(response: ResponseInfo) -> None:  # type: ignore[misc]
+        """
+        Keep created_dagruns[*].start_date non-null for previous API versions.
+
+        Clients of those versions declare the field non-nullable and reject the whole response
+        when it is null, which happens while a created Dag run is queued or has been cleared.
+        Fall back to run_after, then drop the field those clients never knew about.
+        """
+        for event in response.body.get("asset_events") or ():
+            if not isinstance(event, dict):
+                continue
+            for dag_run in event.get("created_dagruns") or ():
+                if not isinstance(dag_run, dict):
+                    continue
+                if dag_run.get("start_date") is None:
+                    dag_run["start_date"] = dag_run.get("run_after")
+                dag_run.pop("run_after", None)

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2026_06_30/test_asset_events.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2026_06_30/test_asset_events.py
@@ -1,0 +1,99 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy import delete
+
+from airflow._shared.timezones import timezone
+from airflow.models.asset import AssetActive, AssetEvent, AssetModel
+from airflow.models.dagrun import DagRun
+from airflow.utils.state import DagRunState
+from airflow.utils.types import DagRunType
+
+pytestmark = pytest.mark.db_test
+
+DEFAULT_DATE = timezone.parse("2021-01-01T00:00:00")
+
+
+@pytest.fixture
+def ver_client(client):
+    """Newest released Task SDK pins this version; it requires a non-null start_date."""
+    client.headers["Airflow-API-Version"] = "2026-06-30"
+    return client
+
+
+@pytest.fixture
+def asset_with_queued_created_dagrun(session):
+    asset = AssetModel(
+        id=1,
+        name="test_asset",
+        uri="s3://bucket/key",
+        group="asset",
+        extra={},
+        created_at=DEFAULT_DATE,
+        updated_at=DEFAULT_DATE,
+    )
+    session.add_all([asset, AssetActive.for_asset(asset)])
+    event = AssetEvent(
+        id=1,
+        asset_id=1,
+        timestamp=datetime(2021, 1, 2, tzinfo=timezone.utc),
+        extra={},
+        source_dag_id="source_dag",
+        source_task_id="source_task",
+        source_run_id="source_run",
+        source_map_index=-1,
+        partition_key=None,
+    )
+    session.add(event)
+    event.created_dagruns.append(
+        DagRun(
+            dag_id="created_dag",
+            run_id="queued_run",
+            logical_date=DEFAULT_DATE,
+            state=DagRunState.QUEUED,
+            run_type=DagRunType.ASSET_TRIGGERED,
+            data_interval=(DEFAULT_DATE, DEFAULT_DATE),
+        )
+    )
+    session.commit()
+
+    yield asset
+
+    session.execute(delete(AssetEvent))
+    session.execute(delete(DagRun))
+    session.execute(delete(AssetActive))
+    session.execute(delete(AssetModel))
+    session.commit()
+
+
+@pytest.mark.usefixtures("asset_with_queued_created_dagrun")
+def test_created_dagrun_start_date_is_never_null(ver_client):
+    """A queued created Dag run must still report a non-null start_date at this version.
+
+    Clients of this version declare ``start_date`` non-nullable and reject the whole response
+    when it is null, so the value falls back to ``run_after``.
+    """
+    response = ver_client.get("/execution/asset-events/by-asset", params={"name": "test_asset", "uri": None})
+
+    assert response.status_code == 200
+    created = response.json()["asset_events"][0]["created_dagruns"][0]
+    assert created["start_date"] is not None
+    assert "run_after" not in created

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -136,6 +136,7 @@ class DagRunAssetReference(BaseModel):
     dag_id: Annotated[str, Field(title="Dag Id")]
     logical_date: Annotated[AwareDatetime | None, Field(title="Logical Date")]
     start_date: Annotated[AwareDatetime | None, Field(title="Start Date")]
+    run_after: Annotated[AwareDatetime, Field(title="Run After")]
     end_date: Annotated[AwareDatetime | None, Field(title="End Date")]
     state: Annotated[str, Field(title="State")]
     data_interval_start: Annotated[AwareDatetime | None, Field(title="Data Interval Start")]

--- a/task-sdk/src/airflow/sdk/execution_time/schema/schema.json
+++ b/task-sdk/src/airflow/sdk/execution_time/schema/schema.json
@@ -1158,6 +1158,11 @@
           ],
           "title": "Start Date"
         },
+        "run_after": {
+          "format": "date-time",
+          "title": "Run After",
+          "type": "string"
+        },
         "end_date": {
           "anyOf": [
             {
@@ -1215,6 +1220,7 @@
         "dag_id",
         "logical_date",
         "start_date",
+        "run_after",
         "end_date",
         "state",
         "data_interval_start",

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -1213,6 +1213,7 @@ class TestAssetEventOperations:
                         "run_id": "queued_run",
                         "logical_date": "2023-01-01T00:00:00Z",
                         "start_date": None,
+                        "run_after": "2023-01-01T00:00:00Z",
                         "end_date": None,
                         "state": "queued",
                         "data_interval_start": None,

--- a/ts-sdk/src/generated/supervisor.ts
+++ b/ts-sdk/src/generated/supervisor.ts
@@ -38,6 +38,7 @@ export type RunId = string;
 export type DagId = string;
 export type LogicalDate = string | null;
 export type StartDate = string | null;
+export type RunAfter = string;
 export type EndDate = string | null;
 export type State = string;
 export type DataIntervalStart = string | null;
@@ -132,7 +133,7 @@ export type RunId2 = string;
 export type LogicalDate1 = string | null;
 export type DataIntervalStart1 = string | null;
 export type DataIntervalEnd1 = string | null;
-export type RunAfter = string;
+export type RunAfter1 = string;
 export type StartDate1 = string | null;
 export type EndDate1 = string | null;
 export type ClearNumber = number;
@@ -291,7 +292,7 @@ export type RunId4 = string;
 export type LogicalDate2 = string | null;
 export type DataIntervalStart2 = string | null;
 export type DataIntervalEnd2 = string | null;
-export type RunAfter1 = string;
+export type RunAfter2 = string;
 export type StartDate3 = string | null;
 export type EndDate2 = string | null;
 export type ClearNumber1 = number | null;
@@ -600,7 +601,7 @@ export type RenderedMapIndex5 = string | null;
 export type Type79 = "TaskStateStoreResult";
 export type Type80 = "TaskStatesResult";
 export type LogicalDate6 = string | null;
-export type RunAfter2 = string | null;
+export type RunAfter3 = string | null;
 export type Conf2 = {
   [k: string]: unknown;
 } | null;
@@ -686,6 +687,7 @@ export interface DagRunAssetReference {
   dag_id: DagId;
   logical_date: LogicalDate;
   start_date: StartDate;
+  run_after: RunAfter;
   end_date: EndDate;
   state: State;
   data_interval_start: DataIntervalStart;
@@ -912,7 +914,7 @@ export interface DagRun {
   logical_date: LogicalDate1;
   data_interval_start: DataIntervalStart1;
   data_interval_end: DataIntervalEnd1;
-  run_after: RunAfter;
+  run_after: RunAfter1;
   start_date: StartDate1;
   end_date: EndDate1;
   clear_number?: ClearNumber;
@@ -1149,7 +1151,7 @@ export interface DagRunResult {
   logical_date: LogicalDate2;
   data_interval_start: DataIntervalStart2;
   data_interval_end: DataIntervalEnd2;
-  run_after: RunAfter1;
+  run_after: RunAfter2;
   start_date: StartDate3;
   end_date: EndDate2;
   clear_number?: ClearNumber1;
@@ -1853,7 +1855,7 @@ export interface TaskStates {
  */
 export interface TriggerDagRun {
   logical_date?: LogicalDate6;
-  run_after?: RunAfter2;
+  run_after?: RunAfter3;
   conf?: Conf2;
   reset_dag_run?: ResetDagRun;
   partition_key?: PartitionKey7;


### PR DESCRIPTION
`inlet_events` fails on any released Task SDK when an asset event created a Dag run that has not started yet. The worker raises:

```
pydantic_core.ValidationError: 1 validation error for AssetEventsResponse
asset_events.0.created_dagruns.0.start_date
  Input should be a valid datetime [type=datetime_type, input_value=None]
```

### Root cause

#71379 changed `DagRunAssetReference.start_date` to `datetime | None` in the Execution API, which is correct at head: a queued or cleared Dag run genuinely has no start date, and returning one was the 500 reported in #71360.

That PR touched no file under `execution_api/versions/`, so no `VersionChange` pins the old type. Cadwyn regenerates the response model for every older version from head, so those versions inherited the nullability too, and the server now serialises `start_date: null` at every negotiated version. Every released Task SDK declares the field non-nullable with `extra="forbid"`, so `AssetEventsResponse.model_validate_json` rejects the whole response and the task fails.

The newest released Task SDK (1.3.0) pins API version `2026-06-30` and is affected.

### Fix

`MakeAssetEventDagRunStartDateNullable` pins the old non-null type for previous versions and backfills the value, following `MakeDagRunStartDateNullable` which handled the same change for `DagRun`.

Converters only see the response body, so the fallback value has to be in the body. Every other datetime on this model is nullable, so the change adds `run_after` — always set on a Dag run — and the same `VersionChange` hides it from older versions. Head clients see the real `start_date` unchanged, including `null`.

The change registers into the existing `2026-10-30` version rather than a new one, because no released SDK negotiates `2026-10-30` yet: 1.3.0 pins `2026-06-30`. Clients of `2026-06-30` and older get the migrated shape.

### Verification

The regression test asserts the response is non-null at `2026-06-30`. Beyond that, the released client model was extracted from the `task-sdk/1.3.0` tag and used to validate the actual response body: it rejects the current output and accepts it after this change.

Generated artifacts (`_generated.py`, `schema.json`, `supervisor.ts`) were regenerated by their hooks, not edited by hand.

related: #71379
related: #71360

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)