### PR TITLE
Document proxy setup for Google provider using PySocks

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1335,6 +1335,7 @@ protobuf
 provisioner
 proxied
 proxies
+proxying
 psql
 psrp
 psycopg

--- a/providers/google/docs/connections/gcp.rst
+++ b/providers/google/docs/connections/gcp.rst
@@ -393,6 +393,79 @@ Using a quota project affects where API usage is billed, which quotas are applie
 usage is reported for monitoring and auditing.
 
 
+.. _howto/connection:google_cloud_platform:corporate_proxy:
+
+Using the Google Cloud Connection Behind a Corporate Proxy
+----------------------------------------------------------
+
+If Airflow workers are deployed behind a corporate HTTP proxy, two things are required for
+Google API calls to reach the internet.
+
+**1. Set the standard proxy environment variables on each worker:**
+
+.. code-block:: bash
+
+    export HTTPS_PROXY=http://<proxy-host>:<port>
+    export HTTP_PROXY=http://<proxy-host>:<port>
+    export NO_PROXY=localhost,127.0.0.1,.cluster.local
+
+In a Kubernetes / Helm deployment add them to ``values.yaml``:
+
+.. code-block:: yaml
+
+    env:
+      - name: HTTPS_PROXY
+        value: "http://<proxy-host>:<port>"
+      - name: HTTP_PROXY
+        value: "http://<proxy-host>:<port>"
+      - name: NO_PROXY
+        value: "localhost,127.0.0.1,.cluster.local"
+
+**2. Install the** ``PySocks`` **package in the worker image — this is mandatory.**
+
+.. code-block:: bash
+
+    pip install pysocks
+
+Why PySocks is required even for an HTTP proxy
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+All Google API endpoints (``oauth2.googleapis.com``, ``bigquery.googleapis.com``, etc.) are
+HTTPS. To route an HTTPS request through an HTTP proxy, the client must first open an
+``HTTP CONNECT`` tunnel and then do TLS end-to-end inside it.
+
+The ``httplib2`` library — used by ``google-api-python-client`` and the
+``_authorize()`` path of ``GoogleBaseHook`` for services such as BigQuery Jobs API,
+Dataflow, Compute, Cloud SQL, Datastore, Cloud Functions, and Marketing Platform — does
+**not** implement ``CONNECT`` tunneling itself. It delegates *all* proxying to
+`PySocks <https://github.com/Anorov/PySocks>`_ via a ``socks.socksocket``. If PySocks is
+not installed, ``httplib2`` silently skips the proxy even when ``HTTPS_PROXY`` is set, and
+the worker attempts a direct DNS lookup of the Google endpoint — which fails in a
+network-restricted environment.
+
+The symptom is a ``socket.gaierror: [Errno -2] Name or service not known`` (or
+``[Errno 11001] getaddrinfo failed`` on Windows) when a task first tries to authenticate
+or call a Google service.
+
+.. note::
+   Hooks backed by the newer ``google-cloud-*`` client libraries (Cloud Storage / GCS,
+   Pub/Sub, Spanner, BigQuery Storage API, etc.) use ``google-auth`` with the ``requests``
+   transport, which has native ``CONNECT``-tunnel support and does **not** need PySocks.
+   Only the ``discovery``-based hooks that go through ``_authorize()`` are affected.
+
+Quick verification
+~~~~~~~~~~~~~~~~~~
+
+Run the following inside the worker container to confirm the proxy and PySocks are working:
+
+.. code-block:: bash
+
+    # Proxy can reach Google (a 404 from Google = tunnel succeeded)
+    curl -x http://<proxy-host>:<port> https://oauth2.googleapis.com
+
+    # PySocks is importable
+    python -c "import socks; print('PySocks OK')"
+
 Authenticating to Google Sovereign Cloud in Airflow
 ---------------------------------------------------
 

--- a/providers/google/docs/connections/gcp.rst
+++ b/providers/google/docs/connections/gcp.rst
@@ -423,9 +423,24 @@ In a Kubernetes / Helm deployment add them to ``values.yaml``:
 
 **2. Install the** ``PySocks`` **package in the worker image — this is mandatory.**
 
-.. code-block:: bash
+For a bare-metal or custom Docker image, add it at build time:
 
-    pip install pysocks
+.. code-block:: dockerfile
+
+    RUN pip install pysocks
+
+In a Kubernetes / Helm deployment, add it to ``values.yaml`` so it survives pod restarts:
+
+.. code-block:: yaml
+
+    workers:
+      extraEnv:
+        - name: _PIP_ADDITIONAL_REQUIREMENTS
+          value: "pysocks"
+
+.. warning::
+   Running ``pip install pysocks`` inside a running container is **not** sufficient for
+   Kubernetes deployments — the package will be lost on the next pod restart.
 
 Why PySocks is required even for an HTTP proxy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -437,11 +452,12 @@ HTTPS. To route an HTTPS request through an HTTP proxy, the client must first op
 The ``httplib2`` library — used by ``google-api-python-client`` and the
 ``_authorize()`` path of ``GoogleBaseHook`` for services such as BigQuery Jobs API,
 Dataflow, Compute, Cloud SQL, Datastore, Cloud Functions, and Marketing Platform — does
-**not** implement ``CONNECT`` tunneling itself. It delegates *all* proxying to
-`PySocks <https://github.com/Anorov/PySocks>`_ via a ``socks.socksocket``. If PySocks is
-not installed, ``httplib2`` silently skips the proxy even when ``HTTPS_PROXY`` is set, and
-the worker attempts a direct DNS lookup of the Google endpoint — which fails in a
-network-restricted environment.
+**not** implement ``CONNECT`` tunneling itself. It bundles a minimal socks adapter but
+relies on the external `PySocks <https://pypi.org/project/PySocks/>`_ package being
+importable at runtime to activate its HTTP ``CONNECT`` tunnel path via a ``socks.socksocket``.
+If PySocks is not installed, ``httplib2`` silently falls back to a direct connection even
+when ``HTTPS_PROXY`` is set, and the worker attempts a direct DNS lookup of the Google
+endpoint — which fails in a network-restricted environment.
 
 The symptom is a ``socket.gaierror: [Errno -2] Name or service not known`` (or
 ``[Errno 11001] getaddrinfo failed`` on Windows) when a task first tries to authenticate

--- a/providers/google/docs/connections/gcp.rst
+++ b/providers/google/docs/connections/gcp.rst
@@ -429,18 +429,15 @@ For a bare-metal or custom Docker image, add it at build time:
 
     RUN pip install pysocks
 
-In a Kubernetes / Helm deployment, add it to ``values.yaml`` so it survives pod restarts:
+In a Kubernetes / Helm deployment, bake ``pysocks`` into your custom worker image the same way as
+above, then point the chart at that image in ``values.yaml``:
 
 .. code-block:: yaml
 
-    workers:
-      extraEnv:
-        - name: _PIP_ADDITIONAL_REQUIREMENTS
-          value: "pysocks"
-
-.. warning::
-   Running ``pip install pysocks`` inside a running container is **not** sufficient for
-   Kubernetes deployments — the package will be lost on the next pod restart.
+    images:
+      airflow:
+        repository: your-registry/airflow-with-pysocks
+        tag: "3.x.x"
 
 Why PySocks is required even for an HTTP proxy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Workers deployed behind a corporate HTTP proxy fail to reach Google APIs with a `socket.gaierror: Name or service not known` even when `HTTPS_PROXY` / `HTTP_PROXY` are set. The root cause is non-obvious and not documented anywhere in the provider:
`httplib2` (used by `google-api-python-client` for the `discovery`-based hook path) does **not** implement HTTP CONNECT tunneling itself — it delegates *all* proxying to PySocks. Without PySocks installed, `httplib2` silently skips the proxy and makes a direct DNS lookup that fails in restricted networks.

This PR adds a dedicated "Corporate Proxy" section to the Google Cloud connection reference documenting:

- the proxy env vars to set (`HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY`) for both bare-metal and Kubernetes/Helm deployments
- the mandatory `pysocks` dependency and a clear explanation of *why* it is required even for an HTTP proxy when the target endpoint is HTTPS
- which hooks are affected (`discovery`-based: BigQuery Jobs API, Dataflow, Compute, Cloud SQL, Datastore, Cloud Functions, Marketing Platform, etc.) vs. which are not (newer `google-cloud-*` client hooks that use `requests` and already have native CONNECT support)
- a quick in-container verification checklist

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ x ] Yes (please specify the tool below)

Claude Sonnet 4.6 (GitHub Copilot)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
