### PR TITLE
Drop the redundant re-validation round trip in airflowctl list pagination

### DIFF
--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -237,8 +237,7 @@ class BaseOperations:
             entry = safe_validate(self.response.content)
             offset = offset + limit
             entry_list.extend(getattr(entry, found_key))
-        obj = data_model(**{found_key: entry_list, "total_entries": total_entries})
-        return data_model.model_validate(obj.model_dump())  # type: ignore[union-attr]
+        return data_model(**{found_key: entry_list, "total_entries": total_entries})
 
 
 # Login operations


### PR DESCRIPTION
### Summary

`BaseOperations.execute_list` merges all pages of a paginated list call into one collection object, then did `data_model.model_validate(obj.model_dump())` before returning it -- serializing the already-built object back to a dict and re-validating it as the same model.

That round trip doesn't catch anything: `obj` was already fully validated when it was constructed (Pydantic validates on `__init__`),
and every entry inside it had already been validated individually by `safe_validate()` while parsing its own page. The extra step just re-derives the same values at the cost of a full serialize + deserialize pass over the merged result.

Benchmarked with `dev/benchmark_ctl_execute_list_roundtrip.py` (20,000 entries): the redundant round trip cost ~520ms and ~94 MiB of peak memory that a bare `return obj` doesn't pay.

| N entries | current (s) | proposed (s) | extra peak MiB |
|---|---|---|---|
| 1,000 | 0.0137 | ~0 | 4.71 |
| 5,000 | 0.0919 | ~0 | 23.57 |
| 20,000 | 0.5199 | ~0 | 94.29 |

### Change

`airflow-ctl/src/airflowctl/api/operations.py`: `execute_list` now returns the already-validated merged object directly instead of round-tripping it through `model_dump()` + `model_validate()`.

---

##### Was generative AI tooling used to co-author this PR?

No