### PR TITLE
Support service account impersonation for Cloud SQL Proxy connections

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/hooks/cloud_sql.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/cloud_sql.py
@@ -41,6 +41,7 @@ from tempfile import NamedTemporaryFile, _TemporaryFileWrapper, gettempdir
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import quote_plus
 
+import google.auth.transport.requests
 import httpx
 from aiohttp import ClientSession
 from gcloud.aio.auth import AioSession, Token
@@ -560,6 +561,17 @@ class CloudSqlProxyRunner(LoggingMixin):
     :param sql_proxy_binary_path: If specified, then proxy will be
         used from the path specified rather than dynamically generated. This means
         that if the binary is not present in that path it will also be downloaded.
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity.
+        The cloud-sql-proxy binary itself has no impersonation support, so a short-lived
+        access token is minted on the Airflow side and passed via ``-token``; unlike
+        key-based auth, the proxy does not refresh this token, so it is only valid for
+        the impersonated credentials' lifetime (up to 1 hour by default).
     """
 
     def __init__(
@@ -572,6 +584,7 @@ class CloudSqlProxyRunner(LoggingMixin):
         sql_proxy_binary_path: str | None = None,
         *,
         sql_proxy_enable_iam_login: bool = False,
+        impersonation_chain: str | Sequence[str] | None = None,
     ) -> None:
         super().__init__()
         self.path_prefix = path_prefix
@@ -585,6 +598,7 @@ class CloudSqlProxyRunner(LoggingMixin):
         self.project_id = project_id
         self.gcp_conn_id = gcp_conn_id
         self.sql_proxy_enable_iam_login = sql_proxy_enable_iam_login
+        self.impersonation_chain = impersonation_chain
         self.command_line_parameters: list[str] = []
         self.cloud_sql_proxy_socket_directory = self.path_prefix
         self.sql_proxy_path = sql_proxy_binary_path or f"{self.path_prefix}_cloud_sql_proxy"
@@ -651,28 +665,31 @@ class CloudSqlProxyRunner(LoggingMixin):
 
     def _get_credential_parameters(self) -> list[str]:
         extras = GoogleBaseHook.get_connection(conn_id=self.gcp_conn_id).extra_dejson
-        key_path = get_field(extras, "key_path")
-        keyfile_dict = get_field(extras, "keyfile_dict")
-        if key_path:
-            credential_params = ["-credential_file", key_path]
-        elif keyfile_dict:
-            keyfile_content = keyfile_dict if isinstance(keyfile_dict, dict) else json.loads(keyfile_dict)
-            self.log.info("Saving credentials to %s", self.credentials_path)
-            # Explicit 0o600 — the file holds a service-account private key. The plain
-            # ``open()`` form inherits the process umask (typically 0o644), which leaves the
-            # key world-readable on shared worker hosts.
-            fd = os.open(self.credentials_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-            with os.fdopen(fd, "w") as file:
-                json.dump(keyfile_content, file)
-            credential_params = ["-credential_file", self.credentials_path]
+        if self.impersonation_chain:
+            credential_params = ["-token", self._get_impersonated_access_token()]
         else:
-            self.log.info(
-                "The credentials are not supplied by neither key_path nor "
-                "keyfile_dict of the gcp connection %s. Falling back to "
-                "default activated account",
-                self.gcp_conn_id,
-            )
-            credential_params = []
+            key_path = get_field(extras, "key_path")
+            keyfile_dict = get_field(extras, "keyfile_dict")
+            if key_path:
+                credential_params = ["-credential_file", key_path]
+            elif keyfile_dict:
+                keyfile_content = keyfile_dict if isinstance(keyfile_dict, dict) else json.loads(keyfile_dict)
+                self.log.info("Saving credentials to %s", self.credentials_path)
+                # Explicit 0o600 — the file holds a service-account private key. The plain
+                # ``open()`` form inherits the process umask (typically 0o644), which leaves the
+                # key world-readable on shared worker hosts.
+                fd = os.open(self.credentials_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+                with os.fdopen(fd, "w") as file:
+                    json.dump(keyfile_content, file)
+                credential_params = ["-credential_file", self.credentials_path]
+            else:
+                self.log.info(
+                    "The credentials are not supplied by neither key_path nor "
+                    "keyfile_dict of the gcp connection %s. Falling back to "
+                    "default activated account",
+                    self.gcp_conn_id,
+                )
+                credential_params = []
 
         if not self.instance_specification:
             project_id = get_field(extras, "project")
@@ -687,6 +704,21 @@ class CloudSqlProxyRunner(LoggingMixin):
                 )
             credential_params.extend(["-projects", project_id])
         return credential_params
+
+    def _get_impersonated_access_token(self) -> str:
+        """
+        Mint a short-lived access token for ``impersonation_chain``.
+
+        cloud-sql-proxy v1 has no flag to impersonate a service account itself (that was
+        added in the v2 rewrite); it only accepts a pre-minted Bearer token via ``-token``,
+        so impersonation is resolved through the Google Cloud connection before the proxy
+        ever starts.
+        """
+        credentials = GoogleBaseHook(
+            gcp_conn_id=self.gcp_conn_id, impersonation_chain=self.impersonation_chain
+        ).get_credentials()
+        credentials.refresh(google.auth.transport.requests.Request())
+        return credentials.token
 
     def start_proxy(self) -> None:
         """
@@ -853,6 +885,16 @@ class CloudSQLDatabaseHook(BaseHook):
     :param gcp_cloudsql_conn_id: URL of the connection
     :param gcp_conn_id: The connection ID used to connect to Google Cloud for
         cloud-sql-proxy authentication.
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity.
+        Used both for the Cloud SQL Proxy connection (see
+        :class:`~airflow.providers.google.cloud.hooks.cloud_sql.CloudSqlProxyRunner`) and for
+        reading SSL certificates from Secret Manager when ``ssl_secret_id`` is set.
     :param default_gcp_project_id: Default project id used if project_id not specified
         in the connection URL
     :param ssl_cert: Optional. Path to client certificate to authenticate when SSL is used. Overrides the
@@ -1296,6 +1338,7 @@ class CloudSQLDatabaseHook(BaseHook):
             sql_proxy_binary_path=self.sql_proxy_binary_path,
             gcp_conn_id=self.gcp_conn_id,
             sql_proxy_enable_iam_login=self.sql_proxy_enable_iam_login,
+            impersonation_chain=self.impersonation_chain,
         )
 
     def get_database_hook(self, connection: Connection) -> DbApiHook:

--- a/providers/google/src/airflow/providers/google/cloud/operators/cloud_sql.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/cloud_sql.py
@@ -1178,6 +1178,14 @@ class CloudSQLExecuteQueryOperator(GoogleCloudBaseOperator):
        details on how to define ``gcpcloudsql://`` connection.
     :param sql_proxy_binary_path: (optional) Path to the cloud-sql-proxy binary.
           is not specified or the binary is not present, it is automatically downloaded.
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
     :param ssl_cert: (optional) Path to client certificate to authenticate when SSL is used. Overrides the
         connection field ``sslcert``.
     :param ssl_key: (optional) Path to client private key to authenticate when SSL is used. Overrides the
@@ -1206,6 +1214,7 @@ class CloudSQLExecuteQueryOperator(GoogleCloudBaseOperator):
         "ssl_client_cert",
         "ssl_client_key",
         "ssl_secret_id",
+        "impersonation_chain",
     )
     template_ext: Sequence[str] = (".sql",)
     template_fields_renderers = {"sql": "sql"}
@@ -1225,6 +1234,7 @@ class CloudSQLExecuteQueryOperator(GoogleCloudBaseOperator):
         ssl_client_cert: str | None = None,
         ssl_client_key: str | None = None,
         ssl_secret_id: str | None = None,
+        impersonation_chain: str | Sequence[str] | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -1239,6 +1249,7 @@ class CloudSQLExecuteQueryOperator(GoogleCloudBaseOperator):
         self.ssl_client_cert = ssl_client_cert
         self.ssl_client_key = ssl_client_key
         self.ssl_secret_id = ssl_secret_id
+        self.impersonation_chain = impersonation_chain
 
     @contextmanager
     def cloud_sql_proxy_context(self, hook: CloudSQLDatabaseHook):
@@ -1281,6 +1292,7 @@ class CloudSQLExecuteQueryOperator(GoogleCloudBaseOperator):
             ssl_cert=self.ssl_client_cert,
             ssl_key=self.ssl_client_key,
             ssl_secret_id=self.ssl_secret_id,
+            impersonation_chain=self.impersonation_chain,
         )
 
     def get_openlineage_facets_on_complete(self, _) -> OperatorLineage | None:

--- a/providers/google/tests/unit/google/cloud/hooks/test_cloud_sql.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_cloud_sql.py
@@ -1584,6 +1584,12 @@ class TestCloudSqlDatabaseQueryHook:
         instance_spec = f"{project}:{location}:{instance}"
         assert sqlproxy_runner.instance_specification == instance_spec
 
+    def test_get_sqlproxy_runner_passes_impersonation_chain(self):
+        self.db_hook.impersonation_chain = "impersonated@project.iam.gserviceaccount.com"
+        self.db_hook._generate_connection_uri()
+        sqlproxy_runner = self.db_hook.get_sqlproxy_runner()
+        assert sqlproxy_runner.impersonation_chain == "impersonated@project.iam.gserviceaccount.com"
+
     @mock.patch("airflow.providers.google.cloud.hooks.cloud_sql.CloudSQLDatabaseHook.get_connection")
     def test_hook_with_not_too_long_unix_socket_path(self, get_connection):
         uri = (
@@ -1981,6 +1987,33 @@ class TestCloudSqlProxyRunner:
         assert creds_path.exists()
         # Mask off the file-type bits, keep only the permission bits.
         assert stat.S_IMODE(creds_path.stat().st_mode) == 0o600
+
+    @mock.patch("airflow.providers.google.cloud.hooks.cloud_sql.GoogleBaseHook.get_credentials")
+    @mock.patch("airflow.providers.google.cloud.hooks.cloud_sql.GoogleBaseHook.get_connection")
+    def test_cloud_sql_proxy_runner_uses_impersonated_token(self, get_connection, get_credentials):
+        """When impersonation_chain is set, an impersonated Bearer token is used instead of
+        key-based credentials, since the v1 proxy binary has no impersonation flag of its own.
+        """
+        connection = Connection(conn_id="google_conn", conn_type="google_cloud_platform")
+        # key_path is present but must be ignored in favor of the impersonated token.
+        if AIRFLOW_V_3_1_PLUS:
+            connection.extra = json.dumps({"key_path": "/tmp/key.json"})
+        else:
+            connection.set_extra(json.dumps({"key_path": "/tmp/key.json"}))
+        get_connection.return_value = connection
+        mock_credentials = mock.MagicMock()
+        mock_credentials.token = "impersonated-token"
+        get_credentials.return_value = mock_credentials
+
+        runner = CloudSqlProxyRunner(
+            path_prefix="12345678",
+            instance_specification="project:us-east-1:instance",
+            gcp_conn_id="google_conn",
+            impersonation_chain="impersonated@project.iam.gserviceaccount.com",
+        )
+
+        assert runner._get_credential_parameters() == ["-token", "impersonated-token"]
+        mock_credentials.refresh.assert_called_once()
 
 
 class TestCloudSQLAsyncHook:

--- a/providers/google/tests/unit/google/cloud/operators/test_cloud_sql.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_cloud_sql.py
@@ -849,6 +849,23 @@ class TestCloudSqlQueryValidation:
         err = ctx.value
         assert "The UNIX socket path length cannot exceed" in str(err)
 
+    @mock.patch("airflow.providers.google.cloud.operators.cloud_sql.CloudSQLDatabaseHook")
+    @mock.patch(f"{BASEHOOK_PATCH_PATH}.get_connection")
+    def test_hook_passes_impersonation_chain(self, get_connection, mock_hook):
+        get_connection.return_value = mock.MagicMock(extra_dejson={})
+        impersonation_chain = "impersonated@project.iam.gserviceaccount.com"
+        op = CloudSQLExecuteQueryOperator(
+            sql="SELECT 1",
+            task_id="task_id",
+            impersonation_chain=impersonation_chain,
+        )
+
+        assert "impersonation_chain" in op.template_fields
+
+        _ = op.hook
+
+        assert mock_hook.call_args.kwargs["impersonation_chain"] == impersonation_chain
+
     @pytest.mark.parametrize(
         ("connection_port", "default_port", "expected_port"),
         [(None, 4321, 4321), (1234, None, 1234), (1234, 4321, 1234)],


### PR DESCRIPTION
The cloud-sql-proxy v1 binary has no flag to impersonate a service account itself; that capability only exists in the unrelated v2 rewrite, and migrating the CLI syntax to pull it in was flagged as too risky in the prior attempt at this feature (GH-44564). Instead, resolve impersonation on the Airflow side through the existing GoogleBaseHook credential machinery and hand the proxy a short-lived Bearer token via the already-supported -token flag, so no proxy version bump or CLI syntax change is needed. CloudSQLExecuteQueryOperator was also missing impersonation_chain entirely, unlike every other Cloud SQL operator in this module.

closes: #39546

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)

Generated-by: Claude Code (Sonnet 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)