### PR TITLE
Honor Airflow log levels in Go task logging

### DIFF
--- a/go-sdk/README.md
+++ b/go-sdk/README.md
@@ -194,6 +194,17 @@ func extract(ctx sdk.TIRunContext, log *slog.Logger) (any, error) {
 `TryNumber`; `ctx.DagRun()` returns `DagID`, `RunID`, and the `*time.Time` fields `LogicalDate`,
 `DataIntervalStart`, and `DataIntervalEnd` (nil when the run has no such value, e.g. a manual trigger).
 
+### Task logging
+
+In coordinator mode, the injected logger filters records using Airflow's configured `[logging] logging_level` before sending them to the supervisor. Airflow also propagates `[logging] namespace_levels`; because `slog` does not have named loggers, bind the namespace as the top-level `logger` attribute:
+
+```go
+databaseLog := log.With("logger", "example.database")
+databaseLog.Debug("query complete", "rows", 42)
+```
+
+Namespace levels use longest dotted-prefix matching, so an `example=DEBUG` override also applies to `example.database` unless a more specific override takes precedence.
+
 ## Deployment
 
 A Python task runner executes the Go task directly, with no separate Go worker process to run on the host.

--- a/go-sdk/README.md
+++ b/go-sdk/README.md
@@ -196,10 +196,10 @@ func extract(ctx sdk.TIRunContext, log *slog.Logger) (any, error) {
 
 ### Task logging
 
-In coordinator mode, the injected logger filters records using Airflow's configured `[logging] logging_level` before sending them to the supervisor. Airflow also propagates `[logging] namespace_levels`; because `slog` does not have named loggers, bind the namespace as the top-level `logger` attribute:
+In coordinator mode, the injected logger filters records using Airflow's configured `[logging] logging_level` before sending them to the supervisor. Airflow also propagates `[logging] namespace_levels`; use a group-scoped logger to set the namespace:
 
 ```go
-databaseLog := log.With("logger", "example.database")
+databaseLog := log.WithGroup("example.database")
 databaseLog.Debug("query complete", "rows", 42)
 ```
 

--- a/go-sdk/pkg/execution/integration_test.go
+++ b/go-sdk/pkg/execution/integration_test.go
@@ -20,10 +20,12 @@ package execution
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"log/slog"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -658,6 +660,73 @@ func TestServeStartupDetailsEndToEnd(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("Serve did not return after task completion")
 	}
+}
+
+func TestServeUsesSupervisorLogLevelEnvironment(t *testing.T) {
+	t.Setenv(loggingLevelEnv, "ERROR")
+	t.Setenv(namespaceLevelsEnv, "example=DEBUG")
+
+	commAddr, logsAddr, commCh, logsCh, cleanup := startSupervisor(t)
+	defer cleanup()
+
+	provider := &fakeProvider{
+		register: func(r bundlev1.Registry) error {
+			r.AddDag("dag1").AddTaskWithName("logging", func(logger *slog.Logger) error {
+				logger.Info("global filtered")
+				logger.With("logger", "example.child").Debug("namespace debug")
+				logger.With("logger", "unrelated").Warn("unrelated filtered")
+				logger.Error("global error")
+				return nil
+			})
+			return nil
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- Serve(provider, commAddr, logsAddr) }()
+
+	commConn := <-commCh
+	defer commConn.Close()
+	logsConn := <-logsCh
+	defer logsConn.Close()
+	require.NoError(t, commConn.SetDeadline(time.Now().Add(10*time.Second)))
+	require.NoError(t, logsConn.SetDeadline(time.Now().Add(10*time.Second)))
+
+	payload, err := encodeRequest(0, map[string]any{
+		"type": "StartupDetails",
+		"ti": map[string]any{
+			"id":         "550e8400-e29b-41d4-a716-446655440000",
+			"dag_id":     "dag1",
+			"task_id":    "logging",
+			"run_id":     "run1",
+			"try_number": 1,
+		},
+		"bundle_info": map[string]any{"name": "fake", "version": "1.0"},
+	})
+	require.NoError(t, err)
+	require.NoError(t, writeFrame(commConn, payload))
+
+	frame, err := readFrame(commConn)
+	require.NoError(t, err)
+	require.True(t, isNilRaw(frame.Err))
+	assert.Equal(t, "SucceedTask", peekBodyType(frame.Body))
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve did not return after task completion")
+	}
+
+	output, err := io.ReadAll(logsConn)
+	require.NoError(t, err)
+	var events []string
+	for line := range strings.Lines(string(output)) {
+		var entry map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &entry))
+		events = append(events, entry["event"].(string))
+	}
+	assert.Equal(t, []string{"namespace debug", "global error"}, events)
 }
 
 // TestServeClientRoundTripEndToEnd drives a task that calls back into the

--- a/go-sdk/pkg/execution/integration_test.go
+++ b/go-sdk/pkg/execution/integration_test.go
@@ -673,8 +673,8 @@ func TestServeUsesSupervisorLogLevelEnvironment(t *testing.T) {
 		register: func(r bundlev1.Registry) error {
 			r.AddDag("dag1").AddTaskWithName("logging", func(logger *slog.Logger) error {
 				logger.Info("global filtered")
-				logger.With("logger", "example.child").Debug("namespace debug")
-				logger.With("logger", "unrelated").Warn("unrelated filtered")
+				logger.WithGroup("example.child").Debug("namespace debug")
+				logger.WithGroup("unrelated").Warn("unrelated filtered")
 				logger.Error("global error")
 				return nil
 			})

--- a/go-sdk/pkg/execution/logger.go
+++ b/go-sdk/pkg/execution/logger.go
@@ -158,22 +158,20 @@ func parseLogLevel(value string) (slog.Level, bool) {
 	}
 }
 
-func getAirflowLogLevelName(level slog.Level) (string, bool) {
-	switch level {
-	case notsetLogLevel:
-		return "notset", true
-	case slog.LevelDebug:
-		return "debug", true
-	case slog.LevelInfo:
-		return "info", true
-	case slog.LevelWarn:
-		return "warning", true
-	case slog.LevelError:
-		return "error", true
-	case criticalLogLevel:
-		return "critical", true
+func getAirflowLogLevelName(level slog.Level) string {
+	switch {
+	case level < slog.LevelDebug:
+		return "notset"
+	case level < slog.LevelInfo:
+		return "debug"
+	case level < slog.LevelWarn:
+		return "info"
+	case level < slog.LevelError:
+		return "warning"
+	case level < criticalLogLevel:
+		return "error"
 	default:
-		return "", false
+		return "critical"
 	}
 }
 
@@ -263,11 +261,7 @@ func (h *SocketLogHandler) Handle(_ context.Context, r slog.Record) error {
 	if !h.filter.isEnabled(loggerName, r.Level) {
 		return nil
 	}
-	levelName, ok := getAirflowLogLevelName(r.Level)
-	if !ok {
-		return nil
-	}
-	entry["level"] = levelName
+	entry["level"] = getAirflowLogLevelName(r.Level)
 
 	line, err := json.Marshal(entry)
 	if err != nil {

--- a/go-sdk/pkg/execution/logger.go
+++ b/go-sdk/pkg/execution/logger.go
@@ -90,7 +90,6 @@ var _ slog.Handler = (*SocketLogHandler)(nil)
 type logLevelFilter struct {
 	defaultLevel    slog.Level
 	namespaceLevels map[string]slog.Level
-	minimumLevel    slog.Level
 }
 
 // NewSocketLogHandler creates a new handler. If writer is nil, messages are
@@ -126,16 +125,9 @@ func newLogLevelFilter(
 	defaultLevel slog.Level,
 	namespaceLevels map[string]slog.Level,
 ) *logLevelFilter {
-	minimumLevel := defaultLevel
-	for _, level := range namespaceLevels {
-		if level < minimumLevel {
-			minimumLevel = level
-		}
-	}
 	return &logLevelFilter{
 		defaultLevel:    defaultLevel,
 		namespaceLevels: namespaceLevels,
-		minimumLevel:    minimumLevel,
 	}
 }
 
@@ -225,13 +217,15 @@ func (h *SocketLogHandler) Connect(w io.Writer) {
 }
 
 func (h *SocketLogHandler) Enabled(_ context.Context, level slog.Level) bool {
-	// slog calls Enabled before it constructs a Record, so its logger attribute
-	// is not available yet. Admit every level that any namespace could accept;
-	// Handle applies the exact namespace threshold before buffering or writing.
-	return level >= h.filter.minimumLevel
+	return h.filter.isEnabled(h.getLoggerName(), level)
 }
 
 func (h *SocketLogHandler) Handle(_ context.Context, r slog.Record) error {
+	loggerName := h.getLoggerName()
+	if !h.filter.isEnabled(loggerName, r.Level) {
+		return nil
+	}
+
 	entry := make(map[string]any)
 
 	// Set standard fields.
@@ -257,9 +251,8 @@ func (h *SocketLogHandler) Handle(_ context.Context, r slog.Record) error {
 		return true
 	})
 
-	loggerName, _ := entry["logger"].(string)
-	if !h.filter.isEnabled(loggerName, r.Level) {
-		return nil
+	if loggerName != "" {
+		entry["logger"] = loggerName
 	}
 	entry["level"] = getAirflowLogLevelName(r.Level)
 
@@ -315,6 +308,10 @@ func (h *SocketLogHandler) WithGroup(name string) slog.Handler {
 		attrs:  h.attrs,
 		groups: append(append([]string{}, h.groups...), name),
 	}
+}
+
+func (h *SocketLogHandler) getLoggerName() string {
+	return strings.Join(h.groups, ".")
 }
 
 // groupPrefix returns the dotted prefix (including trailing ".") to apply to

--- a/go-sdk/pkg/execution/logger.go
+++ b/go-sdk/pkg/execution/logger.go
@@ -141,7 +141,7 @@ func parseLogLevel(value string) (slog.Level, bool) {
 		return slog.LevelInfo, true
 	case "WARN", "WARNING":
 		return slog.LevelWarn, true
-	case "ERROR":
+	case "ERROR", "EXCEPTION":
 		return slog.LevelError, true
 	case "CRITICAL", "FATAL":
 		return criticalLogLevel, true

--- a/go-sdk/pkg/execution/logger.go
+++ b/go-sdk/pkg/execution/logger.go
@@ -103,10 +103,16 @@ func newSocketLogHandlerFromEnv(writer io.Writer) *SocketLogHandler {
 	if !ok {
 		defaultLevel = slog.LevelInfo
 	}
-	return newSocketLogHandler(
+	namespaceLevels, invalidEntries := parseNamespaceLogLevels(os.Getenv(namespaceLevelsEnv))
+	handler := newSocketLogHandler(
 		writer,
-		newLogLevelFilter(defaultLevel, parseNamespaceLogLevels(os.Getenv(namespaceLevelsEnv))),
+		newLogLevelFilter(defaultLevel, namespaceLevels),
 	)
+	logger := slog.New(handler)
+	for _, invalidEntry := range invalidEntries {
+		logger.Error("Ignoring invalid namespace_levels entry", "entry", invalidEntry)
+	}
+	return handler
 }
 
 func newSocketLogHandler(writer io.Writer, filter *logLevelFilter) *SocketLogHandler {
@@ -167,8 +173,9 @@ func getAirflowLogLevelName(level slog.Level) string {
 	}
 }
 
-func parseNamespaceLogLevels(value string) map[string]slog.Level {
+func parseNamespaceLogLevels(value string) (map[string]slog.Level, []string) {
 	levels := make(map[string]slog.Level)
+	var invalidEntries []string
 	entries := strings.FieldsFunc(value, func(r rune) bool {
 		return r == ',' || unicode.IsSpace(r)
 	})
@@ -177,11 +184,12 @@ func parseNamespaceLogLevels(value string) map[string]slog.Level {
 		loggerName = strings.TrimSpace(loggerName)
 		level, validLevel := parseLogLevel(levelName)
 		if !ok || loggerName == "" || !validLevel {
+			invalidEntries = append(invalidEntries, entry)
 			continue
 		}
 		levels[loggerName] = level
 	}
-	return levels
+	return levels, invalidEntries
 }
 
 func (f *logLevelFilter) getLevel(loggerName string) slog.Level {

--- a/go-sdk/pkg/execution/logger.go
+++ b/go-sdk/pkg/execution/logger.go
@@ -22,9 +22,21 @@ import (
 	"encoding/json"
 	"io"
 	"log/slog"
+	"os"
 	"strings"
 	"sync"
 	"time"
+	"unicode"
+)
+
+const (
+	loggingLevelEnv    = "AIRFLOW__LOGGING__LOGGING_LEVEL"
+	namespaceLevelsEnv = "AIRFLOW__LOGGING__NAMESPACE_LEVELS"
+
+	// NOTSET sits below every supported record level. CRITICAL sits above ERROR
+	// because slog has no built-in equivalents for either Airflow level.
+	notsetLogLevel   = slog.Level(-100)
+	criticalLogLevel = slog.LevelError + 4
 )
 
 // SocketLogHandler is an slog.Handler that streams structured JSON log lines
@@ -44,7 +56,7 @@ import (
 // updating the supervisor side in lockstep.
 type SocketLogHandler struct {
 	shared *socketLogHandlerShared
-	level  slog.Level
+	filter *logLevelFilter
 	// attrs is the list of attributes accumulated via WithAttrs. Each entry's
 	// key has already been qualified with whatever groups were active at the
 	// WithAttrs call site, so a later WithGroup does NOT retroactively prefix
@@ -75,9 +87,30 @@ type socketLogHandlerShared struct {
 
 var _ slog.Handler = (*SocketLogHandler)(nil)
 
+type logLevelFilter struct {
+	defaultLevel    slog.Level
+	namespaceLevels map[string]slog.Level
+	minimumLevel    slog.Level
+}
+
 // NewSocketLogHandler creates a new handler. If writer is nil, messages are
 // buffered until Connect() is called.
 func NewSocketLogHandler(writer io.Writer, level slog.Level) *SocketLogHandler {
+	return newSocketLogHandler(writer, newLogLevelFilter(level, nil))
+}
+
+func newSocketLogHandlerFromEnv(writer io.Writer) *SocketLogHandler {
+	defaultLevel, ok := parseLogLevel(os.Getenv(loggingLevelEnv))
+	if !ok {
+		defaultLevel = slog.LevelInfo
+	}
+	return newSocketLogHandler(
+		writer,
+		newLogLevelFilter(defaultLevel, parseNamespaceLogLevels(os.Getenv(namespaceLevelsEnv))),
+	)
+}
+
+func newSocketLogHandler(writer io.Writer, filter *logLevelFilter) *SocketLogHandler {
 	shared := &socketLogHandlerShared{}
 	if writer != nil {
 		shared.writer = writer
@@ -85,8 +118,98 @@ func NewSocketLogHandler(writer io.Writer, level slog.Level) *SocketLogHandler {
 	}
 	return &SocketLogHandler{
 		shared: shared,
-		level:  level,
+		filter: filter,
 	}
+}
+
+func newLogLevelFilter(
+	defaultLevel slog.Level,
+	namespaceLevels map[string]slog.Level,
+) *logLevelFilter {
+	minimumLevel := defaultLevel
+	for _, level := range namespaceLevels {
+		if level < minimumLevel {
+			minimumLevel = level
+		}
+	}
+	return &logLevelFilter{
+		defaultLevel:    defaultLevel,
+		namespaceLevels: namespaceLevels,
+		minimumLevel:    minimumLevel,
+	}
+}
+
+func parseLogLevel(value string) (slog.Level, bool) {
+	switch strings.ToUpper(strings.TrimSpace(value)) {
+	case "NOTSET":
+		return notsetLogLevel, true
+	case "DEBUG":
+		return slog.LevelDebug, true
+	case "INFO":
+		return slog.LevelInfo, true
+	case "WARN", "WARNING":
+		return slog.LevelWarn, true
+	case "ERROR":
+		return slog.LevelError, true
+	case "CRITICAL", "FATAL":
+		return criticalLogLevel, true
+	default:
+		return 0, false
+	}
+}
+
+func getAirflowLogLevelName(level slog.Level) (string, bool) {
+	switch level {
+	case notsetLogLevel:
+		return "notset", true
+	case slog.LevelDebug:
+		return "debug", true
+	case slog.LevelInfo:
+		return "info", true
+	case slog.LevelWarn:
+		return "warning", true
+	case slog.LevelError:
+		return "error", true
+	case criticalLogLevel:
+		return "critical", true
+	default:
+		return "", false
+	}
+}
+
+func parseNamespaceLogLevels(value string) map[string]slog.Level {
+	levels := make(map[string]slog.Level)
+	entries := strings.FieldsFunc(value, func(r rune) bool {
+		return r == ',' || unicode.IsSpace(r)
+	})
+	for _, entry := range entries {
+		loggerName, levelName, ok := strings.Cut(entry, "=")
+		loggerName = strings.TrimSpace(loggerName)
+		level, validLevel := parseLogLevel(levelName)
+		if !ok || loggerName == "" || !validLevel {
+			continue
+		}
+		levels[loggerName] = level
+	}
+	return levels
+}
+
+func (f *logLevelFilter) getLevel(loggerName string) slog.Level {
+	for namespace := loggerName; namespace != ""; {
+		if level, ok := f.namespaceLevels[namespace]; ok {
+			return level
+		}
+		separator := strings.LastIndexByte(namespace, '.')
+		if separator == -1 {
+			break
+		}
+		namespace = namespace[:separator]
+	}
+	return f.defaultLevel
+}
+
+func (f *logLevelFilter) isEnabled(loggerName string, level slog.Level) bool {
+	return level >= f.getLevel(loggerName)
 }
 
 // Connect sets the writer and flushes any buffered log messages.
@@ -104,7 +227,10 @@ func (h *SocketLogHandler) Connect(w io.Writer) {
 }
 
 func (h *SocketLogHandler) Enabled(_ context.Context, level slog.Level) bool {
-	return level >= h.level
+	// slog calls Enabled before it constructs a Record, so its logger attribute
+	// is not available yet. Admit every level that any namespace could accept;
+	// Handle applies the exact namespace threshold before buffering or writing.
+	return level >= h.filter.minimumLevel
 }
 
 func (h *SocketLogHandler) Handle(_ context.Context, r slog.Record) error {
@@ -112,7 +238,6 @@ func (h *SocketLogHandler) Handle(_ context.Context, r slog.Record) error {
 
 	// Set standard fields.
 	entry["event"] = r.Message
-	entry["level"] = strings.ToLower(r.Level.String())
 	if !r.Time.IsZero() {
 		entry["timestamp"] = r.Time.Format(time.RFC3339Nano)
 	}
@@ -133,6 +258,16 @@ func (h *SocketLogHandler) Handle(_ context.Context, r slog.Record) error {
 		appendAttr(entry, prefix, a)
 		return true
 	})
+
+	loggerName, _ := entry["logger"].(string)
+	if !h.filter.isEnabled(loggerName, r.Level) {
+		return nil
+	}
+	levelName, ok := getAirflowLogLevelName(r.Level)
+	if !ok {
+		return nil
+	}
+	entry["level"] = levelName
 
 	line, err := json.Marshal(entry)
 	if err != nil {
@@ -170,7 +305,7 @@ func (h *SocketLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	}
 	return &SocketLogHandler{
 		shared: h.shared,
-		level:  h.level,
+		filter: h.filter,
 		attrs:  newAttrs,
 		groups: h.groups,
 	}
@@ -182,7 +317,7 @@ func (h *SocketLogHandler) WithGroup(name string) slog.Handler {
 	}
 	return &SocketLogHandler{
 		shared: h.shared,
-		level:  h.level,
+		filter: h.filter,
 		attrs:  h.attrs,
 		groups: append(append([]string{}, h.groups...), name),
 	}

--- a/go-sdk/pkg/execution/logger_test.go
+++ b/go-sdk/pkg/execution/logger_test.go
@@ -19,6 +19,7 @@ package execution
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -64,7 +65,104 @@ func TestSocketLogHandlerLevelFiltering(t *testing.T) {
 	var entry map[string]any
 	require.NoError(t, json.Unmarshal([]byte(lines[0]), &entry))
 	assert.Equal(t, "should appear", entry["event"])
-	assert.Equal(t, "warn", entry["level"])
+	assert.Equal(t, "warning", entry["level"])
+}
+
+func TestParseLogLevel(t *testing.T) {
+	tests := map[string]slog.Level{
+		"notset":   notsetLogLevel,
+		"DEBUG":    slog.LevelDebug,
+		" info ":   slog.LevelInfo,
+		"WARN":     slog.LevelWarn,
+		"warning":  slog.LevelWarn,
+		"ERROR":    slog.LevelError,
+		"critical": criticalLogLevel,
+		"FATAL":    criticalLogLevel,
+	}
+	for value, expected := range tests {
+		level, ok := parseLogLevel(value)
+		assert.True(t, ok, value)
+		assert.Equal(t, expected, level, value)
+	}
+
+	_, ok := parseLogLevel("verbose")
+	assert.False(t, ok)
+}
+
+func TestGetAirflowLogLevelName(t *testing.T) {
+	tests := map[slog.Level]string{
+		notsetLogLevel:   "notset",
+		slog.LevelDebug:  "debug",
+		slog.LevelInfo:   "info",
+		slog.LevelWarn:   "warning",
+		slog.LevelError:  "error",
+		criticalLogLevel: "critical",
+	}
+	for level, expected := range tests {
+		name, ok := getAirflowLogLevelName(level)
+		assert.True(t, ok, level)
+		assert.Equal(t, expected, name, level)
+	}
+
+	_, ok := getAirflowLogLevelName(slog.LevelDebug + 1)
+	assert.False(t, ok)
+}
+
+func TestParseNamespaceLogLevels(t *testing.T) {
+	assert.Equal(t, map[string]slog.Level{
+		"example":        slog.LevelWarn,
+		"example.detail": slog.LevelDebug,
+	}, parseNamespaceLogLevels(
+		"example=INFO, malformed example.detail=DEBUG example=WARNING =ERROR empty= unknown=VERBOSE",
+	))
+}
+
+func TestLogLevelFilterUsesLongestNamespacePrefix(t *testing.T) {
+	filter := newLogLevelFilter(slog.LevelError, map[string]slog.Level{
+		"example":        slog.LevelInfo,
+		"example.detail": slog.LevelDebug,
+	})
+
+	assert.Equal(t, slog.LevelDebug, filter.getLevel("example.detail.child"))
+	assert.Equal(t, slog.LevelInfo, filter.getLevel("example.other"))
+	assert.Equal(t, slog.LevelError, filter.getLevel("exampled"))
+	assert.Equal(t, slog.LevelError, filter.getLevel(""))
+}
+
+func TestSocketLogHandlerUsesEnvironmentLevelFiltering(t *testing.T) {
+	t.Setenv(loggingLevelEnv, "ERROR")
+	t.Setenv(namespaceLevelsEnv, "example=DEBUG, example.noisy=WARNING")
+
+	var buf bytes.Buffer
+	logger := slog.New(newSocketLogHandlerFromEnv(&buf))
+	logger.Info("global filtered")
+	logger.With("logger", "example.detail").Debug("namespace debug")
+	logger.With("logger", "example.noisy.child").Info("namespace filtered")
+	logger.With("logger", "example.noisy.child").Warn("namespace warning")
+	logger.With("logger", "unrelated").Warn("unrelated filtered")
+	logger.Log(context.Background(), slog.LevelDebug+1, "unsupported level")
+	logger.Error("global error")
+
+	var events []string
+	for line := range strings.Lines(buf.String()) {
+		var entry map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &entry))
+		events = append(events, entry["event"].(string))
+	}
+	assert.Equal(t, []string{"namespace debug", "namespace warning", "global error"}, events)
+}
+
+func TestSocketLogHandlerDefaultsInvalidEnvironmentLevelToInfo(t *testing.T) {
+	t.Setenv(loggingLevelEnv, "VERBOSE")
+	t.Setenv(namespaceLevelsEnv, "")
+
+	var buf bytes.Buffer
+	logger := slog.New(newSocketLogHandlerFromEnv(&buf))
+	logger.Debug("filtered")
+	logger.Info("included")
+
+	assert.Contains(t, buf.String(), `"event":"included"`)
+	assert.NotContains(t, buf.String(), "filtered")
 }
 
 func TestSocketLogHandlerBuffering(t *testing.T) {

--- a/go-sdk/pkg/execution/logger_test.go
+++ b/go-sdk/pkg/execution/logger_test.go
@@ -160,10 +160,10 @@ func TestSocketLogHandlerUsesEnvironmentLevelFiltering(t *testing.T) {
 	logger := slog.New(newSocketLogHandlerFromEnv(&buf))
 	logger.Info("global filtered")
 	logger.WithGroup("example.detail").Debug("namespace debug")
+	logger.WithGroup("example.detail").Log(context.Background(), slog.LevelDebug+1, "custom level")
 	logger.WithGroup("example.noisy.child").Info("namespace filtered")
 	logger.WithGroup("example.noisy.child").Warn("namespace warning")
 	logger.WithGroup("unrelated").Warn("unrelated filtered")
-	logger.Log(context.Background(), slog.LevelDebug+1, "unsupported level")
 	logger.Error("global error")
 
 	var entries []map[string]any
@@ -172,13 +172,15 @@ func TestSocketLogHandlerUsesEnvironmentLevelFiltering(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(line), &entry))
 		entries = append(entries, entry)
 	}
-	require.Len(t, entries, 3)
+	require.Len(t, entries, 4)
 	assert.Equal(t, "namespace debug", entries[0]["event"])
 	assert.Equal(t, "example.detail", entries[0]["logger"])
-	assert.Equal(t, "namespace warning", entries[1]["event"])
-	assert.Equal(t, "example.noisy.child", entries[1]["logger"])
-	assert.Equal(t, "global error", entries[2]["event"])
-	assert.NotContains(t, entries[2], "logger")
+	assert.Equal(t, "custom level", entries[1]["event"])
+	assert.Equal(t, "debug", entries[1]["level"])
+	assert.Equal(t, "namespace warning", entries[2]["event"])
+	assert.Equal(t, "example.noisy.child", entries[2]["logger"])
+	assert.Equal(t, "global error", entries[3]["event"])
+	assert.NotContains(t, entries[3], "logger")
 }
 
 func TestSocketLogHandlerUsesGroupNamespaceInEnabled(t *testing.T) {

--- a/go-sdk/pkg/execution/logger_test.go
+++ b/go-sdk/pkg/execution/logger_test.go
@@ -115,12 +115,29 @@ func TestGetAirflowLogLevelName(t *testing.T) {
 }
 
 func TestParseNamespaceLogLevels(t *testing.T) {
+	levels, invalidEntries := parseNamespaceLogLevels(
+		"example=INFO, malformed example.detail=DEBUG example=WARNING =ERROR empty= unknown=VERBOSE",
+	)
 	assert.Equal(t, map[string]slog.Level{
 		"example":        slog.LevelWarn,
 		"example.detail": slog.LevelDebug,
-	}, parseNamespaceLogLevels(
-		"example=INFO, malformed example.detail=DEBUG example=WARNING =ERROR empty= unknown=VERBOSE",
-	))
+	}, levels)
+	assert.Equal(t, []string{"malformed", "=ERROR", "empty=", "unknown=VERBOSE"}, invalidEntries)
+}
+
+func TestSocketLogHandlerReportsInvalidNamespaceLevels(t *testing.T) {
+	t.Setenv(loggingLevelEnv, "INFO")
+	invalidEntry := "example=DEB" + "GU"
+	t.Setenv(namespaceLevelsEnv, invalidEntry)
+
+	var buf bytes.Buffer
+	newSocketLogHandlerFromEnv(&buf)
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &entry))
+	assert.Equal(t, "Ignoring invalid namespace_levels entry", entry["event"])
+	assert.Equal(t, invalidEntry, entry["entry"])
+	assert.Equal(t, "error", entry["level"])
 }
 
 func TestLogLevelFilterUsesLongestNamespacePrefix(t *testing.T) {

--- a/go-sdk/pkg/execution/logger_test.go
+++ b/go-sdk/pkg/execution/logger_test.go
@@ -141,20 +141,37 @@ func TestSocketLogHandlerUsesEnvironmentLevelFiltering(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(newSocketLogHandlerFromEnv(&buf))
 	logger.Info("global filtered")
-	logger.With("logger", "example.detail").Debug("namespace debug")
-	logger.With("logger", "example.noisy.child").Info("namespace filtered")
-	logger.With("logger", "example.noisy.child").Warn("namespace warning")
-	logger.With("logger", "unrelated").Warn("unrelated filtered")
+	logger.WithGroup("example.detail").Debug("namespace debug")
+	logger.WithGroup("example.noisy.child").Info("namespace filtered")
+	logger.WithGroup("example.noisy.child").Warn("namespace warning")
+	logger.WithGroup("unrelated").Warn("unrelated filtered")
 	logger.Log(context.Background(), slog.LevelDebug+1, "unsupported level")
 	logger.Error("global error")
 
-	var events []string
+	var entries []map[string]any
 	for line := range strings.Lines(buf.String()) {
 		var entry map[string]any
 		require.NoError(t, json.Unmarshal([]byte(line), &entry))
-		events = append(events, entry["event"].(string))
+		entries = append(entries, entry)
 	}
-	assert.Equal(t, []string{"namespace debug", "namespace warning", "global error"}, events)
+	require.Len(t, entries, 3)
+	assert.Equal(t, "namespace debug", entries[0]["event"])
+	assert.Equal(t, "example.detail", entries[0]["logger"])
+	assert.Equal(t, "namespace warning", entries[1]["event"])
+	assert.Equal(t, "example.noisy.child", entries[1]["logger"])
+	assert.Equal(t, "global error", entries[2]["event"])
+	assert.NotContains(t, entries[2], "logger")
+}
+
+func TestSocketLogHandlerUsesGroupNamespaceInEnabled(t *testing.T) {
+	filter := newLogLevelFilter(slog.LevelError, map[string]slog.Level{"example": slog.LevelDebug})
+	handler := newSocketLogHandler(nil, filter)
+
+	assert.True(
+		t,
+		handler.WithGroup("example.detail").Enabled(context.Background(), slog.LevelDebug),
+	)
+	assert.False(t, handler.WithGroup("unrelated").Enabled(context.Background(), slog.LevelWarn))
 }
 
 func TestSocketLogHandlerDefaultsInvalidEnvironmentLevelToInfo(t *testing.T) {
@@ -214,6 +231,7 @@ func TestSocketLogHandlerWithGroup(t *testing.T) {
 	var entry map[string]any
 	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &entry))
 	assert.Equal(t, "val", entry["grp.key"])
+	assert.Equal(t, "grp", entry["logger"])
 }
 
 // TestSocketLogHandlerInlineGroup verifies that an inline slog.Group passed as

--- a/go-sdk/pkg/execution/logger_test.go
+++ b/go-sdk/pkg/execution/logger_test.go
@@ -91,21 +91,26 @@ func TestParseLogLevel(t *testing.T) {
 
 func TestGetAirflowLogLevelName(t *testing.T) {
 	tests := map[slog.Level]string{
-		notsetLogLevel:   "notset",
-		slog.LevelDebug:  "debug",
-		slog.LevelInfo:   "info",
-		slog.LevelWarn:   "warning",
-		slog.LevelError:  "error",
-		criticalLogLevel: "critical",
+		notsetLogLevel:       "notset",
+		slog.LevelDebug - 1:  "notset",
+		slog.LevelDebug:      "debug",
+		slog.LevelDebug + 1:  "debug",
+		slog.LevelInfo - 1:   "debug",
+		slog.LevelInfo:       "info",
+		slog.LevelInfo + 1:   "info",
+		slog.LevelWarn - 1:   "info",
+		slog.LevelWarn:       "warning",
+		slog.LevelWarn + 1:   "warning",
+		slog.LevelError - 1:  "warning",
+		slog.LevelError:      "error",
+		slog.LevelError + 1:  "error",
+		criticalLogLevel - 1: "error",
+		criticalLogLevel:     "critical",
+		criticalLogLevel + 1: "critical",
 	}
 	for level, expected := range tests {
-		name, ok := getAirflowLogLevelName(level)
-		assert.True(t, ok, level)
-		assert.Equal(t, expected, name, level)
+		assert.Equal(t, expected, getAirflowLogLevelName(level), level)
 	}
-
-	_, ok := getAirflowLogLevelName(slog.LevelDebug + 1)
-	assert.False(t, ok)
 }
 
 func TestParseNamespaceLogLevels(t *testing.T) {

--- a/go-sdk/pkg/execution/logger_test.go
+++ b/go-sdk/pkg/execution/logger_test.go
@@ -70,14 +70,15 @@ func TestSocketLogHandlerLevelFiltering(t *testing.T) {
 
 func TestParseLogLevel(t *testing.T) {
 	tests := map[string]slog.Level{
-		"notset":   notsetLogLevel,
-		"DEBUG":    slog.LevelDebug,
-		" info ":   slog.LevelInfo,
-		"WARN":     slog.LevelWarn,
-		"warning":  slog.LevelWarn,
-		"ERROR":    slog.LevelError,
-		"critical": criticalLogLevel,
-		"FATAL":    criticalLogLevel,
+		"notset":    notsetLogLevel,
+		"DEBUG":     slog.LevelDebug,
+		" info ":    slog.LevelInfo,
+		"WARN":      slog.LevelWarn,
+		"warning":   slog.LevelWarn,
+		"ERROR":     slog.LevelError,
+		"exception": slog.LevelError,
+		"critical":  criticalLogLevel,
+		"FATAL":     criticalLogLevel,
 	}
 	for value, expected := range tests {
 		level, ok := parseLogLevel(value)

--- a/go-sdk/pkg/execution/logger_test.go
+++ b/go-sdk/pkg/execution/logger_test.go
@@ -342,6 +342,21 @@ func TestSocketLogHandlerKeyMapping(t *testing.T) {
 	assert.False(t, hasTime)
 }
 
+func TestSocketLogHandlerStandardFieldsOverrideAttrs(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewSocketLogHandler(&buf, slog.LevelDebug)
+	logger := slog.New(handler).
+		With("level", "custom", "logger", "custom").
+		WithGroup("example")
+
+	logger.Info("message")
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &entry))
+	assert.Equal(t, "info", entry["level"])
+	assert.Equal(t, "example", entry["logger"])
+}
+
 // TestSocketLogHandlerStringifiesErrorAttr verifies that an attribute whose
 // value is a stock `error` is rendered as its .Error() string. Without value
 // resolution the underlying struct's unexported fields would be marshaled as

--- a/go-sdk/pkg/execution/server.go
+++ b/go-sdk/pkg/execution/server.go
@@ -92,7 +92,7 @@ func Serve(provider bundlev1.BundleProvider, commAddr, logsAddr string) error {
 	// Buffer log records until the logs socket is connected. Anything the
 	// runtime emits between Connect-time and the first frame still gets
 	// flushed.
-	logHandler := NewSocketLogHandler(nil, slog.LevelDebug)
+	logHandler := newSocketLogHandlerFromEnv(nil)
 	logger := slog.New(logHandler)
 	slog.SetDefault(logger)
 


### PR DESCRIPTION
## Why

Coordinator-mode Go tasks currently transmit records below Airflow's configured logging thresholds. This diverges from Python task behavior and overstates Go task-logging compatibility.

## What

- Read the global and namespace thresholds propagated by the supervisor when the Go runtime starts.
- Apply longest dotted-prefix matching to the structured `logger` attribute and filter records before buffering or socket transmission.
- Normalize Go log levels to Airflow's supported names and drop unsupported levels.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
