### PR TITLE
Prevent deadlocks when Dags update shared assets

### DIFF
--- a/airflow-core/newsfragments/71936.bugfix.rst
+++ b/airflow-core/newsfragments/71936.bugfix.rst
@@ -1,0 +1,1 @@
+Prevent retries during ``airflow dags reserialize`` from discarding previously published bundles, and recover Dag publication after database uniqueness conflicts.

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -870,12 +870,10 @@ def dag_test(args, dag: DAG | None = None, *, session: Session = NEW_SESSION) ->
 
 @cli_utils.action_cli
 @providers_configuration_loaded
-@provide_session
-def dag_reserialize(args, *, session: Session = NEW_SESSION) -> None:
+def dag_reserialize(args) -> None:
     """Serialize a DAG instance."""
     manager = DagBundlesManager()
-    manager.sync_bundles_to_db(session=session)
-    session.commit()
+    manager.sync_bundles_to_db()
 
     all_bundles = list(manager.get_all_dag_bundles())
     if args.bundle_name:
@@ -890,6 +888,5 @@ def dag_reserialize(args, *, session: Session = NEW_SESSION) -> None:
         bundle.initialize()
         dag_bag = BundleDagBag(bundle.path, bundle_path=bundle.path, bundle_name=bundle.name)
         version, version_data = unpack_bundle_version(bundle.get_current_version(), bundle)
-        sync_bag_to_db(
-            dag_bag, bundle.name, bundle_version=version, version_data=version_data, session=session
-        )
+        # Each publication owns its transaction so retries cannot roll back earlier bundles.
+        sync_bag_to_db(dag_bag, bundle.name, bundle_version=version, version_data=version_data)

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -581,11 +581,15 @@ class DagModelOperation(NamedTuple):
 
     def find_orm_dags(self, *, session: Session) -> dict[str, DagModel]:
         """Find existing DagModel objects from DAG objects."""
+        # Ordered, because these rows are locked, and two writers taking the same ones the other
+        # way round deadlock. Dag ids are shared between writers whenever a Dag moves file or a
+        # reserialize runs beside the Dag processor.
         stmt: Select[Unpack[tuple[DagModel]]] = with_row_locks(
             (
                 select(DagModel)
                 .options(joinedload(DagModel.tags, innerjoin=False))
                 .where(DagModel.dag_id.in_(self.dags))
+                .order_by(DagModel.dag_id)
                 .options(joinedload(DagModel.schedule_asset_references))
                 .options(joinedload(DagModel.schedule_asset_alias_references))
                 .options(joinedload(DagModel.task_outlet_asset_references))
@@ -603,7 +607,8 @@ class DagModelOperation(NamedTuple):
             for model in _create_orm_dags(
                 bundle_name=self.bundle_name,
                 bundle_version=self.bundle_version,
-                dags=(dag for dag_id, dag in self.dags.items() if dag_id not in orm_dags),
+                # Sorted for the same reason the lock above is: insertion order is lock order.
+                dags=(dag for dag_id, dag in sorted(self.dags.items()) if dag_id not in orm_dags),
                 session=session,
             )
         )

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -850,8 +850,13 @@ class AssetModelOperation(NamedTuple):
                 dag_id: list(_get_dag_assets(dag, SerializedAsset, inlets=False, outlets=True))
                 for dag_id, dag in dags.items()
             },
-            assets={(asset.name, asset.uri): asset for asset in _find_all_assets(dags.values())},
-            asset_aliases={alias.name: alias for alias in _find_all_asset_aliases(dags.values())},
+            # Insertion order is lock order, and assets are shared, so two writers taking them
+            # in opposite orders deadlock. Deduplicated before sorting: sorting the pairs first
+            # compares SerializedAssets wherever a Dag repeats one, which they do not support.
+            assets=dict(sorted({(a.name, a.uri): a for a in _find_all_assets(dags.values())}.items())),
+            asset_aliases=dict(
+                sorted({alias.name: alias for alias in _find_all_asset_aliases(dags.values())}.items())
+            ),
         )
         return coll
 
@@ -876,7 +881,9 @@ class AssetModelOperation(NamedTuple):
                 session=session,
             )
         )
-        return orm_assets
+        # Sorted again: the rows that already existed came back in the query's order, and
+        # ``activate_assets_if_possible`` locks them in the order it is handed.
+        return dict(sorted(orm_assets.items()))
 
     def sync_asset_aliases(self, *, session: Session) -> dict[str, AssetAliasModel]:
         # Optimization: skip all database calls if no asset aliases were collected.

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -32,7 +32,7 @@ from operator import itemgetter
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
 import structlog
-from sqlalchemy import delete, false, func, insert, select, tuple_, update
+from sqlalchemy import delete, false, func, insert, or_, select, tuple_, update
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import joinedload, load_only
 
@@ -956,16 +956,18 @@ class AssetModelOperation(NamedTuple):
             stmt = sqlite_insert(AssetActive).on_conflict_do_nothing()
         # ``asset_active`` is unique on name and on uri separately, and no order of this insert
         # is consistent for both indexes -- two writers can sort identically and still take the
-        # two uris the opposite way round. So the rows are serialized on their assets instead:
-        # every writer takes those in one order, which leaves the insert below to run without a
-        # second writer inside it, and lets the database go on arbitrating which of two
-        # conflicting assets wins.
+        # two uris the opposite way round. So the rows are serialized first, on every asset
+        # sharing a name or a uri with one being activated rather than on the exact pairs: two
+        # writers activating different assets still meet on those two columns. Taking them in one
+        # order leaves the insert below to run without a second writer inside it, and lets the
+        # database go on arbitrating which of two conflicting assets wins.
         session.execute(
             with_row_locks(
                 select(AssetModel.id)
                 .where(
-                    tuple_(AssetModel.name, AssetModel.uri).in_(
-                        [(model.name, model.uri) for model in candidates]
+                    or_(
+                        AssetModel.name.in_({model.name for model in candidates}),
+                        AssetModel.uri.in_({model.uri for model in candidates}),
                     )
                 )
                 .order_by(AssetModel.name, AssetModel.uri),

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -31,7 +31,7 @@ import traceback
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
 import structlog
-from sqlalchemy import delete, false, func, insert, select, tuple_, update
+from sqlalchemy import delete, false, func, insert, or_, select, tuple_, update
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import joinedload, load_only
 
@@ -890,13 +890,13 @@ class AssetModelOperation(NamedTuple):
             (asset for name_uri, asset in self.assets.items() if name_uri not in orm_assets),
             key=lambda asset: (asset.name, asset.uri),
         )
-        created = {
-            (model.name, model.uri): model
+        orm_assets.update(
+            ((model.name, model.uri), model)
             for model in asset_manager.create_assets(to_create, session=session)
-        }
-        # Back in collection order, which is what decides the activation below.
-        orm_assets.update((key, created[key]) for key in self.assets if key in created)
-        return orm_assets
+        )
+        # In collection order, which is what decides the activation below. The rows that already
+        # existed came back in whatever order the query returned them.
+        return {key: orm_assets[key] for key in self.assets if key in orm_assets}
 
     def sync_asset_aliases(self, *, session: Session) -> dict[str, AssetAliasModel]:
         # Optimization: skip all database calls if no asset aliases were collected.
@@ -947,14 +947,27 @@ class AssetModelOperation(NamedTuple):
             from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
             stmt = sqlite_insert(AssetActive).on_conflict_do_nothing()
-        # Of two assets sharing a name or a uri only the one offered first is activated. Choosing
-        # that here rather than leaving it to the insert means the rows can then be sorted, which
-        # they must be: ``asset_active`` is unique on both columns, so two writers inserting them
-        # in opposite orders deadlock on the index.
-        claimed_names: set[str] = set()
-        claimed_uris: set[str] = set()
+        candidates = list(models)
+        if not candidates:
+            return
+        # Of two assets sharing a name or a uri only one can be active, and deciding which here
+        # rather than leaving it to the insert is what lets the rows be sorted -- ``asset_active``
+        # is unique on both columns, so two writers inserting in opposite orders deadlock on the
+        # index. The claim starts from what is already active, the way the scheduler's
+        # ``_activate_referenced_assets`` does: a candidate the insert would reject anyway must not
+        # take a name or uri from one that would have gone in.
+        active = session.execute(
+            select(AssetActive.name, AssetActive.uri).where(
+                or_(
+                    AssetActive.name.in_({model.name for model in candidates}),
+                    AssetActive.uri.in_({model.uri for model in candidates}),
+                )
+            )
+        ).all()
+        claimed_names = {name for name, _ in active}
+        claimed_uris = {uri for _, uri in active}
         values = []
-        for model in models:
+        for model in candidates:
             if model.name in claimed_names or model.uri in claimed_uris:
                 continue
             claimed_names.add(model.name)

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -28,7 +28,6 @@ This should generally only be called by internal methods such as
 from __future__ import annotations
 
 import traceback
-from operator import itemgetter
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
 import structlog
@@ -596,11 +595,11 @@ class DagModelOperation(NamedTuple):
                 select(DagModel)
                 .options(joinedload(DagModel.tags, innerjoin=False))
                 .where(DagModel.dag_id.in_(self.dags))
-                .order_by(DagModel.dag_id)
                 .options(joinedload(DagModel.schedule_asset_references))
                 .options(joinedload(DagModel.schedule_asset_alias_references))
                 .options(joinedload(DagModel.task_outlet_asset_references))
                 .options(joinedload(DagModel.dag_owner_links))
+                .order_by(DagModel.dag_id)
             ),
             of=DagModel,
             session=session,
@@ -614,11 +613,7 @@ class DagModelOperation(NamedTuple):
             for model in _create_orm_dags(
                 bundle_name=self.bundle_name,
                 bundle_version=self.bundle_version,
-                dags=(
-                    dag
-                    for dag_id, dag in sorted(self.dags.items(), key=itemgetter(0))
-                    if dag_id not in orm_dags
-                ),
+                dags=(dag for dag_id, dag in sorted(self.dags.items()) if dag_id not in orm_dags),
                 session=session,
             )
         )
@@ -874,19 +869,11 @@ class AssetModelOperation(NamedTuple):
         # Optimization: skip all database calls if no assets were collected.
         if not self.assets:
             return {}
-        # Acquire the requested rows before metadata updates or reference writes can lock a subset.
-        # MySQL can otherwise lock rows in primary-key order before sorting the result.
+        # Metadata updates acquire locks at flush; unchanged shared assets need no write lock.
         orm_assets: dict[tuple[str, str], AssetModel] = {
             (am.name, am.uri): am
             for am in session.scalars(
-                with_row_locks(
-                    select(AssetModel)
-                    .with_hint(AssetModel, "FORCE INDEX (idx_asset_name_uri_unique)", dialect_name="mysql")
-                    .where(tuple_(AssetModel.name, AssetModel.uri).in_(self.assets))
-                    .order_by(AssetModel.name, AssetModel.uri),
-                    session=session,
-                    of=AssetModel,
-                )
+                select(AssetModel).where(tuple_(AssetModel.name, AssetModel.uri).in_(self.assets))
             )
         }
         for key, model in orm_assets.items():
@@ -901,7 +888,7 @@ class AssetModelOperation(NamedTuple):
             ((model.name, model.uri), model)
             for model in asset_manager.create_assets(to_create, session=session)
         )
-        # Physical write order must not change which conflicting candidate is offered first.
+        # Preserve collection order for activation when candidates share a name or URI.
         return {key: orm_assets[key] for key in self.assets}
 
     def sync_asset_aliases(self, *, session: Session) -> dict[str, AssetAliasModel]:
@@ -911,16 +898,7 @@ class AssetModelOperation(NamedTuple):
         orm_aliases: dict[str, AssetAliasModel] = {
             da.name: da
             for da in session.scalars(
-                with_row_locks(
-                    select(AssetAliasModel)
-                    .with_hint(
-                        AssetAliasModel, "FORCE INDEX (idx_asset_alias_name_unique)", dialect_name="mysql"
-                    )
-                    .where(AssetAliasModel.name.in_(self.asset_aliases))
-                    .order_by(AssetAliasModel.name),
-                    session=session,
-                    of=AssetAliasModel,
-                )
+                select(AssetAliasModel).where(AssetAliasModel.name.in_(self.asset_aliases))
             )
         }
         for name, model in orm_aliases.items():

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -1021,7 +1021,7 @@ class AssetModelOperation(NamedTuple):
                     session.delete(ref)
             session.bulk_save_objects(
                 DagScheduleAssetAliasReference(alias_id=alias_id, dag_id=dag_id)
-                for alias_id in referenced_alias_ids
+                for alias_id in sorted(referenced_alias_ids)
                 if alias_id not in orm_refs
             )
 
@@ -1221,12 +1221,16 @@ class AssetModelOperation(NamedTuple):
             # Add new references
             for name_uri, trigger_hashes in sorted(refs_to_add.items(), key=itemgetter(0)):
                 asset_model = assets[name_uri]
-
-                for trigger_hash in sorted(trigger_hashes):
-                    trigger = triggers.get(trigger_hash)
-                    orm_trigger = orm_triggers.get(trigger_hash)
-                    if orm_trigger and trigger:
-                        asset_model.add_trigger(orm_trigger, trigger["watcher_name"])
+                # ``asset_watcher`` is keyed on (asset_id, trigger_id). Ordering by the trigger
+                # hash would order nothing: it is a builtin hash of a str and bytes, so its value
+                # differs between processes. The row ids do not.
+                watchers = [
+                    (orm_triggers[trigger_hash], triggers[trigger_hash])
+                    for trigger_hash in trigger_hashes
+                    if trigger_hash in orm_triggers and trigger_hash in triggers
+                ]
+                for orm_trigger, trigger in sorted(watchers, key=lambda pair: pair[0].id):
+                    asset_model.add_trigger(orm_trigger, trigger["watcher_name"])
 
         if refs_to_remove:
             # Remove old references

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -32,7 +32,7 @@ from operator import itemgetter
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
 import structlog
-from sqlalchemy import delete, false, func, insert, or_, select, tuple_, update
+from sqlalchemy import delete, false, func, insert, select, tuple_, update
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import joinedload, load_only
 
@@ -937,9 +937,6 @@ class AssetModelOperation(NamedTuple):
         there's a conflict. The scheduler makes a more comprehensive pass
         through all assets in ``_update_asset_orphanage``.
         """
-        candidates = list(models)
-        if not candidates:
-            return
         if (dialect_name := get_dialect_name(session)) == "postgresql":
             from sqlalchemy.dialects.postgresql import insert as postgresql_insert
 
@@ -954,28 +951,11 @@ class AssetModelOperation(NamedTuple):
             from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
             stmt = sqlite_insert(AssetActive).on_conflict_do_nothing()
-        # ``asset_active`` is unique on name and on uri separately, so choosing the winner here
-        # rather than leaving it to the insert is what lets these rows be sorted. The read is a
-        # snapshot; a row deactivated meanwhile is missed until the next orphanage pass.
-        active = session.execute(
-            select(AssetActive.name, AssetActive.uri).where(
-                or_(
-                    AssetActive.name.in_({model.name for model in candidates}),
-                    AssetActive.uri.in_({model.uri for model in candidates}),
-                )
-            )
-        ).all()
-        claimed_names = {name for name, _ in active}
-        claimed_uris = {uri for _, uri in active}
-        values = []
-        for model in candidates:
-            if model.name in claimed_names or model.uri in claimed_uris:
-                continue
-            claimed_names.add(model.name)
-            claimed_uris.add(model.uri)
-            values.append({"name": model.name, "uri": model.uri})
-        if values:
-            session.execute(stmt, sorted(values, key=itemgetter("name", "uri")))
+        # Left to the insert: ``asset_active`` is unique on name and on uri separately, and no
+        # single order can be consistent for both, so choosing a winner here would only narrow
+        # what the database already arbitrates.
+        if values := [{"name": model.name, "uri": model.uri} for model in models]:
+            session.execute(stmt, values)
 
     def add_dag_asset_references(
         self,

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -33,8 +33,9 @@ from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
 import structlog
 from sqlalchemy import delete, false, func, insert, select, tuple_, update
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import joinedload, load_only
+from sqlalchemy.orm.exc import StaleDataError
 
 from airflow._shared.timezones.timezone import utcnow
 from airflow.assets.manager import asset_manager
@@ -289,7 +290,7 @@ def _serialize_dag_capturing_errors(
             _sync_dag_perms(dag, session=session)
 
         return []
-    except OperationalError:
+    except (DBAPIError, StaleDataError):
         raise
     except Exception:
         log.exception("Failed to write serialized DAG dag_id=%s fileloc=%s", dag.dag_id, dag.fileloc)
@@ -508,13 +509,13 @@ def update_dag_parsing_results_in_db(
 
     ``import_errors`` will be updated in place with an new errors
 
+    Retries roll back the entire session and replay this publication. Callers must use a transaction
+    dedicated to this publication.
+
     :param files_parsed: Set of (bundle_name, relative_fileloc) tuples for all files that were parsed.
         If None, will be inferred from dags and import_errors. Passing this explicitly ensures that
         import errors are cleared for files that were parsed but no longer contain DAGs.
     """
-    # Retry 'DAG.bulk_write_to_db' & 'SerializedDagModel.bulk_sync_to_db' in case
-    # of any Operational Errors
-    # In case of failures, provide_session handles rollback
     try:
         duplicate_warnings = _build_duplicate_dag_id_warnings(dags, bundle_name, session)
     except Exception:
@@ -554,7 +555,8 @@ def update_dag_parsing_results_in_db(
                             _prefetched=prefetched_metadata.get(dag.dag_id),
                         )
                     )
-            except OperationalError:
+                session.flush()
+            except (DBAPIError, StaleDataError):
                 session.rollback()
                 raise
             # Only now we are "complete" do we update import_errors - don't want to record errors from

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -587,11 +587,15 @@ class DagModelOperation(NamedTuple):
 
     def find_orm_dags(self, *, session: Session) -> dict[str, DagModel]:
         """Find existing DagModel objects from DAG objects."""
+        # Ordered, because these rows are locked, and two writers taking the same ones the other
+        # way round deadlock. Dag ids are shared between writers whenever a Dag moves file or a
+        # reserialize runs beside the Dag processor.
         stmt: Select[Unpack[tuple[DagModel]]] = with_row_locks(
             (
                 select(DagModel)
                 .options(joinedload(DagModel.tags, innerjoin=False))
                 .where(DagModel.dag_id.in_(self.dags))
+                .order_by(DagModel.dag_id)
                 .options(joinedload(DagModel.schedule_asset_references))
                 .options(joinedload(DagModel.schedule_asset_alias_references))
                 .options(joinedload(DagModel.task_outlet_asset_references))
@@ -609,7 +613,8 @@ class DagModelOperation(NamedTuple):
             for model in _create_orm_dags(
                 bundle_name=self.bundle_name,
                 bundle_version=self.bundle_version,
-                dags=(dag for dag_id, dag in self.dags.items() if dag_id not in orm_dags),
+                # Sorted for the same reason the lock above is: insertion order is lock order.
+                dags=(dag for dag_id, dag in sorted(self.dags.items()) if dag_id not in orm_dags),
                 session=session,
             )
         )

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -861,13 +861,12 @@ class AssetModelOperation(NamedTuple):
                 dag_id: list(_get_dag_assets(dag, SerializedAsset, inlets=False, outlets=True))
                 for dag_id, dag in dags.items()
             },
-            # Insertion order is lock order, and assets are shared, so two writers taking them
-            # in opposite orders deadlock. Deduplicated before sorting: sorting the pairs first
-            # compares SerializedAssets wherever a Dag repeats one, which they do not support.
-            assets=dict(sorted({(a.name, a.uri): a for a in _find_all_assets(dags.values())}.items())),
-            asset_aliases=dict(
-                sorted({alias.name: alias for alias in _find_all_asset_aliases(dags.values())}.items())
-            ),
+            # Left in the order the Dags define them: that order decides which of two assets
+            # sharing a name is activated, so sorting here would move it, and a sweep would stop
+            # landing where writing its files one at a time does. Rows are sorted where they are
+            # inserted instead.
+            assets={(asset.name, asset.uri): asset for asset in _find_all_assets(dags.values())},
+            asset_aliases={alias.name: alias for alias in _find_all_asset_aliases(dags.values())},
         )
         return coll
 
@@ -885,16 +884,19 @@ class AssetModelOperation(NamedTuple):
             asset = self.assets[key]
             model.group = asset.group
             model.extra = asset.extra
-        orm_assets.update(
-            ((model.name, model.uri), model)
-            for model in asset_manager.create_assets(
-                [asset for name_uri, asset in self.assets.items() if name_uri not in orm_assets],
-                session=session,
-            )
+        # ``asset`` is unique on (name, uri), so two writers inserting the same new rows in
+        # opposite orders deadlock on that index.
+        to_create = sorted(
+            (asset for name_uri, asset in self.assets.items() if name_uri not in orm_assets),
+            key=lambda asset: (asset.name, asset.uri),
         )
-        # Sorted again: the rows that already existed came back in the query's order, and
-        # ``activate_assets_if_possible`` locks them in the order it is handed.
-        return dict(sorted(orm_assets.items()))
+        created = {
+            (model.name, model.uri): model
+            for model in asset_manager.create_assets(to_create, session=session)
+        }
+        # Back in collection order, which is what decides the activation below.
+        orm_assets.update((key, created[key]) for key in self.assets if key in created)
+        return orm_assets
 
     def sync_asset_aliases(self, *, session: Session) -> dict[str, AssetAliasModel]:
         # Optimization: skip all database calls if no asset aliases were collected.
@@ -908,10 +910,14 @@ class AssetModelOperation(NamedTuple):
         }
         for name, model in orm_aliases.items():
             model.group = self.asset_aliases[name].group
+        # ``asset_alias`` is unique on name; sorted for the reason the assets above are.
         orm_aliases.update(
             (model.name, model)
             for model in asset_manager.create_asset_aliases(
-                [alias for name, alias in self.asset_aliases.items() if name not in orm_aliases],
+                sorted(
+                    (alias for name, alias in self.asset_aliases.items() if name not in orm_aliases),
+                    key=lambda alias: alias.name,
+                ),
                 session=session,
             )
         )
@@ -941,8 +947,21 @@ class AssetModelOperation(NamedTuple):
             from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
             stmt = sqlite_insert(AssetActive).on_conflict_do_nothing()
-        if values := [{"name": m.name, "uri": m.uri} for m in models]:
-            session.execute(stmt, values)
+        # Of two assets sharing a name or a uri only the one offered first is activated. Choosing
+        # that here rather than leaving it to the insert means the rows can then be sorted, which
+        # they must be: ``asset_active`` is unique on both columns, so two writers inserting them
+        # in opposite orders deadlock on the index.
+        claimed_names: set[str] = set()
+        claimed_uris: set[str] = set()
+        values = []
+        for model in models:
+            if model.name in claimed_names or model.uri in claimed_uris:
+                continue
+            claimed_names.add(model.name)
+            claimed_uris.add(model.uri)
+            values.append({"name": model.name, "uri": model.uri})
+        if values:
+            session.execute(stmt, sorted(values, key=lambda value: (value["name"], value["uri"])))
 
     def add_dag_asset_references(
         self,

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -900,7 +900,7 @@ class AssetModelOperation(NamedTuple):
             for model in asset_manager.create_assets(to_create, session=session)
         )
         # Physical write order must not change which conflicting candidate is offered first.
-        return {key: orm_assets[key] for key in self.assets if key in orm_assets}
+        return {key: orm_assets[key] for key in self.assets}
 
     def sync_asset_aliases(self, *, session: Session) -> dict[str, AssetAliasModel]:
         # Optimization: skip all database calls if no asset aliases were collected.

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -866,10 +866,8 @@ class AssetModelOperation(NamedTuple):
                 dag_id: list(_get_dag_assets(dag, SerializedAsset, inlets=False, outlets=True))
                 for dag_id, dag in dags.items()
             },
-            # Left in the order the Dags define them: that order decides which of two assets
-            # sharing a name is activated, so sorting here would move it, and a sweep would stop
-            # landing where writing its files one at a time does. Rows are sorted where they are
-            # inserted instead.
+            # Definition order decides which of two assets sharing a name is activated; the rows
+            # are sorted where they are inserted instead.
             assets={(asset.name, asset.uri): asset for asset in _find_all_assets(dags.values())},
             asset_aliases={alias.name: alias for alias in _find_all_asset_aliases(dags.values())},
         )
@@ -889,8 +887,7 @@ class AssetModelOperation(NamedTuple):
             asset = self.assets[key]
             model.group = asset.group
             model.extra = asset.extra
-        # ``asset`` is unique on (name, uri), so two writers inserting the same new rows in
-        # opposite orders deadlock on that index.
+        # ``asset`` is unique on (name, uri): opposite insert orders deadlock on that index.
         to_create = sorted(
             (asset for name_uri, asset in self.assets.items() if name_uri not in orm_assets),
             key=lambda asset: (asset.name, asset.uri),
@@ -899,8 +896,7 @@ class AssetModelOperation(NamedTuple):
             ((model.name, model.uri), model)
             for model in asset_manager.create_assets(to_create, session=session)
         )
-        # In collection order, which is what decides the activation below. The rows that already
-        # existed came back in whatever order the query returned them.
+        # Collection order, which decides the activation below; the read-back returns its own.
         return {key: orm_assets[key] for key in self.assets if key in orm_assets}
 
     def sync_asset_aliases(self, *, session: Session) -> dict[str, AssetAliasModel]:
@@ -915,7 +911,7 @@ class AssetModelOperation(NamedTuple):
         }
         for name, model in orm_aliases.items():
             model.group = self.asset_aliases[name].group
-        # ``asset_alias`` is unique on name; sorted for the reason the assets above are.
+        # ``asset_alias`` is unique on name, so the same applies.
         orm_aliases.update(
             (model.name, model)
             for model in asset_manager.create_asset_aliases(
@@ -955,12 +951,10 @@ class AssetModelOperation(NamedTuple):
         candidates = list(models)
         if not candidates:
             return
-        # Of two assets sharing a name or a uri only one can be active, and deciding which here
-        # rather than leaving it to the insert is what lets the rows be sorted -- ``asset_active``
-        # is unique on both columns, so two writers inserting in opposite orders deadlock on the
-        # index. The claim starts from what is already active, the way the scheduler's
-        # ``_activate_referenced_assets`` does: a candidate the insert would reject anyway must not
-        # take a name or uri from one that would have gone in.
+        # Only one of two assets sharing a name or a uri can be active. Deciding that here, from
+        # what is already active, is what lets the rows be sorted -- ``asset_active`` is unique on
+        # both columns. The read is a snapshot: a row deactivated meanwhile is missed until the
+        # scheduler's next orphanage pass.
         active = session.execute(
             select(AssetActive.name, AssetActive.uri).where(
                 or_(

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -937,6 +937,9 @@ class AssetModelOperation(NamedTuple):
         there's a conflict. The scheduler makes a more comprehensive pass
         through all assets in ``_update_asset_orphanage``.
         """
+        candidates = list(models)
+        if not candidates:
+            return
         if (dialect_name := get_dialect_name(session)) == "postgresql":
             from sqlalchemy.dialects.postgresql import insert as postgresql_insert
 
@@ -951,11 +954,26 @@ class AssetModelOperation(NamedTuple):
             from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
             stmt = sqlite_insert(AssetActive).on_conflict_do_nothing()
-        # Left to the insert: ``asset_active`` is unique on name and on uri separately, and no
-        # single order can be consistent for both, so choosing a winner here would only narrow
-        # what the database already arbitrates.
-        if values := [{"name": model.name, "uri": model.uri} for model in models]:
-            session.execute(stmt, values)
+        # ``asset_active`` is unique on name and on uri separately, and no order of this insert
+        # is consistent for both indexes -- two writers can sort identically and still take the
+        # two uris the opposite way round. So the rows are serialized on their assets instead:
+        # every writer takes those in one order, which leaves the insert below to run without a
+        # second writer inside it, and lets the database go on arbitrating which of two
+        # conflicting assets wins.
+        session.execute(
+            with_row_locks(
+                select(AssetModel.id)
+                .where(
+                    tuple_(AssetModel.name, AssetModel.uri).in_(
+                        [(model.name, model.uri) for model in candidates]
+                    )
+                )
+                .order_by(AssetModel.name, AssetModel.uri),
+                session=session,
+                of=AssetModel,
+            )
+        )
+        session.execute(stmt, [{"name": model.name, "uri": model.uri} for model in candidates])
 
     def add_dag_asset_references(
         self,

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -231,7 +231,9 @@ def _update_dag_tags(tag_names: set[str], dm: DagModel, *, session: Session) -> 
                 # Refresh the tags relationship from the database to reflect the deletions.
                 session.expire(dm, ["tags"])
 
-    dm.tags.extend(DagTag(name=name, dag_id=dm.dag_id) for name in tags_to_add)
+    # Sorted, like every other insert here: ``dag_tag`` is keyed on (name, dag_id), and a set
+    # iterates differently in each writer.
+    dm.tags.extend(DagTag(name=name, dag_id=dm.dag_id) for name in sorted(tags_to_add))
 
 
 def _update_dag_owner_links(dag_owner_links: dict[str, str], dm: DagModel, *, session: Session) -> None:
@@ -377,7 +379,7 @@ def _update_dag_warnings(
     for warning_to_delete in stored_warnings - warnings:
         session.delete(warning_to_delete)
 
-    for warning_to_add in warnings:
+    for warning_to_add in sorted(warnings, key=lambda warning: (warning.dag_id, warning.warning_type)):
         session.merge(warning_to_add)
 
 
@@ -588,9 +590,10 @@ class DagModelOperation(NamedTuple):
 
     def find_orm_dags(self, *, session: Session) -> dict[str, DagModel]:
         """Find existing DagModel objects from DAG objects."""
-        # Ordered, because these rows are locked, and two writers taking the same ones the other
-        # way round deadlock. Dag ids are shared between writers whenever a Dag moves file or a
-        # reserialize runs beside the Dag processor.
+        # Ordered because these rows are locked: two writers taking the same ones the other way
+        # round deadlock, which they can whenever a Dag moves between files or a reserialize runs
+        # beside the Dag processor. ``dag_id`` is the primary key, so the scan is in that order on
+        # MySQL too, where ``ORDER BY`` alone would not govern when locks are taken.
         stmt: Select[Unpack[tuple[DagModel]]] = with_row_locks(
             (
                 select(DagModel)
@@ -896,7 +899,7 @@ class AssetModelOperation(NamedTuple):
             ((model.name, model.uri), model)
             for model in asset_manager.create_assets(to_create, session=session)
         )
-        # Collection order, which decides the activation below; the read-back returns its own.
+        # Restore collection order; the read-back returns rows in whatever order it likes.
         return {key: orm_assets[key] for key in self.assets if key in orm_assets}
 
     def sync_asset_aliases(self, *, session: Session) -> dict[str, AssetAliasModel]:
@@ -934,6 +937,9 @@ class AssetModelOperation(NamedTuple):
         there's a conflict. The scheduler makes a more comprehensive pass
         through all assets in ``_update_asset_orphanage``.
         """
+        candidates = list(models)
+        if not candidates:
+            return
         if (dialect_name := get_dialect_name(session)) == "postgresql":
             from sqlalchemy.dialects.postgresql import insert as postgresql_insert
 
@@ -948,13 +954,9 @@ class AssetModelOperation(NamedTuple):
             from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
             stmt = sqlite_insert(AssetActive).on_conflict_do_nothing()
-        candidates = list(models)
-        if not candidates:
-            return
-        # Only one of two assets sharing a name or a uri can be active. Deciding that here, from
-        # what is already active, is what lets the rows be sorted -- ``asset_active`` is unique on
-        # both columns. The read is a snapshot: a row deactivated meanwhile is missed until the
-        # scheduler's next orphanage pass.
+        # ``asset_active`` is unique on name and on uri separately, so choosing the winner here
+        # rather than leaving it to the insert is what lets these rows be sorted. The read is a
+        # snapshot; a row deactivated meanwhile is missed until the next orphanage pass.
         active = session.execute(
             select(AssetActive.name, AssetActive.uri).where(
                 or_(
@@ -973,7 +975,7 @@ class AssetModelOperation(NamedTuple):
             claimed_uris.add(model.uri)
             values.append({"name": model.name, "uri": model.uri})
         if values:
-            session.execute(stmt, sorted(values, key=lambda value: (value["name"], value["uri"])))
+            session.execute(stmt, sorted(values, key=itemgetter("name", "uri")))
 
     def add_dag_asset_references(
         self,
@@ -985,7 +987,7 @@ class AssetModelOperation(NamedTuple):
         # Optimization: No assets means there are no references to update.
         if not assets:
             return
-        for dag_id, references in self.schedule_asset_references.items():
+        for dag_id, references in sorted(self.schedule_asset_references.items(), key=itemgetter(0)):
             # Optimization: no references at all; this is faster than repeated delete().
             if not references:
                 dags[dag_id].schedule_asset_references = []
@@ -1027,7 +1029,7 @@ class AssetModelOperation(NamedTuple):
         # Optimization: No aliases means there are no references to update.
         if not aliases:
             return
-        for dag_id, references in self.schedule_asset_alias_references.items():
+        for dag_id, references in sorted(self.schedule_asset_alias_references.items(), key=itemgetter(0)):
             # Optimization: no references at all; this is faster than repeated delete().
             if not references:
                 dags[dag_id].schedule_asset_alias_references = []
@@ -1066,7 +1068,7 @@ class AssetModelOperation(NamedTuple):
         if old_refs:
             session.execute(delete(model).where(tuple_(model.dag_id, getattr(model, attr)).in_(old_refs)))
         if new_refs:
-            session.execute(insert(model), [{"dag_id": d, attr: r} for d, r in new_refs])
+            session.execute(insert(model), [{"dag_id": d, attr: r} for d, r in sorted(new_refs)])
 
     def add_dag_asset_name_uri_references(self, *, session: Session) -> None:
         self._add_dag_asset_references(
@@ -1092,7 +1094,7 @@ class AssetModelOperation(NamedTuple):
         # Optimization: No assets means there are no references to update.
         if not assets:
             return
-        for dag_id, references in self.inlet_references.items():
+        for dag_id, references in sorted(self.inlet_references.items(), key=itemgetter(0)):
             # Optimization: no references at all; this is faster than repeated delete().
             if not references:
                 dags[dag_id].task_inlet_asset_references = []
@@ -1107,10 +1109,10 @@ class AssetModelOperation(NamedTuple):
                     session.delete(ref)
             session.bulk_save_objects(
                 TaskInletAssetReference(asset_id=asset_id, dag_id=dag_id, task_id=task_id)
-                for task_id, asset_id in referenced_inlets
+                for task_id, asset_id in sorted(referenced_inlets)
                 if (task_id, asset_id) not in orm_refs
             )
-        for dag_id, references in self.outlet_references.items():
+        for dag_id, references in sorted(self.outlet_references.items(), key=itemgetter(0)):
             # Optimization: no references at all; this is faster than repeated delete().
             if not references:
                 dags[dag_id].task_outlet_asset_references = []
@@ -1237,10 +1239,10 @@ class AssetModelOperation(NamedTuple):
             )
 
             # Add new references
-            for name_uri, trigger_hashes in refs_to_add.items():
+            for name_uri, trigger_hashes in sorted(refs_to_add.items(), key=itemgetter(0)):
                 asset_model = assets[name_uri]
 
-                for trigger_hash in trigger_hashes:
+                for trigger_hash in sorted(trigger_hashes):
                     trigger = triggers.get(trigger_hash)
                     orm_trigger = orm_triggers.get(trigger_hash)
                     if orm_trigger and trigger:

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -32,7 +32,7 @@ from operator import itemgetter
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
 import structlog
-from sqlalchemy import delete, false, func, insert, or_, select, tuple_, update
+from sqlalchemy import delete, false, func, insert, select, tuple_, update
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import joinedload, load_only
 
@@ -231,9 +231,7 @@ def _update_dag_tags(tag_names: set[str], dm: DagModel, *, session: Session) -> 
                 # Refresh the tags relationship from the database to reflect the deletions.
                 session.expire(dm, ["tags"])
 
-    # Sorted, like every other insert here: ``dag_tag`` is keyed on (name, dag_id), and a set
-    # iterates differently in each writer.
-    dm.tags.extend(DagTag(name=name, dag_id=dm.dag_id) for name in sorted(tags_to_add))
+    dm.tags.extend(DagTag(name=name, dag_id=dm.dag_id) for name in tags_to_add)
 
 
 def _update_dag_owner_links(dag_owner_links: dict[str, str], dm: DagModel, *, session: Session) -> None:
@@ -379,7 +377,7 @@ def _update_dag_warnings(
     for warning_to_delete in stored_warnings - warnings:
         session.delete(warning_to_delete)
 
-    for warning_to_add in sorted(warnings, key=lambda warning: (warning.dag_id, warning.warning_type)):
+    for warning_to_add in warnings:
         session.merge(warning_to_add)
 
 
@@ -590,10 +588,7 @@ class DagModelOperation(NamedTuple):
 
     def find_orm_dags(self, *, session: Session) -> dict[str, DagModel]:
         """Find existing DagModel objects from DAG objects."""
-        # Ordered because these rows are locked: two writers taking the same ones the other way
-        # round deadlock, which they can whenever a Dag moves between files or a reserialize runs
-        # beside the Dag processor. ``dag_id`` is the primary key, so the scan is in that order on
-        # MySQL too, where ``ORDER BY`` alone would not govern when locks are taken.
+        # Reserialization and per-file parsing can reach the same Dags in different orders.
         stmt: Select[Unpack[tuple[DagModel]]] = with_row_locks(
             (
                 select(DagModel)
@@ -617,7 +612,6 @@ class DagModelOperation(NamedTuple):
             for model in _create_orm_dags(
                 bundle_name=self.bundle_name,
                 bundle_version=self.bundle_version,
-                # Sorted for the same reason the lock above is: insertion order is lock order.
                 dags=(
                     dag
                     for dag_id, dag in sorted(self.dags.items(), key=itemgetter(0))
@@ -869,8 +863,6 @@ class AssetModelOperation(NamedTuple):
                 dag_id: list(_get_dag_assets(dag, SerializedAsset, inlets=False, outlets=True))
                 for dag_id, dag in dags.items()
             },
-            # Definition order decides which of two assets sharing a name is activated; the rows
-            # are sorted where they are inserted instead.
             assets={(asset.name, asset.uri): asset for asset in _find_all_assets(dags.values())},
             asset_aliases={alias.name: alias for alias in _find_all_asset_aliases(dags.values())},
         )
@@ -880,17 +872,25 @@ class AssetModelOperation(NamedTuple):
         # Optimization: skip all database calls if no assets were collected.
         if not self.assets:
             return {}
+        # Acquire the requested rows before metadata updates or reference writes can lock a subset.
+        # MySQL can otherwise lock rows in primary-key order before sorting the result.
         orm_assets: dict[tuple[str, str], AssetModel] = {
             (am.name, am.uri): am
             for am in session.scalars(
-                select(AssetModel).where(tuple_(AssetModel.name, AssetModel.uri).in_(self.assets))
+                with_row_locks(
+                    select(AssetModel)
+                    .with_hint(AssetModel, "FORCE INDEX (idx_asset_name_uri_unique)", dialect_name="mysql")
+                    .where(tuple_(AssetModel.name, AssetModel.uri).in_(self.assets))
+                    .order_by(AssetModel.name, AssetModel.uri),
+                    session=session,
+                    of=AssetModel,
+                )
             )
         }
         for key, model in orm_assets.items():
             asset = self.assets[key]
             model.group = asset.group
             model.extra = asset.extra
-        # ``asset`` is unique on (name, uri): opposite insert orders deadlock on that index.
         to_create = sorted(
             (asset for name_uri, asset in self.assets.items() if name_uri not in orm_assets),
             key=lambda asset: (asset.name, asset.uri),
@@ -899,7 +899,7 @@ class AssetModelOperation(NamedTuple):
             ((model.name, model.uri), model)
             for model in asset_manager.create_assets(to_create, session=session)
         )
-        # Restore collection order; the read-back returns rows in whatever order it likes.
+        # Physical write order must not change which conflicting candidate is offered first.
         return {key: orm_assets[key] for key in self.assets if key in orm_assets}
 
     def sync_asset_aliases(self, *, session: Session) -> dict[str, AssetAliasModel]:
@@ -909,12 +909,20 @@ class AssetModelOperation(NamedTuple):
         orm_aliases: dict[str, AssetAliasModel] = {
             da.name: da
             for da in session.scalars(
-                select(AssetAliasModel).where(AssetAliasModel.name.in_(self.asset_aliases))
+                with_row_locks(
+                    select(AssetAliasModel)
+                    .with_hint(
+                        AssetAliasModel, "FORCE INDEX (idx_asset_alias_name_unique)", dialect_name="mysql"
+                    )
+                    .where(AssetAliasModel.name.in_(self.asset_aliases))
+                    .order_by(AssetAliasModel.name),
+                    session=session,
+                    of=AssetAliasModel,
+                )
             )
         }
         for name, model in orm_aliases.items():
             model.group = self.asset_aliases[name].group
-        # ``asset_alias`` is unique on name, so the same applies.
         orm_aliases.update(
             (model.name, model)
             for model in asset_manager.create_asset_aliases(
@@ -937,9 +945,6 @@ class AssetModelOperation(NamedTuple):
         there's a conflict. The scheduler makes a more comprehensive pass
         through all assets in ``_update_asset_orphanage``.
         """
-        candidates = list(models)
-        if not candidates:
-            return
         if (dialect_name := get_dialect_name(session)) == "postgresql":
             from sqlalchemy.dialects.postgresql import insert as postgresql_insert
 
@@ -954,28 +959,8 @@ class AssetModelOperation(NamedTuple):
             from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
             stmt = sqlite_insert(AssetActive).on_conflict_do_nothing()
-        # ``asset_active`` is unique on name and on uri separately, and no order of this insert
-        # is consistent for both indexes -- two writers can sort identically and still take the
-        # two uris the opposite way round. So the rows are serialized first, on every asset
-        # sharing a name or a uri with one being activated rather than on the exact pairs: two
-        # writers activating different assets still meet on those two columns. Taking them in one
-        # order leaves the insert below to run without a second writer inside it, and lets the
-        # database go on arbitrating which of two conflicting assets wins.
-        session.execute(
-            with_row_locks(
-                select(AssetModel.id)
-                .where(
-                    or_(
-                        AssetModel.name.in_({model.name for model in candidates}),
-                        AssetModel.uri.in_({model.uri for model in candidates}),
-                    )
-                )
-                .order_by(AssetModel.name, AssetModel.uri),
-                session=session,
-                of=AssetModel,
-            )
-        )
-        session.execute(stmt, [{"name": model.name, "uri": model.uri} for model in candidates])
+        if values := [{"name": m.name, "uri": m.uri} for m in models]:
+            session.execute(stmt, values)
 
     def add_dag_asset_references(
         self,
@@ -987,7 +972,7 @@ class AssetModelOperation(NamedTuple):
         # Optimization: No assets means there are no references to update.
         if not assets:
             return
-        for dag_id, references in sorted(self.schedule_asset_references.items(), key=itemgetter(0)):
+        for dag_id, references in self.schedule_asset_references.items():
             # Optimization: no references at all; this is faster than repeated delete().
             if not references:
                 dags[dag_id].schedule_asset_references = []
@@ -1029,7 +1014,7 @@ class AssetModelOperation(NamedTuple):
         # Optimization: No aliases means there are no references to update.
         if not aliases:
             return
-        for dag_id, references in sorted(self.schedule_asset_alias_references.items(), key=itemgetter(0)):
+        for dag_id, references in self.schedule_asset_alias_references.items():
             # Optimization: no references at all; this is faster than repeated delete().
             if not references:
                 dags[dag_id].schedule_asset_alias_references = []
@@ -1041,7 +1026,7 @@ class AssetModelOperation(NamedTuple):
                     session.delete(ref)
             session.bulk_save_objects(
                 DagScheduleAssetAliasReference(alias_id=alias_id, dag_id=dag_id)
-                for alias_id in sorted(referenced_alias_ids)
+                for alias_id in referenced_alias_ids
                 if alias_id not in orm_refs
             )
 
@@ -1068,7 +1053,7 @@ class AssetModelOperation(NamedTuple):
         if old_refs:
             session.execute(delete(model).where(tuple_(model.dag_id, getattr(model, attr)).in_(old_refs)))
         if new_refs:
-            session.execute(insert(model), [{"dag_id": d, attr: r} for d, r in sorted(new_refs)])
+            session.execute(insert(model), [{"dag_id": d, attr: r} for d, r in new_refs])
 
     def add_dag_asset_name_uri_references(self, *, session: Session) -> None:
         self._add_dag_asset_references(
@@ -1094,7 +1079,7 @@ class AssetModelOperation(NamedTuple):
         # Optimization: No assets means there are no references to update.
         if not assets:
             return
-        for dag_id, references in sorted(self.inlet_references.items(), key=itemgetter(0)):
+        for dag_id, references in self.inlet_references.items():
             # Optimization: no references at all; this is faster than repeated delete().
             if not references:
                 dags[dag_id].task_inlet_asset_references = []
@@ -1109,10 +1094,10 @@ class AssetModelOperation(NamedTuple):
                     session.delete(ref)
             session.bulk_save_objects(
                 TaskInletAssetReference(asset_id=asset_id, dag_id=dag_id, task_id=task_id)
-                for task_id, asset_id in sorted(referenced_inlets)
+                for task_id, asset_id in referenced_inlets
                 if (task_id, asset_id) not in orm_refs
             )
-        for dag_id, references in sorted(self.outlet_references.items(), key=itemgetter(0)):
+        for dag_id, references in self.outlet_references.items():
             # Optimization: no references at all; this is faster than repeated delete().
             if not references:
                 dags[dag_id].task_outlet_asset_references = []
@@ -1239,18 +1224,14 @@ class AssetModelOperation(NamedTuple):
             )
 
             # Add new references
-            for name_uri, trigger_hashes in sorted(refs_to_add.items(), key=itemgetter(0)):
+            for name_uri, trigger_hashes in refs_to_add.items():
                 asset_model = assets[name_uri]
-                # ``asset_watcher`` is keyed on (asset_id, trigger_id). Ordering by the trigger
-                # hash would order nothing: it is a builtin hash of a str and bytes, so its value
-                # differs between processes. The row ids do not.
-                watchers = [
-                    (orm_triggers[trigger_hash], triggers[trigger_hash])
-                    for trigger_hash in trigger_hashes
-                    if trigger_hash in orm_triggers and trigger_hash in triggers
-                ]
-                for orm_trigger, trigger in sorted(watchers, key=lambda pair: pair[0].id):
-                    asset_model.add_trigger(orm_trigger, trigger["watcher_name"])
+
+                for trigger_hash in trigger_hashes:
+                    trigger = triggers.get(trigger_hash)
+                    orm_trigger = orm_triggers.get(trigger_hash)
+                    if orm_trigger and trigger:
+                        asset_model.add_trigger(orm_trigger, trigger["watcher_name"])
 
         if refs_to_remove:
             # Remove old references

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -28,6 +28,7 @@ This should generally only be called by internal methods such as
 from __future__ import annotations
 
 import traceback
+from operator import itemgetter
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
 import structlog
@@ -614,7 +615,11 @@ class DagModelOperation(NamedTuple):
                 bundle_name=self.bundle_name,
                 bundle_version=self.bundle_version,
                 # Sorted for the same reason the lock above is: insertion order is lock order.
-                dags=(dag for dag_id, dag in sorted(self.dags.items()) if dag_id not in orm_dags),
+                dags=(
+                    dag
+                    for dag_id, dag in sorted(self.dags.items(), key=itemgetter(0))
+                    if dag_id not in orm_dags
+                ),
                 session=session,
             )
         )

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -856,8 +856,13 @@ class AssetModelOperation(NamedTuple):
                 dag_id: list(_get_dag_assets(dag, SerializedAsset, inlets=False, outlets=True))
                 for dag_id, dag in dags.items()
             },
-            assets={(asset.name, asset.uri): asset for asset in _find_all_assets(dags.values())},
-            asset_aliases={alias.name: alias for alias in _find_all_asset_aliases(dags.values())},
+            # Insertion order is lock order, and assets are shared, so two writers taking them
+            # in opposite orders deadlock. Deduplicated before sorting: sorting the pairs first
+            # compares SerializedAssets wherever a Dag repeats one, which they do not support.
+            assets=dict(sorted({(a.name, a.uri): a for a in _find_all_assets(dags.values())}.items())),
+            asset_aliases=dict(
+                sorted({alias.name: alias for alias in _find_all_asset_aliases(dags.values())}.items())
+            ),
         )
         return coll
 
@@ -882,7 +887,9 @@ class AssetModelOperation(NamedTuple):
                 session=session,
             )
         )
-        return orm_assets
+        # Sorted again: the rows that already existed came back in the query's order, and
+        # ``activate_assets_if_possible`` locks them in the order it is handed.
+        return dict(sorted(orm_assets.items()))
 
     def sync_asset_aliases(self, *, session: Session) -> dict[str, AssetAliasModel]:
         # Optimization: skip all database calls if no asset aliases were collected.

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -30,6 +30,7 @@ import pendulum
 import pytest
 import time_machine
 from sqlalchemy import func, select
+from sqlalchemy.exc import OperationalError
 
 from airflow import settings
 from airflow._shared.timezones import timezone
@@ -47,10 +48,12 @@ from airflow.providers.standard.triggers.temporal import DateTimeTrigger, TimeDe
 from airflow.sdk import DAG, Asset, BaseOperator, CronPartitionTimetable, PartitionedAssetTimetable, task
 from airflow.sdk.definitions.dag import _run_inline_trigger
 from airflow.sdk.execution_time.comms import _RequestFrame, _ResponseFrame
+from airflow.serialization.definitions.dag import SerializedDAG
 from airflow.serialization.serialized_objects import DagSerialization, LazyDeserializedDAG
 from airflow.timetables.base import Timetable
 from airflow.triggers.base import TriggerEvent
 from airflow.utils.cli import get_db_dag
+from airflow.utils.retries import MAX_DB_RETRIES
 from airflow.utils.session import create_session
 from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.types import DagRunType
@@ -1227,6 +1230,39 @@ class TestCliDagsReserialize:
 
         serialized_dag_ids = set(session.execute(select(SerializedDagModel.dag_id)).scalars())
         assert serialized_dag_ids == {"test_example_bash_operator", "test_sensor"}
+
+    @conf_vars({("core", "load_examples"): "false"})
+    @pytest.mark.parametrize("failures", [1, MAX_DB_RETRIES], ids=["recovered", "exhausted"])
+    def test_reserialize_preserves_previous_bundles_after_retry(self, configure_dag_bundles, failures):
+        bundles = {name: self.test_bundles_config[name] for name in ("bundle1", "bundle2")}
+        attempts = {name: 0 for name in bundles}
+        bulk_write = SerializedDAG.bulk_write_to_db
+
+        def write_then_fail(bundle_name, *args, **kwargs):
+            attempts[bundle_name] += 1
+            result = bulk_write(bundle_name, *args, **kwargs)
+            if bundle_name == "bundle2" and attempts[bundle_name] <= failures:
+                raise OperationalError("publish bundle", {}, RuntimeError("retry publication"))
+            return result
+
+        with (
+            configure_dag_bundles(bundles),
+            mock.patch.object(SerializedDAG, "bulk_write_to_db", autospec=True, side_effect=write_then_fail),
+        ):
+            args = self.parser.parse_args(["dags", "reserialize"])
+            if failures == MAX_DB_RETRIES:
+                with pytest.raises(OperationalError, match="retry publication"):
+                    dag_command.dag_reserialize(args)
+            else:
+                dag_command.dag_reserialize(args)
+
+        expected = {"test_example_bash_operator"}
+        if failures < MAX_DB_RETRIES:
+            expected.add("test_sensor")
+        with create_session(scoped=False) as observer:
+            assert set(observer.scalars(select(DagModel.dag_id))) == expected
+            assert set(observer.scalars(select(SerializedDagModel.dag_id))) == expected
+        assert attempts == {"bundle1": 1, "bundle2": min(failures + 1, MAX_DB_RETRIES)}
 
     @conf_vars({("core", "load_examples"): "false"})
     def test_reserialize_should_make_equal_hash_with_dag_processor(self, configure_dag_bundles, session):

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -27,7 +27,7 @@ from unittest import mock
 from unittest.mock import patch
 
 import pytest
-from sqlalchemy import delete, func, inspect as sa_inspect, select
+from sqlalchemy import delete, event, func, inspect as sa_inspect, select
 from sqlalchemy.exc import OperationalError, SAWarning
 
 import airflow.dag_processing.collection
@@ -170,6 +170,60 @@ def test_statement_latest_runs_partitioned_sorted_by_partition_date(dag_maker, s
 
 
 @pytest.mark.db_test
+class TestDagModelOperation:
+    @pytest.fixture(autouse=True)
+    def per_test(self) -> Generator:
+        clear_db_dags()
+        yield
+        clear_db_dags()
+
+    @staticmethod
+    def _build_dags(dag_maker, names):
+        dags = {}
+        for name in names:
+            with dag_maker(dag_id=name) as dag:
+                EmptyOperator(task_id="mytask")
+            dags[name] = LazyDeserializedDAG.from_dag(dag)
+        return dags
+
+    @pytest.mark.usefixtures("testing_dag_bundle")
+    def test_existing_dag_rows_are_locked_in_a_stable_order(self, dag_maker, session):
+        dags = self._build_dags(dag_maker, ("c_dag", "a_dag", "b_dag"))
+        statements: list[str] = []
+
+        def record(conn, cursor, statement, parameters, context, executemany):
+            statements.append(statement)
+
+        bind = session.get_bind()
+        event.listen(bind, "before_cursor_execute", record)
+        try:
+            DagModelOperation(dags, "testing", None).find_orm_dags(session=session)
+        finally:
+            event.remove(bind, "before_cursor_execute", record)
+
+        locks = [q for q in statements if "dag_id IN" in q]
+        assert locks, statements
+        assert all("ORDER BY" in q for q in locks), f"dag rows are locked in plan order:\n{locks}"
+
+    @pytest.mark.usefixtures("testing_dag_bundle")
+    def test_new_dag_rows_are_created_in_a_stable_order(self, dag_maker, session):
+        dags = self._build_dags(dag_maker, ("c_dag", "a_dag", "b_dag"))
+        created: list[str] = []
+
+        def spy(*, bundle_name, bundle_version, dags, session):
+            created.extend(dag.dag_id for dag in dags)
+            return []
+
+        with (
+            mock.patch.object(DagModelOperation, "find_orm_dags", autospec=True, return_value={}),
+            mock.patch("airflow.dag_processing.collection._create_orm_dags", spy),
+        ):
+            DagModelOperation(dags, "testing", None).add_dags(session=session)
+
+        assert created == ["a_dag", "b_dag", "c_dag"], created
+
+
+@pytest.mark.db_test
 class TestAssetModelOperation:
     @staticmethod
     def clean_db():
@@ -184,7 +238,7 @@ class TestAssetModelOperation:
         self.clean_db()
 
     @staticmethod
-    def _dags_for(dag_maker, schedules):
+    def _build_dags_for(dag_maker, schedules):
         """One Dag per schedule, keyed by dag_id in the order given."""
         dags = {}
         for index, schedule in enumerate(schedules):
@@ -195,7 +249,7 @@ class TestAssetModelOperation:
 
     def test_shared_assets_and_aliases_are_collected_in_a_stable_order(self, dag_maker):
         """Two writers reaching the same rows must take them the same way round or they deadlock."""
-        dags = self._dags_for(
+        dags = self._build_dags_for(
             dag_maker,
             [
                 Asset("c_asset"),
@@ -218,7 +272,7 @@ class TestAssetModelOperation:
     @pytest.mark.usefixtures("testing_dag_bundle")
     def test_assets_that_already_exist_keep_the_stable_order(self, dag_maker, session):
         """Existing rows come back in the query's order, so it is put back before returning."""
-        dags = self._dags_for(dag_maker, [Asset("c_asset"), Asset("b_asset"), Asset("a_asset")])
+        dags = self._build_dags_for(dag_maker, [Asset("c_asset"), Asset("b_asset"), Asset("a_asset")])
         asset_op = AssetModelOperation.collect(dags)
         committed = session.scalars(select(AssetModel).order_by(AssetModel.name)).all()
         assert [a.name for a in committed] == ["a_asset", "b_asset", "c_asset"], committed

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -183,6 +183,55 @@ class TestAssetModelOperation:
         yield
         self.clean_db()
 
+    @staticmethod
+    def _dags_for(dag_maker, schedules):
+        """One Dag per schedule, keyed by dag_id in the order given."""
+        dags = {}
+        for index, schedule in enumerate(schedules):
+            with dag_maker(dag_id=f"dag_{index}", schedule=[schedule]) as dag:
+                EmptyOperator(task_id="mytask")
+            dags[dag.dag_id] = LazyDeserializedDAG.from_dag(dag)
+        return dags
+
+    def test_shared_assets_and_aliases_are_collected_in_a_stable_order(self, dag_maker):
+        """Two writers reaching the same rows must take them the same way round or they deadlock."""
+        dags = self._dags_for(
+            dag_maker,
+            [
+                Asset("c_asset"),
+                AssetAlias("z_alias"),
+                Asset("a_asset"),
+                AssetAlias("a_alias"),
+                Asset("b_asset"),
+            ],
+        )
+        reversed_dags = dict(reversed(list(dags.items())))
+
+        forwards = AssetModelOperation.collect(dags)
+        backwards = AssetModelOperation.collect(reversed_dags)
+
+        assert [name for name, _ in forwards.assets] == ["a_asset", "b_asset", "c_asset"]
+        assert list(forwards.assets) == list(backwards.assets)
+        assert list(forwards.asset_aliases) == ["a_alias", "z_alias"]
+        assert list(forwards.asset_aliases) == list(backwards.asset_aliases)
+
+    @pytest.mark.usefixtures("testing_dag_bundle")
+    def test_assets_that_already_exist_keep_the_stable_order(self, dag_maker, session):
+        """Existing rows come back in the query's order, so it is put back before returning."""
+        dags = self._dags_for(dag_maker, [Asset("c_asset"), Asset("b_asset"), Asset("a_asset")])
+        asset_op = AssetModelOperation.collect(dags)
+        committed = session.scalars(select(AssetModel).order_by(AssetModel.name)).all()
+        assert [a.name for a in committed] == ["a_asset", "b_asset", "c_asset"], committed
+
+        # No backend returns a chosen bad order on demand, so stub it -- with the rows that really
+        # are there, or the write below creates one the database already holds.
+        with mock.patch.object(session, "scalars", autospec=True, return_value=list(reversed(committed))):
+            orm_assets = asset_op.sync_assets(session=session)
+
+        assert [name for name, _ in orm_assets] == ["a_asset", "b_asset", "c_asset"], (
+            "rows that already existed kept the order the database returned them in"
+        )
+
     @pytest.mark.usefixtures("testing_dag_bundle")
     def test_sync_assets_preserves_access_control_from_other_bundle(self, dag_maker, session):
         """When a producer bundle (without access_control) is synced after a consumer bundle

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -248,19 +248,61 @@ class TestAssetModelOperation:
             dags[dag.dag_id] = LazyDeserializedDAG.from_dag(dag)
         return dags
 
-    def test_new_assets_and_aliases_are_inserted_in_a_stable_order(self, dag_maker, session):
+    def test_dag_tags_are_inserted_in_a_stable_order(self, session, testing_dag_bundle):
+        """``dag_tag`` is keyed on (name, dag_id), and the names arrive as a set."""
+        from airflow.dag_processing.collection import _update_dag_tags
+
+        dm = DagModel(dag_id="tagged_dag", bundle_name="testing")
+        session.add(dm)
+        session.flush()
+
+        _update_dag_tags({"finance", "ops", "daily"}, dm, session=session)
+
+        assert [tag.name for tag in dm.tags] == ["daily", "finance", "ops"]
+
+    def test_asset_name_references_are_inserted_in_a_stable_order(self, session, testing_dag_bundle):
+        """``dag_schedule_asset_name_reference`` is keyed on (name, dag_id), and so is its set."""
+        session.add_all(
+            [DagModel(dag_id="a_dag", bundle_name="testing"), DagModel(dag_id="b_dag", bundle_name="testing")]
+        )
+        session.flush()
+        inserted: list[dict] = []
+
+        def record(conn, cursor, statement, parameters, context, executemany):
+            if "insert into dag_schedule_asset_name_reference" in statement.lower():
+                inserted.extend(parameters if executemany else [parameters])
+
+        bind = session.get_bind()
+        event.listen(bind, "before_cursor_execute", record)
+        try:
+            AssetModelOperation._add_dag_asset_references(
+                {("b_dag", "n2"), ("a_dag", "n1"), ("b_dag", "n1"), ("a_dag", "n2")},
+                DagScheduleAssetNameReference,
+                "name",
+                session=session,
+            )
+            session.flush()
+        finally:
+            event.remove(bind, "before_cursor_execute", record)
+
+        assert [(row["dag_id"], row["name"]) for row in inserted] == [
+            ("a_dag", "n1"),
+            ("a_dag", "n2"),
+            ("b_dag", "n1"),
+            ("b_dag", "n2"),
+        ]
+
+    def test_new_assets_and_aliases_are_inserted_in_a_stable_order(self, session):
         """Two writers reaching the same rows must take them the same way round or they deadlock."""
-        dags = self._build_dags_for(
-            dag_maker,
+        dags = self._build_dags_scheduled_on(
             [
-                Asset("c_asset"),
+                Asset(name="dup", uri="s3://zzz"),
                 AssetAlias("z_alias"),
                 Asset("a_asset"),
                 AssetAlias("a_alias"),
-                Asset("b_asset"),
-            ],
+                Asset(name="dup", uri="s3://aaa"),
+            ]
         )
-        clear_db_assets()
 
         def inserted(op):
             with (
@@ -280,31 +322,36 @@ class TestAssetModelOperation:
                 op.sync_assets(session=session)
                 op.sync_asset_aliases(session=session)
             return (
-                [a.name for a in assets.call_args.args[0]],
+                [(a.name, a.uri) for a in assets.call_args.args[0]],
                 [a.name for a in aliases.call_args.args[0]],
             )
 
         forwards = inserted(AssetModelOperation.collect(dags))
         backwards = inserted(AssetModelOperation.collect(dict(reversed(list(dags.items())))))
 
-        assert forwards == (["a_asset", "b_asset", "c_asset"], ["a_alias", "z_alias"])
+        # Two rows share a name, so the uri half of the key decides their order.
+        assert forwards == (
+            [("a_asset", "a_asset"), ("dup", "s3://aaa/"), ("dup", "s3://zzz/")],
+            ["a_alias", "z_alias"],
+        )
         assert forwards == backwards, "the order the Dags arrived in reached the insert"
 
     @staticmethod
-    def _dags_for(assets: list[Asset]) -> dict:
+    def _build_dags_scheduled_on(schedules: list) -> dict:
+        """One unpersisted Dag per schedule, so nothing is written before the call under test."""
         return {
-            f"dag_{i}": LazyDeserializedDAG.from_dag(DAG(dag_id=f"dag_{i}", schedule=[asset]))
-            for i, asset in enumerate(assets)
+            f"dag_{i}": LazyDeserializedDAG.from_dag(DAG(dag_id=f"dag_{i}", schedule=[schedule]))
+            for i, schedule in enumerate(schedules)
         }
 
-    def _active(self, session) -> list[tuple[str, str]]:
+    @staticmethod
+    def _read_active_assets(session) -> list[tuple[str, str]]:
         return sorted((a.name, a.uri) for a in session.scalars(select(AssetActive)))
 
     def test_activation_rows_are_inserted_in_a_stable_order(self, session):
         """``asset_active`` is unique on both its columns, so its insert needs one order too."""
-        clear_db_assets()
         op = AssetModelOperation.collect(
-            self._dags_for([Asset("c_asset"), Asset("a_asset"), Asset("b_asset")])
+            self._build_dags_scheduled_on([Asset("c_asset"), Asset("a_asset"), Asset("b_asset")])
         )
         orm_assets = op.sync_assets(session=session)
         session.flush()
@@ -320,8 +367,7 @@ class TestAssetModelOperation:
 
     def test_activating_assets_costs_one_read_and_one_insert(self, session):
         """Deciding the claim needs what is already active; nothing else here may add a round trip."""
-        clear_db_assets()
-        op = AssetModelOperation.collect(self._dags_for([Asset("a_asset"), Asset("b_asset")]))
+        op = AssetModelOperation.collect(self._build_dags_scheduled_on([Asset("a_asset"), Asset("b_asset")]))
         orm_assets = op.sync_assets(session=session)
         session.flush()
 
@@ -340,31 +386,63 @@ class TestAssetModelOperation:
 
         assert statements == ["SELECT", "INSERT"], statements
 
-    def test_a_candidate_the_insert_would_reject_does_not_take_the_claim(self, session):
+    @pytest.mark.parametrize(
+        ("blocker", "batch", "expected"),
+        [
+            pytest.param(
+                Asset(name="n9", uri="s3://u1"),
+                [Asset(name="n1", uri="s3://u1"), Asset(name="n1", uri="s3://u2")],
+                [("n1", "s3://u2/"), ("n9", "s3://u1/")],
+                id="blocker-holds-the-uri",
+            ),
+            pytest.param(
+                Asset(name="n1", uri="s3://u9"),
+                [Asset(name="n1", uri="s3://u2"), Asset(name="n2", uri="s3://u2")],
+                [("n1", "s3://u9/"), ("n2", "s3://u2/")],
+                id="blocker-holds-the-name",
+            ),
+        ],
+    )
+    def test_a_candidate_the_insert_would_reject_does_not_take_the_claim(
+        self, blocker, batch, expected, session
+    ):
         """
         The claim has to start from what is already active, not from the batch alone.
 
-        With ``n9`` holding ``s3://u1``, ``("n1", "s3://u1")`` cannot be activated whatever happens
-        -- its uri is taken. Were it to claim the name anyway, ``("n1", "s3://u2/")`` would be passed
+        The first candidate cannot be activated whatever happens -- the blocker holds one of its
+        two columns. Were it to claim the other anyway, the candidate behind it would be passed
         over and the insert would then drop the claimer too, leaving neither active.
         """
-        clear_db_assets()
-        blocker = AssetModelOperation.collect(self._dags_for([Asset(name="n9", uri="s3://u1")]))
-        blocked = blocker.sync_assets(session=session)
+        held = AssetModelOperation.collect(self._build_dags_scheduled_on([blocker]))
+        orm_held = held.sync_assets(session=session)
         session.flush()
-        blocker.activate_assets_if_possible(blocked.values(), session=session)
+        held.activate_assets_if_possible(orm_held.values(), session=session)
         session.flush()
-        assert self._active(session) == [("n9", "s3://u1/")]
 
-        op = AssetModelOperation.collect(
-            self._dags_for([Asset(name="n1", uri="s3://u1"), Asset(name="n1", uri="s3://u2")])
-        )
+        op = AssetModelOperation.collect(self._build_dags_scheduled_on(batch))
         orm_assets = op.sync_assets(session=session)
         session.flush()
         op.activate_assets_if_possible(orm_assets.values(), session=session)
         session.flush()
 
-        assert self._active(session) == [("n1", "s3://u2/"), ("n9", "s3://u1/")]
+        assert self._read_active_assets(session) == expected
+
+    def test_activating_nothing_asks_the_database_nothing(self, session):
+        """The guard exists so an empty batch does not pay for the claim it has nothing to make."""
+        op = AssetModelOperation.collect(self._build_dags_scheduled_on([Asset("only_asset")]))
+        statements: list[str] = []
+
+        def record(conn, cursor, statement, parameters, context, executemany):
+            statements.append(statement.split()[0].upper())
+
+        bind = session.get_bind()
+        event.listen(bind, "before_cursor_execute", record)
+        try:
+            op.activate_assets_if_possible([], session=session)
+        finally:
+            event.remove(bind, "before_cursor_execute", record)
+
+        assert statements == []
 
     @pytest.mark.parametrize(
         "seeded",
@@ -384,15 +462,17 @@ class TestAssetModelOperation:
             clear_db_assets()
             if seeded:
                 # Written but not activated, so the pass below reads them back as existing rows.
-                AssetModelOperation.collect(self._dags_for(assets)).sync_assets(session=session)
+                AssetModelOperation.collect(self._build_dags_scheduled_on(assets)).sync_assets(
+                    session=session
+                )
                 session.commit()
 
-            op = AssetModelOperation.collect(self._dags_for(assets))
+            op = AssetModelOperation.collect(self._build_dags_scheduled_on(assets))
             orm_assets = op.sync_assets(session=session)
             session.flush()
             op.activate_assets_if_possible(orm_assets.values(), session=session)
             session.flush()
-            return self._active(session)
+            return self._read_active_assets(session)
 
         pair = [Asset(name="dup", uri="s3://zzz"), Asset(name="dup", uri="s3://aaa")]
 

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -260,6 +260,124 @@ class TestAssetModelOperation:
 
         assert [tag.name for tag in dm.tags] == ["daily", "finance", "ops"]
 
+    def test_dag_warnings_are_merged_in_a_stable_order(self, session):
+        """``dag_warning`` is keyed on (dag_id, warning_type), and the warnings arrive as a set."""
+        from airflow.dag_processing.collection import _update_dag_warnings
+
+        warnings = {
+            DagWarning(dag_id="b_dag", warning_type=DagWarningType.NONEXISTENT_POOL, message="b"),
+            DagWarning(dag_id="a_dag", warning_type=DagWarningType.NONEXISTENT_POOL, message="a"),
+        }
+
+        with mock.patch.object(session, "merge", autospec=True) as merge:
+            _update_dag_warnings(
+                ["a_dag", "b_dag"],
+                warnings,
+                (DagWarningType.NONEXISTENT_POOL,),
+                session=session,
+            )
+
+        assert [call.args[0].dag_id for call in merge.call_args_list] == ["a_dag", "b_dag"]
+
+    def test_reference_rows_are_written_dag_by_dag_in_a_stable_order(self, session, testing_dag_bundle):
+        """
+        The reference loops walk ``self.dags``, whose order differs between a per-file Dag
+        processor and a bundle-wide reserialize.
+        """
+        dags = {
+            dag_id: LazyDeserializedDAG.from_dag(DAG(dag_id=dag_id, schedule=[Asset("shared_ref")]))
+            for dag_id in ("z_dag", "a_dag")
+        }
+        orm_dags = DagModelOperation(dags, "testing", None).add_dags(session=session)
+        op = AssetModelOperation.collect(dags)
+        orm_assets = op.sync_assets(session=session)
+        session.flush()
+
+        inserted: list[dict] = []
+
+        def record(conn, cursor, statement, parameters, context, executemany):
+            if "insert into dag_schedule_asset_reference" in statement.lower():
+                inserted.extend(context.compiled_parameters)
+
+        bind = session.get_bind()
+        event.listen(bind, "before_cursor_execute", record)
+        try:
+            op.add_dag_asset_references(orm_dags, orm_assets, session=session)
+            session.flush()
+        finally:
+            event.remove(bind, "before_cursor_execute", record)
+
+        assert [row["dag_id"] for row in inserted] == ["a_dag", "z_dag"]
+
+    def test_task_reference_rows_are_written_in_a_stable_order(self, session, testing_dag_bundle):
+        """Inlets arrive as a set, and both task loops walk ``self.dags``."""
+        asset = Asset("task_ref_asset")
+        dags = {}
+        for dag_id in ("z_dag", "a_dag"):
+            with DAG(dag_id=dag_id, schedule=None) as dag:
+                EmptyOperator(task_id="t_b", inlets=[asset], outlets=[asset])
+                EmptyOperator(task_id="t_a", inlets=[asset], outlets=[asset])
+            dags[dag_id] = LazyDeserializedDAG.from_dag(dag)
+
+        orm_dags = DagModelOperation(dags, "testing", None).add_dags(session=session)
+        op = AssetModelOperation.collect(dags)
+        orm_assets = op.sync_assets(session=session)
+        session.flush()
+
+        inlets: list[dict] = []
+        outlets: list[dict] = []
+
+        def record(conn, cursor, statement, parameters, context, executemany):
+            lowered = statement.lower()
+            if "insert into task_inlet_asset_reference" in lowered:
+                inlets.extend(context.compiled_parameters)
+            elif "insert into task_outlet_asset_reference" in lowered:
+                outlets.extend(context.compiled_parameters)
+
+        bind = session.get_bind()
+        event.listen(bind, "before_cursor_execute", record)
+        try:
+            op.add_task_asset_references(orm_dags, orm_assets, session=session)
+            session.flush()
+        finally:
+            event.remove(bind, "before_cursor_execute", record)
+
+        assert [(row["dag_id"], row["task_id"]) for row in inlets] == [
+            ("a_dag", "t_a"),
+            ("a_dag", "t_b"),
+            ("z_dag", "t_a"),
+            ("z_dag", "t_b"),
+        ]
+        assert [row["dag_id"] for row in outlets] == ["a_dag", "a_dag", "z_dag", "z_dag"]
+
+    def test_alias_reference_rows_are_written_in_a_stable_order(self, session, testing_dag_bundle):
+        """The alias loop walks ``self.dags`` just as the asset one does."""
+        alias = AssetAlias("shared_alias")
+        dags = {
+            dag_id: LazyDeserializedDAG.from_dag(DAG(dag_id=dag_id, schedule=[alias]))
+            for dag_id in ("z_dag", "a_dag")
+        }
+        orm_dags = DagModelOperation(dags, "testing", None).add_dags(session=session)
+        op = AssetModelOperation.collect(dags)
+        orm_aliases = op.sync_asset_aliases(session=session)
+        session.flush()
+
+        inserted: list[dict] = []
+
+        def record(conn, cursor, statement, parameters, context, executemany):
+            if "insert into dag_schedule_asset_alias_reference" in statement.lower():
+                inserted.extend(context.compiled_parameters)
+
+        bind = session.get_bind()
+        event.listen(bind, "before_cursor_execute", record)
+        try:
+            op.add_dag_asset_alias_references(orm_dags, orm_aliases, session=session)
+            session.flush()
+        finally:
+            event.remove(bind, "before_cursor_execute", record)
+
+        assert [row["dag_id"] for row in inserted] == ["a_dag", "z_dag"]
+
     def test_asset_name_references_are_inserted_in_a_stable_order(self, session, testing_dag_bundle):
         """``dag_schedule_asset_name_reference`` is keyed on (name, dag_id), and so is its set."""
         session.add_all(
@@ -269,8 +387,10 @@ class TestAssetModelOperation:
         inserted: list[dict] = []
 
         def record(conn, cursor, statement, parameters, context, executemany):
+            # ``parameters`` is dicts on psycopg but positional tuples on MySQL; the compiled ones
+            # are dicts on every backend.
             if "insert into dag_schedule_asset_name_reference" in statement.lower():
-                inserted.extend(parameters if executemany else [parameters])
+                inserted.extend(context.compiled_parameters)
 
         bind = session.get_bind()
         event.listen(bind, "before_cursor_execute", record)

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -27,7 +27,7 @@ from unittest import mock
 from unittest.mock import patch
 
 import pytest
-from sqlalchemy import delete, event, func, inspect as sa_inspect, select
+from sqlalchemy import delete, event, func, inspect as sa_inspect, select, text
 from sqlalchemy.exc import OperationalError, SAWarning
 
 import airflow.dag_processing.collection
@@ -39,6 +39,7 @@ from airflow.dag_processing.collection import (
     _get_latest_runs_stmt,
     _get_latest_runs_stmt_partitioned,
     _update_dag_tags,
+    _update_dag_warnings,
     _update_import_errors,
     update_dag_parsing_results_in_db,
 )
@@ -238,20 +239,57 @@ class TestAssetModelOperation:
         yield
         self.clean_db()
 
-    @staticmethod
-    def _build_dags_for(dag_maker, schedules):
-        """One Dag per schedule, keyed by dag_id in the order given."""
-        dags = {}
-        for index, schedule in enumerate(schedules):
-            with dag_maker(dag_id=f"dag_{index}", schedule=[schedule]) as dag:
-                EmptyOperator(task_id="mytask")
-            dags[dag.dag_id] = LazyDeserializedDAG.from_dag(dag)
-        return dags
+    @pytest.mark.backend("postgres")
+    def test_two_writers_cannot_activate_the_same_assets_at_once(self, session):
+        """
+        Two writers reactivating the same inactive assets in opposite order would otherwise
+        insert one row each and then wait on the other's uncommitted unique conflict. Taking the
+        assets in one order first moves that wait outside the insert.
+        """
+        from sqlalchemy.orm import Session as SqlaSession
+
+        from airflow import settings
+
+        pair = [Asset(name="x_asset", uri="s3://x"), Asset(name="y_asset", uri="s3://y")]
+        seeded = AssetModelOperation.collect(self._build_dags_scheduled_on(pair))
+        seeded.sync_assets(session=session)
+        session.commit()
+
+        holder = AssetModelOperation.collect(self._build_dags_scheduled_on(pair))
+        orm_held = holder.sync_assets(session=session)
+        session.flush()
+        holder.activate_assets_if_possible(orm_held.values(), session=session)
+
+        other = SqlaSession(bind=settings.engine)
+        try:
+            other.execute(text("SET lock_timeout = '750ms'"))
+            waiter = AssetModelOperation.collect(self._build_dags_scheduled_on(list(reversed(pair))))
+            orm_waiting = waiter.sync_assets(session=other)
+
+            # Where it waits is the whole point: on the assets, before it has inserted anything.
+            # Without the lock it gets as far as the insert and waits on the unique index there,
+            # which is the position two writers deadlock from.
+            attempted: list[str] = []
+
+            def record(conn, cursor, statement, parameters, context, executemany):
+                if "insert into asset_active" in statement.lower():
+                    attempted.append(statement)
+
+            event.listen(settings.engine, "before_cursor_execute", record)
+            try:
+                with pytest.raises(OperationalError, match="lock timeout"):
+                    waiter.activate_assets_if_possible(orm_waiting.values(), session=other)
+            finally:
+                event.remove(settings.engine, "before_cursor_execute", record)
+
+            assert attempted == [], "the second writer reached the insert before waiting"
+        finally:
+            other.rollback()
+            other.close()
+        session.rollback()
 
     def test_dag_tags_are_inserted_in_a_stable_order(self, session, testing_dag_bundle):
         """``dag_tag`` is keyed on (name, dag_id), and the names arrive as a set."""
-        from airflow.dag_processing.collection import _update_dag_tags
-
         dm = DagModel(dag_id="tagged_dag", bundle_name="testing")
         session.add(dm)
         session.flush()
@@ -262,8 +300,6 @@ class TestAssetModelOperation:
 
     def test_dag_warnings_are_merged_in_a_stable_order(self, session):
         """``dag_warning`` is keyed on (dag_id, warning_type), and the warnings arrive as a set."""
-        from airflow.dag_processing.collection import _update_dag_warnings
-
         warnings = {
             DagWarning(dag_id="b_dag", warning_type=DagWarningType.NONEXISTENT_POOL, message="b"),
             DagWarning(dag_id="a_dag", warning_type=DagWarningType.NONEXISTENT_POOL, message="a"),
@@ -352,9 +388,16 @@ class TestAssetModelOperation:
 
     def test_alias_reference_rows_are_written_in_a_stable_order(self, session, testing_dag_bundle):
         """The alias loop walks ``self.dags`` just as the asset one does."""
-        aliases = [AssetAlias("z_alias"), AssetAlias("a_alias"), AssetAlias("m_alias")]
+        # Nine aliases so the two the Dags use get ids 2 and 9. As a set those iterate 9 before
+        # 2 -- consecutive ids come out ascending either way and would prove nothing.
+        seeded = AssetModelOperation.collect(
+            self._build_dags_scheduled_on([AssetAlias(f"alias_{i}") for i in range(1, 10)])
+        )
+        seeded.sync_asset_aliases(session=session)
+        session.flush()
+        chosen = [AssetAlias("alias_2"), AssetAlias("alias_9")]
         dags = {
-            dag_id: LazyDeserializedDAG.from_dag(DAG(dag_id=dag_id, schedule=aliases))
+            dag_id: LazyDeserializedDAG.from_dag(DAG(dag_id=dag_id, schedule=chosen))
             for dag_id in ("z_dag", "a_dag")
         }
         orm_dags = DagModelOperation(dags, "testing", None).add_dags(session=session)
@@ -379,7 +422,7 @@ class TestAssetModelOperation:
         # Sorted within each Dag as well as across them: the alias ids come out of a set.
         by_dag = [(row["dag_id"], row["alias_id"]) for row in inserted]
         assert by_dag == sorted(by_dag), by_dag
-        assert [dag_id for dag_id, _ in by_dag] == ["a_dag"] * 3 + ["z_dag"] * 3
+        assert [dag_id for dag_id, _ in by_dag] == ["a_dag"] * 2 + ["z_dag"] * 2
 
     @pytest.mark.usefixtures("testing_dag_bundle")
     def test_watcher_rows_are_written_in_trigger_id_order(self, dag_maker, session):
@@ -387,14 +430,16 @@ class TestAssetModelOperation:
         ``asset_watcher`` is keyed on (asset_id, trigger_id).
 
         The trigger hash cannot order it: it is a builtin hash of a str and bytes, so two
-        processes compute different values for the same trigger.
+        processes compute different values for the same trigger. The hashes are pinned here to
+        values whose set iteration -- and so the order the rows are created and given ids --
+        differs from their ascending order, which is what tells the two sorts apart.
         """
+        hashes = {"/tmp/a": 16, "/tmp/b": 9, "/tmp/c": 2}
         asset = Asset(
             "watched_asset",
             watchers=[
-                AssetWatcher(name="w_c", trigger=FileDeleteTrigger(filepath="/tmp/c")),
-                AssetWatcher(name="w_a", trigger=FileDeleteTrigger(filepath="/tmp/a")),
-                AssetWatcher(name="w_b", trigger=FileDeleteTrigger(filepath="/tmp/b")),
+                AssetWatcher(name=f"w_{path[-1]}", trigger=FileDeleteTrigger(filepath=path))
+                for path in hashes
             ],
         )
         with dag_maker(dag_id="watch_dag", schedule=[asset]) as dag:
@@ -423,8 +468,13 @@ class TestAssetModelOperation:
         bind = session.get_bind()
         event.listen(bind, "before_cursor_execute", record)
         try:
-            op.add_asset_trigger_references(orm_assets, session=session)
-            session.flush()
+            with mock.patch.object(
+                BaseEventTrigger,
+                "hash",
+                staticmethod(lambda classpath, kwargs: hashes[kwargs["filepath"]]),
+            ):
+                op.add_asset_trigger_references(orm_assets, session=session)
+                session.flush()
         finally:
             event.remove(bind, "before_cursor_execute", record)
 

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import logging
 import warnings
+from collections import defaultdict
 from collections.abc import Generator
 from datetime import timedelta
 from typing import TYPE_CHECKING
@@ -29,8 +30,10 @@ from unittest.mock import patch
 import pytest
 from sqlalchemy import delete, event, func, inspect as sa_inspect, select, text
 from sqlalchemy.exc import OperationalError, SAWarning
+from sqlalchemy.orm import Session as SqlaSession
 
 import airflow.dag_processing.collection
+from airflow import settings
 from airflow._shared.timezones import timezone as tz
 from airflow.configuration import conf
 from airflow.dag_processing.collection import (
@@ -47,6 +50,7 @@ from airflow.exceptions import SerializationError
 from airflow.models import DagModel, DagRun
 from airflow.models.asset import (
     AssetActive,
+    AssetAliasModel,
     AssetModel,
     DagScheduleAssetNameReference,
     DagScheduleAssetUriReference,
@@ -246,16 +250,15 @@ class TestAssetModelOperation:
         insert one row each and then wait on the other's uncommitted unique conflict. Taking the
         assets in one order first moves that wait outside the insert.
         """
-        from sqlalchemy.orm import Session as SqlaSession
-
-        from airflow import settings
-
-        pair = [Asset(name="x_asset", uri="s3://x"), Asset(name="y_asset", uri="s3://y")]
-        seeded = AssetModelOperation.collect(self._build_dags_scheduled_on(pair))
+        # Disjoint asset rows that meet on the uri column: locking the exact pairs leaves these
+        # two writers free to reach the insert together, holding one uri each.
+        held = [Asset(name="a_asset", uri="s3://z"), Asset(name="c_asset", uri="s3://y")]
+        waiting = [Asset(name="b_asset", uri="s3://y"), Asset(name="c_asset", uri="s3://z")]
+        seeded = AssetModelOperation.collect(self._build_dags_scheduled_on(held + waiting))
         seeded.sync_assets(session=session)
         session.commit()
 
-        holder = AssetModelOperation.collect(self._build_dags_scheduled_on(pair))
+        holder = AssetModelOperation.collect(self._build_dags_scheduled_on(held))
         orm_held = holder.sync_assets(session=session)
         session.flush()
         holder.activate_assets_if_possible(orm_held.values(), session=session)
@@ -263,7 +266,7 @@ class TestAssetModelOperation:
         other = SqlaSession(bind=settings.engine)
         try:
             other.execute(text("SET lock_timeout = '750ms'"))
-            waiter = AssetModelOperation.collect(self._build_dags_scheduled_on(list(reversed(pair))))
+            waiter = AssetModelOperation.collect(self._build_dags_scheduled_on(waiting))
             orm_waiting = waiter.sync_assets(session=other)
 
             # Where it waits is the whole point: on the assets, before it has inserted anything.
@@ -388,12 +391,10 @@ class TestAssetModelOperation:
 
     def test_alias_reference_rows_are_written_in_a_stable_order(self, session, testing_dag_bundle):
         """The alias loop walks ``self.dags`` just as the asset one does."""
-        # Nine aliases so the two the Dags use get ids 2 and 9. As a set those iterate 9 before
-        # 2 -- consecutive ids come out ascending either way and would prove nothing.
-        seeded = AssetModelOperation.collect(
-            self._build_dags_scheduled_on([AssetAlias(f"alias_{i}") for i in range(1, 10)])
-        )
-        seeded.sync_asset_aliases(session=session)
+        # Ids 2 and 9 exactly: as a set those iterate 9 before 2, where consecutive ids come out
+        # ascending either way and would prove nothing. Written rather than seeded, because
+        # clearing rows leaves the sequence where it was and the next ids are anyone's guess.
+        session.add_all([AssetAliasModel(id=2, name="alias_2"), AssetAliasModel(id=9, name="alias_9")])
         session.flush()
         chosen = [AssetAlias("alias_2"), AssetAlias("alias_9")]
         dags = {
@@ -430,19 +431,21 @@ class TestAssetModelOperation:
         ``asset_watcher`` is keyed on (asset_id, trigger_id).
 
         The trigger hash cannot order it: it is a builtin hash of a str and bytes, so two
-        processes compute different values for the same trigger. The hashes are pinned here to
-        values whose set iteration -- and so the order the rows are created and given ids --
-        differs from their ascending order, which is what tells the two sorts apart.
+        processes compute different values for the same trigger. Trigger ids are handed out while
+        iterating the hashes of *every* asset, so one asset's own hashes can iterate the other way
+        -- ``{5, 9}`` alone comes out ``9, 5`` where it comes out ``5, 9`` inside ``{1,2,3,5,9}``,
+        which is what tells ordering by id apart from taking the hashes as they come.
         """
-        hashes = {"/tmp/a": 16, "/tmp/b": 9, "/tmp/c": 2}
-        asset = Asset(
-            "watched_asset",
-            watchers=[
-                AssetWatcher(name=f"w_{path[-1]}", trigger=FileDeleteTrigger(filepath=path))
-                for path in hashes
-            ],
-        )
-        with dag_maker(dag_id="watch_dag", schedule=[asset]) as dag:
+        hashes = {"/tmp/w1": 5, "/tmp/w2": 9, "/tmp/o1": 1, "/tmp/o2": 2, "/tmp/o3": 3}
+
+        def watchers_for(*paths):
+            return [
+                AssetWatcher(name=f"w{path[-1]}", trigger=FileDeleteTrigger(filepath=path)) for path in paths
+            ]
+
+        watched = Asset("watched_asset", watchers=watchers_for("/tmp/w1", "/tmp/w2"))
+        other = Asset("other_asset", watchers=watchers_for("/tmp/o1", "/tmp/o2", "/tmp/o3"))
+        with dag_maker(dag_id="watch_dag", schedule=[watched, other]) as dag:
             EmptyOperator(task_id="mytask")
 
         dags = {dag.dag_id: LazyDeserializedDAG.from_dag(dag)}
@@ -454,6 +457,8 @@ class TestAssetModelOperation:
         session.flush()
         op.add_dag_asset_references(orm_dags, orm_assets, session=session)
         op.activate_assets_if_possible(orm_assets.values(), session=session)
+        # dag_maker already wrote these; clearing them is what leaves the pass below something to
+        # add, and the ids it hands out are the ones under test.
         session.execute(delete(Trigger))
         for asset_model in orm_assets.values():
             asset_model.watchers = []
@@ -478,9 +483,12 @@ class TestAssetModelOperation:
         finally:
             event.remove(bind, "before_cursor_execute", record)
 
-        trigger_ids = [row["trigger_id"] for row in inserted]
-        assert len(trigger_ids) == 3, inserted
-        assert trigger_ids == sorted(trigger_ids), trigger_ids
+        assert len(inserted) == 5, inserted
+        per_asset: dict[int, list[int]] = defaultdict(list)
+        for row in inserted:
+            per_asset[row["asset_id"]].append(row["trigger_id"])
+        for asset_id, trigger_ids in per_asset.items():
+            assert trigger_ids == sorted(trigger_ids), (asset_id, trigger_ids)
 
     def test_asset_name_references_are_inserted_in_a_stable_order(self, session, testing_dag_bundle):
         """``dag_schedule_asset_name_reference`` is keyed on (name, dag_id), and so is its set."""

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -171,6 +171,60 @@ def test_statement_latest_runs_partitioned_sorted_by_partition_date(dag_maker, s
 
 
 @pytest.mark.db_test
+class TestDagModelOperation:
+    @pytest.fixture(autouse=True)
+    def per_test(self) -> Generator:
+        clear_db_dags()
+        yield
+        clear_db_dags()
+
+    @staticmethod
+    def _build_dags(dag_maker, names):
+        dags = {}
+        for name in names:
+            with dag_maker(dag_id=name) as dag:
+                EmptyOperator(task_id="mytask")
+            dags[name] = LazyDeserializedDAG.from_dag(dag)
+        return dags
+
+    @pytest.mark.usefixtures("testing_dag_bundle")
+    def test_existing_dag_rows_are_locked_in_a_stable_order(self, dag_maker, session):
+        dags = self._build_dags(dag_maker, ("c_dag", "a_dag", "b_dag"))
+        statements: list[str] = []
+
+        def record(conn, cursor, statement, parameters, context, executemany):
+            statements.append(statement)
+
+        bind = session.get_bind()
+        event.listen(bind, "before_cursor_execute", record)
+        try:
+            DagModelOperation(dags, "testing", None).find_orm_dags(session=session)
+        finally:
+            event.remove(bind, "before_cursor_execute", record)
+
+        locks = [q for q in statements if "dag_id IN" in q]
+        assert locks, statements
+        assert all("ORDER BY" in q for q in locks), f"dag rows are locked in plan order:\n{locks}"
+
+    @pytest.mark.usefixtures("testing_dag_bundle")
+    def test_new_dag_rows_are_created_in_a_stable_order(self, dag_maker, session):
+        dags = self._build_dags(dag_maker, ("c_dag", "a_dag", "b_dag"))
+        created: list[str] = []
+
+        def spy(*, bundle_name, bundle_version, dags, session):
+            created.extend(dag.dag_id for dag in dags)
+            return []
+
+        with (
+            mock.patch.object(DagModelOperation, "find_orm_dags", autospec=True, return_value={}),
+            mock.patch("airflow.dag_processing.collection._create_orm_dags", spy),
+        ):
+            DagModelOperation(dags, "testing", None).add_dags(session=session)
+
+        assert created == ["a_dag", "b_dag", "c_dag"], created
+
+
+@pytest.mark.db_test
 class TestAssetModelOperation:
     @staticmethod
     def clean_db():
@@ -185,7 +239,7 @@ class TestAssetModelOperation:
         self.clean_db()
 
     @staticmethod
-    def _dags_for(dag_maker, schedules):
+    def _build_dags_for(dag_maker, schedules):
         """One Dag per schedule, keyed by dag_id in the order given."""
         dags = {}
         for index, schedule in enumerate(schedules):
@@ -196,7 +250,7 @@ class TestAssetModelOperation:
 
     def test_shared_assets_and_aliases_are_collected_in_a_stable_order(self, dag_maker):
         """Two writers reaching the same rows must take them the same way round or they deadlock."""
-        dags = self._dags_for(
+        dags = self._build_dags_for(
             dag_maker,
             [
                 Asset("c_asset"),
@@ -219,7 +273,7 @@ class TestAssetModelOperation:
     @pytest.mark.usefixtures("testing_dag_bundle")
     def test_assets_that_already_exist_keep_the_stable_order(self, dag_maker, session):
         """Existing rows come back in the query's order, so it is put back before returning."""
-        dags = self._dags_for(dag_maker, [Asset("c_asset"), Asset("b_asset"), Asset("a_asset")])
+        dags = self._build_dags_for(dag_maker, [Asset("c_asset"), Asset("b_asset"), Asset("a_asset")])
         asset_op = AssetModelOperation.collect(dags)
         committed = session.scalars(select(AssetModel).order_by(AssetModel.name)).all()
         assert [a.name for a in committed] == ["a_asset", "b_asset", "c_asset"], committed

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -485,15 +485,11 @@ class TestAssetModelOperation:
             ),
         ],
     )
-    def test_a_candidate_the_insert_would_reject_does_not_take_the_claim(
-        self, blocker, batch, expected, session
-    ):
+    def test_the_database_activates_the_candidate_that_fits(self, blocker, batch, expected, session):
         """
-        The claim has to start from what is already active, not from the batch alone.
-
         The first candidate cannot be activated whatever happens -- the blocker holds one of its
-        two columns. Were it to claim the other anyway, the candidate behind it would be passed
-        over and the insert would then drop the claimer too, leaving neither active.
+        two columns -- and the one behind it can. Deciding that in Python instead got it wrong
+        twice, so this pins the outcome rather than the mechanism.
         """
         held = AssetModelOperation.collect(self._build_dags_scheduled_on([blocker]))
         orm_held = held.sync_assets(session=session)

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -468,44 +468,6 @@ class TestAssetModelOperation:
     def _read_active_assets(session) -> list[tuple[str, str]]:
         return sorted((a.name, a.uri) for a in session.scalars(select(AssetActive)))
 
-    def test_activation_rows_are_inserted_in_a_stable_order(self, session):
-        """``asset_active`` is unique on both its columns, so its insert needs one order too."""
-        op = AssetModelOperation.collect(
-            self._build_dags_scheduled_on([Asset("c_asset"), Asset("a_asset"), Asset("b_asset")])
-        )
-        orm_assets = op.sync_assets(session=session)
-        session.flush()
-
-        with mock.patch.object(session, "execute", autospec=True) as execute:
-            op.activate_assets_if_possible(orm_assets.values(), session=session)
-
-        assert [value["name"] for value in execute.call_args.args[1]] == [
-            "a_asset",
-            "b_asset",
-            "c_asset",
-        ]
-
-    def test_activating_assets_costs_one_read_and_one_insert(self, session):
-        """Deciding the claim needs what is already active; nothing else here may add a round trip."""
-        op = AssetModelOperation.collect(self._build_dags_scheduled_on([Asset("a_asset"), Asset("b_asset")]))
-        orm_assets = op.sync_assets(session=session)
-        session.flush()
-
-        statements: list[str] = []
-
-        def record(conn, cursor, statement, parameters, context, executemany):
-            statements.append(statement.split()[0].upper())
-
-        bind = session.get_bind()
-        event.listen(bind, "before_cursor_execute", record)
-        try:
-            op.activate_assets_if_possible(orm_assets.values(), session=session)
-            session.flush()
-        finally:
-            event.remove(bind, "before_cursor_execute", record)
-
-        assert statements == ["SELECT", "INSERT"], statements
-
     @pytest.mark.parametrize(
         ("blocker", "batch", "expected"),
         [

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -20,9 +20,10 @@ from __future__ import annotations
 
 import logging
 import warnings
-from collections import defaultdict
 from collections.abc import Generator
 from datetime import timedelta
+from functools import partial
+from threading import Event, Thread
 from typing import TYPE_CHECKING
 from unittest import mock
 from unittest.mock import patch
@@ -42,7 +43,6 @@ from airflow.dag_processing.collection import (
     _get_latest_runs_stmt,
     _get_latest_runs_stmt_partitioned,
     _update_dag_tags,
-    _update_dag_warnings,
     _update_import_errors,
     update_dag_parsing_results_in_db,
 )
@@ -52,7 +52,9 @@ from airflow.models.asset import (
     AssetActive,
     AssetAliasModel,
     AssetModel,
+    DagScheduleAssetAliasReference,
     DagScheduleAssetNameReference,
+    DagScheduleAssetReference,
     DagScheduleAssetUriReference,
 )
 from airflow.models.dag import DagTag
@@ -73,6 +75,8 @@ from airflow.serialization.encoders import encode_trigger, ensure_serialized_ass
 from airflow.serialization.serialized_objects import LazyDeserializedDAG
 from airflow.timetables.simple import PartitionedAtRuntime
 from airflow.triggers.base import BaseEventTrigger
+from airflow.utils.retries import run_with_db_retries
+from airflow.utils.session import create_session
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.config import conf_vars
@@ -243,286 +247,155 @@ class TestAssetModelOperation:
         yield
         self.clean_db()
 
-    @pytest.mark.backend("postgres")
-    def test_two_writers_cannot_activate_the_same_assets_at_once(self, session):
-        """
-        Two writers reactivating the same inactive assets in opposite order would otherwise
-        insert one row each and then wait on the other's uncommitted unique conflict. Taking the
-        assets in one order first moves that wait outside the insert.
-        """
-        # Disjoint asset rows that meet on the uri column: locking the exact pairs leaves these
-        # two writers free to reach the insert together, holding one uri each.
-        held = [Asset(name="a_asset", uri="s3://z"), Asset(name="c_asset", uri="s3://y")]
-        waiting = [Asset(name="b_asset", uri="s3://y"), Asset(name="c_asset", uri="s3://z")]
-        seeded = AssetModelOperation.collect(self._build_dags_scheduled_on(held + waiting))
-        seeded.sync_assets(session=session)
+    @pytest.mark.backend("postgres", "mysql")
+    @pytest.mark.parametrize("kind", ["asset", "alias"])
+    @pytest.mark.usefixtures("testing_dag_bundle")
+    @patch(
+        "airflow.dag_processing.collection.run_with_db_retries",
+        autospec=True,
+        side_effect=partial(run_with_db_retries, max_retries=1),
+    )
+    def test_shared_metadata_is_locked_before_full_parser_writes(self, retries, session, kind):
+        model = AssetModel if kind == "asset" else AssetAliasModel
+        reference = DagScheduleAssetReference if kind == "asset" else DagScheduleAssetAliasReference
+        method_name = "sync_assets" if kind == "asset" else "sync_asset_aliases"
+        table = model.__tablename__
+        for name in ("shared_b", "shared_a"):
+            kwargs = {"uri": f"s3://bucket/{name}"} if kind == "asset" else {}
+            session.add(model(name=name, group="original", **kwargs))
+        session.add_all(DagModel(dag_id=name, bundle_name="testing") for name in ("first", "second"))
         session.commit()
 
-        holder = AssetModelOperation.collect(self._build_dags_scheduled_on(held))
-        orm_held = holder.sync_assets(session=session)
-        session.flush()
-        holder.activate_assets_if_possible(orm_held.values(), session=session)
-
-        other = SqlaSession(bind=settings.engine)
-        try:
-            other.execute(text("SET lock_timeout = '750ms'"))
-            waiter = AssetModelOperation.collect(self._build_dags_scheduled_on(waiting))
-            orm_waiting = waiter.sync_assets(session=other)
-
-            # Where it waits is the whole point: on the assets, before it has inserted anything.
-            # Without the lock it gets as far as the insert and waits on the unique index there,
-            # which is the position two writers deadlock from.
-            attempted: list[str] = []
-
-            def record(conn, cursor, statement, parameters, context, executemany):
-                if "insert into asset_active" in statement.lower():
-                    attempted.append(statement)
-
-            event.listen(settings.engine, "before_cursor_execute", record)
-            try:
-                with pytest.raises(OperationalError, match="lock timeout"):
-                    waiter.activate_assets_if_possible(orm_waiting.values(), session=other)
-            finally:
-                event.remove(settings.engine, "before_cursor_execute", record)
-
-            assert attempted == [], "the second writer reached the insert before waiting"
-        finally:
-            other.rollback()
-            other.close()
-        session.rollback()
-
-    def test_dag_tags_are_inserted_in_a_stable_order(self, session, testing_dag_bundle):
-        """``dag_tag`` is keyed on (name, dag_id), and the names arrive as a set."""
-        dm = DagModel(dag_id="tagged_dag", bundle_name="testing")
-        session.add(dm)
-        session.flush()
-
-        _update_dag_tags({"finance", "ops", "daily"}, dm, session=session)
-
-        assert [tag.name for tag in dm.tags] == ["daily", "finance", "ops"]
-
-    def test_dag_warnings_are_merged_in_a_stable_order(self, session):
-        """``dag_warning`` is keyed on (dag_id, warning_type), and the warnings arrive as a set."""
-        warnings = {
-            DagWarning(dag_id="b_dag", warning_type=DagWarningType.NONEXISTENT_POOL, message="b"),
-            DagWarning(dag_id="a_dag", warning_type=DagWarningType.NONEXISTENT_POOL, message="a"),
-        }
-
-        with mock.patch.object(session, "merge", autospec=True) as merge:
-            _update_dag_warnings(
-                ["a_dag", "b_dag"],
-                warnings,
-                (DagWarningType.NONEXISTENT_POOL,),
-                session=session,
-            )
-
-        assert [call.args[0].dag_id for call in merge.call_args_list] == ["a_dag", "b_dag"]
-
-    def test_reference_rows_are_written_dag_by_dag_in_a_stable_order(self, session, testing_dag_bundle):
-        """
-        The reference loops walk ``self.dags``, whose order differs between a per-file Dag
-        processor and a bundle-wide reserialize.
-        """
-        dags = {
-            dag_id: LazyDeserializedDAG.from_dag(DAG(dag_id=dag_id, schedule=[Asset("shared_ref")]))
-            for dag_id in ("z_dag", "a_dag")
-        }
-        orm_dags = DagModelOperation(dags, "testing", None).add_dags(session=session)
-        op = AssetModelOperation.collect(dags)
-        orm_assets = op.sync_assets(session=session)
-        session.flush()
-
-        inserted: list[dict] = []
-
-        def record(conn, cursor, statement, parameters, context, executemany):
-            if "insert into dag_schedule_asset_reference" in statement.lower():
-                inserted.extend(context.compiled_parameters)
-
-        bind = session.get_bind()
-        event.listen(bind, "before_cursor_execute", record)
-        try:
-            op.add_dag_asset_references(orm_dags, orm_assets, session=session)
-            session.flush()
-        finally:
-            event.remove(bind, "before_cursor_execute", record)
-
-        assert [row["dag_id"] for row in inserted] == ["a_dag", "z_dag"]
-
-    def test_task_reference_rows_are_written_in_a_stable_order(self, session, testing_dag_bundle):
-        """Inlets arrive as a set, and both task loops walk ``self.dags``."""
-        asset = Asset("task_ref_asset")
-        dags = {}
-        for dag_id in ("z_dag", "a_dag"):
-            with DAG(dag_id=dag_id, schedule=None) as dag:
-                EmptyOperator(task_id="t_b", inlets=[asset], outlets=[asset])
-                EmptyOperator(task_id="t_a", inlets=[asset], outlets=[asset])
-            dags[dag_id] = LazyDeserializedDAG.from_dag(dag)
-
-        orm_dags = DagModelOperation(dags, "testing", None).add_dags(session=session)
-        op = AssetModelOperation.collect(dags)
-        orm_assets = op.sync_assets(session=session)
-        session.flush()
-
-        inlets: list[dict] = []
-        outlets: list[dict] = []
-
-        def record(conn, cursor, statement, parameters, context, executemany):
-            lowered = statement.lower()
-            if "insert into task_inlet_asset_reference" in lowered:
-                inlets.extend(context.compiled_parameters)
-            elif "insert into task_outlet_asset_reference" in lowered:
-                outlets.extend(context.compiled_parameters)
-
-        bind = session.get_bind()
-        event.listen(bind, "before_cursor_execute", record)
-        try:
-            op.add_task_asset_references(orm_dags, orm_assets, session=session)
-            session.flush()
-        finally:
-            event.remove(bind, "before_cursor_execute", record)
-
-        assert [(row["dag_id"], row["task_id"]) for row in inlets] == [
-            ("a_dag", "t_a"),
-            ("a_dag", "t_b"),
-            ("z_dag", "t_a"),
-            ("z_dag", "t_b"),
-        ]
-        assert [row["dag_id"] for row in outlets] == ["a_dag", "a_dag", "z_dag", "z_dag"]
-
-    def test_alias_reference_rows_are_written_in_a_stable_order(self, session, testing_dag_bundle):
-        """The alias loop walks ``self.dags`` just as the asset one does."""
-        # Ids 2 and 9 exactly: as a set those iterate 9 before 2, where consecutive ids come out
-        # ascending either way and would prove nothing. Written rather than seeded, because
-        # clearing rows leaves the sequence where it was and the next ids are anyone's guess.
-        session.add_all([AssetAliasModel(id=2, name="alias_2"), AssetAliasModel(id=9, name="alias_9")])
-        session.flush()
-        chosen = [AssetAlias("alias_2"), AssetAlias("alias_9")]
-        dags = {
-            dag_id: LazyDeserializedDAG.from_dag(DAG(dag_id=dag_id, schedule=chosen))
-            for dag_id in ("z_dag", "a_dag")
-        }
-        orm_dags = DagModelOperation(dags, "testing", None).add_dags(session=session)
-        op = AssetModelOperation.collect(dags)
-        orm_aliases = op.sync_asset_aliases(session=session)
-        session.flush()
-
-        inserted: list[dict] = []
-
-        def record(conn, cursor, statement, parameters, context, executemany):
-            if "insert into dag_schedule_asset_alias_reference" in statement.lower():
-                inserted.extend(context.compiled_parameters)
-
-        bind = session.get_bind()
-        event.listen(bind, "before_cursor_execute", record)
-        try:
-            op.add_dag_asset_alias_references(orm_dags, orm_aliases, session=session)
-            session.flush()
-        finally:
-            event.remove(bind, "before_cursor_execute", record)
-
-        # Sorted within each Dag as well as across them: the alias ids come out of a set.
-        by_dag = [(row["dag_id"], row["alias_id"]) for row in inserted]
-        assert by_dag == sorted(by_dag), by_dag
-        assert [dag_id for dag_id, _ in by_dag] == ["a_dag"] * 2 + ["z_dag"] * 2
-
-    @pytest.mark.usefixtures("testing_dag_bundle")
-    def test_watcher_rows_are_written_in_trigger_id_order(self, dag_maker, session):
-        """
-        ``asset_watcher`` is keyed on (asset_id, trigger_id).
-
-        The trigger hash cannot order it: it is a builtin hash of a str and bytes, so two
-        processes compute different values for the same trigger. Trigger ids are handed out while
-        iterating the hashes of *every* asset, so one asset's own hashes can iterate the other way
-        -- ``{5, 9}`` alone comes out ``9, 5`` where it comes out ``5, 9`` inside ``{1,2,3,5,9}``,
-        which is what tells ordering by id apart from taking the hashes as they come.
-        """
-        hashes = {"/tmp/w1": 5, "/tmp/w2": 9, "/tmp/o1": 1, "/tmp/o2": 2, "/tmp/o3": 3}
-
-        def watchers_for(*paths):
-            return [
-                AssetWatcher(name=f"w{path[-1]}", trigger=FileDeleteTrigger(filepath=path)) for path in paths
+        def build_dag(dag_id):
+            names = ("shared_b", "shared_a") if dag_id == "first" else ("shared_a", "shared_b")
+            schedules = [
+                Asset(name=name, uri=f"s3://bucket/{name}", group=dag_id)
+                if kind == "asset"
+                else AssetAlias(name, group=dag_id)
+                for name in names
             ]
+            with DAG(dag_id, schedule=schedules, is_paused_upon_creation=False) as dag:
+                EmptyOperator(task_id="task")
+            dag.fileloc = __file__
+            dag.relative_fileloc = "test_collection.py"
+            return LazyDeserializedDAG.from_dag(dag)
 
-        watched = Asset("watched_asset", watchers=watchers_for("/tmp/w1", "/tmp/w2"))
-        other = Asset("other_asset", watchers=watchers_for("/tmp/o1", "/tmp/o2", "/tmp/o3"))
-        with dag_maker(dag_id="watch_dag", schedule=[watched, other]) as dag:
-            EmptyOperator(task_id="mytask")
+        def publish(dag, *, session):
+            errors = {}
+            update_dag_parsing_results_in_db("testing", None, [dag], errors, None, set(), session=session)
+            assert not errors
 
-        dags = {dag.dag_id: LazyDeserializedDAG.from_dag(dag)}
-        orm_dags = DagModelOperation(dags, "testing", None).add_dags(session=session)
-        orm_dags[dag.dag_id].is_stale = False
-        orm_dags[dag.dag_id].is_paused = False
-        op = AssetModelOperation.collect(dags)
-        orm_assets = op.sync_assets(session=session)
-        session.flush()
-        op.add_dag_asset_references(orm_dags, orm_assets, session=session)
-        op.activate_assets_if_possible(orm_assets.values(), session=session)
-        # dag_maker already wrote these; clearing them is what leaves the pass below something to
-        # add, and the ids it hands out are the ones under test.
-        session.execute(delete(Trigger))
-        for asset_model in orm_assets.values():
-            asset_model.watchers = []
-        session.flush()
+        locked, release = Event(), Event()
+        first_errors: list[Exception] = []
+        real_sync = getattr(AssetModelOperation, method_name)
 
-        inserted: list[dict] = []
+        def sync_then_pause(operation, *, session):
+            result = real_sync(operation, session=session)
+            if "first" in operation.schedule_asset_references:
+                locked.set()
+                assert release.wait(15), "first publication was not released"
+            return result
 
-        def record(conn, cursor, statement, parameters, context, executemany):
-            if "insert into asset_watcher" in statement.lower():
-                inserted.extend(context.compiled_parameters)
+        def publish_first():
+            try:
+                with create_session(scoped=False) as first_session:
+                    publish(build_dag("first"), session=first_session)
+            except Exception as error:
+                first_errors.append(error)
 
-        bind = session.get_bind()
-        event.listen(bind, "before_cursor_execute", record)
-        try:
-            with mock.patch.object(
-                BaseEventTrigger,
-                "hash",
-                staticmethod(lambda classpath, kwargs: hashes[kwargs["filepath"]]),
-            ):
-                op.add_asset_trigger_references(orm_assets, session=session)
-                session.flush()
-        finally:
-            event.remove(bind, "before_cursor_execute", record)
-
-        assert len(inserted) == 5, inserted
-        per_asset: dict[int, list[int]] = defaultdict(list)
-        for row in inserted:
-            per_asset[row["asset_id"]].append(row["trigger_id"])
-        for asset_id, trigger_ids in per_asset.items():
-            assert trigger_ids == sorted(trigger_ids), (asset_id, trigger_ids)
-
-    def test_asset_name_references_are_inserted_in_a_stable_order(self, session, testing_dag_bundle):
-        """``dag_schedule_asset_name_reference`` is keyed on (name, dag_id), and so is its set."""
-        session.add_all(
-            [DagModel(dag_id="a_dag", bundle_name="testing"), DagModel(dag_id="b_dag", bundle_name="testing")]
-        )
-        session.flush()
-        inserted: list[dict] = []
+        statements: list[str] = []
 
         def record(conn, cursor, statement, parameters, context, executemany):
-            # ``parameters`` is dicts on psycopg but positional tuples on MySQL; the compiled ones
-            # are dicts on every backend.
-            if "insert into dag_schedule_asset_name_reference" in statement.lower():
-                inserted.extend(context.compiled_parameters)
+            statements.append(statement.lower())
 
-        bind = session.get_bind()
-        event.listen(bind, "before_cursor_execute", record)
-        try:
-            AssetModelOperation._add_dag_asset_references(
-                {("b_dag", "n2"), ("a_dag", "n1"), ("b_dag", "n1"), ("a_dag", "n2")},
-                DagScheduleAssetNameReference,
-                "name",
-                session=session,
-            )
-            session.flush()
-        finally:
-            event.remove(bind, "before_cursor_execute", record)
+        with patch.object(AssetModelOperation, method_name, autospec=True, side_effect=sync_then_pause):
+            first = Thread(target=publish_first, daemon=True)
+            first.start()
+            try:
+                assert locked.wait(15), first_errors
+                with (
+                    settings.engine.connect() as connection,
+                    SqlaSession(bind=connection, autoflush=False) as second_session,
+                ):
+                    is_postgres = connection.dialect.name == "postgresql"
+                    second_session.execute(
+                        text(
+                            "SET LOCAL lock_timeout = '500ms'"
+                            if is_postgres
+                            else "SET SESSION innodb_lock_wait_timeout = 1"
+                        )
+                    )
+                    event.listen(connection, "before_cursor_execute", record)
+                    try:
+                        with pytest.raises(OperationalError) as failure:
+                            publish(build_dag("second"), session=second_session)
+                    finally:
+                        event.remove(connection, "before_cursor_execute", record)
+                        second_session.rollback()
+                        if not is_postgres:
+                            connection.execute(text("SET SESSION innodb_lock_wait_timeout = DEFAULT"))
+                    failed_statement = failure.value.statement.lower()
+                    assert failed_statement.startswith("select")
+                    assert f"from {table}" in failed_statement
+                    assert any(clause in failed_statement for clause in ("for update", "for no key update"))
+                    ordering = f"order by {table}.name" + (", asset.uri" if kind == "asset" else "")
+                    assert ordering in failed_statement
+                    assert not any(statement.startswith(f"update {table} ") for statement in statements)
+            finally:
+                release.set()
+                first.join(15)
+            assert not first.is_alive()
+            assert first_errors == []
 
-        assert [(row["dag_id"], row["name"]) for row in inserted] == [
-            ("a_dag", "n1"),
-            ("a_dag", "n2"),
-            ("b_dag", "n1"),
-            ("b_dag", "n2"),
+        with create_session(scoped=False) as observer:
+            assert observer.scalars(select(model.group)).all() == ["first", "first"]
+            assert observer.scalars(select(SerializedDagModel.dag_id)).all() == ["first"]
+        with create_session(scoped=False) as retry_session:
+            publish(build_dag("second"), session=retry_session)
+        with create_session(scoped=False) as observer:
+            assert observer.scalars(select(model.group)).all() == ["second", "second"]
+            assert sorted(observer.scalars(select(SerializedDagModel.dag_id))) == ["first", "second"]
+            assert sorted(observer.scalars(select(reference.dag_id))) == ["first"] * 2 + ["second"] * 2
+
+    @pytest.mark.backend("mysql")
+    @pytest.mark.parametrize("kind", ["asset", "alias"])
+    def test_large_lookup_locks_rows_in_index_order(self, session, kind):
+        model = AssetModel if kind == "asset" else AssetAliasModel
+        for index in range(1000):
+            name = f"asset_{index:04}"
+            kwargs = {"uri": name} if kind == "asset" else {}
+            session.add(model(id=1000 - index, name=name, group="asset", **kwargs))
+        session.commit()
+        schedules = [
+            Asset(f"asset_{index:04}") if kind == "asset" else AssetAlias(f"asset_{index:04}")
+            for index in range(400)
         ]
+        operation = AssetModelOperation.collect(self._build_dags_scheduled_on(schedules))
+        queries = []
+
+        def record(conn, cursor, statement, parameters, context, executemany):
+            if statement.startswith("SELECT") and "FOR UPDATE" in statement:
+                queries.append((statement, parameters))
+
+        connection = session.connection()
+        event.listen(connection, "before_cursor_execute", record)
+        try:
+            if kind == "asset":
+                operation.sync_assets(session=session)
+            else:
+                operation.sync_asset_aliases(session=session)
+        finally:
+            event.remove(connection, "before_cursor_execute", record)
+
+        assert len(queries) == 1
+        statement, parameters = queries[0]
+        plan = connection.exec_driver_sql("EXPLAIN " + statement, parameters).mappings().one()
+        assert plan["key"] == (
+            "idx_asset_name_uri_unique" if kind == "asset" else "idx_asset_alias_name_unique"
+        )
+        extra = (plan["Extra"] or "").lower()
+        assert "filesort" not in extra
+        assert "mrr" not in extra
 
     def test_new_assets_and_aliases_are_inserted_in_a_stable_order(self, session):
         """Two writers reaching the same rows must take them the same way round or they deadlock."""
@@ -580,42 +453,28 @@ class TestAssetModelOperation:
     def _read_active_assets(session) -> list[tuple[str, str]]:
         return sorted((a.name, a.uri) for a in session.scalars(select(AssetActive)))
 
+    @pytest.mark.parametrize("reverse", [False, True], ids=["forward", "reverse"])
     @pytest.mark.parametrize(
-        "seeded",
-        [
-            pytest.param(False, id="all-new"),
-            pytest.param(True, id="already-in-the-asset-table"),
-        ],
+        "existing_indices", [(), (0, 1), (0,), (1,)], ids=["new", "existing", "existing-first", "new-first"]
     )
-    def test_collection_order_decides_which_asset_is_activated(self, seeded, session):
-        """
-        ``asset_active`` is unique on name and on uri separately, so of two assets sharing a name
-        only one is activated, and the Dags decide which. Neither sorting the rows for insertion nor
-        the order the read-back returns rows already in ``asset`` may move that.
-        """
-
-        def activate(assets: list[Asset]) -> list[tuple[str, str]]:
-            clear_db_assets()
-            if seeded:
-                # Written but not activated, so the pass below reads them back as existing rows.
-                AssetModelOperation.collect(self._build_dags_scheduled_on(assets)).sync_assets(
-                    session=session
-                )
-                session.commit()
-
-            op = AssetModelOperation.collect(self._build_dags_scheduled_on(assets))
-            orm_assets = op.sync_assets(session=session)
-            session.flush()
-            op.activate_assets_if_possible(orm_assets.values(), session=session)
-            session.flush()
-            return self._read_active_assets(session)
-
-        pair = [Asset(name="dup", uri="s3://zzz"), Asset(name="dup", uri="s3://aaa")]
-
-        assert activate(pair) == [("dup", "s3://zzz/")]
-        assert activate(list(reversed(pair))) == [("dup", "s3://aaa/")], (
-            "the winner came from the sort or the read-back, not from the Dags"
+    def test_collection_order_decides_which_asset_is_activated(self, existing_indices, reverse, session):
+        candidates = [Asset(name="dup", uri="s3://zzz/"), Asset(name="dup", uri="s3://aaa/")]
+        if reverse:
+            candidates.reverse()
+        session.add_all(
+            AssetModel(id=-1 - index, name=asset.name, uri=asset.uri, group=asset.group)
+            for index, asset in reversed(list(enumerate(candidates)))
+            if index in existing_indices
         )
+        session.commit()
+
+        operation = AssetModelOperation.collect(self._build_dags_scheduled_on(candidates))
+        orm_assets = operation.sync_assets(session=session)
+        session.flush()
+        operation.activate_assets_if_possible(orm_assets.values(), session=session)
+
+        assert list(orm_assets) == [(asset.name, asset.uri) for asset in candidates]
+        assert self._read_active_assets(session) == [(candidates[0].name, candidates[0].uri)]
 
     @pytest.mark.usefixtures("testing_dag_bundle")
     def test_sync_assets_preserves_access_control_from_other_bundle(self, dag_maker, session):

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -298,7 +298,7 @@ class TestAssetModelOperation:
         }
 
     def _active(self, session) -> list[tuple[str, str]]:
-        return sorted((a.name, a.uri.rstrip("/")) for a in session.scalars(select(AssetActive)))
+        return sorted((a.name, a.uri) for a in session.scalars(select(AssetActive)))
 
     def test_activation_rows_are_inserted_in_a_stable_order(self, session):
         """``asset_active`` is unique on both its columns, so its insert needs one order too."""
@@ -318,12 +318,34 @@ class TestAssetModelOperation:
             "c_asset",
         ]
 
+    def test_activating_assets_costs_one_read_and_one_insert(self, session):
+        """Deciding the claim needs what is already active; nothing else here may add a round trip."""
+        clear_db_assets()
+        op = AssetModelOperation.collect(self._dags_for([Asset("a_asset"), Asset("b_asset")]))
+        orm_assets = op.sync_assets(session=session)
+        session.flush()
+
+        statements: list[str] = []
+
+        def record(conn, cursor, statement, parameters, context, executemany):
+            statements.append(statement.split()[0].upper())
+
+        bind = session.get_bind()
+        event.listen(bind, "before_cursor_execute", record)
+        try:
+            op.activate_assets_if_possible(orm_assets.values(), session=session)
+            session.flush()
+        finally:
+            event.remove(bind, "before_cursor_execute", record)
+
+        assert statements == ["SELECT", "INSERT"], statements
+
     def test_a_candidate_the_insert_would_reject_does_not_take_the_claim(self, session):
         """
         The claim has to start from what is already active, not from the batch alone.
 
         With ``n9`` holding ``s3://u1``, ``("n1", "s3://u1")`` cannot be activated whatever happens
-        -- its uri is taken. Were it to claim the name anyway, ``("n1", "s3://u2")`` would be passed
+        -- its uri is taken. Were it to claim the name anyway, ``("n1", "s3://u2/")`` would be passed
         over and the insert would then drop the claimer too, leaving neither active.
         """
         clear_db_assets()
@@ -332,7 +354,7 @@ class TestAssetModelOperation:
         session.flush()
         blocker.activate_assets_if_possible(blocked.values(), session=session)
         session.flush()
-        assert self._active(session) == [("n9", "s3://u1")]
+        assert self._active(session) == [("n9", "s3://u1/")]
 
         op = AssetModelOperation.collect(
             self._dags_for([Asset(name="n1", uri="s3://u1"), Asset(name="n1", uri="s3://u2")])
@@ -342,7 +364,7 @@ class TestAssetModelOperation:
         op.activate_assets_if_possible(orm_assets.values(), session=session)
         session.flush()
 
-        assert self._active(session) == [("n1", "s3://u2"), ("n9", "s3://u1")]
+        assert self._active(session) == [("n1", "s3://u2/"), ("n9", "s3://u1/")]
 
     @pytest.mark.parametrize(
         "seeded",
@@ -374,8 +396,8 @@ class TestAssetModelOperation:
 
         pair = [Asset(name="dup", uri="s3://zzz"), Asset(name="dup", uri="s3://aaa")]
 
-        assert activate(pair) == [("dup", "s3://zzz")]
-        assert activate(list(reversed(pair))) == [("dup", "s3://aaa")], (
+        assert activate(pair) == [("dup", "s3://zzz/")]
+        assert activate(list(reversed(pair))) == [("dup", "s3://aaa/")], (
             "the winner came from the sort or the read-back, not from the Dags"
         )
 

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -248,7 +248,7 @@ class TestAssetModelOperation:
             dags[dag.dag_id] = LazyDeserializedDAG.from_dag(dag)
         return dags
 
-    def test_shared_assets_and_aliases_are_collected_in_a_stable_order(self, dag_maker):
+    def test_new_assets_and_aliases_are_inserted_in_a_stable_order(self, dag_maker, session):
         """Two writers reaching the same rows must take them the same way round or they deadlock."""
         dags = self._build_dags_for(
             dag_maker,
@@ -260,31 +260,81 @@ class TestAssetModelOperation:
                 Asset("b_asset"),
             ],
         )
-        reversed_dags = dict(reversed(list(dags.items())))
+        clear_db_assets()
 
-        forwards = AssetModelOperation.collect(dags)
-        backwards = AssetModelOperation.collect(reversed_dags)
+        def inserted(op):
+            with (
+                mock.patch.object(
+                    airflow.dag_processing.collection.asset_manager,
+                    "create_assets",
+                    autospec=True,
+                    return_value=[],
+                ) as assets,
+                mock.patch.object(
+                    airflow.dag_processing.collection.asset_manager,
+                    "create_asset_aliases",
+                    autospec=True,
+                    return_value=[],
+                ) as aliases,
+            ):
+                op.sync_assets(session=session)
+                op.sync_asset_aliases(session=session)
+            return (
+                [a.name for a in assets.call_args.args[0]],
+                [a.name for a in aliases.call_args.args[0]],
+            )
 
-        assert [name for name, _ in forwards.assets] == ["a_asset", "b_asset", "c_asset"]
-        assert list(forwards.assets) == list(backwards.assets)
-        assert list(forwards.asset_aliases) == ["a_alias", "z_alias"]
-        assert list(forwards.asset_aliases) == list(backwards.asset_aliases)
+        forwards = inserted(AssetModelOperation.collect(dags))
+        backwards = inserted(AssetModelOperation.collect(dict(reversed(list(dags.items())))))
 
-    @pytest.mark.usefixtures("testing_dag_bundle")
-    def test_assets_that_already_exist_keep_the_stable_order(self, dag_maker, session):
-        """Existing rows come back in the query's order, so it is put back before returning."""
-        dags = self._build_dags_for(dag_maker, [Asset("c_asset"), Asset("b_asset"), Asset("a_asset")])
-        asset_op = AssetModelOperation.collect(dags)
-        committed = session.scalars(select(AssetModel).order_by(AssetModel.name)).all()
-        assert [a.name for a in committed] == ["a_asset", "b_asset", "c_asset"], committed
+        assert forwards == (["a_asset", "b_asset", "c_asset"], ["a_alias", "z_alias"])
+        assert forwards == backwards, "the order the Dags arrived in reached the insert"
 
-        # No backend returns a chosen bad order on demand, so stub it -- with the rows that really
-        # are there, or the write below creates one the database already holds.
-        with mock.patch.object(session, "scalars", autospec=True, return_value=list(reversed(committed))):
-            orm_assets = asset_op.sync_assets(session=session)
+    def test_activation_rows_are_inserted_in_a_stable_order(self, session):
+        """``asset_active`` is unique on both its columns, so its insert needs one order too."""
+        clear_db_assets()
+        dags = {
+            f"dag_{i}": LazyDeserializedDAG.from_dag(DAG(dag_id=f"dag_{i}", schedule=[Asset(name)]))
+            for i, name in enumerate(("c_asset", "a_asset", "b_asset"))
+        }
+        op = AssetModelOperation.collect(dags)
+        orm_assets = op.sync_assets(session=session)
+        session.flush()
 
-        assert [name for name, _ in orm_assets] == ["a_asset", "b_asset", "c_asset"], (
-            "rows that already existed kept the order the database returned them in"
+        with mock.patch.object(session, "execute", autospec=True) as execute:
+            op.activate_assets_if_possible(orm_assets.values(), session=session)
+
+        assert [value["name"] for value in execute.call_args.args[1]] == [
+            "a_asset",
+            "b_asset",
+            "c_asset",
+        ]
+
+    def test_collection_order_decides_which_asset_is_activated(self, session):
+        """
+        ``asset_active`` is unique on name and on uri separately, so of two assets sharing a name
+        only one is activated. Sorting the rows for insertion must not move which one: a sweep has
+        to land where writing its files one at a time would, and that is collection order.
+        """
+
+        def activate(assets: list[Asset]):
+            clear_db_assets()
+            dags = {
+                f"dag_{i}": LazyDeserializedDAG.from_dag(DAG(dag_id=f"dag_{i}", schedule=[asset]))
+                for i, asset in enumerate(assets)
+            }
+            op = AssetModelOperation.collect(dags)
+            orm_assets = op.sync_assets(session=session)
+            session.flush()
+            op.activate_assets_if_possible(orm_assets.values(), session=session)
+            session.flush()
+            return [(a.name, a.uri.rstrip("/")) for a in session.scalars(select(AssetActive))]
+
+        zulu_first = [Asset(name="dup", uri="s3://zzz"), Asset(name="dup", uri="s3://aaa")]
+
+        assert activate(zulu_first) == [("dup", "s3://zzz")]
+        assert activate(list(reversed(zulu_first))) == [("dup", "s3://aaa")], (
+            "the winner is lexicographic, not the one the Dags defined first"
         )
 
     @pytest.mark.usefixtures("testing_dag_bundle")

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -310,6 +310,70 @@ class TestAssetModelOperation:
             "c_asset",
         ]
 
+    @staticmethod
+    def _dags_for(assets: list[Asset]) -> dict:
+        return {
+            f"dag_{i}": LazyDeserializedDAG.from_dag(DAG(dag_id=f"dag_{i}", schedule=[asset]))
+            for i, asset in enumerate(assets)
+        }
+
+    def _active(self, session) -> list[tuple[str, str]]:
+        return sorted((a.name, a.uri.rstrip("/")) for a in session.scalars(select(AssetActive)))
+
+    def test_a_candidate_the_insert_would_reject_does_not_take_the_claim(self, session):
+        """
+        The claim has to start from what is already active, not from the batch alone.
+
+        With ``n9`` holding ``s3://u1``, ``("n1", "s3://u1")`` cannot be activated whatever happens
+        -- its uri is taken. Were it to claim the name anyway, ``("n1", "s3://u2")`` would be passed
+        over and the insert would then drop the claimer too, leaving neither active.
+        """
+        clear_db_assets()
+        blocker = AssetModelOperation.collect(self._dags_for([Asset(name="n9", uri="s3://u1")]))
+        blocked = blocker.sync_assets(session=session)
+        session.flush()
+        blocker.activate_assets_if_possible(blocked.values(), session=session)
+        session.flush()
+        assert self._active(session) == [("n9", "s3://u1")]
+
+        op = AssetModelOperation.collect(
+            self._dags_for([Asset(name="n1", uri="s3://u1"), Asset(name="n1", uri="s3://u2")])
+        )
+        orm_assets = op.sync_assets(session=session)
+        session.flush()
+        op.activate_assets_if_possible(orm_assets.values(), session=session)
+        session.flush()
+
+        assert self._active(session) == [("n1", "s3://u2"), ("n9", "s3://u1")]
+
+    def test_collection_order_decides_the_winner_among_assets_that_already_exist(self, session):
+        """
+        The read-back in ``sync_assets`` returns existing rows in the query's order, so collection
+        order has to be put back before activation -- otherwise which of two assets sharing a name
+        wins depends on the database rather than on the Dags.
+        """
+
+        def activate(assets: list[Asset]) -> list[tuple[str, str]]:
+            clear_db_assets()
+            # Written but not activated, so the second pass reads them back as existing rows.
+            seeded = AssetModelOperation.collect(self._dags_for(assets))
+            seeded.sync_assets(session=session)
+            session.commit()
+
+            op = AssetModelOperation.collect(self._dags_for(assets))
+            orm_assets = op.sync_assets(session=session)
+            session.flush()
+            op.activate_assets_if_possible(orm_assets.values(), session=session)
+            session.flush()
+            return self._active(session)
+
+        pair = [Asset(name="dup", uri="s3://zzz"), Asset(name="dup", uri="s3://aaa")]
+
+        assert activate(pair) == [("dup", "s3://zzz")]
+        assert activate(list(reversed(pair))) == [("dup", "s3://aaa")], (
+            "the winner came from the read-back's order, not the Dags'"
+        )
+
     def test_collection_order_decides_which_asset_is_activated(self, session):
         """
         ``asset_active`` is unique on name and on uri separately, so of two assets sharing a name

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -352,9 +352,9 @@ class TestAssetModelOperation:
 
     def test_alias_reference_rows_are_written_in_a_stable_order(self, session, testing_dag_bundle):
         """The alias loop walks ``self.dags`` just as the asset one does."""
-        alias = AssetAlias("shared_alias")
+        aliases = [AssetAlias("z_alias"), AssetAlias("a_alias"), AssetAlias("m_alias")]
         dags = {
-            dag_id: LazyDeserializedDAG.from_dag(DAG(dag_id=dag_id, schedule=[alias]))
+            dag_id: LazyDeserializedDAG.from_dag(DAG(dag_id=dag_id, schedule=aliases))
             for dag_id in ("z_dag", "a_dag")
         }
         orm_dags = DagModelOperation(dags, "testing", None).add_dags(session=session)
@@ -376,7 +376,61 @@ class TestAssetModelOperation:
         finally:
             event.remove(bind, "before_cursor_execute", record)
 
-        assert [row["dag_id"] for row in inserted] == ["a_dag", "z_dag"]
+        # Sorted within each Dag as well as across them: the alias ids come out of a set.
+        by_dag = [(row["dag_id"], row["alias_id"]) for row in inserted]
+        assert by_dag == sorted(by_dag), by_dag
+        assert [dag_id for dag_id, _ in by_dag] == ["a_dag"] * 3 + ["z_dag"] * 3
+
+    @pytest.mark.usefixtures("testing_dag_bundle")
+    def test_watcher_rows_are_written_in_trigger_id_order(self, dag_maker, session):
+        """
+        ``asset_watcher`` is keyed on (asset_id, trigger_id).
+
+        The trigger hash cannot order it: it is a builtin hash of a str and bytes, so two
+        processes compute different values for the same trigger.
+        """
+        asset = Asset(
+            "watched_asset",
+            watchers=[
+                AssetWatcher(name="w_c", trigger=FileDeleteTrigger(filepath="/tmp/c")),
+                AssetWatcher(name="w_a", trigger=FileDeleteTrigger(filepath="/tmp/a")),
+                AssetWatcher(name="w_b", trigger=FileDeleteTrigger(filepath="/tmp/b")),
+            ],
+        )
+        with dag_maker(dag_id="watch_dag", schedule=[asset]) as dag:
+            EmptyOperator(task_id="mytask")
+
+        dags = {dag.dag_id: LazyDeserializedDAG.from_dag(dag)}
+        orm_dags = DagModelOperation(dags, "testing", None).add_dags(session=session)
+        orm_dags[dag.dag_id].is_stale = False
+        orm_dags[dag.dag_id].is_paused = False
+        op = AssetModelOperation.collect(dags)
+        orm_assets = op.sync_assets(session=session)
+        session.flush()
+        op.add_dag_asset_references(orm_dags, orm_assets, session=session)
+        op.activate_assets_if_possible(orm_assets.values(), session=session)
+        session.execute(delete(Trigger))
+        for asset_model in orm_assets.values():
+            asset_model.watchers = []
+        session.flush()
+
+        inserted: list[dict] = []
+
+        def record(conn, cursor, statement, parameters, context, executemany):
+            if "insert into asset_watcher" in statement.lower():
+                inserted.extend(context.compiled_parameters)
+
+        bind = session.get_bind()
+        event.listen(bind, "before_cursor_execute", record)
+        try:
+            op.add_asset_trigger_references(orm_assets, session=session)
+            session.flush()
+        finally:
+            event.remove(bind, "before_cursor_execute", record)
+
+        trigger_ids = [row["trigger_id"] for row in inserted]
+        assert len(trigger_ids) == 3, inserted
+        assert trigger_ids == sorted(trigger_ids), trigger_ids
 
     def test_asset_name_references_are_inserted_in_a_stable_order(self, session, testing_dag_bundle):
         """``dag_schedule_asset_name_reference`` is keyed on (name, dag_id), and so is its set."""
@@ -467,60 +521,6 @@ class TestAssetModelOperation:
     @staticmethod
     def _read_active_assets(session) -> list[tuple[str, str]]:
         return sorted((a.name, a.uri) for a in session.scalars(select(AssetActive)))
-
-    @pytest.mark.parametrize(
-        ("blocker", "batch", "expected"),
-        [
-            pytest.param(
-                Asset(name="n9", uri="s3://u1"),
-                [Asset(name="n1", uri="s3://u1"), Asset(name="n1", uri="s3://u2")],
-                [("n1", "s3://u2/"), ("n9", "s3://u1/")],
-                id="blocker-holds-the-uri",
-            ),
-            pytest.param(
-                Asset(name="n1", uri="s3://u9"),
-                [Asset(name="n1", uri="s3://u2"), Asset(name="n2", uri="s3://u2")],
-                [("n1", "s3://u9/"), ("n2", "s3://u2/")],
-                id="blocker-holds-the-name",
-            ),
-        ],
-    )
-    def test_the_database_activates_the_candidate_that_fits(self, blocker, batch, expected, session):
-        """
-        The first candidate cannot be activated whatever happens -- the blocker holds one of its
-        two columns -- and the one behind it can. Deciding that in Python instead got it wrong
-        twice, so this pins the outcome rather than the mechanism.
-        """
-        held = AssetModelOperation.collect(self._build_dags_scheduled_on([blocker]))
-        orm_held = held.sync_assets(session=session)
-        session.flush()
-        held.activate_assets_if_possible(orm_held.values(), session=session)
-        session.flush()
-
-        op = AssetModelOperation.collect(self._build_dags_scheduled_on(batch))
-        orm_assets = op.sync_assets(session=session)
-        session.flush()
-        op.activate_assets_if_possible(orm_assets.values(), session=session)
-        session.flush()
-
-        assert self._read_active_assets(session) == expected
-
-    def test_activating_nothing_asks_the_database_nothing(self, session):
-        """The guard exists so an empty batch does not pay for the claim it has nothing to make."""
-        op = AssetModelOperation.collect(self._build_dags_scheduled_on([Asset("only_asset")]))
-        statements: list[str] = []
-
-        def record(conn, cursor, statement, parameters, context, executemany):
-            statements.append(statement.split()[0].upper())
-
-        bind = session.get_bind()
-        event.listen(bind, "before_cursor_execute", record)
-        try:
-            op.activate_assets_if_possible([], session=session)
-        finally:
-            event.remove(bind, "before_cursor_execute", record)
-
-        assert statements == []
 
     @pytest.mark.parametrize(
         "seeded",

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -184,6 +184,55 @@ class TestAssetModelOperation:
         yield
         self.clean_db()
 
+    @staticmethod
+    def _dags_for(dag_maker, schedules):
+        """One Dag per schedule, keyed by dag_id in the order given."""
+        dags = {}
+        for index, schedule in enumerate(schedules):
+            with dag_maker(dag_id=f"dag_{index}", schedule=[schedule]) as dag:
+                EmptyOperator(task_id="mytask")
+            dags[dag.dag_id] = LazyDeserializedDAG.from_dag(dag)
+        return dags
+
+    def test_shared_assets_and_aliases_are_collected_in_a_stable_order(self, dag_maker):
+        """Two writers reaching the same rows must take them the same way round or they deadlock."""
+        dags = self._dags_for(
+            dag_maker,
+            [
+                Asset("c_asset"),
+                AssetAlias("z_alias"),
+                Asset("a_asset"),
+                AssetAlias("a_alias"),
+                Asset("b_asset"),
+            ],
+        )
+        reversed_dags = dict(reversed(list(dags.items())))
+
+        forwards = AssetModelOperation.collect(dags)
+        backwards = AssetModelOperation.collect(reversed_dags)
+
+        assert [name for name, _ in forwards.assets] == ["a_asset", "b_asset", "c_asset"]
+        assert list(forwards.assets) == list(backwards.assets)
+        assert list(forwards.asset_aliases) == ["a_alias", "z_alias"]
+        assert list(forwards.asset_aliases) == list(backwards.asset_aliases)
+
+    @pytest.mark.usefixtures("testing_dag_bundle")
+    def test_assets_that_already_exist_keep_the_stable_order(self, dag_maker, session):
+        """Existing rows come back in the query's order, so it is put back before returning."""
+        dags = self._dags_for(dag_maker, [Asset("c_asset"), Asset("b_asset"), Asset("a_asset")])
+        asset_op = AssetModelOperation.collect(dags)
+        committed = session.scalars(select(AssetModel).order_by(AssetModel.name)).all()
+        assert [a.name for a in committed] == ["a_asset", "b_asset", "c_asset"], committed
+
+        # No backend returns a chosen bad order on demand, so stub it -- with the rows that really
+        # are there, or the write below creates one the database already holds.
+        with mock.patch.object(session, "scalars", autospec=True, return_value=list(reversed(committed))):
+            orm_assets = asset_op.sync_assets(session=session)
+
+        assert [name for name, _ in orm_assets] == ["a_asset", "b_asset", "c_asset"], (
+            "rows that already existed kept the order the database returned them in"
+        )
+
     @pytest.mark.usefixtures("testing_dag_bundle")
     def test_sync_assets_preserves_access_control_from_other_bundle(self, dag_maker, session):
         """When a producer bundle (without access_control) is synced after a consumer bundle

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -22,7 +22,6 @@ import logging
 import warnings
 from collections.abc import Generator
 from datetime import timedelta
-from functools import partial
 from threading import Event, Thread
 from typing import TYPE_CHECKING
 from unittest import mock
@@ -75,7 +74,6 @@ from airflow.serialization.encoders import encode_trigger, ensure_serialized_ass
 from airflow.serialization.serialized_objects import LazyDeserializedDAG
 from airflow.timetables.simple import PartitionedAtRuntime
 from airflow.triggers.base import BaseEventTrigger
-from airflow.utils.retries import run_with_db_retries
 from airflow.utils.session import create_session
 from airflow.utils.types import DagRunType
 
@@ -215,9 +213,11 @@ class TestDagModelOperation:
         assert locks, statements
         assert all("ORDER BY dag.dag_id" in q for q in locks), f"dag rows are locked in plan order:\n{locks}"
 
-    @pytest.mark.usefixtures("testing_dag_bundle")
-    def test_new_dag_rows_are_created_in_a_stable_order(self, dag_maker, session):
-        dags = self._build_dags(dag_maker, ("c_dag", "a_dag", "b_dag"))
+    def test_new_dag_rows_are_created_in_a_stable_order(self, session):
+        dags = {
+            name: LazyDeserializedDAG.from_dag(DAG(dag_id=name, schedule=None))
+            for name in ("c_dag", "a_dag", "b_dag")
+        }
         created: list[str] = []
 
         def spy(*, bundle_name, bundle_version, dags, session):
@@ -250,12 +250,7 @@ class TestAssetModelOperation:
     @pytest.mark.backend("postgres", "mysql")
     @pytest.mark.parametrize("kind", ["asset", "alias"])
     @pytest.mark.usefixtures("testing_dag_bundle")
-    @patch(
-        "airflow.dag_processing.collection.run_with_db_retries",
-        autospec=True,
-        side_effect=partial(run_with_db_retries, max_retries=1),
-    )
-    def test_shared_metadata_is_locked_before_full_parser_writes(self, retries, session, kind):
+    def test_shared_metadata_lock_timeout_retries_full_parser_writes(self, session, kind):
         model = AssetModel if kind == "asset" else AssetAliasModel
         reference = DagScheduleAssetReference if kind == "asset" else DagScheduleAssetAliasReference
         method_name = "sync_assets" if kind == "asset" else "sync_asset_aliases"
@@ -285,11 +280,15 @@ class TestAssetModelOperation:
             update_dag_parsing_results_in_db("testing", None, [dag], errors, None, set(), session=session)
             assert not errors
 
-        locked, release = Event(), Event()
+        locked, release, first_finished = Event(), Event(), Event()
         first_errors: list[Exception] = []
+        second_sync_attempts = 0
         real_sync = getattr(AssetModelOperation, method_name)
 
         def sync_then_pause(operation, *, session):
+            nonlocal second_sync_attempts
+            if "second" in operation.schedule_asset_references:
+                second_sync_attempts += 1
             result = real_sync(operation, session=session)
             if "first" in operation.schedule_asset_references:
                 locked.set()
@@ -302,8 +301,11 @@ class TestAssetModelOperation:
                     publish(build_dag("first"), session=first_session)
             except Exception as error:
                 first_errors.append(error)
+            finally:
+                first_finished.set()
 
         statements: list[str] = []
+        lock_failures: list[tuple[OperationalError, list[str]]] = []
 
         def record(conn, cursor, statement, parameters, context, executemany):
             statements.append(statement.lower())
@@ -325,33 +327,55 @@ class TestAssetModelOperation:
                             else "SET SESSION innodb_lock_wait_timeout = 1"
                         )
                     )
+
+                    def release_after_lock_timeout(context):
+                        if context.connection is connection and isinstance(
+                            context.sqlalchemy_exception, OperationalError
+                        ):
+                            lock_failures.append((context.sqlalchemy_exception, statements.copy()))
+                            release.set()
+                            assert first_finished.wait(15), ("first publication did not finish", first_errors)
+
                     event.listen(connection, "before_cursor_execute", record)
+                    event.listen(connection.engine, "handle_error", release_after_lock_timeout)
                     try:
-                        with pytest.raises(OperationalError) as failure:
-                            publish(build_dag("second"), session=second_session)
+                        publish(build_dag("second"), session=second_session)
+                        second_session.commit()
                     finally:
+                        event.remove(connection.engine, "handle_error", release_after_lock_timeout)
                         event.remove(connection, "before_cursor_execute", record)
                         second_session.rollback()
                         if not is_postgres:
                             connection.execute(text("SET SESSION innodb_lock_wait_timeout = DEFAULT"))
-                    failed_statement = failure.value.statement.lower()
+                    assert len(lock_failures) == 1, lock_failures
+                    failure, statements_before_timeout = lock_failures[0]
+                    assert failure.orig is not None
+                    dbapi = connection.dialect.dbapi
+                    assert dbapi is not None
+                    assert isinstance(failure.orig, dbapi.OperationalError), failure
+                    error_code = (
+                        getattr(failure.orig, "sqlstate", None) or getattr(failure.orig, "pgcode", None)
+                        if is_postgres
+                        else failure.orig.args[0]
+                    )
+                    assert error_code == ("55P03" if is_postgres else 1205), failure
+                    assert failure.statement is not None
+                    failed_statement = failure.statement.lower()
                     assert failed_statement.startswith("select")
                     assert f"from {table}" in failed_statement
                     assert any(clause in failed_statement for clause in ("for update", "for no key update"))
                     ordering = f"order by {table}.name" + (", asset.uri" if kind == "asset" else "")
                     assert ordering in failed_statement
-                    assert not any(statement.startswith(f"update {table} ") for statement in statements)
+                    assert not any(
+                        statement.startswith(f"update {table} ") for statement in statements_before_timeout
+                    ), statements_before_timeout
             finally:
                 release.set()
                 first.join(15)
             assert not first.is_alive()
             assert first_errors == []
+            assert second_sync_attempts == 2, (second_sync_attempts, lock_failures)
 
-        with create_session(scoped=False) as observer:
-            assert observer.scalars(select(model.group)).all() == ["first", "first"]
-            assert observer.scalars(select(SerializedDagModel.dag_id)).all() == ["first"]
-        with create_session(scoped=False) as retry_session:
-            publish(build_dag("second"), session=retry_session)
         with create_session(scoped=False) as observer:
             assert observer.scalars(select(model.group)).all() == ["second", "second"]
             assert sorted(observer.scalars(select(SerializedDagModel.dag_id))) == ["first", "second"]
@@ -415,13 +439,17 @@ class TestAssetModelOperation:
                     airflow.dag_processing.collection.asset_manager,
                     "create_assets",
                     autospec=True,
-                    return_value=[],
+                    side_effect=lambda assets, *, session: [
+                        AssetModel.from_serialized(asset) for asset in assets
+                    ],
                 ) as assets,
                 mock.patch.object(
                     airflow.dag_processing.collection.asset_manager,
                     "create_asset_aliases",
                     autospec=True,
-                    return_value=[],
+                    side_effect=lambda aliases, *, session: [
+                        AssetAliasModel.from_serialized(alias) for alias in aliases
+                    ],
                 ) as aliases,
             ):
                 op.sync_assets(session=session)

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -204,7 +204,7 @@ class TestDagModelOperation:
 
         locks = [q for q in statements if "dag_id IN" in q]
         assert locks, statements
-        assert all("ORDER BY" in q for q in locks), f"dag rows are locked in plan order:\n{locks}"
+        assert all("ORDER BY dag.dag_id" in q for q in locks), f"dag rows are locked in plan order:\n{locks}"
 
     @pytest.mark.usefixtures("testing_dag_bundle")
     def test_new_dag_rows_are_created_in_a_stable_order(self, dag_maker, session):
@@ -290,14 +290,22 @@ class TestAssetModelOperation:
         assert forwards == (["a_asset", "b_asset", "c_asset"], ["a_alias", "z_alias"])
         assert forwards == backwards, "the order the Dags arrived in reached the insert"
 
+    @staticmethod
+    def _dags_for(assets: list[Asset]) -> dict:
+        return {
+            f"dag_{i}": LazyDeserializedDAG.from_dag(DAG(dag_id=f"dag_{i}", schedule=[asset]))
+            for i, asset in enumerate(assets)
+        }
+
+    def _active(self, session) -> list[tuple[str, str]]:
+        return sorted((a.name, a.uri.rstrip("/")) for a in session.scalars(select(AssetActive)))
+
     def test_activation_rows_are_inserted_in_a_stable_order(self, session):
         """``asset_active`` is unique on both its columns, so its insert needs one order too."""
         clear_db_assets()
-        dags = {
-            f"dag_{i}": LazyDeserializedDAG.from_dag(DAG(dag_id=f"dag_{i}", schedule=[Asset(name)]))
-            for i, name in enumerate(("c_asset", "a_asset", "b_asset"))
-        }
-        op = AssetModelOperation.collect(dags)
+        op = AssetModelOperation.collect(
+            self._dags_for([Asset("c_asset"), Asset("a_asset"), Asset("b_asset")])
+        )
         orm_assets = op.sync_assets(session=session)
         session.flush()
 
@@ -309,16 +317,6 @@ class TestAssetModelOperation:
             "b_asset",
             "c_asset",
         ]
-
-    @staticmethod
-    def _dags_for(assets: list[Asset]) -> dict:
-        return {
-            f"dag_{i}": LazyDeserializedDAG.from_dag(DAG(dag_id=f"dag_{i}", schedule=[asset]))
-            for i, asset in enumerate(assets)
-        }
-
-    def _active(self, session) -> list[tuple[str, str]]:
-        return sorted((a.name, a.uri.rstrip("/")) for a in session.scalars(select(AssetActive)))
 
     def test_a_candidate_the_insert_would_reject_does_not_take_the_claim(self, session):
         """
@@ -346,19 +344,26 @@ class TestAssetModelOperation:
 
         assert self._active(session) == [("n1", "s3://u2"), ("n9", "s3://u1")]
 
-    def test_collection_order_decides_the_winner_among_assets_that_already_exist(self, session):
+    @pytest.mark.parametrize(
+        "seeded",
+        [
+            pytest.param(False, id="all-new"),
+            pytest.param(True, id="already-in-the-asset-table"),
+        ],
+    )
+    def test_collection_order_decides_which_asset_is_activated(self, seeded, session):
         """
-        The read-back in ``sync_assets`` returns existing rows in the query's order, so collection
-        order has to be put back before activation -- otherwise which of two assets sharing a name
-        wins depends on the database rather than on the Dags.
+        ``asset_active`` is unique on name and on uri separately, so of two assets sharing a name
+        only one is activated, and the Dags decide which. Neither sorting the rows for insertion nor
+        the order the read-back returns rows already in ``asset`` may move that.
         """
 
         def activate(assets: list[Asset]) -> list[tuple[str, str]]:
             clear_db_assets()
-            # Written but not activated, so the second pass reads them back as existing rows.
-            seeded = AssetModelOperation.collect(self._dags_for(assets))
-            seeded.sync_assets(session=session)
-            session.commit()
+            if seeded:
+                # Written but not activated, so the pass below reads them back as existing rows.
+                AssetModelOperation.collect(self._dags_for(assets)).sync_assets(session=session)
+                session.commit()
 
             op = AssetModelOperation.collect(self._dags_for(assets))
             orm_assets = op.sync_assets(session=session)
@@ -371,34 +376,7 @@ class TestAssetModelOperation:
 
         assert activate(pair) == [("dup", "s3://zzz")]
         assert activate(list(reversed(pair))) == [("dup", "s3://aaa")], (
-            "the winner came from the read-back's order, not the Dags'"
-        )
-
-    def test_collection_order_decides_which_asset_is_activated(self, session):
-        """
-        ``asset_active`` is unique on name and on uri separately, so of two assets sharing a name
-        only one is activated. Sorting the rows for insertion must not move which one: a sweep has
-        to land where writing its files one at a time would, and that is collection order.
-        """
-
-        def activate(assets: list[Asset]):
-            clear_db_assets()
-            dags = {
-                f"dag_{i}": LazyDeserializedDAG.from_dag(DAG(dag_id=f"dag_{i}", schedule=[asset]))
-                for i, asset in enumerate(assets)
-            }
-            op = AssetModelOperation.collect(dags)
-            orm_assets = op.sync_assets(session=session)
-            session.flush()
-            op.activate_assets_if_possible(orm_assets.values(), session=session)
-            session.flush()
-            return [(a.name, a.uri.rstrip("/")) for a in session.scalars(select(AssetActive))]
-
-        zulu_first = [Asset(name="dup", uri="s3://zzz"), Asset(name="dup", uri="s3://aaa")]
-
-        assert activate(zulu_first) == [("dup", "s3://zzz")]
-        assert activate(list(reversed(zulu_first))) == [("dup", "s3://aaa")], (
-            "the winner is lexicographic, not the one the Dags defined first"
+            "the winner came from the sort or the read-back, not from the Dags"
         )
 
     @pytest.mark.usefixtures("testing_dag_bundle")

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -29,8 +29,9 @@ from unittest.mock import patch
 
 import pytest
 from sqlalchemy import delete, event, func, inspect as sa_inspect, select, text
-from sqlalchemy.exc import OperationalError, SAWarning
+from sqlalchemy.exc import IntegrityError, OperationalError, SAWarning
 from sqlalchemy.orm import Session as SqlaSession
+from sqlalchemy.orm.exc import StaleDataError
 
 import airflow.dag_processing.collection
 from airflow import settings
@@ -58,6 +59,7 @@ from airflow.models.asset import (
 )
 from airflow.models.dag import DagTag
 from airflow.models.dagbundle import DagBundleModel
+from airflow.models.dagcode import DagCode
 from airflow.models.dagwarning import DagWarning, DagWarningType
 from airflow.models.errors import ParseImportError
 from airflow.models.serialized_dag import SerializedDagModel
@@ -70,6 +72,7 @@ from airflow.providers.standard.triggers.file import FileDeleteTrigger
 from airflow.sdk import DAG, Asset, AssetAlias, AssetAll, AssetWatcher
 from airflow.sdk.definitions.timetables.assets import PartitionedAssetTimetable
 from airflow.serialization.definitions.assets import SerializedAsset
+from airflow.serialization.definitions.dag import SerializedDAG
 from airflow.serialization.encoders import encode_trigger, ensure_serialized_asset
 from airflow.serialization.serialized_objects import LazyDeserializedDAG
 from airflow.timetables.simple import PartitionedAtRuntime
@@ -1045,64 +1048,126 @@ class TestUpdateDagParsingResults:
 
         serialized_dags_count = session.scalar(select(func.count(SerializedDagModel.dag_id)))
 
-    @patch.object(SerializedDagModel, "write_dag")
-    @patch("airflow.serialization.definitions.dag.SerializedDAG.bulk_write_to_db")
-    def test_sync_to_db_is_retried(
-        self, mock_bulk_write_to_db, mock_s10n_write_dag, testing_dag_bundle, session
-    ):
-        """Test that important DB operations in db sync are retried on OperationalError"""
-        serialized_dags_count = session.scalar(select(func.count(SerializedDagModel.dag_id)))
-        assert serialized_dags_count == 0
-        mock_dag = mock.MagicMock()
-        dags = [mock_dag]
+    @pytest.mark.usefixtures("clean_db", "testing_dag_bundle")
+    @pytest.mark.parametrize("error_type", [OperationalError, IntegrityError, StaleDataError])
+    @pytest.mark.parametrize(
+        ("model", "method"),
+        [(SerializedDAG, "bulk_write_to_db"), (SerializedDagModel, "write_dag")],
+        ids=["metadata", "serialization"],
+    )
+    def test_sync_to_db_is_retried(self, session, error_type, model, method):
+        with DAG("retried_dag", schedule=None, description="published after retry") as dag:
+            EmptyOperator(task_id="task")
+        dag.fileloc = __file__
+        dag.relative_fileloc = "test_collection.py"
+        serialized_dag = LazyDeserializedDAG.from_dag(dag)
+        write = getattr(model, method)
+        attempts = 0
 
-        op_error = OperationalError(statement=mock.ANY, params=mock.ANY, orig=mock.ANY)
+        def write_then_fail(*args, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            result = write(*args, **kwargs)
+            if attempts < 3:
+                if error_type is IntegrityError:
+                    session.add_all(AssetModel(name="duplicate", uri="duplicate") for _ in range(2))
+                    if method == "bulk_write_to_db":
+                        session.flush()
+                elif error_type is OperationalError:
+                    raise OperationalError("publish Dag", {}, RuntimeError("retry publication"))
+                else:
+                    raise StaleDataError("retry publication")
+            return result
 
-        # Mock error for the first 2 tries and a successful third try
-        side_effect = [op_error, op_error, mock.ANY]
+        import_errors = {}
+        with (
+            mock.patch.object(model, method, autospec=True, side_effect=write_then_fail),
+            mock.patch.object(session, "rollback", autospec=True, side_effect=session.rollback) as rollback,
+        ):
+            update_dag_parsing_results_in_db(
+                "testing", None, [serialized_dag], import_errors, None, set(), session=session
+            )
+        session.commit()
 
-        mock_bulk_write_to_db.side_effect = side_effect
+        assert attempts == 3
+        assert rollback.call_count == 2
+        assert import_errors == {}
+        with create_session(scoped=False) as observer:
+            assert observer.get(DagModel, dag.dag_id).description == "published after retry"
+            assert observer.scalar(select(SerializedDagModel.dag_id)) == dag.dag_id
+            assert observer.scalar(select(AssetModel.id).where(AssetModel.name == "duplicate")) is None
 
-        mock_session = mock.MagicMock()
-        update_dag_parsing_results_in_db(
-            "testing",
-            None,
-            dags=dags,
-            import_errors={},
-            parse_duration=None,
-            warnings=set(),
-            session=mock_session,
-        )
+    @pytest.mark.backend("postgres", "mysql")
+    @pytest.mark.usefixtures("clean_db", "testing_dag_bundle")
+    @conf_vars({("core", "min_serialized_dag_update_interval"): "0"})
+    def test_deferred_source_update_is_retried_after_lock_timeout(self, session):
+        dag = DAG("retried_source", schedule=None)
+        dag.fileloc = __file__
+        dag.relative_fileloc = "test_collection.py"
+        serialized = LazyDeserializedDAG.from_dag(dag)
 
-        # Test that 3 attempts were made to run 'DAG.bulk_write_to_db' successfully
-        mock_bulk_write_to_db.assert_has_calls(
-            [
-                mock.call("testing", None, mock.ANY, None, session=mock.ANY),
-                mock.call("testing", None, mock.ANY, None, session=mock.ANY),
-                mock.call("testing", None, mock.ANY, None, session=mock.ANY),
-            ]
-        )
-        # Assert that rollback is called twice (i.e. whenever OperationalError occurs)
-        mock_session.rollback.assert_has_calls([mock.call(), mock.call()])
-        # Check that 'SerializedDagModel.write_dag' is also called
-        # Only called once since the other two times the 'DAG.bulk_write_to_db' error'd
-        # and the session was roll-backed before even reaching 'SerializedDagModel.write_dag'
-        mock_s10n_write_dag.assert_has_calls(
-            [
-                mock.call(
-                    mock_dag,
-                    bundle_name="testing",
-                    bundle_version=None,
-                    version_data=None,
-                    min_update_interval=mock.ANY,
-                    session=mock_session,
-                    _prefetched=mock.ANY,
-                ),
-            ]
-        )
+        def publish(writer):
+            update_dag_parsing_results_in_db("testing", None, [serialized], {}, None, set(), session=writer)
 
-        serialized_dags_count = session.scalar(select(func.count(SerializedDagModel.dag_id)))
-        assert serialized_dags_count == 0
+        publish(session)
+        session.commit()
+        code = session.scalar(select(DagCode).where(DagCode.dag_id == dag.dag_id))
+        expected_source = code.source_code
+        code.source_code = "previous source"
+        code.source_code_hash = DagCode.dag_source_hash(code.source_code)
+        session.commit()
+        session.close()
+
+        failures = []
+        with (
+            create_session(scoped=False) as blocker,
+            settings.engine.connect() as connection,
+            SqlaSession(bind=connection, autoflush=False) as writer,
+            mock.patch.object(
+                SerializedDagModel, "write_dag", autospec=True, side_effect=SerializedDagModel.write_dag
+            ) as write_dag,
+        ):
+            blocker.scalar(select(DagCode).where(DagCode.dag_id == dag.dag_id).with_for_update())
+            is_postgres = connection.dialect.name == "postgresql"
+            writer.execute(
+                text(
+                    "SET LOCAL lock_timeout = '200ms'"
+                    if is_postgres
+                    else "SET SESSION innodb_lock_wait_timeout = 1"
+                )
+            )
+
+            def release_after_error(context):
+                if context.connection is connection:
+                    failures.append(context.sqlalchemy_exception)
+                    blocker.rollback()
+
+            event.listen(connection.engine, "handle_error", release_after_error)
+            try:
+                publish(writer)
+                writer.commit()
+            finally:
+                event.remove(connection.engine, "handle_error", release_after_error)
+                writer.rollback()
+                if not is_postgres:
+                    connection.execute(text("SET SESSION innodb_lock_wait_timeout = DEFAULT"))
+
+            assert write_dag.call_count == 2
+            assert len(failures) == 1
+            failure = failures[0]
+            assert isinstance(failure, OperationalError)
+            assert failure.statement.lower().startswith("update dag_code ")
+            error_code = (
+                getattr(failure.orig, "sqlstate", None) or getattr(failure.orig, "pgcode", None)
+                if is_postgres
+                else failure.orig.args[0]
+            )
+            assert error_code == ("55P03" if is_postgres else 1205)
+
+        with create_session(scoped=False) as observer:
+            code = observer.scalar(select(DagCode).where(DagCode.dag_id == dag.dag_id))
+            assert code.source_code == expected_source
+            assert code.source_code_hash == DagCode.dag_source_hash(expected_source)
 
     def test_serialized_dags_are_written_to_db_on_sync(self, testing_dag_bundle, session):
         """Test DAGs are Serialized and written to DB when parsing result is updated"""

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -22,7 +22,6 @@ import logging
 import warnings
 from collections.abc import Generator
 from datetime import timedelta
-from threading import Event, Thread
 from typing import TYPE_CHECKING
 from unittest import mock
 from unittest.mock import patch
@@ -198,7 +197,7 @@ class TestDagModelOperation:
         return dags
 
     @pytest.mark.usefixtures("testing_dag_bundle")
-    def test_existing_dag_rows_are_locked_in_a_stable_order(self, dag_maker, session):
+    def test_existing_dag_lookup_orders_by_dag_id(self, dag_maker, session):
         dags = self._build_dags(dag_maker, ("c_dag", "a_dag", "b_dag"))
         statements: list[str] = []
 
@@ -212,9 +211,9 @@ class TestDagModelOperation:
         finally:
             event.remove(bind, "before_cursor_execute", record)
 
-        locks = [q for q in statements if "dag_id IN" in q]
-        assert locks, statements
-        assert all("ORDER BY dag.dag_id" in q for q in locks), f"dag rows are locked in plan order:\n{locks}"
+        queries = [q for q in statements if "dag_id IN" in q]
+        assert queries, statements
+        assert all("ORDER BY dag.dag_id" in q for q in queries), queries
 
     def test_new_dag_rows_are_created_in_a_stable_order(self, session):
         dags = {
@@ -252,27 +251,21 @@ class TestAssetModelOperation:
 
     @pytest.mark.backend("postgres", "mysql")
     @pytest.mark.parametrize("kind", ["asset", "alias"])
+    @pytest.mark.parametrize("metadata_changed", [False, True], ids=["unchanged", "updated"])
     @pytest.mark.usefixtures("testing_dag_bundle")
-    def test_shared_metadata_lock_timeout_retries_full_parser_writes(self, session, kind):
+    @conf_vars({("core", "min_serialized_dag_update_interval"): "0"})
+    def test_parser_waits_for_shared_metadata_only_when_updating(self, session, kind, metadata_changed):
         model = AssetModel if kind == "asset" else AssetAliasModel
         reference = DagScheduleAssetReference if kind == "asset" else DagScheduleAssetAliasReference
-        method_name = "sync_assets" if kind == "asset" else "sync_asset_aliases"
-        table = model.__tablename__
-        for name in ("shared_b", "shared_a"):
-            kwargs = {"uri": f"s3://bucket/{name}"} if kind == "asset" else {}
-            session.add(model(name=name, group="original", **kwargs))
-        session.add_all(DagModel(dag_id=name, bundle_name="testing") for name in ("first", "second"))
-        session.commit()
 
-        def build_dag(dag_id):
-            names = ("shared_b", "shared_a") if dag_id == "first" else ("shared_a", "shared_b")
+        def build_dag(group, description):
             schedules = [
-                Asset(name=name, uri=f"s3://bucket/{name}", group=dag_id)
+                Asset(name=name, uri=f"s3://bucket/{name}", group=group)
                 if kind == "asset"
-                else AssetAlias(name, group=dag_id)
-                for name in names
+                else AssetAlias(name, group=group)
+                for name in ("shared_b", "shared_a")
             ]
-            with DAG(dag_id, schedule=schedules, is_paused_upon_creation=False) as dag:
+            with DAG("shared_metadata", schedule=schedules, description=description) as dag:
                 EmptyOperator(task_id="task")
             dag.fileloc = __file__
             dag.relative_fileloc = "test_collection.py"
@@ -283,146 +276,64 @@ class TestAssetModelOperation:
             update_dag_parsing_results_in_db("testing", None, [dag], errors, None, set(), session=session)
             assert not errors
 
-        locked, release, first_finished = Event(), Event(), Event()
-        first_errors: list[Exception] = []
-        second_sync_attempts = 0
-        real_sync = getattr(AssetModelOperation, method_name)
+        publish(build_dag("original", "previous publication"), session=session)
+        session.commit()
+        session.close()
+        group = "updated" if metadata_changed else "original"
+        failures = []
+        with (
+            create_session(scoped=False) as blocker,
+            settings.engine.connect() as connection,
+            SqlaSession(bind=connection, autoflush=False) as writer,
+            mock.patch.object(
+                SerializedDAG, "bulk_write_to_db", autospec=True, side_effect=SerializedDAG.bulk_write_to_db
+            ) as write_dags,
+        ):
+            blocker.scalars(select(model).with_for_update()).all()
+            is_postgres = connection.dialect.name == "postgresql"
+            writer.execute(
+                text(
+                    "SET LOCAL lock_timeout = '200ms'"
+                    if is_postgres
+                    else "SET SESSION innodb_lock_wait_timeout = 1"
+                )
+            )
 
-        def sync_then_pause(operation, *, session):
-            nonlocal second_sync_attempts
-            if "second" in operation.schedule_asset_references:
-                second_sync_attempts += 1
-            result = real_sync(operation, session=session)
-            if "first" in operation.schedule_asset_references:
-                locked.set()
-                assert release.wait(15), "first publication was not released"
-            return result
+            def release_after_error(context):
+                if context.connection is connection:
+                    failures.append(context.sqlalchemy_exception)
+                    blocker.rollback()
 
-        def publish_first():
+            event.listen(connection.engine, "handle_error", release_after_error)
             try:
-                with create_session(scoped=False) as first_session:
-                    publish(build_dag("first"), session=first_session)
-            except Exception as error:
-                first_errors.append(error)
+                publish(build_dag(group, "published during contention"), session=writer)
+                writer.commit()
             finally:
-                first_finished.set()
+                event.remove(connection.engine, "handle_error", release_after_error)
+                writer.rollback()
+                if not is_postgres:
+                    connection.execute(text("SET SESSION innodb_lock_wait_timeout = DEFAULT"))
 
-        statements: list[str] = []
-        lock_failures: list[tuple[OperationalError, list[str]]] = []
-
-        def record(conn, cursor, statement, parameters, context, executemany):
-            statements.append(statement.lower())
-
-        with patch.object(AssetModelOperation, method_name, autospec=True, side_effect=sync_then_pause):
-            first = Thread(target=publish_first, daemon=True)
-            first.start()
-            try:
-                assert locked.wait(15), first_errors
-                with (
-                    settings.engine.connect() as connection,
-                    SqlaSession(bind=connection, autoflush=False) as second_session,
-                ):
-                    is_postgres = connection.dialect.name == "postgresql"
-                    second_session.execute(
-                        text(
-                            "SET LOCAL lock_timeout = '500ms'"
-                            if is_postgres
-                            else "SET SESSION innodb_lock_wait_timeout = 1"
-                        )
-                    )
-
-                    def release_after_lock_timeout(context):
-                        if context.connection is connection and isinstance(
-                            context.sqlalchemy_exception, OperationalError
-                        ):
-                            lock_failures.append((context.sqlalchemy_exception, statements.copy()))
-                            release.set()
-                            assert first_finished.wait(15), ("first publication did not finish", first_errors)
-
-                    event.listen(connection, "before_cursor_execute", record)
-                    event.listen(connection.engine, "handle_error", release_after_lock_timeout)
-                    try:
-                        publish(build_dag("second"), session=second_session)
-                        second_session.commit()
-                    finally:
-                        event.remove(connection.engine, "handle_error", release_after_lock_timeout)
-                        event.remove(connection, "before_cursor_execute", record)
-                        second_session.rollback()
-                        if not is_postgres:
-                            connection.execute(text("SET SESSION innodb_lock_wait_timeout = DEFAULT"))
-                    assert len(lock_failures) == 1, lock_failures
-                    failure, statements_before_timeout = lock_failures[0]
-                    assert failure.orig is not None
-                    dbapi = connection.dialect.dbapi
-                    assert dbapi is not None
-                    assert isinstance(failure.orig, dbapi.OperationalError), failure
-                    error_code = (
-                        getattr(failure.orig, "sqlstate", None) or getattr(failure.orig, "pgcode", None)
-                        if is_postgres
-                        else failure.orig.args[0]
-                    )
-                    assert error_code == ("55P03" if is_postgres else 1205), failure
-                    assert failure.statement is not None
-                    failed_statement = failure.statement.lower()
-                    assert failed_statement.startswith("select")
-                    assert f"from {table}" in failed_statement
-                    assert any(clause in failed_statement for clause in ("for update", "for no key update"))
-                    ordering = f"order by {table}.name" + (", asset.uri" if kind == "asset" else "")
-                    assert ordering in failed_statement
-                    assert not any(
-                        statement.startswith(f"update {table} ") for statement in statements_before_timeout
-                    ), statements_before_timeout
-            finally:
-                release.set()
-                first.join(15)
-            assert not first.is_alive()
-            assert first_errors == []
-            assert second_sync_attempts == 2, (second_sync_attempts, lock_failures)
+            assert write_dags.call_count == (2 if metadata_changed else 1)
+            assert len(failures) == (1 if metadata_changed else 0)
+            if metadata_changed:
+                failure = failures[0]
+                assert isinstance(failure, OperationalError)
+                assert failure.statement.lower().startswith(f"update {model.__tablename__} ")
+                error_code = (
+                    getattr(failure.orig, "sqlstate", None) or getattr(failure.orig, "pgcode", None)
+                    if is_postgres
+                    else failure.orig.args[0]
+                )
+                assert error_code == ("55P03" if is_postgres else 1205)
 
         with create_session(scoped=False) as observer:
-            assert observer.scalars(select(model.group)).all() == ["second", "second"]
-            assert sorted(observer.scalars(select(SerializedDagModel.dag_id))) == ["first", "second"]
-            assert sorted(observer.scalars(select(reference.dag_id))) == ["first"] * 2 + ["second"] * 2
-
-    @pytest.mark.backend("mysql")
-    @pytest.mark.parametrize("kind", ["asset", "alias"])
-    def test_large_lookup_locks_rows_in_index_order(self, session, kind):
-        model = AssetModel if kind == "asset" else AssetAliasModel
-        for index in range(1000):
-            name = f"asset_{index:04}"
-            kwargs = {"uri": name} if kind == "asset" else {}
-            session.add(model(id=1000 - index, name=name, group="asset", **kwargs))
-        session.commit()
-        schedules = [
-            Asset(f"asset_{index:04}") if kind == "asset" else AssetAlias(f"asset_{index:04}")
-            for index in range(400)
-        ]
-        operation = AssetModelOperation.collect(self._build_dags_scheduled_on(schedules))
-        queries = []
-
-        def record(conn, cursor, statement, parameters, context, executemany):
-            if statement.startswith("SELECT") and "FOR UPDATE" in statement:
-                queries.append((statement, parameters))
-
-        connection = session.connection()
-        event.listen(connection, "before_cursor_execute", record)
-        try:
-            if kind == "asset":
-                operation.sync_assets(session=session)
-            else:
-                operation.sync_asset_aliases(session=session)
-        finally:
-            event.remove(connection, "before_cursor_execute", record)
-
-        assert len(queries) == 1
-        statement, parameters = queries[0]
-        plan = connection.exec_driver_sql("EXPLAIN " + statement, parameters).mappings().one()
-        assert plan["key"] == (
-            "idx_asset_name_uri_unique" if kind == "asset" else "idx_asset_alias_name_unique"
-        )
-        extra = (plan["Extra"] or "").lower()
-        assert "filesort" not in extra
-        assert "mrr" not in extra
+            assert observer.scalars(select(model.group)).all() == [group, group]
+            assert observer.get(DagModel, "shared_metadata").description == "published during contention"
+            assert observer.scalar(select(SerializedDagModel)).data["dag"]["description"] == (
+                "published during contention"
+            )
+            assert observer.scalars(select(reference.dag_id)).all() == ["shared_metadata"] * 2
 
     def test_new_assets_and_aliases_are_inserted_in_a_stable_order(self, session):
         """Two writers reaching the same rows must take them the same way round or they deadlock."""


### PR DESCRIPTION
Concurrent Dag parsing and `airflow dags reserialize` can reach shared database rows in different orders. Database conflicts can also leave publication retries using an aborted transaction, or cause a retry in a later bundle to roll back previously published bundles.

This PR reduces ordering-related conflicts and makes recovery cover the metadata and serialization writes for a publication:

- Order the existing Dag lookup by `dag_id`, and create new Dags, assets, and aliases in deterministic order: `dag_id`, `(name, uri)`, and alias name respectively.
- Keep existing asset and alias lookups as ordinary reads. Dirty metadata acquires write locks at flush, without locking unchanged shared assets during lookup.
- Propagate `DBAPIError` (including uniqueness violations) and `StaleDataError` to the existing retry policy, rolling back before retrying. Flush pending serialization writes inside the retry boundary so deferred failures, such as a DagCode update, are handled there too.
- Give each bundle published by `airflow dags reserialize` its own transaction, so a later bundle's retry or exhausted retries cannot discard an earlier successful publication.

Activation candidates remain in collection order so sorting asset creation does not change which conflicting candidate is offered first. `asset_active` retains the database's native conflict handling. Its separate name and URI uniqueness constraints mean crossed activation claims can still deadlock; this PR relies on publication rollback and bounded retries for recovery rather than adding broad locks around activation. Sustained contention can exhaust those retries, and locks acquired by actual writes remain held until the transaction ends.

The scope is parser publication and CLI reserialization. Scheduler activation, task/event publication, watcher insertion order, and the schema are unchanged. `[scheduler] use_row_level_locking` still controls the existing Dag row-lock helper; deterministic creation order and retry recovery do not depend on that setting. Import-error and warning persistence remain outside the retry loop, and listener side effects are not made transactional or exactly-once.

Validation through Breeze, run before the latest rebase:

| Collection tests and CLI reserialization tests | Passed | Skipped |
| --- | ---: | ---: |
| PostgreSQL | 91 | 2 |
| MySQL | 91 | 2 |
| SQLite | 86 | 7 |

The skips cover the Fab-only tests and backend-specific locking cases on SQLite. Coverage includes deterministic creation, activation precedence, rollback after database errors, deferred-write recovery, and preserving earlier bundles when a later publication retries or exhausts its retries. Additional PostgreSQL and MySQL concurrency probes verified recovery from native uniqueness conflicts during simultaneous asset/alias creation and from crossed activation claims. Fast static checks, core mypy, applicable manual checks, and commit hooks passed. The latest rebase preserved all 17 patches unchanged according to `git range-diff`; the full database matrix has not been rerun after it.

<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 5 and Codex (GPT-6)

Generated-by: Claude Opus 5 and Codex (GPT-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

Drafted-by: Codex (GPT-6) (no human review before posting)
