### PR TITLE
Surface connection test errors in the UI instead of failing silently

### DIFF
--- a/airflow-core/src/airflow/ui/src/queries/useTestConnection.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useTestConnection.ts
@@ -22,6 +22,7 @@ import { useTranslation } from "react-i18next";
 import { useConnectionServiceTestConnection } from "openapi/queries";
 import type { ConnectionTestResponse } from "openapi/requests/types.gen";
 import { toaster } from "src/components/ui";
+import { createErrorToaster } from "src/utils";
 
 export const useTestConnection = (setConnected: Dispatch<SetStateAction<boolean | undefined>>) => {
   const { t: translate } = useTranslation("admin");
@@ -43,8 +44,9 @@ export const useTestConnection = (setConnected: Dispatch<SetStateAction<boolean 
     }
   };
 
-  const onError = () => {
+  const onError = (error: unknown) => {
     setConnected(false);
+    createErrorToaster(error, { titleKey: "connections.testError.title" }, translate);
   };
 
   return useConnectionServiceTestConnection({


### PR DESCRIPTION
When testing a connection from the UI, only a successful test or a failed *test result* (HTTP 200 with `status=false`) showed a message. If the request itself errored (e.g. an unexpected `500`, or a `404`), `useTestConnection`'s `onError` just set the connection state to failed and showed **nothing** — leaving the user with a red icon and no explanation, exactly as reported ("I only get a red wifi with crossbeam across it … it should tell me if the connection succeeded or not").

This routes those errors through the shared `createErrorToaster` used by every other mutation, so the reason is shown. `403` (testing disabled) continues to be handled by the global `MutationCache` handler, unchanged.

Scope note: I could not reproduce the CLI `airflow connections test` "conn_id isn't defined" half on current `main` — it now resolves the connection and reports the real hook error — so this addresses the UI silent-failure, which is the reproducible part of the report.

closes: #58567

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)