### PR TITLE
Allow SparkKubernetesOperator to set spec.arguments on the SparkApplication CRD

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
@@ -56,6 +56,11 @@ class SparkKubernetesOperator(KubernetesPodOperator):
         containing only [a-z0-9.-]).
     :param application_file: filepath to kubernetes custom_resource_definition of sparkApplication
     :param template_spec: kubernetes sparkApplication specification
+    :param application_arguments: list of arguments for the Spark application, merged into
+        ``spec.arguments`` of the SparkApplication CRD, overriding any arguments already present
+        in application_file/template_spec. Not to be confused with ``arguments``, which is inherited
+        from ``KubernetesPodOperator`` and sets the driver container's entrypoint args. Templated, so
+        it can be populated from Dag run Params entered when triggering the Dag via the UI.
     :param get_logs: get the stdout of the container as logs of the tasks.
     :param do_xcom_push: If True, the content of the file
         /airflow/xcom/return.json in the container will also be pushed to an
@@ -73,7 +78,13 @@ class SparkKubernetesOperator(KubernetesPodOperator):
     :param random_name_suffix: If True, adds a random suffix to the pod name
     """
 
-    template_fields = ["application_file", "namespace", "template_spec", "kubernetes_conn_id"]
+    template_fields = [
+        "application_file",
+        "namespace",
+        "template_spec",
+        "kubernetes_conn_id",
+        "application_arguments",
+    ]
     template_fields_renderers = {"template_spec": "py"}
     template_ext = ("yaml", "yml", "json")
     ui_color = "#f4a460"
@@ -89,6 +100,7 @@ class SparkKubernetesOperator(KubernetesPodOperator):
         name: str | None = None,
         application_file: str | None = None,
         template_spec=None,
+        application_arguments: list[str] | None = None,
         get_logs: bool = True,
         do_xcom_push: bool = False,
         success_run_history_limit: int = 1,
@@ -105,6 +117,7 @@ class SparkKubernetesOperator(KubernetesPodOperator):
         self.code_path = code_path
         self.application_file = application_file
         self.template_spec = template_spec
+        self.application_arguments = application_arguments
         self.kubernetes_conn_id = kubernetes_conn_id
         self.startup_timeout_seconds = startup_timeout_seconds
         self.reattach_on_restart = reattach_on_restart
@@ -401,6 +414,8 @@ class SparkKubernetesOperator(KubernetesPodOperator):
                 spec_dict[component]["labels"].update(task_context_labels)
 
         spec_dict = template_body.setdefault("spark", {}).setdefault("spec", {})
+        if self.application_arguments:
+            spec_dict["arguments"] = self.application_arguments
         for component in ["driver", "executor"]:
             env_list = spec_dict.setdefault(component, {}).setdefault("env", [])
             if not any(e.get("name") == "SPARK_APPLICATION_NAME" for e in env_list):

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_spark_kubernetes.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_spark_kubernetes.py
@@ -1358,6 +1358,23 @@ def test_template_body_templating(create_task_instance_of_operator, session):
 
 
 @pytest.mark.db_test
+def test_application_arguments_templating(create_task_instance_of_operator, session):
+    ti = create_task_instance_of_operator(
+        SparkKubernetesOperator,
+        template_spec={"spec": {}},
+        application_arguments=["{{ ds }}", "static-arg"],
+        kubernetes_conn_id="kubernetes_default_kube_config",
+        dag_id="test_application_arguments_templating_dag",
+        task_id="test_application_arguments_templating_task",
+        session=session,
+    )
+    session.add(ti)
+    session.commit()
+    task = ti.render_templates()
+    assert task.application_arguments == ["2016-01-01", "static-arg"]
+
+
+@pytest.mark.db_test
 def test_resolve_application_file_template_file(create_task_instance_of_operator, tmp_path, session):
     filename = "test-application-file.yml"
     (tmp_path / filename).write_text("foo: {{ ds }}\nbar: {{ dag_run.dag_id }}\nspam: egg")
@@ -1651,3 +1668,77 @@ class TestSparkKubernetesLifecycle:
             app_name_envs = [e for e in env if e["name"] == "SPARK_APPLICATION_NAME"]
             assert len(app_name_envs) == 1  # not duplicated
             assert app_name_envs[0]["value"] == "user-defined"
+
+    @patch("airflow.providers.cncf.kubernetes.operators.spark_kubernetes.SparkKubernetesOperator.client")
+    def test_application_arguments_merged_into_spec(self, mock_client):
+        op = SparkKubernetesOperator(
+            task_id="test_task",
+            namespace="default",
+            template_spec={
+                "apiVersion": "sparkoperator.k8s.io/v1beta2",
+                "kind": "SparkApplication",
+                "spec": {
+                    "driver": {},
+                    "executor": {},
+                },
+            },
+            application_arguments=["--input", "s3://bucket/data"],
+            reattach_on_restart=False,
+        )
+        op.name = "my-spark-app-abc123"
+
+        with mock.patch.object(op, "get_or_create_spark_crd", return_value=mock.MagicMock()):
+            op._setup_spark_configuration(mock.MagicMock())
+
+        assert op.launcher.body["spec"]["arguments"] == ["--input", "s3://bucket/data"]
+
+    @patch("airflow.providers.cncf.kubernetes.operators.spark_kubernetes.SparkKubernetesOperator.client")
+    def test_application_arguments_override_existing_spec_arguments(self, mock_client):
+        op = SparkKubernetesOperator(
+            task_id="test_task",
+            namespace="default",
+            template_spec={
+                "apiVersion": "sparkoperator.k8s.io/v1beta2",
+                "kind": "SparkApplication",
+                "spec": {
+                    "arguments": ["--from-template"],
+                    "driver": {},
+                    "executor": {},
+                },
+            },
+            application_arguments=["--from-operator"],
+            reattach_on_restart=False,
+        )
+        op.name = "my-spark-app-abc123"
+
+        with mock.patch.object(op, "get_or_create_spark_crd", return_value=mock.MagicMock()):
+            op._setup_spark_configuration(mock.MagicMock())
+
+        assert op.launcher.body["spec"]["arguments"] == ["--from-operator"]
+
+    @patch("airflow.providers.cncf.kubernetes.operators.spark_kubernetes.SparkKubernetesOperator.client")
+    def test_application_arguments_do_not_shadow_container_arguments(self, mock_client):
+        """application_arguments (spec.arguments) must stay independent of the inherited
+        KubernetesPodOperator `arguments` param (driver container entrypoint args)."""
+        op = SparkKubernetesOperator(
+            task_id="test_task",
+            namespace="default",
+            template_spec={
+                "apiVersion": "sparkoperator.k8s.io/v1beta2",
+                "kind": "SparkApplication",
+                "spec": {
+                    "driver": {},
+                    "executor": {},
+                },
+            },
+            arguments=["--container-arg"],
+            application_arguments=["--spec-arg"],
+            reattach_on_restart=False,
+        )
+        op.name = "my-spark-app-abc123"
+
+        with mock.patch.object(op, "get_or_create_spark_crd", return_value=mock.MagicMock()):
+            op._setup_spark_configuration(mock.MagicMock())
+
+        assert op.arguments == ["--container-arg"]
+        assert op.launcher.body["spec"]["arguments"] == ["--spec-arg"]


### PR DESCRIPTION
Users triggering a Dag from the UI had no way to pass ad-hoc arguments to a Spark application: SparkKubernetesOperator only accepted a full application_file/template_spec, so any per-run value had to be baked into the CRD spec ahead of time. Exposing application_arguments as a templated operator param lets callers reference Dag run Params (e.g. arguments=["{{ params.input_path }}"]) and have them merged into the CRD's spec.arguments field at submission time, following the same merge-into-template_body pattern already used for driver/executor labels and the SPARK_APPLICATION_NAME env var.

The parameter is named application_arguments rather than arguments because KubernetesPodOperator already defines an unrelated `arguments` param (driver container entrypoint args); reusing that name would have silently changed its meaning for this operator.

closes: #16728

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)

Generated-by: Claude Code (Sonnet 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)