### PR TITLE
Prevent React plugins from inheriting a prior bundle's component

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/ReactPlugin.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/ReactPlugin.test.tsx
@@ -30,7 +30,7 @@ import type {
 } from "openapi/requests/types.gen";
 import { Wrapper } from "src/utils/Wrapper";
 
-import { ReactPlugin, type PluginProps } from "./ReactPlugin";
+import { loadPlugin, ReactPlugin, type PluginProps } from "./ReactPlugin";
 
 const mockAsset = { id: 1, name: "my_asset", uri: "s3://bucket/key" } as AssetResponse;
 const mockDag = { dag_display_name: "My Dag", dag_id: "my_dag" } as DAGDetailsResponse;
@@ -140,5 +140,29 @@ describe("ReactPlugin context props", () => {
     expect(capturedProps?.assetId).toBe("1");
     expect(capturedProps?.asset).toStrictEqual(mockAsset);
     expect(capturedProps?.assetUri).toBe(mockAsset.uri);
+  });
+});
+
+const pluginA = { bundle_url: "http://localhost/a.js", name: "PluginA" } as ReactAppResponse;
+const pluginB = { bundle_url: "http://localhost/b.js", name: "PluginB" } as ReactAppResponse;
+const componentA = () => null;
+
+describe("loadPlugin", () => {
+  afterEach(() => {
+    for (const key of ["AirflowPlugin", pluginA.name, pluginB.name]) {
+      (globalThis as Record<string, unknown>)[key] = undefined;
+    }
+  });
+
+  it("does not let a malformed bundle inherit a previously-loaded plugin's component", async () => {
+    // A well-formed bundle sets globalThis.AirflowPlugin on import; a malformed one sets nothing.
+    await loadPlugin(pluginA, () => {
+      (globalThis as Record<string, unknown>).AirflowPlugin = componentA;
+
+      return Promise.resolve();
+    });
+    const { default: component } = await loadPlugin(pluginB, () => Promise.resolve());
+
+    expect(component).not.toBe(componentA);
   });
 });

--- a/airflow-core/src/airflow/ui/src/pages/ReactPlugin.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/ReactPlugin.tsx
@@ -51,9 +51,14 @@ export type PluginProps = {
 
 type PluginComponentType = FC<PluginProps>;
 
-const loadPlugin = (reactApp: ReactAppResponse): Promise<{ default: PluginComponentType }> =>
+export const loadPlugin = (
+  reactApp: ReactAppResponse,
+  importBundle: (url: string) => Promise<unknown> = (url) => import(/* @vite-ignore */ url),
+): Promise<{ default: PluginComponentType }> => {
+  (globalThis as Record<string, unknown>).AirflowPlugin = undefined;
+
   // We are assuming the plugin manager is trusted and the bundle_url is safe
-  import(/* @vite-ignore */ new URL(reactApp.bundle_url, document.baseURI).href)
+  return importBundle(new URL(reactApp.bundle_url, document.baseURI).href)
     .then(() => {
       // Store components in globalThis[reactApp.name] to avoid conflicts with the shared globalThis.AirflowPlugin
       // global variable.
@@ -78,6 +83,7 @@ const loadPlugin = (reactApp: ReactAppResponse): Promise<{ default: PluginCompon
 
       return { default: ErrorPage };
     });
+};
 
 export const ReactPlugin = ({ reactApp }: { readonly reactApp: ReactAppResponse }) => {
   const { assetId, dagId, mapIndex, runId, taskId } = useParams();


### PR DESCRIPTION
A React plugin bundle exports its component by assigning to the shared `globalThis.AirflowPlugin` as a side effect of being imported. When a bundle is malformed or empty and never makes that assignment, the loader read whatever value a *previously-loaded* plugin had left on `globalThis.AirflowPlugin` — so one plugin silently rendered another plugin's component instead of failing. The `typeof !== "function"` guard didn't catch it because the stale value is a valid function.

This clears the shared global before each import, so a bundle that assigns nothing surfaces a clear error (and the error page) rather than inheriting a stale component. The resolved component is also cached under its plugin name only after validation, so a failed load never leaves a bad value behind.

## Before
### Plugin A
<img width="1440" height="900" alt="01-plugin-a" src="https://github.com/user-attachments/assets/88f442bf-f2e5-4709-9f78-2cb916c0fa9d" />
### Plugin B
<img width="1440" height="900" alt="02-plugin-b" src="https://github.com/user-attachments/assets/6743a427-5356-465f-916b-798c00a1b646" />



## After
### Plugin A
<img width="1440" height="900" alt="01-plugin-a" src="https://github.com/user-attachments/assets/1f4e86f2-9921-42a6-abf1-7320b288c9f6" />
### Plugin B
<img width="1440" height="900" alt="02-plugin-b" src="https://github.com/user-attachments/assets/41222ca6-3f05-46c8-9372-413c72873d1e" />


closes: #56169

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)