### PR TITLE
Document REMOTE_TASK_LOG/DEFAULT_REMOTE_CONN_ID for custom logging configs

### DIFF
--- a/airflow-core/docs/administration-and-deployment/logging-monitoring/advanced-logging-configuration.rst
+++ b/airflow-core/docs/administration-and-deployment/logging-monitoring/advanced-logging-configuration.rst
@@ -102,6 +102,49 @@ See :doc:`../modules_management` for details on how Python and Airflow manage mo
    You can override the way both standard logs of the components and "task" logs are handled.
 
 
+Custom logging configs and remote logging
+-----------------------------------------
+
+When ``[logging] remote_logging = True`` and you point ``logging_config_class``
+at your own module, define two module-level attributes in that module:
+
+* ``REMOTE_TASK_LOG`` — an instance of
+  :class:`~airflow.logging.remote.RemoteLogIO` (or
+  :class:`~airflow.logging.remote.RemoteLogStreamIO`) that uploads task logs
+  and reads them back for the UI.
+* ``DEFAULT_REMOTE_CONN_ID`` — default Airflow connection id used when
+  ``[logging] remote_log_conn_id`` is unset.
+
+If ``REMOTE_TASK_LOG`` is missing, Airflow emits one ``WARNING`` at startup
+(``Remote log handler could not be loaded; logs will be available locally only.``)
+and the UI cannot read task logs back from the remote backend.
+
+    .. code-block:: python
+
+      # ~/airflow/config/log_config.py
+      from airflow.logging.remote import RemoteLogIO
+
+
+      class MyRemoteLogIO:
+          @property
+          def processors(self):
+              return ()
+
+          def upload(self, path, ti): ...  # upload local log file at ``path`` to your backend
+
+          def read(self, relative_path, ti): ...  # return (source_info, log_messages) for the UI
+
+
+      REMOTE_TASK_LOG: RemoteLogIO | None = MyRemoteLogIO()
+      DEFAULT_REMOTE_CONN_ID: str | None = "my_remote_conn"
+
+.. note::
+
+   Define ``REMOTE_TASK_LOG`` in your own module rather than re-exporting it
+   from ``airflow.config_templates.airflow_local_settings``, which is planned
+   for deprecation.
+
+
 Custom logger for Operators, Hooks and Tasks
 --------------------------------------------
 


### PR DESCRIPTION
Fixes #71768

## Problem

With `[logging] remote_logging = True` and a user-defined `logging_config_class`, Airflow 3.2.x discovers the remote task log handler by reading two module-level attributes from the user's module (`discover_remote_log_handler` in `shared/logging/src/airflow_shared/logging/remote.py`):

- `REMOTE_TASK_LOG`
- `DEFAULT_REMOTE_CONN_ID`

If `REMOTE_TASK_LOG` is missing, the scheduler warns `Remote log handler could not be loaded; logs will be available locally only.` and task logs are never uploaded to the remote backend. The 3.2.2 documentation did not mention these attributes at all, so users migrating from 2.x (where a plain extended `LOGGING_CONFIG` dict was enough) hit this silently. The section already exists on `main` (and shipped in 3.3.x docs); this backports it to the `v3-2-test` branch so the 3.2 docs match.

## Change

Backport the "Custom logging configs and remote logging" section from `main` into `airflow-core/docs/administration-and-deployment/logging-monitoring/advanced-logging-configuration.rst`, including:

- the two required module-level attributes and what they do
- the exact startup warning users see when `REMOTE_TASK_LOG` is missing
- a working `MyRemoteLogIO` example
- the note about defining it in your own module rather than re-exporting from `airflow_local_settings`

Docs-only change; verified the referenced API (`airflow.logging.remote.RemoteLogIO`, discovery of both globals) exists on the `v3-2-test` branch.