### PR TITLE
Warn when inline gitSync SSH keys lack known hosts

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -83,7 +83,7 @@ WARNING:
 {{- end }}
 {{- end }}
 
-{{- if and .Values.dags.gitSync.enabled .Values.dags.gitSync.sshKeySecret (not .Values.dags.gitSync.knownHosts)}}
+{{- if and .Values.dags.gitSync.enabled (or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey) (not .Values.dags.gitSync.knownHosts)}}
 
 #####################################################
 #  WARNING: You should set dags.gitSync.knownHosts  #

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -182,7 +182,7 @@ WARNING:
 {{- end }}
 {{- end }}
 
-{{- if and .Values.dags.gitSync.enabled .Values.dags.gitSync.sshKeySecret (not .Values.dags.gitSync.knownHosts)}}
+{{- if and .Values.dags.gitSync.enabled (or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey) (not .Values.dags.gitSync.knownHosts)}}
 
 #####################################################
 #  WARNING: You should set dags.gitSync.knownHosts  #


### PR DESCRIPTION
The Helm chart supports both a named `dags.gitSync.sshKeySecret` and an inline `dags.gitSync.sshKey` for SSH authentication. However, the post-install notes only warned about missing `knownHosts` configuration for the named-secret path, so inline-key users could miss the same host-verification warning.

Include both SSH key sources in the warning condition while continuing to suppress the warning when `knownHosts` is configured.

## Testing

- `breeze testing helm-tests --test-type airflow_aux -- -q` (`665 passed`)
- `prek run --files chart/templates/NOTES.txt --stage pre-commit`
- `helm lint chart` with Helm 3.19
- Helm 4 client-side dry-run matrix covering inline key, named secret, configured known hosts, and no SSH key

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes — Codex (GPT-5) was used as an assistant.

Developed and reviewed by @LE0-Lin with assistance from Codex (GPT-5), following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions).