### PR TITLE
Clarify Breeze CI image build helper names

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
@@ -143,7 +143,7 @@ def check_if_image_building_is_needed(ci_image_params: BuildCiParams, output: Ou
     if result.returncode != 0:
         return True
     if not ci_image_params.force_build and not ci_image_params.upgrade_to_newer_dependencies:
-        if not should_we_run_the_build(build_ci_params=ci_image_params):
+        if not confirm_build_if_sources_changed(build_ci_params=ci_image_params):
             return False
     return True
 
@@ -765,10 +765,9 @@ def is_ci_image_built_from_current_sources(ci_image_params: BuildCiParams) -> bo
     return image_sources_hash == calculate_ci_sources_hash()
 
 
-def should_we_run_the_build(build_ci_params: BuildCiParams) -> bool:
+def confirm_build_if_sources_changed(build_ci_params: BuildCiParams) -> bool:
     """
-    Check if we should run the build based on what files have been modified since last build and answer from
-    the user.
+    Confirm whether to build based on important source changes and the user's answer.
 
     * If the image already matches current sources (e.g. it was built in another git worktree
       sharing the same Docker daemon), the local build cache is refreshed and no build is needed
@@ -926,9 +925,9 @@ def run_build_ci_image(
     return build_command_result.returncode, f"Image build: {param_description}"
 
 
-def rebuild_or_pull_ci_image_if_needed(command_params: ShellParams | BuildCiParams) -> None:
+def build_ci_image_if_needed(command_params: ShellParams | BuildCiParams) -> None:
     """
-    Rebuilds CI image if needed and user confirms it.
+    Build the CI image if needed and the user confirms it.
 
     :param command_params: parameters of the command to execute
     """

--- a/dev/breeze/src/airflow_breeze/commands/developer_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/developer_commands.py
@@ -31,7 +31,7 @@ from time import sleep
 import click
 
 from airflow_breeze.branch_defaults import DEFAULT_AIRFLOW_CONSTRAINTS_BRANCH
-from airflow_breeze.commands.ci_image_commands import rebuild_or_pull_ci_image_if_needed
+from airflow_breeze.commands.ci_image_commands import build_ci_image_if_needed
 from airflow_breeze.commands.common_options import (
     argument_doc_packages,
     option_airflow_extras,
@@ -506,7 +506,7 @@ def shell(
         warn_image_upgrade_needed=warn_image_upgrade_needed,
     )
     perform_environment_checks(quiet=shell_params.quiet)
-    rebuild_or_pull_ci_image_if_needed(command_params=shell_params)
+    build_ci_image_if_needed(command_params=shell_params)
     result = enter_shell(shell_params=shell_params)
     fix_ownership_using_docker()
     sys.exit(result.returncode)
@@ -737,7 +737,7 @@ def start_airflow(
         use_distributions_from_dist=use_distributions_from_dist,
         use_uv=use_uv,
     )
-    rebuild_or_pull_ci_image_if_needed(command_params=shell_params)
+    build_ci_image_if_needed(command_params=shell_params)
     result = enter_shell(shell_params=shell_params)
     fix_ownership_using_docker()
     if CELERY_INTEGRATION in integration and executor not in ALLOWED_CELERY_EXECUTORS:
@@ -908,7 +908,7 @@ def _build_python_docs(
         python=DEFAULT_PYTHON_MAJOR_MINOR_VERSION,
         builder=builder,
     )
-    rebuild_or_pull_ci_image_if_needed(command_params=build_params)
+    build_ci_image_if_needed(command_params=build_params)
     if clean_build:
         directories_to_clean = ["_build", "_doctrees", "apis"]
     else:
@@ -1279,7 +1279,7 @@ def autogenerate(
     build_params = BuildCiParams(
         github_repository=github_repository, python=DEFAULT_PYTHON_MAJOR_MINOR_VERSION, builder=builder
     )
-    rebuild_or_pull_ci_image_if_needed(command_params=build_params)
+    build_ci_image_if_needed(command_params=build_params)
     shell_params = ShellParams(
         github_repository=github_repository,
         python=DEFAULT_PYTHON_MAJOR_MINOR_VERSION,
@@ -1410,7 +1410,7 @@ def run(
     """
     import uuid
 
-    from airflow_breeze.commands.ci_image_commands import rebuild_or_pull_ci_image_if_needed
+    from airflow_breeze.commands.ci_image_commands import build_ci_image_if_needed
     from airflow_breeze.params.shell_params import ShellParams
     from airflow_breeze.utils.ci_group import ci_group
     from airflow_breeze.utils.docker_command_utils import (
@@ -1462,8 +1462,7 @@ def run(
         console_print(f"[info]Running command in Breeze: {full_command}[/]")
         console_print(f"[info]Using project name: {unique_project_name}[/]")
 
-    # Build or pull the CI image if needed
-    rebuild_or_pull_ci_image_if_needed(command_params=shell_params)
+    build_ci_image_if_needed(command_params=shell_params)
 
     # Execute the command in the shell, cleaning up Docker resources afterward
     try:

--- a/dev/breeze/src/airflow_breeze/commands/registry_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/registry_commands.py
@@ -26,7 +26,7 @@ from pathlib import Path
 import click
 import yaml
 
-from airflow_breeze.commands.ci_image_commands import rebuild_or_pull_ci_image_if_needed
+from airflow_breeze.commands.ci_image_commands import build_ci_image_if_needed
 from airflow_breeze.commands.common_options import option_dry_run, option_python, option_verbose
 from airflow_breeze.params.shell_params import ShellParams
 from airflow_breeze.utils.ci_group import ci_group
@@ -97,7 +97,7 @@ def extract_data(python: str, provider: str | None, allow_unreleased: bool):
         extra_args=(),
     )
 
-    rebuild_or_pull_ci_image_if_needed(command_params=shell_params)
+    build_ci_image_if_needed(command_params=shell_params)
 
     # Install suspended providers that aren't in the CI image so runtime
     # discovery (issubclass) can find their classes.
@@ -313,7 +313,7 @@ def _backfill_docker(
         extra_args=(),
     )
 
-    rebuild_or_pull_ci_image_if_needed(command_params=shell_params)
+    build_ci_image_if_needed(command_params=shell_params)
 
     # Place isolated providers.json under dev/registry/ so it's visible inside the container
     # at /opt/airflow/dev/registry/

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -44,7 +44,7 @@ from rich.progress import Progress
 from rich.syntax import Syntax
 
 from airflow_breeze.branch_defaults import AIRFLOW_BRANCH
-from airflow_breeze.commands.ci_image_commands import rebuild_or_pull_ci_image_if_needed
+from airflow_breeze.commands.ci_image_commands import build_ci_image_if_needed
 from airflow_breeze.commands.common_options import (
     argument_doc_packages,
     option_airflow_extras,
@@ -1787,7 +1787,7 @@ def install_provider_distributions(
         use_airflow_version=use_airflow_version,
         use_distributions_from_dist=use_distributions_from_dist,
     )
-    rebuild_or_pull_ci_image_if_needed(command_params=shell_params)
+    build_ci_image_if_needed(command_params=shell_params)
     if run_in_parallel:
         list_of_all_providers = get_all_providers_in_dist(
             distribution_format=distribution_format, install_selected_providers=install_selected_providers
@@ -1926,7 +1926,7 @@ def verify_provider_distributions(
         use_airflow_version=use_airflow_version,
         use_distributions_from_dist=use_distributions_from_dist,
     )
-    rebuild_or_pull_ci_image_if_needed(command_params=shell_params)
+    build_ci_image_if_needed(command_params=shell_params)
     result_command = execute_command_in_shell(
         shell_params,
         project_name="breeze-providers",
@@ -4989,7 +4989,7 @@ def version_check(
         python=python,
         builder=builder,
     )
-    rebuild_or_pull_ci_image_if_needed(command_params=build_params)
+    build_ci_image_if_needed(command_params=build_params)
     if os.environ.get("CI", "false") == "true":
         # Show output outside the group in CI
         print("::endgroup::")

--- a/dev/breeze/src/airflow_breeze/commands/testing_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/testing_commands.py
@@ -29,7 +29,7 @@ from time import sleep
 import click
 from click import IntRange
 
-from airflow_breeze.commands.ci_image_commands import rebuild_or_pull_ci_image_if_needed
+from airflow_breeze.commands.ci_image_commands import build_ci_image_if_needed
 from airflow_breeze.commands.common_options import (
     option_airflow_ui_base_url,
     option_allow_pre_releases,
@@ -1427,7 +1427,7 @@ def python_api_client_tests(
         install_airflow_python_client=True,
         start_api_server_with_examples=True,
     )
-    rebuild_or_pull_ci_image_if_needed(command_params=shell_params)
+    build_ci_image_if_needed(command_params=shell_params)
     fix_ownership_using_docker()
     cleanup_python_generated_files()
     perform_environment_checks()
@@ -1953,7 +1953,7 @@ def _run_test_command(
         run_tests=True,
         db_reset=db_reset if not skip_db_tests else False,
     )
-    rebuild_or_pull_ci_image_if_needed(command_params=shell_params)
+    build_ci_image_if_needed(command_params=shell_params)
     fix_ownership_using_docker()
     cleanup_python_generated_files()
     perform_environment_checks()

--- a/dev/breeze/tests/test_ci_image_commands.py
+++ b/dev/breeze/tests/test_ci_image_commands.py
@@ -23,10 +23,10 @@ from unittest import mock
 import pytest
 
 from airflow_breeze.commands.ci_image_commands import (
+    build_ci_image_if_needed,
+    confirm_build_if_sources_changed,
     get_ci_image_sources_hash_label,
     is_ci_image_built_from_current_sources,
-    rebuild_or_pull_ci_image_if_needed,
-    should_we_run_the_build,
 )
 from airflow_breeze.global_constants import CI_IMAGE_SOURCES_HASH_LABEL
 from airflow_breeze.params.build_ci_params import BuildCiParams
@@ -92,26 +92,26 @@ def test_is_ci_image_built_from_current_sources(
 
 @mock.patch("airflow_breeze.commands.ci_image_commands.mark_image_as_rebuilt")
 @mock.patch("airflow_breeze.commands.ci_image_commands.is_ci_image_built_from_current_sources")
-def test_should_we_run_the_build_skips_build_when_image_matches_current_sources(
+def test_confirm_build_if_sources_changed_skips_build_when_image_matches_current_sources(
     mock_is_ci_image_built_from_current_sources, mock_mark_image_as_rebuilt
 ):
     mock_is_ci_image_built_from_current_sources.return_value = True
     build_ci_params = BuildCiParams()
-    assert should_we_run_the_build(build_ci_params) is False
+    assert confirm_build_if_sources_changed(build_ci_params) is False
     mock_mark_image_as_rebuilt.assert_called_once_with(ci_image_params=build_ci_params)
 
 
 @mock.patch("airflow_breeze.commands.ci_image_commands.md5sum_check_if_build_is_needed")
 @mock.patch("airflow_breeze.commands.ci_image_commands.mark_image_as_rebuilt")
 @mock.patch("airflow_breeze.commands.ci_image_commands.is_ci_image_built_from_current_sources")
-def test_should_we_run_the_build_falls_back_to_md5_check_when_image_does_not_match(
+def test_confirm_build_if_sources_changed_falls_back_to_md5_check_when_image_does_not_match(
     mock_is_ci_image_built_from_current_sources,
     mock_mark_image_as_rebuilt,
     mock_md5sum_check_if_build_is_needed,
 ):
     mock_is_ci_image_built_from_current_sources.return_value = False
     mock_md5sum_check_if_build_is_needed.return_value = False
-    assert should_we_run_the_build(BuildCiParams()) is False
+    assert confirm_build_if_sources_changed(BuildCiParams()) is False
     mock_mark_image_as_rebuilt.assert_not_called()
     mock_md5sum_check_if_build_is_needed.assert_called_once()
 
@@ -119,7 +119,7 @@ def test_should_we_run_the_build_falls_back_to_md5_check_when_image_does_not_mat
 @mock.patch("airflow_breeze.commands.ci_image_commands.run_build_ci_image")
 @mock.patch("airflow_breeze.commands.ci_image_commands.mark_image_as_rebuilt")
 @mock.patch("airflow_breeze.commands.ci_image_commands.is_ci_image_built_from_current_sources")
-def test_rebuild_or_pull_reuses_image_built_in_another_checkout(
+def test_build_ci_image_if_needed_reuses_image_built_in_another_checkout(
     mock_is_ci_image_built_from_current_sources,
     mock_mark_image_as_rebuilt,
     mock_run_build_ci_image,
@@ -128,7 +128,7 @@ def test_rebuild_or_pull_reuses_image_built_in_another_checkout(
 ):
     monkeypatch.setattr("airflow_breeze.commands.ci_image_commands.BUILD_CACHE_PATH", tmp_path)
     mock_is_ci_image_built_from_current_sources.return_value = True
-    rebuild_or_pull_ci_image_if_needed(command_params=BuildCiParams())
+    build_ci_image_if_needed(command_params=BuildCiParams())
     mock_mark_image_as_rebuilt.assert_called_once()
     mock_run_build_ci_image.assert_not_called()
 
@@ -136,7 +136,7 @@ def test_rebuild_or_pull_reuses_image_built_in_another_checkout(
 @mock.patch("airflow_breeze.commands.ci_image_commands.check_if_image_building_is_needed")
 @mock.patch("airflow_breeze.commands.ci_image_commands.run_build_ci_image")
 @mock.patch("airflow_breeze.commands.ci_image_commands.is_ci_image_built_from_current_sources")
-def test_rebuild_or_pull_forces_build_when_image_does_not_match_sources(
+def test_build_ci_image_if_needed_forces_build_when_image_does_not_match_sources(
     mock_is_ci_image_built_from_current_sources,
     mock_run_build_ci_image,
     mock_check_if_image_building_is_needed,
@@ -147,7 +147,7 @@ def test_rebuild_or_pull_forces_build_when_image_does_not_match_sources(
     mock_is_ci_image_built_from_current_sources.return_value = False
     mock_check_if_image_building_is_needed.return_value = True
     mock_run_build_ci_image.return_value = (0, "built")
-    rebuild_or_pull_ci_image_if_needed(command_params=BuildCiParams())
+    build_ci_image_if_needed(command_params=BuildCiParams())
     assert mock_check_if_image_building_is_needed.call_args.kwargs["ci_image_params"].force_build is True
     mock_run_build_ci_image.assert_called_once()
 
@@ -155,7 +155,7 @@ def test_rebuild_or_pull_forces_build_when_image_does_not_match_sources(
 @mock.patch("airflow_breeze.commands.ci_image_commands.check_if_image_building_is_needed")
 @mock.patch("airflow_breeze.commands.ci_image_commands.run_build_ci_image")
 @mock.patch("airflow_breeze.commands.ci_image_commands.is_ci_image_built_from_current_sources")
-def test_rebuild_or_pull_does_not_reuse_image_when_force_build_requested(
+def test_build_ci_image_if_needed_does_not_reuse_image_when_force_build_requested(
     mock_is_ci_image_built_from_current_sources,
     mock_run_build_ci_image,
     mock_check_if_image_building_is_needed,
@@ -165,14 +165,14 @@ def test_rebuild_or_pull_does_not_reuse_image_when_force_build_requested(
     monkeypatch.setattr("airflow_breeze.commands.ci_image_commands.BUILD_CACHE_PATH", tmp_path)
     mock_check_if_image_building_is_needed.return_value = True
     mock_run_build_ci_image.return_value = (0, "built")
-    rebuild_or_pull_ci_image_if_needed(command_params=BuildCiParams(force_build=True))
+    build_ci_image_if_needed(command_params=BuildCiParams(force_build=True))
     mock_is_ci_image_built_from_current_sources.assert_not_called()
     mock_run_build_ci_image.assert_called_once()
 
 
 @mock.patch("airflow_breeze.commands.ci_image_commands.check_if_image_building_is_needed")
 @mock.patch("airflow_breeze.commands.ci_image_commands.is_ci_image_built_from_current_sources")
-def test_rebuild_or_pull_does_not_query_docker_when_marker_present(
+def test_build_ci_image_if_needed_does_not_query_docker_when_marker_present(
     mock_is_ci_image_built_from_current_sources,
     mock_check_if_image_building_is_needed,
     tmp_path,
@@ -184,5 +184,5 @@ def test_rebuild_or_pull_does_not_query_docker_when_marker_present(
     marker.parent.mkdir(parents=True)
     marker.touch()
     mock_check_if_image_building_is_needed.return_value = False
-    rebuild_or_pull_ci_image_if_needed(command_params=command_params)
+    build_ci_image_if_needed(command_params=command_params)
     mock_is_ci_image_built_from_current_sources.assert_not_called()

--- a/dev/breeze/tests/test_developer_commands.py
+++ b/dev/breeze/tests/test_developer_commands.py
@@ -51,23 +51,21 @@ class TestBuildDocsPythonVersion:
 
     def _invoke(self, runner: CliRunner, args: list[str], env: dict[str, str] | None = None):
         with (
-            patch(
-                "airflow_breeze.commands.developer_commands.rebuild_or_pull_ci_image_if_needed"
-            ) as mock_rebuild,
+            patch("airflow_breeze.commands.developer_commands.build_ci_image_if_needed") as mock_build,
             patch("airflow_breeze.commands.developer_commands.execute_command_in_shell") as mock_shell,
         ):
             mock_shell.return_value.returncode = 0
             runner.invoke(build_docs, args, env=env, catch_exceptions=False)
-        return mock_rebuild, mock_shell
+        return mock_build, mock_shell
 
     def test_environment_python_does_not_change_the_docs_build(self, runner):
         # PYTHON_MAJOR_MINOR_VERSION is set on every job of the docs publishing workflow, so an
         # option reading it silently decided what the docs were built with.
-        mock_rebuild, mock_shell = self._invoke(
+        mock_build, mock_shell = self._invoke(
             runner, ["--docs-only"], env={"PYTHON_MAJOR_MINOR_VERSION": "3.12"}
         )
 
-        assert mock_rebuild.call_args.kwargs["command_params"].python == DEFAULT_PYTHON_MAJOR_MINOR_VERSION
+        assert mock_build.call_args.kwargs["command_params"].python == DEFAULT_PYTHON_MAJOR_MINOR_VERSION
         assert mock_shell.call_args.args[0].python == DEFAULT_PYTHON_MAJOR_MINOR_VERSION
 
     def test_python_option_is_rejected(self, runner):


### PR DESCRIPTION
## Why
While I was adding cross-worktree image reuse in #71886, some of the functions' name makes the code tracing harder:
- `rebuild_or_pull_ci_image_if_needed`: it was introduced in #24402, when passing an image tag made the helper pull that CI image. The "pull" path was later removed, but the old name remained. 
- `check_if_image_building_is_needed` calls `should_we_run_the_build`; the similar names hide that the inner helper checks source changes and asks the user for confirmation.

## What

Rename the helpers to `build_ci_image_if_needed` and `confirm_build_if_sources_changed`. Update their call sites, docstrings, mocks, and test names without changing behavior.

related: #71886

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code and Codex (GPT-5)

Generated-by: Claude Code and Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)