### PR TITLE
Keep the HTTPError when an MWAA error body is not JSON

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/mwaa.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/mwaa.py
@@ -152,7 +152,14 @@ class MwaaHook(AwsBaseHook):
             response.raise_for_status()
 
         except requests.HTTPError as e:
-            self.log.error(e.response.json())
+            # The web server can answer with a non-JSON body, for example an
+            # HTML error page from a proxy on a 502. Parsing it unguarded
+            # would raise JSONDecodeError here and replace the HTTPError.
+            try:
+                error_body = e.response.json()
+            except ValueError:
+                error_body = e.response.text
+            self.log.error(error_body)
             raise
 
         return {

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_mwaa.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_mwaa.py
@@ -205,6 +205,31 @@ class TestMwaaHook:
         assert caught_error.value == error
         mock_error_log.assert_called_once_with(example_responses["failure"]["RestApiResponse"])
 
+    @mock.patch.object(MwaaHook, "_get_session_conn")
+    def test_invoke_rest_api_using_local_session_token_failure_with_non_json_body(
+        self, mock_get_session_conn
+    ):
+        error_html = "<html>502 Bad Gateway</html>"
+        mock_response = mock.MagicMock()
+        mock_response.json.side_effect = requests.exceptions.JSONDecodeError("Expecting value", error_html, 0)
+        mock_response.text = error_html
+        error = requests.HTTPError(response=mock_response)
+        mock_response.raise_for_status.side_effect = error
+
+        mock_session = mock.MagicMock()
+        mock_session.request.return_value = mock_response
+
+        mock_get_session_conn.return_value = (mock_session, HOSTNAME, None)
+
+        mock_error_log = mock.MagicMock()
+        self.hook.log.error = mock_error_log
+
+        with pytest.raises(requests.HTTPError) as caught_error:
+            self.hook.invoke_rest_api(env_name=ENV_NAME, path=PATH, method=METHOD, generate_local_token=True)
+
+        assert caught_error.value == error
+        mock_error_log.assert_called_once_with(error_html)
+
     @mock.patch("airflow.providers.amazon.aws.hooks.mwaa.requests.Session")
     def test_get_session_conn_airflow2(self, mock_create_session, mock_conn):
         token = "token"


### PR DESCRIPTION
MwaaHook's local-session-token fallback logs the error body inside its `except requests.HTTPError` handler like this:

```python
        except requests.HTTPError as e:
            self.log.error(e.response.json())
            raise
```

`e.response.json()` is unguarded, so when the MWAA web server answers with a non-JSON body, which is what an HTML error page from a proxy or load balancer on a 502 or 504 looks like, the parse raises `JSONDecodeError` inside the handler. That exception replaces the `HTTPError`, the `raise` on the next line never runs, and callers catching `HTTPError` (or matching on status code) miss the failure entirely. The log line that was supposed to help debug the failure is what destroys it.

This is the same shape as #71702 in the Dataprep hook, found by sweeping other providers for the pattern. The fix mirrors it: guard the parse, fall back to `e.response.text`, and let the original `HTTPError` propagate. `ValueError` covers `JSONDecodeError` whether requests is backed by stdlib json or simplejson.

The new test mirrors the existing `test_invoke_rest_api_using_local_session_token_failure` exactly, with the mock response's `.json()` raising `JSONDecodeError` and `.text` carrying an HTML body: the `HTTPError` must still propagate and the raw text must be what gets logged. Reverting only the source change makes the new test fail with the leaked `JSONDecodeError`, so it pins the bug.

I was not able to run the provider test suite locally (no Airflow dev environment on this machine); both files compile, and the test is a line-for-line variation of its passing sibling. Happy to adjust if CI disagrees.

^ Add meaningful description above

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
