### PR TITLE
Fix Azure AD tenant identifier canonicalization in FAB auth manager

### DIFF
--- a/providers/fab/docs/auth-manager/sso.rst
+++ b/providers/fab/docs/auth-manager/sso.rst
@@ -181,6 +181,14 @@ Provider Examples
        }
    ]
 
+.. note::
+   The ``<tenant-id>`` in the Azure endpoints can be specified as a tenant GUID
+   (e.g., ``72f988bf-86f1-41af-91ab-2d7cd011db47``) or as a tenant domain (e.g.,
+   ``contoso.onmicrosoft.com`` or ``example.com``). Alternatively, you can specify
+   the tenant explicitly by setting ``tenant_id`` inside ``client_kwargs``. Tenant-agnostic
+   authorities (``common``, ``organizations``, ``consumers``) are not accepted; configure a
+   specific tenant GUID or domain instead.
+
 .. seealso::
    For Azure app registration and OAuth setup, see :doc:`apache-airflow-providers-microsoft-azure:connections/azure`
    and the `Azure OAuth2 documentation <https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow>`_.

--- a/providers/fab/docs/changelog.rst
+++ b/providers/fab/docs/changelog.rst
@@ -23,10 +23,20 @@ Changelog
 3.8.1
 .....
 
+.. note::
+    The Azure AD OAuth provider in the FAB auth manager validates the ``iss`` (issuer) and
+    ``aud`` (audience) claims of ``id_token`` by default when ``verify_signature`` is enabled.
+    Both tenant GUID authorities (case-insensitive) and tenant domain authorities (e.g.
+    ``*.onmicrosoft.com`` or custom verified domains) are supported. For domain authorities, the
+    canonical tenant GUID is resolved via Microsoft OpenID Connect discovery. Deployments using
+    tenant-agnostic endpoints (``common``, ``organizations``, ``consumers``) must explicitly
+    configure a specific tenant GUID or domain via ``tenant_id`` in ``client_kwargs``.
+
 Bug Fixes
 ~~~~~~~~~
 
 * ``Validate issuer and audience of Azure AD id_tokens in FAB auth manager (#71735)``
+* ``Support Azure tenant domain and uppercase GUID authorities in FAB auth manager (#71920)``
 
 Misc
 ~~~~

--- a/providers/fab/docs/changelog.rst
+++ b/providers/fab/docs/changelog.rst
@@ -23,20 +23,10 @@ Changelog
 3.8.1
 .....
 
-.. note::
-    The Azure AD OAuth provider in the FAB auth manager validates the ``iss`` (issuer) and
-    ``aud`` (audience) claims of ``id_token`` by default when ``verify_signature`` is enabled.
-    Both tenant GUID authorities (case-insensitive) and tenant domain authorities (e.g.
-    ``*.onmicrosoft.com`` or custom verified domains) are supported. For domain authorities, the
-    canonical tenant GUID is resolved via Microsoft OpenID Connect discovery. Deployments using
-    tenant-agnostic endpoints (``common``, ``organizations``, ``consumers``) must explicitly
-    configure a specific tenant GUID or domain via ``tenant_id`` in ``client_kwargs``.
-
 Bug Fixes
 ~~~~~~~~~
 
 * ``Validate issuer and audience of Azure AD id_tokens in FAB auth manager (#71735)``
-* ``Support Azure tenant domain and uppercase GUID authorities in FAB auth manager (#71920)``
 
 Misc
 ~~~~

--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -30,6 +30,7 @@ import uuid
 from collections.abc import Collection, Iterable, Mapping
 from typing import TYPE_CHECKING, Any
 
+import requests
 from flask import current_app, flash, g, has_app_context, has_request_context, session
 from flask_appbuilder import Model, const
 from flask_appbuilder.const import (
@@ -407,8 +408,6 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         self.create_jwt_manager()
 
     def _get_authentik_jwks(self, jwks_url) -> dict:
-        import requests
-
         resp = requests.get(jwks_url, timeout=30)
         if resp.status_code == 200:
             return resp.json()
@@ -2428,8 +2427,6 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
             session.sid = str(uuid.uuid4())  # type: ignore
 
     def _get_microsoft_jwks(self) -> list[dict[str, Any]]:
-        import requests
-
         return requests.get(MICROSOFT_KEY_SET_URL, timeout=30).json()
 
     def _get_azure_tenant_identifier(self) -> str | None:
@@ -2439,10 +2436,12 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         Prefers an explicit ``tenant_id`` in ``client_kwargs``; otherwise derives it from
         the tenant path segment of configured Azure HTTPS endpoints on ``login.microsoftonline.com``.
 
-        Returns ``None`` when no tenant can be determined or when the configuration uses
-        tenant-agnostic endpoints (``common``, ``organizations``, ``consumers``).
+        Returns ``None`` when an explicit ``tenant_id`` is tenant-agnostic or when no
+        tenant-specific identifier can be derived from the configured endpoints. Tenant-agnostic
+        authorities (``common``, ``organizations``, ``consumers``) are skipped while searching.
         """
         azure = self.oauth_remotes["azure"]
+        tenant_agnostic_authorities = ("common", "organizations", "consumers")
 
         tenant_id = azure.client_kwargs.get("tenant_id")
         if tenant_id and isinstance(tenant_id, str) and tenant_id.strip():
@@ -2463,10 +2462,13 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
                     continue
                 path_parts = [segment for segment in parsed.path.split("/") if segment]
                 if path_parts:
-                    tenant_identifier = path_parts[0]
+                    tenant_candidate = path_parts[0]
+                    if tenant_candidate.lower() in tenant_agnostic_authorities:
+                        continue
+                    tenant_identifier = tenant_candidate
                     break
 
-        if not tenant_identifier or tenant_identifier.lower() in ("common", "organizations", "consumers"):
+        if not tenant_identifier or tenant_identifier.lower() in tenant_agnostic_authorities:
             return None
         return tenant_identifier
 
@@ -2486,8 +2488,6 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
 
         if tenant_identifier in self._azure_tenant_guid_cache:
             return self._azure_tenant_guid_cache[tenant_identifier]
-
-        import requests
 
         encoded_tenant = urllib.parse.quote(tenant_identifier, safe="")
         discovery_url = (

--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -25,6 +25,7 @@ import itertools
 import json
 import logging
 import re
+import urllib.parse
 import uuid
 from collections.abc import Collection, Iterable, Mapping
 from typing import TYPE_CHECKING, Any
@@ -70,7 +71,6 @@ from sqlalchemy.exc import IntegrityError, MultipleResultsFound
 from sqlalchemy.orm import joinedload
 from werkzeug.security import check_password_hash, generate_password_hash
 
-from airflow.exceptions import AirflowConfigException
 from airflow.providers.common.compat.sdk import conf
 from airflow.providers.fab.auth_manager.models import (
     Action,
@@ -160,6 +160,10 @@ MAX_NUM_DATABASE_USER_SESSIONS = 50000
 
 class FabException(Exception):
     """Custom exception for FAB security manager."""
+
+
+class AzureTenantResolutionError(FabException):
+    """Raised when an Azure AD tenant identifier cannot be resolved to a canonical GUID."""
 
 
 class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
@@ -384,6 +388,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         # done in super, but we need it before we can call super.
         self.appbuilder = appbuilder
 
+        self._azure_tenant_guid_cache: dict[str, str] = {}
         self._init_config()
         self._init_auth()
         self._init_data_model()
@@ -2427,44 +2432,126 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
 
         return requests.get(MICROSOFT_KEY_SET_URL, timeout=30).json()
 
-    def _get_azure_tenant_id(self) -> str | None:
+    def _get_azure_tenant_identifier(self) -> str | None:
         """
-        Resolve the Azure AD tenant the deployment is configured against.
+        Extract the configured Azure AD tenant identifier.
 
         Prefers an explicit ``tenant_id`` in ``client_kwargs``; otherwise derives it from
-        the tenant segment of the configured Azure endpoints, which is where the documented
-        configuration puts it (``https://login.microsoftonline.com/<tenant-id>/...``).
+        the tenant path segment of configured Azure HTTPS endpoints on ``login.microsoftonline.com``.
 
-        Returns ``None`` when the configuration is tenant-agnostic (the ``common`` or
-        ``organizations`` endpoints), because there is then no single issuer to pin to.
+        Returns ``None`` when no tenant can be determined or when the configuration uses
+        tenant-agnostic endpoints (``common``, ``organizations``, ``consumers``).
         """
         azure = self.oauth_remotes["azure"]
 
         tenant_id = azure.client_kwargs.get("tenant_id")
-        if tenant_id:
-            return tenant_id
+        if tenant_id and isinstance(tenant_id, str) and tenant_id.strip():
+            tenant_identifier = tenant_id.strip()
+        else:
+            tenant_identifier = None
+            for url in (
+                getattr(azure, "api_base_url", None),
+                getattr(azure, "access_token_url", None),
+                getattr(azure, "authorize_url", None),
+            ):
+                if not isinstance(url, str):
+                    continue
+                parsed = urllib.parse.urlsplit(url)
+                if parsed.scheme.lower() != "https":
+                    continue
+                if (parsed.hostname or "").lower() != "login.microsoftonline.com":
+                    continue
+                path_parts = [segment for segment in parsed.path.split("/") if segment]
+                if path_parts:
+                    tenant_identifier = path_parts[0]
+                    break
 
-        for url in (
-            getattr(azure, "api_base_url", None),
-            getattr(azure, "access_token_url", None),
-            getattr(azure, "authorize_url", None),
-        ):
-            if not isinstance(url, str):
-                continue
-            match = re.search(r"login\.microsoftonline\.com/([^/]+)/", url)
-            if match and match.group(1) not in ("common", "organizations", "consumers"):
-                return match.group(1)
+        if not tenant_identifier or tenant_identifier.lower() in ("common", "organizations", "consumers"):
+            return None
+        return tenant_identifier
 
-        return None
+    def _resolve_azure_tenant_guid(self, tenant_identifier: str) -> str:
+        """
+        Resolve an Azure tenant identifier (GUID or domain) to a canonical tenant GUID.
+
+        If the identifier is a valid UUID, it is normalized to lowercase hyphenated format
+        without calling any network endpoint. If the identifier is a domain, its OpenID
+        discovery metadata is queried from login.microsoftonline.com to extract the canonical
+        tenant GUID from the issuer claim. Successful resolutions are cached.
+        """
+        try:
+            return str(uuid.UUID(tenant_identifier))
+        except (ValueError, AttributeError):
+            pass
+
+        if tenant_identifier in self._azure_tenant_guid_cache:
+            return self._azure_tenant_guid_cache[tenant_identifier]
+
+        import requests
+
+        encoded_tenant = urllib.parse.quote(tenant_identifier, safe="")
+        discovery_url = (
+            f"https://login.microsoftonline.com/{encoded_tenant}/v2.0/.well-known/openid-configuration"
+        )
+        try:
+            resp = requests.get(discovery_url, timeout=5, allow_redirects=False)
+        except requests.exceptions.RequestException as ex:
+            raise AzureTenantResolutionError(
+                f"Failed to resolve Azure tenant identifier '{tenant_identifier}' via OpenID discovery."
+            ) from ex
+
+        if resp.status_code != 200:
+            raise AzureTenantResolutionError(
+                f"Failed to resolve Azure tenant identifier '{tenant_identifier}': "
+                f"OpenID discovery endpoint returned HTTP {resp.status_code}."
+            )
+
+        try:
+            data = resp.json()
+        except ValueError as ex:
+            raise AzureTenantResolutionError(
+                f"Failed to resolve Azure tenant identifier '{tenant_identifier}' via OpenID discovery."
+            ) from ex
+
+        if not isinstance(data, dict):
+            raise AzureTenantResolutionError(
+                f"Failed to resolve Azure tenant identifier '{tenant_identifier}': "
+                "OpenID discovery response is not a JSON object."
+            )
+
+        issuer = data.get("issuer")
+        if not isinstance(issuer, str):
+            raise AzureTenantResolutionError(
+                f"Failed to resolve Azure tenant identifier '{tenant_identifier}': "
+                "OpenID discovery response missing 'issuer' claim."
+            )
+
+        match = re.fullmatch(r"https://login\.microsoftonline\.com/([^/]+)/v2\.0", issuer, re.IGNORECASE)
+        if not match:
+            raise AzureTenantResolutionError(
+                f"Failed to resolve Azure tenant identifier '{tenant_identifier}': "
+                f"OpenID discovery returned unexpected issuer '{issuer}'."
+            )
+
+        try:
+            canonical_guid = str(uuid.UUID(match.group(1)))
+        except (ValueError, AttributeError) as ex:
+            raise AzureTenantResolutionError(
+                f"Failed to resolve Azure tenant identifier '{tenant_identifier}': "
+                f"issuer '{issuer}' does not contain a valid tenant GUID."
+            ) from ex
+
+        self._azure_tenant_guid_cache[tenant_identifier] = canonical_guid
+        return canonical_guid
 
     def _decode_and_validate_azure_jwt(self, id_token: str) -> dict[str, str]:
         verify_signature = self.oauth_remotes["azure"].client_kwargs.get("verify_signature", True)
         if verify_signature:
             from authlib.jose import JsonWebKey, jwt as authlib_jwt
 
-            tenant_id = self._get_azure_tenant_id()
-            if not tenant_id:
-                raise AirflowConfigException(
+            tenant_identifier = self._get_azure_tenant_identifier()
+            if not tenant_identifier:
+                raise AzureTenantResolutionError(
                     "Azure AD tenant could not be determined from the OAuth configuration. "
                     "The Microsoft key set used to verify id_token signatures serves keys for "
                     "every tenant, so without a tenant the issuer of the token cannot be "
@@ -2473,6 +2560,8 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
                     "in the azure provider's client_kwargs."
                 )
 
+            tenant_guid = self._resolve_azure_tenant_guid(tenant_identifier)
+
             claims_options = {
                 # The token must have been issued by the configured tenant. Both the v1.0 and
                 # v2.0 issuer forms are accepted because either may be returned depending on
@@ -2480,8 +2569,8 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
                 "iss": {
                     "essential": True,
                     "values": [
-                        f"https://login.microsoftonline.com/{tenant_id}/v2.0",
-                        f"https://sts.windows.net/{tenant_id}/",
+                        f"https://login.microsoftonline.com/{tenant_guid}/v2.0",
+                        f"https://sts.windows.net/{tenant_guid}/",
                     ],
                 },
                 # The token must have been minted for this application.

--- a/providers/fab/tests/unit/fab/auth_manager/security_manager/test_override.py
+++ b/providers/fab/tests/unit/fab/auth_manager/security_manager/test_override.py
@@ -16,10 +16,14 @@
 # under the License.
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest import mock
 from unittest.mock import Mock, call
 
 import pytest
+import requests
+from authlib.jose import JsonWebKey, jwt as authlib_jwt
+from authlib.jose.errors import InvalidClaimError
 from flask_appbuilder import const
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
@@ -33,16 +37,45 @@ from airflow.providers.fab.auth_manager.models import (
     User,
 )
 from airflow.providers.fab.auth_manager.security_manager.override import (
+    AzureTenantResolutionError,
     FabAirflowSecurityManagerOverride,
     FabException,
 )
+
+TENANT_GUID = "72f988bf-86f1-41af-91ab-2d7cd011db47"
+OTHER_GUID = "00000000-0000-0000-0000-000000000000"
+CLIENT_ID = "app-xyz"
+
+
+def _create_azure_jwt(
+    key,
+    iss=f"https://login.microsoftonline.com/{TENANT_GUID}/v2.0",
+    aud=CLIENT_ID,
+    tid=TENANT_GUID,
+    oid="user-oid",
+    kid="test-kid",
+) -> str:
+    token = authlib_jwt.encode(
+        {"alg": "RS256", "kid": kid},
+        {"iss": iss, "aud": aud, "tid": tid, "oid": oid},
+        key,
+    )
+    return token.decode("utf-8") if isinstance(token, bytes) else token
+
+
+def _create_mock_response(*, status_code=200, json_data=None, json_side_effect=None) -> Mock:
+    response = Mock(spec=requests.Response)
+    response.status_code = status_code
+    response.json.return_value = json_data
+    response.json.side_effect = json_side_effect
+    return response
 
 
 class EmptySecurityManager(FabAirflowSecurityManagerOverride):
     # noinspection PyMissingConstructor
     # super() not called on purpose to avoid the whole chain of init calls
     def __init__(self):
-        pass
+        self._azure_tenant_guid_cache = {}
 
 
 class TestFabAirflowSecurityManagerOverride:
@@ -479,14 +512,18 @@ class TestFabAirflowSecurityManagerOverride:
         # A resolvable tenant is required before the key set is fetched, so the mock
         # carries the tenant-specific endpoint the documented configuration uses.
         sm.oauth_remotes = {
-            "azure": Mock(
+            "azure": SimpleNamespace(
                 client_kwargs={},
-                api_base_url="https://login.microsoftonline.com/tenant-abc/oauth2/v2.0/",
+                client_id="app-xyz",
+                api_base_url=f"https://login.microsoftonline.com/{TENANT_GUID}/oauth2/v2.0/",
             )
         }
 
         with mock.patch.object(
-            EmptySecurityManager, "_get_microsoft_jwks", side_effect=RuntimeError("verify-branch-reached")
+            EmptySecurityManager,
+            "_get_microsoft_jwks",
+            autospec=True,
+            side_effect=RuntimeError("verify-branch-reached"),
         ) as mock_jwks:
             with pytest.raises(RuntimeError, match="verify-branch-reached"):
                 sm._decode_and_validate_azure_jwt("header.payload.signature")
@@ -534,64 +571,431 @@ class TestFabAirflowSecurityManagerOverride:
                 "tenant-from-token-url",
                 id="from-access-token-url",
             ),
+            pytest.param(
+                {
+                    "client_kwargs": {},
+                    "api_base_url": None,
+                    "access_token_url": None,
+                    "authorize_url": "https://login.microsoftonline.com/tenant-from-auth-url/oauth2/v2.0/authorize",
+                },
+                "tenant-from-auth-url",
+                id="from-authorize-url",
+            ),
         ],
     )
-    def test_get_azure_tenant_id_resolves_configured_tenant(self, remote_kwargs, expected):
-        """The tenant is taken from client_kwargs when set, otherwise from the configured endpoints."""
+    def test_get_azure_tenant_identifier_resolves_configured_tenant(self, remote_kwargs, expected):
+        """The tenant identifier is taken from client_kwargs when set, otherwise from configured endpoints."""
         sm = EmptySecurityManager()
-        sm.oauth_remotes = {"azure": Mock(**remote_kwargs)}
+        sm.oauth_remotes = {"azure": SimpleNamespace(**remote_kwargs)}
 
-        assert sm._get_azure_tenant_id() == expected
+        assert sm._get_azure_tenant_identifier() == expected
 
-    @pytest.mark.parametrize("multi_tenant_segment", ["common", "organizations", "consumers"])
-    def test_get_azure_tenant_id_returns_none_for_tenant_agnostic_endpoints(self, multi_tenant_segment):
-        """The shared endpoints identify no single tenant, so no issuer can be pinned."""
+    @pytest.mark.parametrize(
+        "multi_tenant_segment",
+        [
+            pytest.param("common", id="common"),
+            pytest.param("organizations", id="organizations"),
+            pytest.param("consumers", id="consumers"),
+            pytest.param("CONSUMERS", id="case-insensitive"),
+        ],
+    )
+    @pytest.mark.parametrize("configuration_source", ["client-kwargs", "endpoint"])
+    def test_get_azure_tenant_identifier_returns_none_for_tenant_agnostic_authorities(
+        self, multi_tenant_segment, configuration_source
+    ):
+        """Shared authorities identify no deployment-specific tenant, so no issuer can be pinned."""
         sm = EmptySecurityManager()
+        client_kwargs = {"tenant_id": multi_tenant_segment} if configuration_source == "client-kwargs" else {}
+        api_base_url = (
+            None
+            if configuration_source == "client-kwargs"
+            else f"https://login.microsoftonline.com/{multi_tenant_segment}/oauth2/v2.0/"
+        )
         sm.oauth_remotes = {
-            "azure": Mock(
-                client_kwargs={},
-                api_base_url=f"https://login.microsoftonline.com/{multi_tenant_segment}/oauth2/v2.0/",
+            "azure": SimpleNamespace(
+                client_kwargs=client_kwargs,
+                api_base_url=api_base_url,
                 access_token_url=None,
                 authorize_url=None,
             )
         }
 
-        assert sm._get_azure_tenant_id() is None
+        assert sm._get_azure_tenant_identifier() is None
 
-    def test_decode_and_validate_azure_jwt_requires_a_resolvable_tenant(self):
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            pytest.param(
+                "https://LOGIN.MICROSOFTONLINE.COM/tenant-uppercase-host/oauth2/v2.0/",
+                "tenant-uppercase-host",
+                id="case-insensitive-hostname",
+            ),
+            pytest.param(
+                "http://login.microsoftonline.com/tenant-http/oauth2/v2.0/",
+                None,
+                id="reject-non-https",
+            ),
+            pytest.param(
+                "https://evil.com/login.microsoftonline.com/tenant-abc",
+                None,
+                id="reject-microsoft-in-path",
+            ),
+            pytest.param(
+                "https://login.microsoftonline.com@evil.com/tenant-abc",
+                None,
+                id="reject-microsoft-in-userinfo",
+            ),
+            pytest.param(
+                "https://other.microsoftonline.com/tenant-abc",
+                None,
+                id="reject-wrong-subdomain",
+            ),
+            pytest.param(
+                "https://login.microsoftonline.com/",
+                None,
+                id="reject-empty-path",
+            ),
+        ],
+    )
+    def test_get_azure_tenant_identifier_endpoint_validation(self, url, expected):
+        sm = EmptySecurityManager()
+        sm.oauth_remotes = {
+            "azure": SimpleNamespace(
+                client_kwargs={},
+                api_base_url=url,
+                access_token_url=None,
+                authorize_url=None,
+            )
+        }
+        assert sm._get_azure_tenant_identifier() == expected
+
+    @pytest.mark.parametrize(
+        "remote_kwargs",
+        [
+            pytest.param(
+                {
+                    "client_kwargs": {},
+                    "api_base_url": "https://login.microsoftonline.com/common/oauth2/v2.0/",
+                    "access_token_url": None,
+                    "authorize_url": None,
+                },
+                id="common-endpoint",
+            ),
+            pytest.param({"client_kwargs": {"tenant_id": "common"}}, id="common-client-kwargs"),
+            pytest.param({"client_kwargs": {"tenant_id": "organizations"}}, id="organizations-client-kwargs"),
+            pytest.param({"client_kwargs": {"tenant_id": "consumers"}}, id="consumers-client-kwargs"),
+        ],
+    )
+    def test_decode_and_validate_azure_jwt_requires_a_resolvable_tenant(self, remote_kwargs):
         """Without a tenant there is no issuer to check, so the token is not accepted."""
-        from airflow.exceptions import AirflowConfigException
+        sm = EmptySecurityManager()
+        sm.oauth_remotes = {"azure": SimpleNamespace(**remote_kwargs)}
+
+        with mock.patch("requests.get", autospec=True) as mock_requests_get:
+            with pytest.raises(AzureTenantResolutionError, match="tenant could not be determined"):
+                sm._decode_and_validate_azure_jwt("header.payload.signature")
+
+        mock_requests_get.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "configured_tenant",
+        [
+            pytest.param(TENANT_GUID, id="lowercase-guid"),
+            pytest.param(TENANT_GUID.upper(), id="uppercase-guid"),
+        ],
+    )
+    def test_decode_and_validate_azure_jwt_guid_does_not_call_metadata(self, configured_tenant):
+        """GUID tenant identifiers (lowercase and uppercase) canonicalize without metadata HTTP calls."""
+        key = JsonWebKey.generate_key("RSA", 2048, options={"kid": "test-kid"}, is_private=True)
+        public_key = key.as_dict(is_private=False, kid="test-kid")
+        id_token = _create_azure_jwt(key=key)
 
         sm = EmptySecurityManager()
         sm.oauth_remotes = {
-            "azure": Mock(
-                client_kwargs={},
-                api_base_url="https://login.microsoftonline.com/common/oauth2/v2.0/",
+            "azure": SimpleNamespace(
+                client_kwargs={"tenant_id": configured_tenant},
+                client_id=CLIENT_ID,
+            )
+        }
+
+        with (
+            mock.patch.object(
+                EmptySecurityManager,
+                "_get_microsoft_jwks",
+                autospec=True,
+                return_value={"keys": [public_key]},
+            ),
+            mock.patch("requests.get", autospec=True) as mock_requests_get,
+        ):
+            claims = sm._decode_and_validate_azure_jwt(id_token)
+
+        mock_requests_get.assert_not_called()
+        assert claims["iss"] == f"https://login.microsoftonline.com/{TENANT_GUID}/v2.0"
+        assert claims["aud"] == CLIENT_ID
+
+    @pytest.mark.parametrize(
+        "domain",
+        [
+            pytest.param("microsoft.onmicrosoft.com", id="onmicrosoft-domain"),
+            pytest.param("custom.company.org", id="custom-domain"),
+        ],
+    )
+    @pytest.mark.parametrize("configuration_source", ["client-kwargs", "endpoint"])
+    def test_decode_and_validate_azure_jwt_domain_resolves_via_metadata(self, domain, configuration_source):
+        """Domain tenant identifiers resolve canonical GUID via OIDC metadata and validate token."""
+        key = JsonWebKey.generate_key("RSA", 2048, options={"kid": "test-kid"}, is_private=True)
+        public_key = key.as_dict(is_private=False, kid="test-kid")
+        id_token = _create_azure_jwt(key=key)
+
+        sm = EmptySecurityManager()
+        client_kwargs = {"tenant_id": domain} if configuration_source == "client-kwargs" else {}
+        api_base_url = (
+            None
+            if configuration_source == "client-kwargs"
+            else f"https://login.microsoftonline.com/{domain}/oauth2/v2.0/"
+        )
+        sm.oauth_remotes = {
+            "azure": SimpleNamespace(
+                client_kwargs=client_kwargs,
+                client_id=CLIENT_ID,
+                api_base_url=api_base_url,
                 access_token_url=None,
                 authorize_url=None,
             )
         }
 
-        with pytest.raises(AirflowConfigException, match="tenant could not be determined"):
-            sm._decode_and_validate_azure_jwt("header.payload.signature")
+        mock_resp = _create_mock_response(
+            json_data={"issuer": f"https://login.microsoftonline.com/{TENANT_GUID}/v2.0"}
+        )
 
-    def test_decode_and_validate_azure_jwt_pins_issuer_and_audience(self):
-        """The decode call constrains both the issuer and the audience of the token."""
+        with (
+            mock.patch.object(
+                EmptySecurityManager,
+                "_get_microsoft_jwks",
+                autospec=True,
+                return_value={"keys": [public_key]},
+            ),
+            mock.patch("requests.get", autospec=True, return_value=mock_resp) as mock_requests_get,
+        ):
+            claims = sm._decode_and_validate_azure_jwt(id_token)
+
+        mock_requests_get.assert_called_once_with(
+            f"https://login.microsoftonline.com/{domain}/v2.0/.well-known/openid-configuration",
+            timeout=5,
+            allow_redirects=False,
+        )
+        assert claims["iss"] == f"https://login.microsoftonline.com/{TENANT_GUID}/v2.0"
+
+    def test_decode_and_validate_azure_jwt_v1_issuer_supported_with_domain(self):
+        """v1 STS issuer is accepted when domain is configured and resolves to canonical GUID."""
+        key = JsonWebKey.generate_key("RSA", 2048, options={"kid": "test-kid"}, is_private=True)
+        public_key = key.as_dict(is_private=False, kid="test-kid")
+        id_token = _create_azure_jwt(key=key, iss=f"https://sts.windows.net/{TENANT_GUID}/")
+
         sm = EmptySecurityManager()
-        sm.oauth_remotes = {"azure": Mock(client_kwargs={"tenant_id": "tenant-abc"}, client_id="app-xyz")}
+        sm.oauth_remotes = {
+            "azure": SimpleNamespace(
+                client_kwargs={"tenant_id": "microsoft.onmicrosoft.com"},
+                client_id=CLIENT_ID,
+            )
+        }
 
-        with mock.patch.object(EmptySecurityManager, "_get_microsoft_jwks", return_value={"keys": []}):
-            with mock.patch("authlib.jose.JsonWebKey.import_key_set"):
-                with mock.patch("authlib.jose.jwt.decode") as mock_decode:
-                    sm._decode_and_validate_azure_jwt("header.payload.signature")
+        mock_resp = _create_mock_response(
+            json_data={"issuer": f"https://login.microsoftonline.com/{TENANT_GUID}/v2.0"}
+        )
 
-        claims_options = mock_decode.call_args.kwargs["claims_options"]
-        assert claims_options["aud"] == {"essential": True, "value": "app-xyz"}
-        assert claims_options["iss"]["essential"] is True
-        assert claims_options["iss"]["values"] == [
-            "https://login.microsoftonline.com/tenant-abc/v2.0",
-            "https://sts.windows.net/tenant-abc/",
-        ]
+        with (
+            mock.patch.object(
+                EmptySecurityManager,
+                "_get_microsoft_jwks",
+                autospec=True,
+                return_value={"keys": [public_key]},
+            ),
+            mock.patch("requests.get", autospec=True, return_value=mock_resp),
+        ):
+            claims = sm._decode_and_validate_azure_jwt(id_token)
+
+        assert claims["iss"] == f"https://sts.windows.net/{TENANT_GUID}/"
+
+    def test_decode_and_validate_azure_jwt_rejects_issuer_mismatch(self):
+        """Tokens issued for a different tenant are rejected with InvalidClaimError."""
+        key = JsonWebKey.generate_key("RSA", 2048, options={"kid": "test-kid"}, is_private=True)
+        public_key = key.as_dict(is_private=False, kid="test-kid")
+        id_token = _create_azure_jwt(key=key, iss=f"https://login.microsoftonline.com/{OTHER_GUID}/v2.0")
+
+        sm = EmptySecurityManager()
+        sm.oauth_remotes = {
+            "azure": SimpleNamespace(
+                client_kwargs={"tenant_id": "microsoft.onmicrosoft.com"},
+                client_id=CLIENT_ID,
+            )
+        }
+
+        mock_resp = _create_mock_response(
+            json_data={"issuer": f"https://login.microsoftonline.com/{TENANT_GUID}/v2.0"}
+        )
+
+        with (
+            mock.patch.object(
+                EmptySecurityManager,
+                "_get_microsoft_jwks",
+                autospec=True,
+                return_value={"keys": [public_key]},
+            ),
+            mock.patch("requests.get", autospec=True, return_value=mock_resp),
+        ):
+            with pytest.raises(InvalidClaimError, match="invalid_claim: Invalid claim 'iss'"):
+                sm._decode_and_validate_azure_jwt(id_token)
+
+    def test_decode_and_validate_azure_jwt_rejects_audience_mismatch(self):
+        """Tokens minted for another client/application are rejected."""
+        key = JsonWebKey.generate_key("RSA", 2048, options={"kid": "test-kid"}, is_private=True)
+        public_key = key.as_dict(is_private=False, kid="test-kid")
+        id_token = _create_azure_jwt(key=key, aud="wrong-audience")
+
+        sm = EmptySecurityManager()
+        sm.oauth_remotes = {
+            "azure": SimpleNamespace(
+                client_kwargs={"tenant_id": TENANT_GUID},
+                client_id=CLIENT_ID,
+            )
+        }
+
+        with mock.patch.object(
+            EmptySecurityManager,
+            "_get_microsoft_jwks",
+            autospec=True,
+            return_value={"keys": [public_key]},
+        ):
+            with pytest.raises(InvalidClaimError, match="invalid_claim: Invalid claim 'aud'"):
+                sm._decode_and_validate_azure_jwt(id_token)
+
+    @pytest.mark.parametrize(
+        ("response_kwargs", "request_side_effect", "error_match"),
+        [
+            pytest.param({"status_code": 404}, None, "HTTP 404", id="http-404"),
+            pytest.param({"status_code": 500}, None, "HTTP 500", id="http-500"),
+            pytest.param({"status_code": 302}, None, "HTTP 302", id="http-302-redirect"),
+            pytest.param(
+                {},
+                requests.exceptions.Timeout("network timeout"),
+                "via OpenID discovery",
+                id="network-timeout",
+            ),
+            pytest.param(
+                {"json_side_effect": ValueError("bad json")},
+                None,
+                "via OpenID discovery",
+                id="malformed-json",
+            ),
+            pytest.param(
+                {"json_data": ["not", "dict"]},
+                None,
+                "not a JSON object",
+                id="json-not-dict",
+            ),
+            pytest.param({"json_data": {}}, None, "missing 'issuer'", id="missing-issuer"),
+            pytest.param(
+                {
+                    "json_data": {"issuer": f"http://login.microsoftonline.com/{TENANT_GUID}/v2.0"},
+                },
+                None,
+                "unexpected issuer",
+                id="non-https-issuer",
+            ),
+            pytest.param(
+                {
+                    "json_data": {"issuer": f"https://evil.com/{TENANT_GUID}/v2.0"},
+                },
+                None,
+                "unexpected issuer",
+                id="wrong-issuer-host",
+            ),
+            pytest.param(
+                {
+                    "json_data": {"issuer": "https://login.microsoftonline.com/not-a-uuid/v2.0"},
+                },
+                None,
+                "does not contain a valid tenant GUID",
+                id="non-uuid-issuer",
+            ),
+            pytest.param(
+                {
+                    "json_data": {"issuer": f"https://login.microsoftonline.com/{TENANT_GUID}/v3.0"},
+                },
+                None,
+                "unexpected issuer",
+                id="wrong-issuer-path",
+            ),
+        ],
+    )
+    def test_resolve_azure_tenant_guid_metadata_failures(
+        self, response_kwargs, request_side_effect, error_match
+    ):
+        """All metadata discovery failures fail closed with AzureTenantResolutionError."""
+        sm = EmptySecurityManager()
+
+        if request_side_effect:
+            mock_get = mock.patch("requests.get", autospec=True, side_effect=request_side_effect)
+        else:
+            mock_resp = _create_mock_response(**response_kwargs)
+            mock_get = mock.patch("requests.get", autospec=True, return_value=mock_resp)
+
+        with mock_get:
+            with pytest.raises(AzureTenantResolutionError, match=error_match):
+                sm._resolve_azure_tenant_guid("contoso.onmicrosoft.com")
+
+    def test_resolve_azure_tenant_guid_encodes_identifier_as_one_path_segment(self):
+        sm = EmptySecurityManager()
+        mock_resp = _create_mock_response(
+            json_data={"issuer": f"https://login.microsoftonline.com/{TENANT_GUID}/v2.0"}
+        )
+
+        with mock.patch("requests.get", autospec=True, return_value=mock_resp) as mock_requests_get:
+            result = sm._resolve_azure_tenant_guid("tenant/name?query#fragment")
+
+        assert result == TENANT_GUID
+        mock_requests_get.assert_called_once_with(
+            "https://login.microsoftonline.com/tenant%2Fname%3Fquery%23fragment/"
+            "v2.0/.well-known/openid-configuration",
+            timeout=5,
+            allow_redirects=False,
+        )
+
+    def test_resolve_azure_tenant_guid_caches_successful_result(self):
+        """Successful domain resolution is cached and does not make repeated HTTP requests."""
+        sm = EmptySecurityManager()
+        mock_resp = _create_mock_response(
+            json_data={"issuer": f"https://login.microsoftonline.com/{TENANT_GUID}/v2.0"}
+        )
+
+        with mock.patch("requests.get", autospec=True, return_value=mock_resp) as mock_requests_get:
+            res1 = sm._resolve_azure_tenant_guid("contoso.onmicrosoft.com")
+            res2 = sm._resolve_azure_tenant_guid("contoso.onmicrosoft.com")
+
+        assert res1 == TENANT_GUID
+        assert res2 == TENANT_GUID
+        mock_requests_get.assert_called_once()
+
+    def test_resolve_azure_tenant_guid_does_not_cache_transient_failures(self):
+        """Transient discovery failures are not cached; subsequent calls retry HTTP request."""
+        sm = EmptySecurityManager()
+        mock_resp_success = _create_mock_response(
+            json_data={"issuer": f"https://login.microsoftonline.com/{TENANT_GUID}/v2.0"}
+        )
+
+        with mock.patch(
+            "requests.get",
+            autospec=True,
+            side_effect=[requests.exceptions.Timeout("temporary connection failure"), mock_resp_success],
+        ) as mock_requests_get:
+            with pytest.raises(AzureTenantResolutionError, match="via OpenID discovery"):
+                sm._resolve_azure_tenant_guid("contoso.onmicrosoft.com")
+
+            res = sm._resolve_azure_tenant_guid("contoso.onmicrosoft.com")
+
+        assert res == TENANT_GUID
+        assert mock_requests_get.call_count == 2
 
 
 def test_ldap_search_escapes_username_and_validates_filter():

--- a/providers/fab/tests/unit/fab/auth_manager/security_manager/test_override.py
+++ b/providers/fab/tests/unit/fab/auth_manager/security_manager/test_override.py
@@ -574,6 +574,15 @@ class TestFabAirflowSecurityManagerOverride:
             pytest.param(
                 {
                     "client_kwargs": {},
+                    "api_base_url": "https://login.microsoftonline.com/common/oauth2/v2.0/",
+                    "access_token_url": "https://login.microsoftonline.com/tenant-from-token-url/oauth2/v2.0/token",
+                },
+                "tenant-from-token-url",
+                id="skips-tenant-agnostic-endpoint",
+            ),
+            pytest.param(
+                {
+                    "client_kwargs": {},
                     "api_base_url": None,
                     "access_token_url": None,
                     "authorize_url": "https://login.microsoftonline.com/tenant-from-auth-url/oauth2/v2.0/authorize",


### PR DESCRIPTION
related: #71735

## Why

In `apache-airflow-providers-fab==3.8.1rc1` (#71735), Azure AD token validation uses the configured tenant identifier directly as the expected `iss` claim. But Azure mints the issuer published in the tenant's OpenID Connect metadata, which always carries the canonical lowercase tenant GUID-- see [Microsoft Entra ID guidance on validating the issuer](https://learn.microsoft.com/en-us/entra/identity-platform/access-tokens#validate-the-issuer). Deployments configured with a domain name (e.g. `*.onmicrosoft.com` or a custom domain) or an uppercase GUID therefore fail login with `InvalidClaimError`.

## How to Reproduce

In an environment with `apache-airflow-providers-fab==3.8.1rc1` installed, running token validation against domain or uppercase GUID authorities fails:

```python
from types import SimpleNamespace
from airflow.providers.fab.auth_manager.security_manager.override import (
    FabAirflowSecurityManagerOverride as SecurityManager,
)
from authlib.jose import JsonWebKey, jwt as authlib_jwt

TENANT_GUID = "72f988bf-86f1-41af-91ab-2d7cd011db47"
CLIENT_ID = "app-xyz"

key = JsonWebKey.generate_key("RSA", 2048, options={"kid": "test-kid"}, is_private=True)
public_key = key.as_dict(is_private=False, kid="test-kid")
id_token = authlib_jwt.encode(
    {"alg": "RS256", "kid": "test-kid"},
    {
        "iss": f"https://login.microsoftonline.com/{TENANT_GUID}/v2.0",
        "aud": CLIENT_ID,
        "tid": TENANT_GUID,
        "oid": "user-oid",
    },
    key,
).decode()

azure_remote = SimpleNamespace(
    client_kwargs={},
    client_id=CLIENT_ID,
    api_base_url="https://login.microsoftonline.com/microsoft.onmicrosoft.com/oauth2/v2.0/",
)
sm = SimpleNamespace(
    oauth_remotes={"azure": azure_remote},
    _get_azure_tenant_id=lambda: SecurityManager._get_azure_tenant_id(sm),
    _get_microsoft_jwks=lambda: {"keys": [public_key]},
)

# Fails on 3.8.1rc1 with InvalidClaimError: invalid_claim: Invalid claim 'iss'
SecurityManager._decode_and_validate_azure_jwt(sm, id_token)
```

## Summary of Changes

- **Canonicalize & Resolve Tenant GUIDs**: Added `_resolve_azure_tenant_guid()` to normalize GUIDs locally and resolve domain names to canonical tenant GUIDs via Microsoft OpenID Connect discovery (with in-memory caching).
- **Strict Endpoint Parsing & Fail-Closed Security**: Replaced regex with `urllib.parse.urlsplit` to safely extract configured tenant identifiers from HTTPS `login.microsoftonline.com` endpoints, and added `AzureTenantResolutionError(FabException)` for discovery/validation failures.

| Configured `tenant_identifier` | Resolution Strategy | `_resolve_azure_tenant_guid` Output |
| :--- | :--- | :--- |
| **Lowercase GUID** (`72f988bf-86f1-41af-91ab-2d7cd011db47`) | Validated & normalized locally (no HTTP call) | `72f988bf-86f1-41af-91ab-2d7cd011db47` |
| **Uppercase GUID** (`72F988BF-86F1-41AF-91AB-2D7CD011DB47`) | Normalized to canonical lowercase (no HTTP call) | `72f988bf-86f1-41af-91ab-2d7cd011db47` |
| **Default Domain** (`microsoft.onmicrosoft.com`) | Resolved via Microsoft OpenID discovery metadata | `72f988bf-86f1-41af-91ab-2d7cd011db47` |
| **Custom Verified Domain** (`contoso.com`) | Resolved via Microsoft OpenID discovery metadata | `<canonical-tenant-guid>` |

<br>

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: [GPT 5.6-sol] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
