### PR TITLE
Fix scheduler crash when the API server response is a redirect

### DIFF
--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -197,14 +197,27 @@ def get_json_error(response: httpx.Response):
         raise err
 
 
+def _raise_for_status_picklable(response: httpx.Response) -> None:
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        if 400 <= response.status_code < 600:
+            raise
+        wrapped = ServerResponseError(str(e), request=e.request, response=e.response)
+        wrapped.detail = None
+        raise wrapped from e
+
+
 def raise_on_4xx_5xx(response: httpx.Response):
-    return get_json_error(response) or response.raise_for_status()
+    get_json_error(response)
+    _raise_for_status_picklable(response)
 
 
 # Py 3.11+ version
 def raise_on_4xx_5xx_with_note(response: httpx.Response):
     try:
-        return get_json_error(response) or response.raise_for_status()
+        get_json_error(response)
+        _raise_for_status_picklable(response)
     except httpx.HTTPStatusError as e:
         if TYPE_CHECKING:
             assert hasattr(e, "add_note")

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -198,6 +198,22 @@ class TestClient:
         assert unpickled.response.status_code == 404
         assert unpickled.request.url == "http://error"
 
+    def test_redirect_response_raises_picklable_error(self):
+        responses = [httpx.Response(301, headers={"location": "http://proxy-login"})]
+        client = make_client_w_responses(responses)
+
+        with pytest.raises(ServerResponseError) as exc_info:
+            client.get("http://error")
+
+        err = exc_info.value
+        assert err.response.status_code == 301
+        assert err.detail is None
+
+        # Check that the error is picklable, unlike a bare httpx.HTTPStatusError.
+        unpickled = pickle.loads(pickle.dumps(err))
+        assert isinstance(unpickled, ServerResponseError)
+        assert unpickled.response.status_code == 301
+
     @pytest.mark.skipif(sys.version_info < (3, 11), reason="Exception notes (PEP 678) require Python 3.11")
     def test_server_error_detail_added_as_note(self):
         """Notes survive uncaught propagation, handled sites still log detail directly."""


### PR DESCRIPTION
closes: #49099

## Summary

`get_json_error()` only wraps 400-599 responses in the picklable `ServerResponseError` -- it needs a custom `__reduce__` because a plain `httpx.HTTPStatusError` requires keyword-only `request`/`response` arguments that pickle's default reconstruction can't supply (see #47873, fixed for that path by #48517).

A 3xx response -- e.g. a corporate proxy in front of the API server returning a redirect -- falls outside that range, so
`httpx.Response.raise_for_status()` raises the bare, unpicklable `httpx.HTTPStatusError` instead. That crashes the scheduler once the exception crosses a multiprocessing boundary: `LocalExecutor.result_queue` is a `multiprocessing.Queue`, and unpickling the exception on the scheduler side fails with the exact "missing keyword-only arguments" `TypeError` #47873 first reported -- just triggered by a redirect instead of a JSON error body.

Reproduced and confirmed with a standalone script -- the same failure mode as #47873's crash log.

## Change

Added `_raise_for_status_picklable()` in `task-sdk/src/airflow/sdk/api/client.py`, used by both `raise_on_4xx_5xx` and `raise_on_4xx_5xx_with_note`: anything `raise_for_status()` raises outside the 400-599 range now gets wrapped in a `ServerResponseError` (picklable) before propagating. Errors inside 400-599 that `from_response()` couldn't extract a JSON detail
from are left exactly as before -- this only closes the gap for status codes `get_json_error()` never attempted to wrap in the first place.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes -- Claude Code (Sonnet 5) for writing test