### PR TITLE
Fix ForeignKeyViolation crash when rescheduling sensors during failure

### DIFF
--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1882,6 +1882,7 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
         # Actual callbacks are handled by the DAG processor, not the scheduler
         task = getattr(ti, "task", None)
 
+        needs_prepare = False
         if not ti.is_eligible_to_retry():
             ti.state = TaskInstanceState.FAILED
 
@@ -1892,7 +1893,7 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
                 # If the task instance is in the running state, it means it raised an exception and
                 # about to retry so we record the task instance history. For other states, the task
                 # instance was cleared and already recorded in the task instance history.
-                ti.prepare_db_for_next_try(session)
+                needs_prepare = True
 
             ti.state = State.UP_FOR_RETRY
 
@@ -1902,6 +1903,9 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
             )
         except Exception:
             log.exception("error calling listener")
+
+        if needs_prepare:
+            ti.prepare_db_for_next_try(session)
 
         return ti
 


### PR DESCRIPTION
Closes #71923.

### Motivation

When a sensor fails, the scheduler calls `TaskInstance.fetch_handle_failure_context`. This method clears older `task_reschedule` records and mutates `ti.id` to a new UUID by calling `ti.prepare_db_for_next_try`, and then it calls `on_task_instance_failed` listener hooks before flushing the updated `ti.id` to the database.

If a listener hook blocks for seconds (e.g. OpenLineage timing out), the transaction window is extended. Concurrently, an API server might process a reschedule request from the supervisor and insert a new `task_reschedule` row using the *old* `ti.id`. When the listener finishes, the scheduler flushes `UPDATE task_instance SET id = <new_id> WHERE id = <old_id>`. But since the newly inserted `task_reschedule` points to `old_id`, PostgreSQL rejects the update with a `ForeignKeyViolation`, causing the scheduler to crash.

### Changes

- Moved `ti.prepare_db_for_next_try(session)` in `fetch_handle_failure_context` to run *after* the listener hooks.
- This reduces the race window between the `task_reschedule` delete and the `ti.id` update flush from seconds down to microseconds.
- **Bonus correctness fix**: Listener hooks now receive the `TaskInstance` with the *old* (actual) UUID that experienced the failure, rather than the prematurely rolled new UUID that hasn't run yet.