### PR TITLE
Add example Dag for checkpointing progress from an async task

### DIFF
--- a/airflow-core/src/airflow/example_dags/example_task_state_store_async.py
+++ b/airflow-core/src/airflow/example_dags/example_task_state_store_async.py
@@ -1,0 +1,94 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Example DAG for an async task that checkpoints its progress with ``aget``/``aset``.
+
+The task fetches pages concurrently and records which ones finished. A staged failure
+part way through the first attempt shows the retry resuming from the checkpoint instead
+of re-fetching everything, and the Dag run still ends successfully.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime
+
+from airflow.sdk import DAG, task
+from airflow.sdk.execution_time.context import NEVER_EXPIRE
+
+log = logging.getLogger(__name__)
+
+PAGES = list(range(1, 13))
+BATCH_SIZE = 4  # pages awaited concurrently before each checkpoint
+CRASH_AFTER = 6  # staged failure, first attempt only
+
+
+async def _fetch_page(page: int) -> int:
+    """Placeholder for an awaited API call; returns the row count for the page."""
+    await asyncio.sleep(0.2)
+    return page * 100
+
+
+with DAG(
+    dag_id="example_task_state_store_async",
+    schedule=None,
+    start_date=datetime(2026, 1, 1),
+    catchup=False,
+    tags=["example", "task-state-store"],
+    doc_md=__doc__,
+) as dag:
+
+    @task(retries=2, retry_delay=5)
+    async def ingest_pages(task_state_store=None, ti=None) -> dict:
+        """Fetch every page, checkpointing after each concurrent batch."""
+        # Progress and the running total live in one key so a single write keeps
+        # them consistent with each other.
+        progress = await task_state_store.aget("progress", default={"done": [], "rows": 0})
+        done = set(progress["done"])
+        rows = progress["rows"]
+
+        if done:
+            log.info("Resuming: %d of %d pages already fetched", len(done), len(PAGES))
+        else:
+            log.info("Starting from the top: %d pages to fetch", len(PAGES))
+
+        remaining = [page for page in PAGES if page not in done]
+
+        for start in range(0, len(remaining), BATCH_SIZE):
+            batch = remaining[start : start + BATCH_SIZE]
+            rows += sum(await asyncio.gather(*(_fetch_page(page) for page in batch)))
+            done.update(batch)
+
+            # Only this coroutine writes the checkpoint. If each _fetch_page wrote its
+            # own, the writes would interleave at their await points, each overwriting a
+            # stale copy of the set, and finished pages would vanish from the checkpoint.
+            await task_state_store.aset(
+                "progress",
+                {"done": sorted(done), "rows": rows},
+                retention=NEVER_EXPIRE,
+            )
+            log.info("Checkpointed %d/%d pages after batch %s", len(done), len(PAGES), batch)
+
+            if CRASH_AFTER and ti.try_number == 1 and len(done) >= CRASH_AFTER:
+                raise RuntimeError(
+                    f"Staged worker loss after {len(done)} pages. The retry picks up from the checkpoint."
+                )
+
+        log.info("All %d pages fetched, %d rows total", len(done), rows)
+        return {"pages": len(done), "rows": rows}
+
+    ingest_pages()

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -241,6 +241,7 @@ chatbot
 chatbots
 CheckOperator
 checkpointed
+checkpointing
 checksums
 childs
 chmod


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

Adds `example_task_state_store_async.py`, showing an `async def` task that fetches pages concurrently and checkpoints its progress with `aget`/`aset` so a retry resumes instead of starting over.

`aget`/`aset` landed in 3.3 but have no example coverage in the repo, and this is the first `async def` task in `example_dags/`. Two deliberate choices worth calling out for review:

**The checkpoint is a completed-set, not a high-water cursor.** Both async examples in
`task-state-store.rst` track a `last_page` cursor, which assumes ordered sequential
completion. Under `asyncio.gather`, items finish out of order, so a cursor either skips
unfinished work or repeats finished work. A set is correct at any concurrency.

**Only the parent coroutine writes the checkpoint.** If each worker coroutine did its own
`await aset`, the writes would interleave at their await points, each overwriting a stale
copy of the set, and completed items would silently vanish. So the task gathers a bounded
batch and the parent checkpoints once per batch. That is the one thing in the file that
gets a comment, because the bug it avoids leaves no trace.

Progress and the running row total live under a single key so one write keeps them
consistent, which also means a resumed attempt does not lose the previous attempt's total.

The staged failure fires only on the first try, so with `retries=2` the Dag run demonstrates the resume and still ends successfully on a single trigger.

closes: #66842 properly.


### Testing

Try 1
<img width="1674" height="946" alt="image" src="https://github.com/user-attachments/assets/c1336bd5-d402-4745-8ef6-5d6cea740016" />


Try 2
<img width="1674" height="946" alt="image" src="https://github.com/user-attachments/assets/ad32d836-9901-44b5-8185-c79d062ca8c5" />


State store

<img width="1674" height="946" alt="image" src="https://github.com/user-attachments/assets/ad5a7f0a-ba83-4857-81b8-e988f0ce061a" />


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
