### PR TITLE
Fix Spark standalone driver status polling to use the REST API port

### DIFF
--- a/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -715,8 +715,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
             else:
                 # HA: try each master in order (mirrors _StandaloneSparkSubmitBackend.get_job_status)
                 curl_cmds = " || ".join(
-                    f"/usr/bin/curl --fail --max-time {curl_max_wait_time} {shlex.quote(u)}"
-                    for u in urls
+                    f"/usr/bin/curl --fail --max-time {curl_max_wait_time} {shlex.quote(u)}" for u in urls
                 )
                 connection_cmd = ["sh", "-c", curl_cmds]
             self.log.info(connection_cmd)
@@ -1341,9 +1340,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                 ]
             else:
                 # HA: try each master in order
-                curl_cmds = " || ".join(
-                    f"/usr/bin/curl --fail -X DELETE {shlex.quote(u)}" for u in urls
-                )
+                curl_cmds = " || ".join(f"/usr/bin/curl --fail -X DELETE {shlex.quote(u)}" for u in urls)
                 connection_cmd = ["sh", "-c", curl_cmds]
         else:
             # Assume that spark-submit is present in the path to the executing user

--- a/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -668,6 +668,21 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
 
         return connection_cmd
 
+    def _get_standalone_rest_base_url(self) -> str:
+        """
+        Return the Spark standalone REST API base URL derived from the master URL.
+
+        The master URL points at the binary RPC port (default 7077), but the REST API
+        used for driver status/kill requests listens on ``spark.master.rest.port``
+        (default 6066). ``spark-submit --status/--kill`` derives its REST URL from the
+        master URL itself, so it can never connect through the binary port. Mirrors
+        ``_StandaloneSparkSubmitBackend.get_job_status``.
+        """
+        # ponytail: first host only for HA masters; per-host failover lives in the operator backend
+        first_master = self._connection["master"].replace("spark://", "").split(",")[0].strip()
+        host = first_master.split(":")[0]
+        return f"{self._connection['rest_scheme']}://{host}:{self._connection['rest_port']}"
+
     def _build_track_driver_status_command(self) -> list[str]:
         """
         Construct the command to poll the driver status.
@@ -676,22 +691,21 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         """
         curl_max_wait_time = 30
         spark_host = self._connection["master"]
-        if spark_host.endswith(":6066"):
-            spark_host = spark_host.replace("spark://", "http://")
-            connection_cmd = [
-                "/usr/bin/curl",
-                "--max-time",
-                str(curl_max_wait_time),
-                f"{spark_host}/v1/submissions/status/{self._driver_id}",
-            ]
-            self.log.info(connection_cmd)
-
+        if "spark://" in spark_host:
             # The driver id so we can poll for its status
             if not self._driver_id:
                 raise AirflowException(
                     "Invalid status: attempted to poll driver status but no driver id is known. Giving up."
                 )
 
+            url = f"{self._get_standalone_rest_base_url()}/v1/submissions/status/{self._driver_id}"
+            connection_cmd = [
+                "/usr/bin/curl",
+                "--max-time",
+                str(curl_max_wait_time),
+                url,
+            ]
+            self.log.info(connection_cmd)
         else:
             connection_cmd = self._get_spark_binary_path()
 
@@ -1292,19 +1306,29 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
 
     def _build_spark_driver_kill_command(self) -> list[str]:
         """
-        Construct the spark-submit command to kill a driver.
+        Construct the command to kill a driver.
 
         :return: full command to kill a driver
         """
-        # Assume that spark-submit is present in the path to the executing user
-        connection_cmd = [self._connection["spark_binary"]]
+        if "spark://" in self._connection["master"]:
+            # spark-submit --kill derives its REST URL from the master URL (binary RPC
+            # port), which cannot serve REST requests — use the REST API directly.
+            connection_cmd = [
+                "/usr/bin/curl",
+                "-X",
+                "DELETE",
+                f"{self._get_standalone_rest_base_url()}/v1/submissions/kill/{self._driver_id}",
+            ]
+        else:
+            # Assume that spark-submit is present in the path to the executing user
+            connection_cmd = [self._connection["spark_binary"]]
 
-        # The url to the spark master
-        connection_cmd += ["--master", self._connection["master"]]
+            # The url to the spark master
+            connection_cmd += ["--master", self._connection["master"]]
 
-        # The actual kill command
-        if self._driver_id:
-            connection_cmd += ["--kill", self._driver_id]
+            # The actual kill command
+            if self._driver_id:
+                connection_cmd += ["--kill", self._driver_id]
 
         self.log.debug("Spark-Kill cmd: %s", connection_cmd)
 

--- a/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -668,20 +668,23 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
 
         return connection_cmd
 
-    def _get_standalone_rest_base_url(self) -> str:
+    def _get_standalone_rest_base_urls(self) -> list[str]:
         """
-        Return the Spark standalone REST API base URL derived from the master URL.
+        Return Spark standalone REST API base URLs derived from the master URL.
 
         The master URL points at the binary RPC port (default 7077), but the REST API
         used for driver status/kill requests listens on ``spark.master.rest.port``
-        (default 6066). ``spark-submit --status/--kill`` derives its REST URL from the
-        master URL itself, so it can never connect through the binary port. Mirrors
-        ``_StandaloneSparkSubmitBackend.get_job_status``.
+        (default 6066). Mirrors ``_StandaloneSparkSubmitBackend.get_job_status`` which
+        tries each HA master in order.
         """
-        # ponytail: first host only for HA masters; per-host failover lives in the operator backend
-        first_master = self._connection["master"].replace("spark://", "").split(",")[0].strip()
-        host = first_master.split(":")[0]
-        return f"{self._connection['rest_scheme']}://{host}:{self._connection['rest_port']}"
+        scheme = self._connection["rest_scheme"]
+        port = self._connection["rest_port"]
+        masters = self._connection["master"].replace("spark://", "").split(",")
+        return [f"{scheme}://{m.strip().split(':')[0]}:{port}" for m in masters if m.strip()]
+
+    def _get_standalone_rest_base_url(self) -> str:
+        """Return the first Spark standalone REST API base URL (back-compat)."""
+        return self._get_standalone_rest_base_urls()[0]
 
     def _build_track_driver_status_command(self) -> list[str]:
         """
@@ -691,20 +694,31 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         """
         curl_max_wait_time = 30
         spark_host = self._connection["master"]
+        # spark:// indicates Spark standalone cluster mode
         if "spark://" in spark_host:
-            # The driver id so we can poll for its status
             if not self._driver_id:
                 raise AirflowException(
                     "Invalid status: attempted to poll driver status but no driver id is known. Giving up."
                 )
 
-            url = f"{self._get_standalone_rest_base_url()}/v1/submissions/status/{self._driver_id}"
-            connection_cmd = [
-                "/usr/bin/curl",
-                "--max-time",
-                str(curl_max_wait_time),
-                url,
+            urls = [
+                f"{base}/v1/submissions/status/{self._driver_id}"
+                for base in self._get_standalone_rest_base_urls()
             ]
+            if len(urls) == 1:
+                connection_cmd = [
+                    "/usr/bin/curl",
+                    "--max-time",
+                    str(curl_max_wait_time),
+                    urls[0],
+                ]
+            else:
+                # HA: try each master in order (mirrors _StandaloneSparkSubmitBackend.get_job_status)
+                curl_cmds = " || ".join(
+                    f"/usr/bin/curl --fail --max-time {curl_max_wait_time} {shlex.quote(u)}"
+                    for u in urls
+                )
+                connection_cmd = ["sh", "-c", curl_cmds]
             self.log.info(connection_cmd)
         else:
             connection_cmd = self._get_spark_binary_path()
@@ -1310,15 +1324,27 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
 
         :return: full command to kill a driver
         """
+        # spark:// indicates Spark standalone cluster mode
         if "spark://" in self._connection["master"]:
             # spark-submit --kill derives its REST URL from the master URL (binary RPC
             # port), which cannot serve REST requests — use the REST API directly.
-            connection_cmd = [
-                "/usr/bin/curl",
-                "-X",
-                "DELETE",
-                f"{self._get_standalone_rest_base_url()}/v1/submissions/kill/{self._driver_id}",
+            urls = [
+                f"{base}/v1/submissions/kill/{self._driver_id}"
+                for base in self._get_standalone_rest_base_urls()
             ]
+            if len(urls) == 1:
+                connection_cmd = [
+                    "/usr/bin/curl",
+                    "-X",
+                    "DELETE",
+                    urls[0],
+                ]
+            else:
+                # HA: try each master in order
+                curl_cmds = " || ".join(
+                    f"/usr/bin/curl --fail -X DELETE {shlex.quote(u)}" for u in urls
+                )
+                connection_cmd = ["sh", "-c", curl_cmds]
         else:
             # Assume that spark-submit is present in the path to the executing user
             connection_cmd = [self._connection["spark_binary"]]

--- a/providers/apache/spark/tests/unit/apache/spark/hooks/test_spark_submit.py
+++ b/providers/apache/spark/tests/unit/apache/spark/hooks/test_spark_submit.py
@@ -166,6 +166,14 @@ class TestSparkSubmitHook:
         )
         create_connection_without_db(
             Connection(
+                conn_id="spark_standalone_cluster_rpc_port",
+                conn_type="spark",
+                host="spark://spark-standalone-master:7077",
+                extra='{"deploy-mode": "cluster"}',
+            )
+        )
+        create_connection_without_db(
+            Connection(
                 conn_id="spark_principal_set",
                 conn_type="spark",
                 host="yarn",
@@ -355,6 +363,21 @@ class TestSparkSubmitHook:
 
         assert expected_spark_standalone_cluster == build_track_driver_status_spark_standalone_cluster
         assert expected_spark_yarn_cluster == build_track_driver_status_spark_yarn_cluster
+
+    def test_build_track_driver_status_command_rpc_port_master(self):
+        # Regression test for #71881: master URL on the binary RPC port (7077) must still
+        # poll via the REST API port (6066) — spark-submit --status cannot reach it.
+        hook = SparkSubmitHook(conn_id="spark_standalone_cluster_rpc_port")
+        hook._driver_id = "driver-20260820115651-0003"
+
+        cmd = hook._build_track_driver_status_command()
+
+        assert cmd == [
+            "/usr/bin/curl",
+            "--max-time",
+            "30",
+            "http://spark-standalone-master:6066/v1/submissions/status/driver-20260820115651-0003",
+        ]
 
     @pytest.mark.db_test
     @patch("airflow.providers.apache.spark.hooks.spark_submit.subprocess.Popen")
@@ -1195,11 +1218,34 @@ class TestSparkSubmitHook:
         kill_cmd = hook._build_spark_driver_kill_command()
 
         # Then
-        assert kill_cmd[0] == "spark-submit"
-        assert kill_cmd[1] == "--master"
-        assert kill_cmd[2] == "spark://spark-standalone-master:6066"
-        assert kill_cmd[3] == "--kill"
-        assert kill_cmd[4] == "driver-20171128111415-0001"
+        assert kill_cmd == [
+            "/usr/bin/curl",
+            "-X",
+            "DELETE",
+            "http://spark-standalone-master:6066/v1/submissions/kill/driver-20171128111415-0001",
+        ]
+
+    def test_standalone_cluster_rpc_port_process_on_kill(self):
+        # Regression test for #71881: kill must go through the REST API port (6066),
+        # not spark-submit --kill against the binary RPC port master URL.
+        log_lines = [
+            "Running Spark using the REST application submission protocol.",
+            "17/11/28 11:14:15 INFO RestSubmissionClient: Submitting a request "
+            "to launch an application in spark://spark-standalone-master:7077",
+            "17/11/28 11:14:15 INFO RestSubmissionClient: Submission successfully "
+            "created as driver-20171128111415-0001. Polling submission state...",
+        ]
+        hook = SparkSubmitHook(conn_id="spark_standalone_cluster_rpc_port")
+        hook._process_spark_submit_log(log_lines)
+
+        kill_cmd = hook._build_spark_driver_kill_command()
+
+        assert kill_cmd == [
+            "/usr/bin/curl",
+            "-X",
+            "DELETE",
+            "http://spark-standalone-master:6066/v1/submissions/kill/driver-20171128111415-0001",
+        ]
 
     @patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")
     @patch("airflow.providers.apache.spark.hooks.spark_submit.subprocess.Popen")

--- a/providers/apache/spark/tests/unit/apache/spark/hooks/test_spark_submit.py
+++ b/providers/apache/spark/tests/unit/apache/spark/hooks/test_spark_submit.py
@@ -174,6 +174,14 @@ class TestSparkSubmitHook:
         )
         create_connection_without_db(
             Connection(
+                conn_id="spark_standalone_cluster_ha",
+                conn_type="spark",
+                host="spark://host1:7077,host2:7077",
+                extra='{"deploy-mode": "cluster"}',
+            )
+        )
+        create_connection_without_db(
+            Connection(
                 conn_id="spark_principal_set",
                 conn_type="spark",
                 host="yarn",
@@ -378,6 +386,19 @@ class TestSparkSubmitHook:
             "30",
             "http://spark-standalone-master:6066/v1/submissions/status/driver-20260820115651-0003",
         ]
+
+    def test_build_track_driver_status_command_ha(self):
+        # HA master list must try each host in order (mirrors operator backend).
+        hook = SparkSubmitHook(conn_id="spark_standalone_cluster_ha")
+        hook._driver_id = "driver-20260820115651-0003"
+
+        cmd = hook._build_track_driver_status_command()
+
+        assert cmd[0] == "sh"
+        assert cmd[1] == "-c"
+        assert "http://host1:6066/v1/submissions/status/driver-20260820115651-0003" in cmd[2]
+        assert "http://host2:6066/v1/submissions/status/driver-20260820115651-0003" in cmd[2]
+        assert " || " in cmd[2]
 
     @pytest.mark.db_test
     @patch("airflow.providers.apache.spark.hooks.spark_submit.subprocess.Popen")
@@ -1246,6 +1267,18 @@ class TestSparkSubmitHook:
             "DELETE",
             "http://spark-standalone-master:6066/v1/submissions/kill/driver-20171128111415-0001",
         ]
+
+    def test_standalone_cluster_ha_kill(self):
+        # HA kill must try each master (curl ... || curl ...).
+        hook = SparkSubmitHook(conn_id="spark_standalone_cluster_ha")
+        hook._driver_id = "driver-20171128111415-0001"
+
+        kill_cmd = hook._build_spark_driver_kill_command()
+
+        assert kill_cmd[0] == "sh"
+        assert "http://host1:6066/v1/submissions/kill/driver-20171128111415-0001" in kill_cmd[2]
+        assert "http://host2:6066/v1/submissions/kill/driver-20171128111415-0001" in kill_cmd[2]
+        assert " || " in kill_cmd[2]
 
     @patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")
     @patch("airflow.providers.apache.spark.hooks.spark_submit.subprocess.Popen")


### PR DESCRIPTION
Fixes #71881

## Problem

In Spark Standalone cluster mode, `SparkSubmitOperator` fails with `AirflowException: Failed to poll for the driver status 10 times` even though the Spark job itself completes fine.

A Spark Standalone master exposes two endpoints:
- the **binary RPC port** (default 7077) used for submitting applications
- the **REST API** on `spark.master.rest.port` (default 6066) used for status/kill requests

The hook only used curl when the configured master URL literally ended in `:6066`. With the standard setup (master on 7077), it polled via `spark-submit --status`, whose `RestSubmissionClient` derives its HTTP URL from the master URL itself — so it tries to make an HTTP request against the binary RPC port and can never connect. This is also why a retry sometimes "works": if the task retried after the job already finished, the status request happened to succeed through a different path.

## Fix

- Add `_get_standalone_rest_base_url()` which derives the REST base URL from the master host plus the existing `rest-scheme` / `rest-port` connection extras — the same resolution `_StandaloneSparkSubmitBackend.get_job_status()` (added in 3.3) already uses.
- `_build_track_driver_status_command()` now polls via curl for any `spark://` master instead of only `:6066`-suffixed ones.
- Apply the same fix to `_build_spark_driver_kill_command()`: `spark-submit --kill` goes through the same broken `RestSubmissionClient` path, so standalone kills now use `DELETE /v1/submissions/kill/{driverId}`.
- YARN/mesos/local masters keep the existing `spark-submit --status/--kill` behavior.
- Users with non-default REST ports/TLS can set the documented `rest-port` / `rest-scheme` connection extras.

## Tests

- New regression tests: master on RPC port 7077 must produce curl commands against the REST port for both status polling and kill.
- Existing `test_build_track_driver_status_command` / `test_standalone_cluster_process_on_kill` updated for the new kill command shape.
- Full hook + operator suites pass locally: 205 passed.
- `ruff check` / `ruff format --check` clean; scoped prek run clean except a pre-existing environment failure (`check-provider-yaml-valid` rejects AIRFLOW_HOME == checkout dir, fails on clean main too).