### PR TITLE
fix(db_cleanup): skip dag rows whose dag_version cascade is blocked by task_instance FK

### DIFF
--- a/airflow-core/src/airflow/utils/db_cleanup.py
+++ b/airflow-core/src/airflow/utils/db_cleanup.py
@@ -115,6 +115,11 @@ class _TableConfig:
     extra_filters: list[Any] | None = None
     skip_if_referenced: list[tuple[str, str]] | None = None
     referenced_pk_column: str = "id"
+    # When this table is deleted, ON DELETE CASCADE propagates to cascade_table, but
+    # cascade_table rows are still referenced by restrict_table via ON DELETE RESTRICT.
+    # Each item: (cascade_table, cascade_table_fk_to_self, cascade_table_pk,
+    #            restrict_table, restrict_table_fk_to_cascade)
+    skip_if_cascade_blocked: list[tuple[str, str, str, str, str]] | None = None
 
     # Calculated from table_name and populated in __post_init__.
     schema_name: str = dataclasses.field(init=False)
@@ -141,14 +146,15 @@ class _TableConfig:
                 schema=self.schema_name,
             )
 
-        # skip_if_referenced filters on referenced_pk_column, which must be a column of orm_model
-        # (added via extra_columns). Fail fast with a clear message instead of a cryptic KeyError
-        # raised later when _build_query evaluates base_table.c[referenced_pk_column].
-        if self.skip_if_referenced and self.referenced_pk_column not in self.orm_model.c.keys():
+        # skip_if_referenced / skip_if_cascade_blocked filters on referenced_pk_column, which must be
+        # a column of orm_model (added via extra_columns or dag_id_column_name). Fail fast with a
+        # clear message instead of a cryptic KeyError raised later when _build_query evaluates
+        # base_table.c[referenced_pk_column].
+        if (self.skip_if_referenced or self.skip_if_cascade_blocked) and self.referenced_pk_column not in self.orm_model.c.keys():
             raise ValueError(
-                f"_TableConfig for table {self.table_name!r} sets skip_if_referenced but its "
-                f"referenced_pk_column {self.referenced_pk_column!r} is not one of its columns; "
-                f"add {self.referenced_pk_column!r} to extra_columns."
+                f"_TableConfig for table {self.table_name!r} sets skip_if_referenced or "
+                f"skip_if_cascade_blocked but its referenced_pk_column {self.referenced_pk_column!r} "
+                f"is not one of its columns; add {self.referenced_pk_column!r} to extra_columns."
             )
 
     def __lt__(self, other):
@@ -173,6 +179,11 @@ config_list: list[_TableConfig] = [
         recency_column_name="last_parsed_time",
         dependent_tables=["dag_version", "deadline"],
         dag_id_column_name="dag_id",
+        referenced_pk_column="dag_id",
+        # Deleting a dag cascades to dag_version (ON DELETE CASCADE), but
+        # task_instance.dag_version_id is ON DELETE RESTRICT. Skip dags whose
+        # dag_version rows are still referenced by any task instance.
+        skip_if_cascade_blocked=[("dag_version", "dag_id", "id", "task_instance", "dag_version_id")],
     ),
     _TableConfig(
         table_name="dag_run",
@@ -470,6 +481,22 @@ def _build_query(
                 .exists()
             )
 
+    if skip_if_cascade_blocked:
+        # When this table is deleted, ON DELETE CASCADE propagates to cascade_table, but
+        # cascade_table rows are still referenced by restrict_table via ON DELETE RESTRICT.
+        # Exclude rows whose cascade would fail.
+        base_table_pk_col = base_table.c[referenced_pk_column]
+        for cascade_table_name, cascade_fk_to_self, cascade_pk, restrict_table_name, restrict_fk in skip_if_cascade_blocked:
+            cascade_tbl = table(cascade_table_name, column(cascade_fk_to_self), column(cascade_pk))
+            restrict_tbl = table(restrict_table_name, column(restrict_fk))
+            conditions.append(
+                ~select(literal(1))
+                .select_from(cascade_tbl.join(restrict_tbl, cascade_tbl.c[cascade_pk] == restrict_tbl.c[restrict_fk]))
+                .where(cascade_tbl.c[cascade_fk_to_self] == base_table_pk_col)
+                .correlate(base_table)
+                .exists()
+            )
+
     if (dag_ids or exclude_dag_ids) and dag_id_column is not None:
         base_table_dag_id_col = base_table.c[dag_id_column.name]
 
@@ -517,6 +544,7 @@ def _cleanup_table(
     batch_size: int | None = None,
     extra_filters: list[Any] | None = None,
     skip_if_referenced: list[tuple[str, str]] | None = None,
+    skip_if_cascade_blocked: list[tuple[str, str, str, str, str]] | None = None,
     referenced_pk_column: str = "id",
     **kwargs,
 ) -> None:
@@ -535,6 +563,7 @@ def _cleanup_table(
         clean_before_timestamp=clean_before_timestamp,
         extra_filters=extra_filters,
         skip_if_referenced=skip_if_referenced,
+        skip_if_cascade_blocked=skip_if_cascade_blocked,
         referenced_pk_column=referenced_pk_column,
         session=session,
     )

--- a/airflow-core/tests/unit/utils/test_db_cleanup.py
+++ b/airflow-core/tests/unit/utils/test_db_cleanup.py
@@ -562,6 +562,114 @@ class TestDBCleanup:
                 # "id" intentionally omitted from extra_columns
             )
 
+    def test_dag_cleanup_skips_dags_with_pinned_dag_versions(self):
+        """db clean must skip dag rows whose deletion cascades to a pinned dag_version.
+
+        ``dag_version.dag_id`` is ``ON DELETE CASCADE``, so deleting a dag cascades
+        to its ``dag_version`` rows; ``task_instance.dag_version_id`` is ``ON DELETE
+        RESTRICT``, so that cascade fails the foreign key (and, on MySQL, can leave
+        the command blocked on metadata locks).  Cleaning the ``dag`` table must
+        therefore skip dags whose versions are still referenced by a task instance
+        while still pruning genuinely orphaned dags.
+        """
+        base_date = pendulum.DateTime(2022, 1, 1, tzinfo=pendulum.timezone("UTC"))
+        bundle_name = f"testing-{uuid4()}"
+        pinned_dag_id = f"pinned_dag_{uuid4()}"
+        orphan_dag_id = f"orphan_dag_{uuid4()}"
+
+        with create_session() as session:
+            session.add(DagBundleModel(name=bundle_name))
+            session.flush()
+            session.add_all(
+                [
+                    DagModel(
+                        dag_id=pinned_dag_id,
+                        bundle_name=bundle_name,
+                        last_parsed_time=base_date,
+                    ),
+                    DagModel(
+                        dag_id=orphan_dag_id,
+                        bundle_name=bundle_name,
+                        last_parsed_time=base_date,
+                    ),
+                ]
+            )
+            session.flush()
+
+            pinned_version = DagVersion(
+                dag_id=pinned_dag_id,
+                version_number=1,
+                bundle_name=bundle_name,
+                created_at=base_date,
+                last_updated=base_date,
+            )
+            orphan_version = DagVersion(
+                dag_id=orphan_dag_id,
+                version_number=1,
+                bundle_name=bundle_name,
+                created_at=base_date,
+                last_updated=base_date,
+            )
+            session.add_all([pinned_version, orphan_version])
+            session.flush()
+
+            dag = DAG(dag_id=pinned_dag_id)
+            dag_run = DagRun(pinned_dag_id, run_id="run-1", run_type=DagRunType.MANUAL, start_date=base_date)
+            ti = create_task_instance(
+                PythonOperator(task_id="dummy-task", python_callable=print),
+                run_id=dag_run.run_id,
+                dag_version_id=pinned_version.id,
+            )
+            ti.dag_id = dag.dag_id
+            ti.start_date = base_date
+            session.add_all([dag_run, ti])
+            session.commit()
+
+            # Previously this raised an IntegrityError on the FK (dag -> dag_version
+            # CASCADE blocked by task_instance.dag_version_id RESTRICT); with the
+            # cascade guard it must now succeed.
+            _cleanup_table(
+                **config_dict["dag"].__dict__,
+                clean_before_timestamp=base_date.add(days=10),
+                dry_run=False,
+                session=session,
+                table_names=["dag"],
+                skip_archive=True,
+            )
+
+            remaining = set(
+                session.scalars(
+                    select(DagModel.dag_id).where(DagModel.dag_id.in_([pinned_dag_id, orphan_dag_id]))
+                ).all()
+            )
+
+        assert pinned_dag_id in remaining  # dag_version still referenced -> dag skipped
+        assert orphan_dag_id not in remaining  # no references -> dag pruned
+
+    def test_dag_cleanup_cascade_guard_query(self):
+        """The dag cleanup query excludes rows whose dag_version cascade is blocked."""
+        base_date = pendulum.DateTime(2022, 1, 1, tzinfo=pendulum.timezone("UTC"))
+        dag_config = config_dict["dag"]
+        query = _build_query(
+            orm_model=dag_config.orm_model,
+            recency_column=dag_config.recency_column,
+            dag_id_column=dag_config.dag_id_column,
+            keep_last=dag_config.keep_last,
+            keep_last_filters=dag_config.keep_last_filters,
+            keep_last_group_by=dag_config.keep_last_group_by,
+            clean_before_timestamp=base_date.add(days=10),
+            extra_filters=dag_config.extra_filters,
+            skip_if_referenced=dag_config.skip_if_referenced,
+            skip_if_cascade_blocked=dag_config.skip_if_cascade_blocked,
+            referenced_pk_column=dag_config.referenced_pk_column,
+            session=MagicMock(),
+        )
+        sql = str(query.compile())
+        assert "dag_version" in sql
+        assert "task_instance" in sql
+        assert "EXISTS" in sql.upper()
+        assert "dag_version_id" in sql
+
     def test_do_delete_rolls_back_before_drop_on_failure(self):
         session = MagicMock(spec=Session)
         session.get_bind.return_value.dialect.name = "mysql"


### PR DESCRIPTION
## Problem

`airflow db clean` fails with an `IntegrityError` when deleting old `dag` rows. The `dag` → `dag_version` `ON DELETE CASCADE` propagates to `dag_version`, but `task_instance.dag_version_id` is `ON DELETE RESTRICT`, so the cascade fails the foreign key constraint (and, on MySQL, can leave the cleanup command blocked on metadata locks).

PR #68339 added `skip_if_referenced` to protect the `dag_version` table's own cleanup query, but did not protect the `dag` → `dag_version` cascade path.

## Fix

Add a new `skip_if_cascade_blocked` config option to `_TableConfig` that generates a correlated `NOT EXISTS` subquery across the cascade path. Apply it to the `dag` table config: exclude dags whose `dag_version` rows are still referenced by any `task_instance`.

Closes #71864