### PR TITLE
Make GridButton tooltip label use the selected UI timezone

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Bar.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Bar.tsx
@@ -83,8 +83,8 @@ export const Bar = ({ max, onClick, run, showVersionIndicatorMode }: Props) => {
           flexDir="column"
           height={`${(run.duration / max) * BAR_HEIGHT}px`}
           justifyContent="flex-end"
-          label={run.run_after}
           minHeight="14px"
+          runAfter={run.run_after}
           runId={run.run_id}
           searchParams={search}
           state={run.state}

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridButton.test.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridButton.test.tsx
@@ -20,25 +20,28 @@ import "@testing-library/jest-dom";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
+import { TimezoneContext } from "src/context/timezone";
 import { Wrapper } from "src/utils/Wrapper";
 
 import { GridButton } from "./GridButton";
 
 describe("GridButton", () => {
-  it("shows run ID in the grid tooltip", () => {
+  it("shows run details in the grid tooltip respecting the selected timezone", () => {
     vi.useFakeTimers();
 
     render(
-      <GridButton
-        dagId="example_dag"
-        duration={3661}
-        label="2026-04-21T00:00:00+00:00"
-        runId="manual__2026-04-21T00:00:00+00:00"
-        searchParams=""
-        state="success"
-      >
-        <span>bar</span>
-      </GridButton>,
+      <TimezoneContext.Provider value={{ selectedTimezone: "Europe/Vienna", setSelectedTimezone: vi.fn() }}>
+        <GridButton
+          dagId="example_dag"
+          duration={3661}
+          runAfter="2026-04-21T00:00:00+00:00"
+          runId="manual__2026-04-21T00:00:00+00:00"
+          searchParams=""
+          state="success"
+        >
+          <span>bar</span>
+        </GridButton>
+      </TimezoneContext.Provider>,
       { wrapper: Wrapper },
     );
 
@@ -47,6 +50,7 @@ describe("GridButton", () => {
       vi.advanceTimersByTime(500);
     });
 
+    expect(screen.getByTestId("basic-tooltip")).toHaveTextContent("2026-04-21 02:00:00");
     expect(screen.getByTestId("basic-tooltip")).toHaveTextContent(
       "common:runId: manual__2026-04-21T00:00:00+00:00",
     );

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridButton.tsx
@@ -22,13 +22,14 @@ import { Link } from "react-router-dom";
 
 import type { DagRunState, TaskInstanceState } from "openapi/requests/types.gen";
 import { BasicTooltip } from "src/components/BasicTooltip";
+import Time from "src/components/Time";
 import { renderDuration } from "src/utils/datetimeUtils";
 
 type Props = {
   readonly dagId: string;
   readonly duration?: number | null;
   readonly isGroup?: boolean;
-  readonly label: string;
+  readonly runAfter: string;
   readonly runId: string;
   readonly searchParams: string;
   readonly state: DagRunState | TaskInstanceState | null | undefined;
@@ -40,7 +41,7 @@ export const GridButton = ({
   dagId,
   duration,
   isGroup,
-  label,
+  runAfter,
   runId,
   searchParams,
   state,
@@ -51,7 +52,7 @@ export const GridButton = ({
 
   const tooltipContent = (
     <>
-      {label}
+      <Time datetime={runAfter} />
       <br />
       {translate("common:runId")}: {runId}
       <br />


### PR DESCRIPTION
## What

I noticed a minor bug in the Airflow UI.

The plain `runAfter` string was used as the GridButton tooltip label, which resulted in showing this time information in UTC. This was inconsistent with similar values, such as logical date, start date, and end date, which are rendered in the timezone selected in the UI.

**Before:**

<img width="1010" height="354" alt="Screenshot_20260821_141419" src="https://github.com/user-attachments/assets/b282447d-4320-45c5-9c69-809def839070" />

## My changes 

I updated the Grid tooltip to render `run_after` with the existing `<Time>` component so it respects the selected UI timezone. I also updated the corresponding `GridButton` test.

**After:**

<img width="1026" height="355" alt="Screenshot_20260821_141603" src="https://github.com/user-attachments/assets/7285ae5f-1c06-43e0-92af-73a3644a4aa4" />



 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (gpt-5.6-sol)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
