### PR TITLE
Fix minor typos in airflow-core docs

### DIFF
--- a/airflow-core/docs/core-concepts/dags.rst
+++ b/airflow-core/docs/core-concepts/dags.rst
@@ -322,7 +322,7 @@ By default, a Dag will only run a Task when all the Tasks it depends on are succ
 Branching
 ~~~~~~~~~
 
-You can make use of branching in order to tell the Dag *not* to run all dependent tasks, but instead to pick and choose one or more paths to go down. This is where the ``@task.branch`` decorator come in.
+You can make use of branching in order to tell the Dag *not* to run all dependent tasks, but instead to pick and choose one or more paths to go down. This is where the ``@task.branch`` decorator comes in.
 
 The ``@task.branch`` decorator is much like ``@task``, except that it expects the decorated function to return an ID to a task (or a list of IDs). The specified task is followed, while all other paths are skipped. It can also return *None* to skip all downstream tasks.
 
@@ -839,7 +839,7 @@ it in three steps:
 Dag Auto-pausing (Experimental)
 -------------------------------
 Dags can be configured to be auto-paused as well.
-There is a Airflow configuration which allows for automatically disabling of a Dag
+There is an Airflow configuration which allows for automatically disabling of a Dag
 if it fails for ``N`` number of times consecutively.
 
 - :ref:`config:core__max_consecutive_failed_dag_runs_per_dag`

--- a/airflow-core/docs/howto/docker-compose/index.rst
+++ b/airflow-core/docs/howto/docker-compose/index.rst
@@ -247,7 +247,7 @@ You can also run :doc:`CLI commands <../usage-cli>`, but you have to do it in on
 
     docker compose run airflow-worker airflow info
 
-If you have Linux or Mac OS, you can make your work easier and download a optional wrapper scripts that will allow you to run commands with a simpler command.
+If you have Linux or Mac OS, you can make your work easier and download an optional wrapper script that will allow you to run commands with a simpler command.
 
 .. jinja:: quick_start_ctx
 

--- a/airflow-core/docs/howto/timetable.rst
+++ b/airflow-core/docs/howto/timetable.rst
@@ -347,7 +347,7 @@ Changing generated ``run_id``
 
 Since Airflow 2.4, Timetables are also responsible for generating the ``run_id`` for DagRuns.
 
-For example to have the Run ID show a "human friendly" date of when the run started (that is, the end of the data interval, rather then the start which is the date currently used) you could add a method like this to a custom timetable:
+For example to have the Run ID show a "human friendly" date of when the run started (that is, the end of the data interval, rather than the start which is the date currently used) you could add a method like this to a custom timetable:
 
 .. code-block:: python
 


### PR DESCRIPTION
Fixes a handful of small grammar/typo issues found while reviewing airflow-core docs:

- `airflow-core/docs/core-concepts/dags.rst:325` — "decorator come in" → "decorator comes in" (subject-verb agreement)
- `airflow-core/docs/core-concepts/dags.rst:842` — "There is a Airflow configuration" → "There is an Airflow configuration" (a/an)
- `airflow-core/docs/howto/timetable.rst:350` — "rather then the start" → "rather than the start" (then/than)
- `airflow-core/docs/howto/docker-compose/index.rst:250` — "download a optional wrapper scripts" → "download an optional wrapper script" (article/number agreement)

No functional changes, docs only.