### PR TITLE
Make LocalExecutor hold a parallelism slot per dispatched workload

### DIFF
--- a/airflow-core/newsfragments/71914.bugfix.rst
+++ b/airflow-core/newsfragments/71914.bugfix.rst
@@ -1,0 +1,1 @@
+``LocalExecutor`` now counts dispatched workloads against ``core.parallelism``. The executor never recorded dispatched work in its running set, so every slot read as free the moment work was handed to a worker and the scheduler admitted task instances without bound, leaving pool size as the only ceiling.

--- a/airflow-core/src/airflow/executors/local_executor.py
+++ b/airflow-core/src/airflow/executors/local_executor.py
@@ -320,6 +320,11 @@ class LocalExecutor(BaseExecutor):
             )
             if not removed:
                 raise KeyError(f"Workload {workload.key} was not found in any queue")
+            # The workload holds a parallelism slot from dispatch until a worker reports its
+            # result, at which point change_state() releases it. Without this the executor
+            # reports every slot free the moment it hands work off, and the scheduler keeps
+            # admitting more.
+            self.running.add(workload.key)
         with self._unread_messages:
             self._unread_messages.value += len(workload_list)
         self._check_workers()

--- a/airflow-core/tests/unit/executors/test_local_executor.py
+++ b/airflow-core/tests/unit/executors/test_local_executor.py
@@ -239,6 +239,59 @@ class TestLocalExecutor:
             assert executor.event_buffer[ti.key][0] == State.SUCCESS
         assert executor.event_buffer[fail_ti.key][0] == State.FAILED
 
+    @mock.patch.object(LocalExecutor, "_check_workers", new=mock.MagicMock())
+    def test_dispatched_workloads_occupy_parallelism_slots(self):
+        """A dispatched workload holds a slot until its result comes back.
+
+        The scheduler admits work using ``slots_available`` and ``slots_occupied``, both of which
+        count ``running``. If dispatch does not record the workload there, every slot reads free
+        the moment the executor hands work off and ``core.parallelism`` stops capping anything.
+        """
+        parallelism = 2
+        executor = LocalExecutor(parallelism=parallelism)
+        executor.activity_queue = mock.MagicMock()
+        executor._unread_messages = mock.MagicMock()
+        executor._unread_messages.value = 0
+
+        keys = []
+        for i in range(parallelism):
+            ti = TaskInstanceDTO(
+                id=uuid7(),
+                task_id=f"task_{i}",
+                dag_id="test_dag",
+                run_id="run-1",
+                try_number=1,
+                map_index=-1,
+                pool_slots=1,
+                queue="default",
+                priority_weight=1,
+                executor_config={},
+                queued_dttm=timezone.utcnow(),
+                dag_version_id=uuid7(),
+            )
+            workload = workloads.ExecuteTask(
+                token="",
+                ti=ti,
+                dag_rel_path="some/path",
+                log_path=None,
+                bundle_info=dict(name="hi", version="hi"),
+            )
+            keys.append(workload.key)
+            executor.queue_workload(workload, session=mock.MagicMock(spec=Session))
+
+        executor._process_workloads(list(executor.queued_tasks.values()))
+
+        assert executor.slots_occupied == parallelism
+        assert executor.slots_available == 0
+        # The scheduler also uses this to tell "I already dispatched this" from a stale event.
+        assert executor.has_task(mock.Mock(id=keys[0], key=keys[0])) is True
+
+        executor.change_state(keys[0], State.SUCCESS)
+
+        assert executor.slots_occupied == parallelism - 1
+        assert executor.slots_available == 1
+        assert executor.has_task(mock.Mock(id=keys[0], key=keys[0])) is False
+
     @mock.patch("airflow.executors.local_executor.LocalExecutor.sync")
     @mock.patch("airflow.executors.base_executor.BaseExecutor.trigger_tasks")
     @mock.patch("airflow.executors.base_executor.stats.gauge")


### PR DESCRIPTION
`core.parallelism` caps nothing on LocalExecutor. With `parallelism = 4`, admitting `slots_available` workloads per scheduler loop and dispatching them:

```
loop 1: accepted=4  dispatched_total=4   running=0  slots_available=4
loop 2: accepted=4  dispatched_total=8   running=0  slots_available=4
loop 3: accepted=4  dispatched_total=12  running=0  slots_available=4
loop 4: accepted=4  dispatched_total=16  running=0  slots_available=4
loop 5: accepted=4  dispatched_total=20  running=0  slots_available=4
```

Twenty workloads dispatched against a limit of four, and the executor reports full capacity throughout. `config.yml` documents the option as "the maximum number of task instances that can run concurrently per scheduler in Airflow, regardless of the worker count."

### Root cause

`LocalExecutor._process_workloads` puts each workload on the activity queue and pops it from the queued dicts, but never records it in `self.running`. Every other executor does at dispatch — celery, kubernetes, ecs, batch and lambda all call `self.running.add(key)` in their `_process_workloads`. A grep for `running.add` in airflow-core returns nothing.

The scheduler enforces parallelism by reading exactly this set: `slots_available` and `slots_occupied` are computed from `len(self.running)` plus the queued dicts, and `heartbeat` computes `open_slots = self.parallelism - len(self.running)`. With `running` permanently empty, every slot reads free the moment work is handed to a worker, and the scheduler keeps admitting more. The only remaining ceiling is pool size, so with the defaults 128 task instances can be outstanding against 32 workers, and the excess accumulates in the `activity_queue` OS pipe.

This is a regression from #51009, which removed the Airflow 2 code path in executors. The deleted `BaseExecutor._process_tasks` held core's only `self.running.add(key)`, and LocalExecutor was the one in-tree executor relying on the base class for it.

Two second-order effects of the empty set: `has_task()` can never return True, so the "this scheduler has this task already" guard in `process_executor_events` never suppresses a stale event for LocalExecutor; and unbounded admission is what lets the activity-queue pipe fill, which is the precondition for the dispatch deadlock reported in #70526. This PR restores the accounting; it does not claim to fix that deadlock.

### Fix

Record the workload in `running` at dispatch. The release path already exists and is what every terminal state flows through: `sync()` drains the result queue into `change_state()`, which removes the key. The new test pins the full cycle — dispatch occupies a slot, `slots_available` reaches zero at parallelism, `has_task()` sees the dispatched workload, and the result releases the slot.

related: #51009
related: #70526

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)