### PR TITLE
fix(migration/0049): skip NaN sanitize for already-valid JSON values

### DIFF
--- a/airflow-core/src/airflow/migrations/versions/0049_3_0_0_remove_pickled_data_from_xcom_table.py
+++ b/airflow-core/src/airflow/migrations/versions/0049_3_0_0_remove_pickled_data_from_xcom_table.py
@@ -50,28 +50,22 @@ airflow_version = "3.0.0"
 _XCOM_PG_SANITIZE_SQL = r"""
                 UPDATE __TABLE__
                 SET value = convert_to(
-                    regexp_replace(
-                        -- Strip the active U+0000 (NUL) escape (illegal in JSON/JSONB, not quotable).
-                        -- Protect escaped backslashes with chr(1) first so an embedded literal
-                        -- backslash + u0000 in the data is preserved; chr(1) is safe because
-                        -- json.dumps escapes control bytes, so it never appears in the JSON text.
-                        replace(
+                    CASE
+                        WHEN json_valid(convert_from(value, 'UTF8'))
+                            THEN convert_from(value, 'UTF8')
+                        ELSE regexp_replace(
                             replace(
-                                replace(convert_from(value, 'UTF8'), '\\', chr(1)),
-                                '\u0000', ''
+                                replace(
+                                    replace(convert_from(value, 'UTF8'), '\\', chr(1)),
+                                    '\u0000', ''
+                                ),
+                                chr(1), '\\'
                             ),
-                            chr(1), '\\'
-                        ),
-                        -- Group 1 captures the preceding delimiter (:, comma, or [)
-                        -- or ^ for a bare scalar value (the entire XCom value is just NaN).
-                        -- A lookahead is used for the closing delimiter instead of a
-                        -- consuming group so that consecutive tokens in an array
-                        -- (e.g. [NaN, Infinity]) are each matched independently.
-                        -- NaN and Infinity are done in the same query to avoid another table scan.
-                        '([:,\[]\s*|^)(NaN|-?Infinity)(?=\s*[,}\]]|$)',
-                        '\1"\2"',
-                        'g'
-                    ),
+                            '([:,\[]\s*|^)(NaN|-?Infinity)(?=\s*[,}\]]|$)',
+                            '\1"\2"',
+                            'g'
+                        )
+                    END,
                     'UTF8'
                 )
                 WHERE value IS NOT NULL AND get_byte(value, 0) != 128
@@ -79,7 +73,9 @@ _XCOM_PG_SANITIZE_SQL = r"""
 _XCOM_MYSQL_SANITIZE_SQL = """
                 UPDATE __TABLE__
                 SET value = CONVERT(
-                    REGEXP_REPLACE(
+                    CASE
+                        WHEN JSON_VALID(CONVERT(value USING utf8mb4)) THEN CONVERT(value USING utf8mb4)
+                        ELSE REGEXP_REPLACE(
                         -- Strip the active U+0000 (NUL) escape (illegal JSON; see PostgreSQL branch).
                         -- Protect escaped backslashes with CHAR(1) first so an embedded literal
                         -- backslash + u0000 in the data is preserved.
@@ -100,14 +96,17 @@ _XCOM_MYSQL_SANITIZE_SQL = """
                         1,
                         0,
                         'c'
-                    ) USING BINARY
+                    )
+                    END USING BINARY
                 )
                 WHERE value IS NOT NULL AND HEX(SUBSTRING(value, 1, 1)) != '80'
             """
 _XCOM_SQLITE_SANITIZE_SQL = """
                 UPDATE __TABLE__
                 SET value = CAST(
-                    REPLACE(
+                    CASE
+                        WHEN json_valid(CAST(value AS TEXT)) THEN CAST(value AS TEXT)
+                        ELSE REPLACE(
                         REPLACE(
                             -- Step 1: replace NaN first so it doesn't interfere with Infinity.
                             REPLACE(
@@ -128,7 +127,8 @@ _XCOM_SQLITE_SANITIZE_SQL = """
                         ),
                         -- Step 3: fix the -"Infinity" artifact left by step 2.
                         '-"Infinity"', '"-Infinity"'
-                    ) AS BLOB)
+                    )
+                    END AS BLOB)
                 -- NOTE: SQLite lacks REGEXP_REPLACE, so plain REPLACE is used.
                 -- This is a substring operation and will incorrectly alter XCom values
                 -- that contain the literal text 'NaN' or 'Infinity' inside a JSON string

--- a/airflow-core/tests/unit/migrations/test_0049_remove_pickled_data_from_xcom_table.py
+++ b/airflow-core/tests/unit/migrations/test_0049_remove_pickled_data_from_xcom_table.py
@@ -88,6 +88,51 @@ def test_sqlite_sanitize_quotes_nonfinite_strips_nul_and_keeps_literal():
     assert json.loads(rows[2]) == _LITERAL_EXPECTED
 
 
+
+def test_sqlite_sanitize_skips_already_valid_json():
+    """SQLite branch: a value that is already valid JSON (e.g. a JSON string wrapping a JSON
+    document containing NaN tokens) must be left untouched — the sanitizer regex cannot
+    distinguish ``: NaN`` in a JSON syntax position from ``: NaN`` inside a JSON string
+    that is itself the XCom value, and injecting unescaped quotes would break the outer
+    JSON string.  The ``json_valid()`` guard skips the sanitizer for already-valid values."""
+    engine = sa.create_engine("sqlite://")
+    with engine.begin() as conn:
+        conn.execute(sa.text(f"CREATE TABLE {_TABLE} (id INTEGER PRIMARY KEY, value BLOB)"))
+        # A JSON string wrapping a JSON document that contains NaN floats.
+        # json.dumps of a dict with NaN produces {"a": NaN}, which is invalid JSON.
+        # json.dumps again of that invalid-JSON string produces a *valid* JSON string:
+        #   json.dumps(json.dumps({"a": float("nan")}))  →  '"{\"a\": NaN}"'
+        # This is the shape that was reported as broken by the migration (#71921).
+        wrapped = json.dumps(json.dumps({"a": float("nan"), "b": float("inf"), "c": 1.5}))
+        conn.execute(
+            sa.text(f"INSERT INTO {_TABLE} (id, value) VALUES (1, :v)"),
+            {"v": wrapped.encode("utf-8")},
+        )
+        # A dict whose value is a JSON string (json.dumps of a dict with NaN).
+        #   {"report": "{\"amount\": NaN}"}
+        # This is already valid JSON (the NaN is inside a string) and must also be preserved.
+        dict_with_json_string = json.dumps({"report": json.dumps({"amount": float("nan")})})
+        conn.execute(
+            sa.text(f"INSERT INTO {_TABLE} (id, value) VALUES (2, :v)"),
+            {"v": dict_with_json_string.encode("utf-8")},
+        )
+        # Apply the sanitize SQL
+        conn.execute(sa.text(_migration._xcom_sqlite_sanitize_sql(_TABLE)))
+        # Both rows must still be valid JSON (the sanitizer must not corrupt them).
+        rows = dict(conn.execute(sa.text(f"SELECT id, CAST(value AS TEXT) FROM {_TABLE}")).all())
+    # Row 1: the outer JSON string must be preserved.
+    parsed1 = json.loads(rows[1])
+    assert isinstance(parsed1, str), f"Expected a JSON string, got {type(parsed1)}"
+    # Row 2: the dict must be preserved unchanged.
+    parsed2 = json.loads(rows[2])
+    assert isinstance(parsed2, dict) and "report" in parsed2
+    # The inner NaN is still a bare token *inside the string value*, which is legal JSON
+    # for the outer document.  The sanitizer must not touch it (the old regex would have
+    # injected an unescaped quote and corrupted the outer JSON). The string value itself
+    # is preserved byte-for-byte.
+    assert parsed2["report"] == json.dumps({"amount": float("nan")})
+
+
 @pytest.mark.db_test
 class TestPostgresSanitize:
     @pytest.mark.backend("postgres")


### PR DESCRIPTION
## Summary

The 0049 migration's NaN sanitizer (``regexp_replace``) incorrectly matches ``NaN``/``Infinity`` tokens inside JSON string values, injecting an unescaped quote that breaks the outer JSON structure. This causes the migration to abort with ``INVALID_TEXT_REPRESENTATION`` on PostgreSQL and equivalent errors on MySQL/SQLite, making the upgrade 2.x → 3.x fail for any XCom value that is a JSON string wrapping a JSON document containing NaN floats.

This happens when:
- A task pushes already-serialized JSON (e.g. ``json.dumps(json.dumps({"amount": float("nan")}))``)
- A dict value is itself a JSON string (``{"report": "{\"amount\": NaN}"}``)

Both shapes are **already valid JSON** — the NaN token lives inside a JSON string, not at the JSON syntax level. The sanitizer should not touch them.

## Fix

Guard the per-dialect sanitize SQL with the native JSON validity check for each engine:

| Dialect | Function | Available since |
|:---|:---|:---|
| PostgreSQL | ``json_valid()`` | PG 14 (Airflow 3 requires PG 14+) |
| MySQL | ``JSON_VALID()`` | MySQL 5.7+ |
| SQLite | ``json_valid()`` | JSON1 extension (enabled in all modern builds) |

Values that are already valid JSON pass through the sanitizer untouched; only values containing bare NaN/Infinity tokens (which are illegal in strict JSON/JSONB) are quoted.

## Tests

- ``test_sqlite_sanitize_skips_already_valid_json`` — regression test for both shapes using the SQLite branch (backend-independent).
- The existing PG/MySQL backend tests in ``TestPostgresSanitize`` / ``TestMysqlSanitize`` continue to pass (bare NaN/Infinity are still quoted correctly).

Closes #71921