### PR TITLE
Add extraObjects value to the Helm chart

### DIFF
--- a/chart/docs/extending-the-chart.rst
+++ b/chart/docs/extending-the-chart.rst
@@ -123,3 +123,46 @@ you can do it by adding the following section to your ``values.yaml``:
 
    airflow:
      executor: KubernetesExecutor
+
+Deploying extra Kubernetes objects
+----------------------------------
+
+Creating a custom chart is the right approach when the extra templates are a project of their own.
+For a small number of resources the chart does not model, ``extraObjects`` is a lighter alternative:
+every item of that list is rendered as an additional manifest by the Airflow chart itself,
+so no umbrella chart, no ``helm dependency build`` and no second release are needed.
+
+Each item is either a mapping holding a full manifest, or a string holding a rendered manifest.
+Both forms go through ``tpl``, so the chart values, ``.Release`` and ``.Chart`` are available:
+
+.. code-block:: yaml
+   :caption: values.yaml
+
+   extraObjects:
+     - apiVersion: networking.k8s.io/v1
+       kind: NetworkPolicy
+       metadata:
+         name: '{{ .Release.Name }}-deny-egress'
+       spec:
+         podSelector:
+           matchLabels:
+             release: '{{ .Release.Name }}'
+         policyTypes:
+           - Egress
+     - |
+       apiVersion: v1
+       kind: ConfigMap
+       metadata:
+         name: {{ .Release.Name }}-extra-config
+       data:
+         MY_KEY: "my_value"
+
+The manifests are passed through as they are written, which means the chart adds no labels,
+no annotations and no Helm hooks to them, and it applies no validation beyond what the API server does.
+Objects created this way share the lifecycle of the release, so they are removed on ``helm uninstall``.
+
+.. note::
+
+   Use the dedicated values where they exist. Secrets and ConfigMaps consumed by Airflow containers
+   belong in :ref:`extraSecrets and extraConfigMaps <parameters:Kubernetes>`, which do add the chart
+   labels and Helm hooks, and additional containers belong in the ``extra*Containers`` values.

--- a/chart/newsfragments/71942.feature.rst
+++ b/chart/newsfragments/71942.feature.rst
@@ -1,0 +1,1 @@
+Add ``extraObjects`` to deploy extra Kubernetes objects alongside the release

--- a/chart/templates/extra-objects.yaml
+++ b/chart/templates/extra-objects.yaml
@@ -1,0 +1,31 @@
+{{/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/}}
+
+#################################################
+## Extra Kubernetes objects provisioned via the chart values
+#################################################
+{{- $Global := . }}
+{{- range $extraObject := .Values.extraObjects }}
+{{- $manifest := $extraObject }}
+{{- if not (typeIs "string" $extraObject) }}
+  {{- $manifest = toYaml $extraObject }}
+{{- end }}
+---
+{{ tpl $manifest $Global }}
+{{- end }}

--- a/chart/tests/chart_utils/helm_template_generator.py
+++ b/chart/tests/chart_utils/helm_template_generator.py
@@ -113,7 +113,7 @@ def create_validator(api_version, kind, kubernetes_version):
 
 def validate_k8s_object(instance, kubernetes_version):
     # Skip PostgreSQL chart
-    labels = jmespath.search("metadata.labels", instance)
+    labels = jmespath.search("metadata.labels", instance) or {}
     if "helm.sh/chart" in labels:
         chart = labels["helm.sh/chart"]
     else:

--- a/chart/tests/helm_tests/other/test_extra_objects.py
+++ b/chart/tests/helm_tests/other/test_extra_objects.py
@@ -1,0 +1,115 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import textwrap
+
+import yaml
+from chart_utils.helm_template_generator import prepare_k8s_lookup_dict, render_chart
+
+RELEASE_NAME = "test-extra-objects"
+
+
+class TestExtraObjects:
+    """Tests extra objects."""
+
+    def test_no_extra_objects_by_default(self):
+        k8s_objects = render_chart(RELEASE_NAME, show_only=["templates/extra-objects.yaml"])
+
+        assert k8s_objects == []
+
+    def test_extra_objects_as_mapping(self):
+        values_str = textwrap.dedent(
+            """
+            extraObjects:
+              - apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: '{{ .Release.Name }}-extra-configmap'
+                  namespace: '{{ .Release.Namespace }}'
+                data:
+                  HELLO_MESSAGE: "Hi!"
+            """
+        )
+        k8s_objects = render_chart(
+            RELEASE_NAME,
+            values=yaml.safe_load(values_str),
+            show_only=["templates/extra-objects.yaml"],
+        )
+        k8s_objects_by_key = prepare_k8s_lookup_dict(k8s_objects)
+
+        assert set(k8s_objects_by_key.keys()) == {("ConfigMap", f"{RELEASE_NAME}-extra-configmap")}
+
+        configmap_obj = k8s_objects_by_key[("ConfigMap", f"{RELEASE_NAME}-extra-configmap")]
+        assert configmap_obj["metadata"]["namespace"] == "default"
+        assert configmap_obj["data"] == {"HELLO_MESSAGE": "Hi!"}
+
+    def test_extra_objects_as_string(self):
+        values_str = textwrap.dedent(
+            """
+            extraObjects:
+              - |
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: {{ .Release.Name }}-extra-configmap
+                data:
+                  KUBERNETES_NAMESPACE: "{{ .Release.Namespace }}"
+            """
+        )
+        k8s_objects = render_chart(
+            RELEASE_NAME,
+            values=yaml.safe_load(values_str),
+            show_only=["templates/extra-objects.yaml"],
+        )
+        k8s_objects_by_key = prepare_k8s_lookup_dict(k8s_objects)
+
+        assert set(k8s_objects_by_key.keys()) == {("ConfigMap", f"{RELEASE_NAME}-extra-configmap")}
+
+        configmap_obj = k8s_objects_by_key[("ConfigMap", f"{RELEASE_NAME}-extra-configmap")]
+        assert configmap_obj["data"] == {"KUBERNETES_NAMESPACE": "default"}
+
+    def test_multiple_extra_objects(self):
+        values_str = textwrap.dedent(
+            """
+            extraObjects:
+              - apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: '{{ .Release.Name }}-first'
+                data:
+                  KEY: "first"
+              - |
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: {{ .Release.Name }}-second
+                data:
+                  KEY: "second"
+            """
+        )
+        k8s_objects = render_chart(
+            RELEASE_NAME,
+            values=yaml.safe_load(values_str),
+            show_only=["templates/extra-objects.yaml"],
+        )
+        k8s_objects_by_key = prepare_k8s_lookup_dict(k8s_objects)
+
+        assert set(k8s_objects_by_key.keys()) == {
+            ("ConfigMap", f"{RELEASE_NAME}-first"),
+            ("ConfigMap", f"{RELEASE_NAME}-second"),
+        }

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1309,6 +1309,31 @@
                 }
             ]
         },
+        "extraObjects": {
+            "description": "Extra Kubernetes objects that will be managed by the chart (templated). Each item is either a mapping holding a full manifest or a string holding a rendered manifest.",
+            "type": "array",
+            "x-docsSection": "Kubernetes",
+            "default": [],
+            "items": {
+                "type": [
+                    "object",
+                    "string"
+                ]
+            },
+            "examples": [
+                {
+                    "apiVersion": "v1",
+                    "kind": "ConfigMap",
+                    "metadata": {
+                        "name": "{{ .Release.Name }}-my-configmap"
+                    },
+                    "data": {
+                        "MY_KEY": "my_value"
+                    }
+                },
+                "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: {{ .Release.Name }}-my-configmap\ndata:\n  MY_KEY: 'my_value'"
+            ]
+        },
         "data": {
             "description": "Airflow database & redis configuration.",
             "type": "object",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -415,6 +415,36 @@ extraConfigMaps: {}
 #       AIRFLOW_VAR_HELLO_MESSAGE: "Hi!"
 #       AIRFLOW_VAR_KUBERNETES_NAMESPACE: "{{ .Release.Namespace }}"
 
+# Extra Kubernetes objects that will be managed by the chart.
+# Each item is either a mapping holding a full manifest or a string
+# holding a rendered manifest. Both forms are templated.
+# Useful for resources the chart does not model, for example a ServiceMonitor,
+# a VirtualService or a CronJob, without wrapping the chart in an umbrella chart.
+extraObjects: []
+# extraObjects:
+#   - apiVersion: batch/v1
+#     kind: CronJob
+#     metadata:
+#       name: '{{ .Release.Name }}-my-cronjob'
+#     spec:
+#       schedule: "*/5 * * * *"
+#       jobTemplate:
+#         spec:
+#           template:
+#             spec:
+#               restartPolicy: OnFailure
+#               containers:
+#                 - name: my-cronjob
+#                   image: '{{ .Values.defaultAirflowRepository }}:{{ .Values.defaultAirflowTag }}'
+#                   command: ["airflow", "version"]
+#   - |
+#     apiVersion: v1
+#     kind: ConfigMap
+#     metadata:
+#       name: {{ .Release.Name }}-my-configmap
+#     data:
+#       MY_KEY: "my_value"
+
 # Extra env 'items' that will be added to the definition of Airflow containers
 # a string is expected (templated).
 # TODO: difference from `env`? This is a templated string. Probably should template `env` and remove this.

--- a/chart/values_schema.schema.json
+++ b/chart/values_schema.schema.json
@@ -138,6 +138,17 @@
                     {
                         "properties": {
                             "type": {
+                                "const": [
+                                    "object",
+                                    "string"
+                                ]
+                            },
+                            "properties": false
+                        }
+                    },
+                    {
+                        "properties": {
+                            "type": {
                                 "const": "string"
                             }
                         }


### PR DESCRIPTION
## What

Add a top level extraObjects list to the [Airflow Helm chart](https://airflow.apache.org/docs/helm-chart/stable/index.html). Every item of the list is rendered as an additional manifest by the chart itself, by a new template file, chart/templates/extra-objects.yaml.

Each item is either a mapping holding a full manifest, or a string holding a rendered manifest. Both forms go through the Helm [tpl function](https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function), so chart values, .Release and .Chart are available inside them:

    extraObjects:
      - apiVersion: networking.k8s.io/v1
        kind: NetworkPolicy
        metadata:
          name: '{{ .Release.Name }}-deny-egress'
        spec:
          podSelector:
            matchLabels:
              release: '{{ .Release.Name }}'
          policyTypes:
            - Egress
      - |
        apiVersion: v1
        kind: ConfigMap
        metadata:
          name: {{ .Release.Name }}-extra-config
        data:
          MY_KEY: "my_value"

The default is an empty list, so nothing changes for existing users: with default values the template renders no object.

## Why

The chart already provisions extra objects of two specific kinds, extraSecrets and extraConfigMaps (see the [parameters reference](https://airflow.apache.org/docs/helm-chart/stable/parameters-ref.html#kubernetes)), but there is no way to ship any other Kubernetes resource with the release.

Today the documented answer is [Extending the Chart](https://airflow.apache.org/docs/helm-chart/stable/extending-the-chart.html): create a custom chart, add Airflow as a [subchart](https://helm.sh/docs/chart_template_guide/subcharts_and_globals/), run helm dependency build, and keep that wrapper in sync with the Airflow chart version. That is the right shape when the extra templates are a project of their own. It is a lot of machinery for one NetworkPolicy, one CRD instance from an operator the cluster already runs, or one ConfigMap consumed by something other than an Airflow container. The alternative is applying the resource out of band, which splits one deployment into two delivery paths and two lifecycles.

With extraObjects those resources live in the same values file and the same [Helm release](https://helm.sh/docs/intro/using_helm/#three-big-concepts), so they are created, upgraded and removed with it.

## Prior art in other community charts

This value is close to a de facto standard in widely used charts, which is also why extraObjects was picked as the name rather than a new one:

| Chart | Value | Item forms |
| --- | --- | --- |
| [Argo CD](https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/values.yaml) | extraObjects | mapping |
| [External Secrets Operator](https://github.com/external-secrets/external-secrets/blob/main/deploy/charts/external-secrets/values.yaml) | extraObjects | mapping |
| [Traefik](https://github.com/traefik/traefik-helm-chart/blob/master/traefik/templates/extra-objects.yaml) | extraObjects | mapping or string |
| [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml) | extraManifests | mapping or string |

Accepting both a mapping and a string follows [traefik.render](https://github.com/traefik/traefik-helm-chart/blob/master/traefik/templates/_helpers.tpl) in the Traefik chart, which branches on typeIs "string" for exactly this reason: a mapping keeps the value schema validated and readable, while a string lets a whole manifest be generated by a template expression, which is the same trick the chart already relies on for the data field of extraSecrets and extraConfigMaps.

## Deliberate design choices

* No chart metadata is injected. The chart adds no labels, no annotations and no [Helm hooks](https://helm.sh/docs/topics/charts_hooks/) to these manifests, unlike extraSecrets and extraConfigMaps. An extra object is exactly what the user declared, which keeps the value usable for resources whose labels are meaningful to a controller. The trade off is stated in the docs.
* No new validation. Items are typed as object or string in [values.schema.json](https://github.com/apache/airflow/blob/main/chart/values.schema.json), and correctness of the manifest itself is left to the API server.
* Documentation is added to the existing Extending the Chart page rather than a new page, so the umbrella chart approach and this lighter one are compared side by side, with a note pointing back to extraSecrets, extraConfigMaps and the extra container values where those are the better fit.

## On the chart versus Kustomize overlay decision

Following the decision tree in [contributing-docs/29_helm_chart_development.rst](https://github.com/apache/airflow/blob/main/contributing-docs/29_helm_chart_development.rst), extraObjects is not a component: it adds no image, no controller, no CRD and nothing with an external owner, and it introduces no second path to an existing setting. It is a generic escape hatch, so it does not compete with the overlays. My reading is that it supports the direction the overlays take, because a user who needs a resource the chart deliberately does not model can carry it in their own values instead of asking for it to be modelled in the chart. Happy to move this to a discussion on the dev list first if maintainers see it differently.

## Tests

New tests in chart/tests/helm_tests/other/test_extra_objects.py cover the default empty list, the mapping form, the string form, and several items of mixed form rendered in one release, asserting on the rendered objects and on templating of .Release.Name and .Release.Namespace.

One change outside the new files: validate_k8s_object in chart/tests/chart_utils/helm_template_generator.py assumed metadata.labels is always set, which held only because every chart rendered object carries labels. User supplied objects need not, so the labels lookup now uses the "or {}" fallback already used in test_basic_helm_chart.py.

Verified locally: the five tests above plus test_chart_quality.py pass, helm lint is clean, and the values schema hooks (sort_helm_values_schema_file_type_field.py, update_helm_schema_schema_type_fields_match.py, chart_schema.py, lint_json_schema.py) are applied, which accounts for the generated change in values_schema.schema.json.

The newsfragment is added as chart/newsfragments/71942.feature.rst.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

The change was authored with Claude Code and reviewed by me against the chart conventions, the contributing docs and the charts cited above. I ran the chart tests and the schema hooks locally and I take responsibility for the content.
