### PR TITLE
Reduce mapped task creation overhead and scheduling bursts

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/dynamic-task-mapping.rst
+++ b/airflow-core/docs/authoring-and-scheduling/dynamic-task-mapping.rst
@@ -672,6 +672,24 @@ There are two limits that you can place on a task:
 
       BashOperator.partial(task_id="my_task", max_active_tis_per_dag=16).expand(bash_command=commands)
 
+Scheduling large maps
+=====================
+
+During runtime expansion, the scheduler creates mapped task instances in batches
+within the Dag run's transaction. Custom ``task_instance_mutation_hook`` policies continue to apply
+to every instance, including policies that use the attached scheduler session.
+
+The :ref:`config:scheduler__max_tis_per_query` setting limits how many mapped
+instances become ready per Dag run in a scheduling pass. Remaining instances
+are considered in subsequent passes. A value of zero uses
+:ref:`config:core__parallelism`; if both settings are zero, this limit is disabled.
+Ordinary task instances are not subject to this per-run limit.
+
+All mapped instances are still created before expansion completes. Batching
+reduces insertion overhead but does not distribute creation across scheduler
+heartbeats, and dependency checks for blocked instances are not capped by this
+readiness limit.
+
 Automatically skipping zero-length maps
 =======================================
 

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -2822,7 +2822,11 @@ scheduler:
       description: |
         This determines the number of task instances to be evaluated for scheduling
         during each scheduler loop.
-        Set this to 0 to use the value of ``[core] parallelism``
+        It also limits the number of mapped task instances made ready per Dag run
+        in one scheduling pass. Remaining mapped instances are considered in later
+        passes; ordinary task instances are unaffected by this per-run limit.
+        Set this to 0 to use the value of ``[core] parallelism``. If both values
+        are 0, this limit is disabled.
       version_added: ~
       type: integer
       example: ~

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -1685,6 +1685,9 @@ class DagRun(Base, LoggingMixin):
         expansion_happened = False
         # Set of task ids for which was already done _revise_map_indexes_if_mapped
         revised_map_index_task_ids: set[str] = set()
+        max_tis_per_query = airflow_conf.getint("scheduler", "max_tis_per_query")
+        if max_tis_per_query <= 0:
+            max_tis_per_query = airflow_conf.getint("core", "parallelism")
         for schedulable in itertools.chain(schedulable_tis, additional_tis):
             if TYPE_CHECKING:
                 assert isinstance(schedulable.task, Operator)
@@ -1702,7 +1705,21 @@ class DagRun(Base, LoggingMixin):
             if schedulable.map_index < 0:
                 new_tis = _expand_mapped_task_if_needed(schedulable)
                 if new_tis is not None:
-                    additional_tis.extend(new_tis)
+                    expanded_tis = list(new_tis)
+                    # Avoid evaluating a huge number of newly expanded TIs in the same pass.
+                    # They are persisted already and picked up in subsequent loops.
+                    remaining_budget = max(max_tis_per_query - len(additional_tis), 0)
+                    if remaining_budget:
+                        additional_tis.extend(expanded_tis[:remaining_budget])
+                    dropped_tis = len(expanded_tis) - remaining_budget
+                    if dropped_tis > 0:
+                        self.log.debug(
+                            "Deferring dependency checks for expanded TIs to a later scheduler pass",
+                            task_id=schedulable.task_id,
+                            dag_id=self.dag_id,
+                            run_id=self.run_id,
+                            deferred_count=dropped_tis,
+                        )
                     expansion_happened = True
                     # Expansion changes a mapped task's instance count, which invalidates the
                     # trigger-rule upstream-count memo on this DepContext (a downstream evaluated
@@ -2145,17 +2162,50 @@ class DagRun(Base, LoggingMixin):
             )
             session.flush()
 
-        new_tis: list[TI] = []
-        for index in range(total_length):
-            if index in existing_indexes:
-                continue
+        from airflow.settings import task_instance_mutation_hook
+
+        new_indexes = [index for index in range(total_length) if index not in existing_indexes]
+        if not new_indexes:
+            return []
+
+        hook_is_noop = getattr(task_instance_mutation_hook, "is_noop", False) is True
+        if hook_is_noop:
+            ti_mappings = [
+                TI.insert_mapping(
+                    self.run_id,
+                    task,
+                    map_index=index,
+                    dag_version_id=dag_version_id,
+                    dag_run=self,
+                )
+                for index in new_indexes
+            ]
+            session.bulk_insert_mappings(TI.__mapper__, ti_mappings)
+            session.flush()
+            inserted_tis = list(
+                session.scalars(
+                    select(TI)
+                    .where(
+                        TI.dag_id == self.dag_id,
+                        TI.task_id == task.task_id,
+                        TI.run_id == self.run_id,
+                        TI.map_index.in_(new_indexes),
+                    )
+                    .order_by(TI.map_index)
+                ).all()
+            )
+            for ti in inserted_tis:
+                ti.task = task
+            return inserted_tis
+
+        created_tis: list[TI] = []
+        for index in new_indexes:
             ti = TI(task, run_id=self.run_id, map_index=index, state=None, dag_version_id=dag_version_id)
             self.log.debug("Expanding TIs upserted %s", ti)
             _add_and_prime_mapped_ti(ti, task, self, session=session)
-            new_tis.append(ti)
-        if new_tis:
-            session.flush()
-        return new_tis
+            created_tis.append(ti)
+        session.flush()
+        return created_tis
 
     @classmethod
     @provide_session

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -88,7 +88,11 @@ from airflow.models import Deadline, Log
 from airflow.models.backfill import Backfill
 from airflow.models.base import Base, StringID
 from airflow.models.deadline_alert import DeadlineAlert as DeadlineAlertModel
-from airflow.models.taskinstance import TaskInstance as TI, _add_and_prime_mapped_ti, clear_task_instances
+from airflow.models.taskinstance import (
+    TaskInstance as TI,
+    _create_mapped_task_instances,
+    clear_task_instances,
+)
 from airflow.models.taskinstancehistory import TaskInstanceHistory as TIH
 from airflow.models.tasklog import LogTemplate
 from airflow.models.taskmap import TaskMap
@@ -1685,7 +1689,14 @@ class DagRun(Base, LoggingMixin):
         expansion_happened = False
         # Set of task ids for which was already done _revise_map_indexes_if_mapped
         revised_map_index_task_ids: set[str] = set()
+        max_tis_per_query = airflow_conf.getint("scheduler", "max_tis_per_query")
+        if max_tis_per_query <= 0:
+            max_tis_per_query = airflow_conf.getint("core", "parallelism")
+        mapped_ready_count = 0
         for schedulable in itertools.chain(schedulable_tis, additional_tis):
+            if schedulable.map_index >= 0 and 0 < max_tis_per_query <= mapped_ready_count:
+                continue
+
             if TYPE_CHECKING:
                 assert isinstance(schedulable.task, Operator)
             old_state = schedulable.state
@@ -1715,9 +1726,10 @@ class DagRun(Base, LoggingMixin):
                     revised_tis = self._revise_map_indexes_if_mapped(
                         schedulable.task, dag_version_id=schedulable.dag_version_id, session=session
                     )
-                    ready_tis.extend(revised_tis)
-                    revised_map_index_task_ids.add(schedulable.task.task_id)
+                    additional_tis.extend(revised_tis)
+                    revised_map_index_task_ids.add(schedulable.task_id)
                     if revised_tis:
+                        expansion_happened = True
                         # Revising a mapped task can add new instances, growing its instance count
                         # the same way expansion does. Drop the upstream-count memo so a downstream
                         # evaluated later in this pass recomputes it instead of reading a stale value.
@@ -1728,6 +1740,8 @@ class DagRun(Base, LoggingMixin):
                 # the task state to ensure it's still schedulable
                 if schedulable.state in SCHEDULEABLE_STATES:
                     ready_tis.append(schedulable)
+                    if schedulable.map_index >= 0:
+                        mapped_ready_count += 1
 
         # Check if any ti changed state
         tis_filter = TI.filter_for_tis(old_states)
@@ -2145,17 +2159,13 @@ class DagRun(Base, LoggingMixin):
             )
             session.flush()
 
-        new_tis: list[TI] = []
-        for index in range(total_length):
-            if index in existing_indexes:
-                continue
-            ti = TI(task, run_id=self.run_id, map_index=index, state=None, dag_version_id=dag_version_id)
-            self.log.debug("Expanding TIs upserted %s", ti)
-            _add_and_prime_mapped_ti(ti, task, self, session=session)
-            new_tis.append(ti)
-        if new_tis:
-            session.flush()
-        return new_tis
+        return _create_mapped_task_instances(
+            task,
+            self,
+            (index for index in range(total_length) if index not in existing_indexes),
+            dag_version_id=dag_version_id,
+            session=session,
+        )
 
     @classmethod
     @provide_session

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -96,7 +96,12 @@ from airflow.models.taskreschedule import TaskReschedule
 from airflow.models.xcom import XCOM_RETURN_KEY, LazyXComSelectSequence, XComModel
 from airflow.serialization.enums import stringify_encoding_keys
 from airflow.settings import task_instance_mutation_hook
-from airflow.task.priority_strategy import validate_and_load_priority_weight_strategy
+from airflow.task.priority_strategy import (
+    _AbsolutePriorityWeightStrategy,
+    _DownstreamPriorityWeightStrategy,
+    _UpstreamPriorityWeightStrategy,
+    validate_and_load_priority_weight_strategy,
+)
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_deps import REQUEUEABLE_DEPS, RUNNING_DEPS
 from airflow.ti_deps.deps.ready_to_reschedule import ReadyToRescheduleDep
@@ -214,12 +219,97 @@ def _add_and_prime_mapped_ti(
 
     :meta private:
     """
-    task_instance_mutation_hook(ti, dag_run=dag_run)
     session.add(ti)
     if context_carrier is not None:
         ti.context_carrier = context_carrier
     ti.refresh_from_task(task, dag_run=dag_run)
     set_committed_value(ti, "dag_run", dag_run)
+
+
+def _create_mapped_task_instances(
+    task: Operator,
+    dag_run: DagRun,
+    indexes: Iterable[int],
+    *,
+    dag_version_id: UUID | None,
+    session: Session,
+    state: str | None = None,
+    batch_size: int = 1000,
+) -> list[TaskInstance]:
+    """Create mapped instances in bounded batches, preserving attached-session mutation hooks."""
+    if batch_size < 1:
+        raise ValueError("batch_size must be positive")
+    hook_is_noop = (
+        getattr(settings.task_instance_mutation_hook, "is_noop", False) is True
+        and not settings.get_policy_plugin_manager().hook.task_instance_mutation_hook.get_hookimpls()
+    )
+    created_tis: list[TaskInstance] = []
+    mapping_template: dict[str, Any] | None = None
+    weight_rule = task.weight_rule
+    if not hasattr(weight_rule, "get_weight"):
+        weight_rule = validate_and_load_priority_weight_strategy(weight_rule)
+    reuse_mapping = hook_is_noop and type(weight_rule) in (
+        _AbsolutePriorityWeightStrategy,
+        _DownstreamPriorityWeightStrategy,
+        _UpstreamPriorityWeightStrategy,
+    )
+    index_iterator = iter(indexes)
+    while batch := list(itertools.islice(index_iterator, batch_size)):
+        if hook_is_noop:
+            mappings = []
+            for index in batch:
+                if mapping_template is None:
+                    mapping = TaskInstance.insert_mapping(
+                        dag_run.run_id, task, index, dag_version_id=dag_version_id, dag_run=dag_run
+                    )
+                    if reuse_mapping:
+                        # Built-in weights depend only on the task; custom strategies may depend on the index.
+                        mapping_template = mapping
+                else:
+                    mapping = {
+                        **mapping_template,
+                        "map_index": index,
+                        "context_carrier": new_task_run_carrier(dag_run.context_carrier),
+                    }
+                mapping["state"] = state
+                mappings.append(mapping)
+            session.bulk_insert_mappings(TaskInstance.__mapper__, mappings)
+            tis = session.scalars(
+                select(TaskInstance)
+                .options(lazyload(TaskInstance.dag_run))
+                .where(
+                    TaskInstance.dag_id == dag_run.dag_id,
+                    TaskInstance.run_id == dag_run.run_id,
+                    TaskInstance.task_id == task.task_id,
+                    TaskInstance.map_index.in_(batch),
+                )
+                .order_by(TaskInstance.map_index)
+            ).all()
+            for ti in tis:
+                ti.task = task
+                set_committed_value(ti, "dag_run", dag_run)
+                created_tis.append(ti)
+        else:
+            # A hook may query the attached session. Do not flush every pending instance for each query.
+            with session.no_autoflush:
+                for index in batch:
+                    ti = TaskInstance(
+                        task,
+                        run_id=dag_run.run_id,
+                        map_index=index,
+                        state=state,
+                        dag_version_id=dag_version_id,
+                    )
+                    _add_and_prime_mapped_ti(
+                        ti,
+                        task,
+                        dag_run,
+                        session=session,
+                        context_carrier=new_task_run_carrier(dag_run.context_carrier),
+                    )
+                    created_tis.append(ti)
+        session.flush()
+    return created_tis
 
 
 def _recalculate_dagrun_queued_at_deadlines(

--- a/airflow-core/src/airflow/models/taskmap.py
+++ b/airflow-core/src/airflow/models/taskmap.py
@@ -256,22 +256,58 @@ class TaskMap(TaskInstanceDependencies):
                 )
             )
 
+        from airflow.settings import task_instance_mutation_hook
+
+        hook_is_noop = getattr(task_instance_mutation_hook, "is_noop", False) is True
         new_tis: list[TaskInstance] = []
-        for index in indexes_to_map:
-            ti = TaskInstance(
-                task,
-                run_id=run_id,
-                map_index=index,
-                state=state,
-                dag_version_id=dag_version_id,
-            )
-            task.log.debug("Expanding TIs upserted %s", ti)
-            _add_and_prime_mapped_ti(
-                ti, task, dr, session=session, context_carrier=new_task_run_carrier(dr.context_carrier)
-            )
-            new_tis.append(ti)
-        if new_tis:
-            session.flush()
+        if hook_is_noop and isinstance(indexes_to_map, range):
+            ti_mappings = [
+                TaskInstance.insert_mapping(
+                    run_id,
+                    task,
+                    map_index=index,
+                    dag_version_id=dag_version_id,
+                    dag_run=dr,
+                )
+                for index in indexes_to_map
+            ]
+            if state is not None:
+                for ti_mapping in ti_mappings:
+                    ti_mapping["state"] = state
+            if ti_mappings:
+                session.bulk_insert_mappings(TaskInstance.__mapper__, ti_mappings)
+                session.flush()
+                new_tis = list(
+                    session.scalars(
+                        select(TaskInstance)
+                        .where(
+                            TaskInstance.dag_id == task.dag_id,
+                            TaskInstance.task_id == task.task_id,
+                            TaskInstance.run_id == run_id,
+                            TaskInstance.map_index >= indexes_to_map.start,
+                            TaskInstance.map_index < indexes_to_map.stop,
+                        )
+                        .order_by(TaskInstance.map_index)
+                    ).all()
+                )
+                for ti in new_tis:
+                    ti.task = task
+        else:
+            for index in indexes_to_map:
+                ti = TaskInstance(
+                    task,
+                    run_id=run_id,
+                    map_index=index,
+                    state=state,
+                    dag_version_id=dag_version_id,
+                )
+                task.log.debug("Expanding TIs upserted %s", ti)
+                _add_and_prime_mapped_ti(
+                    ti, task, dr, session=session, context_carrier=new_task_run_carrier(dr.context_carrier)
+                )
+                new_tis.append(ti)
+            if new_tis:
+                session.flush()
         all_expanded_tis.extend(new_tis)
 
         # Coerce the None case to 0 -- these two are almost treated identically,

--- a/airflow-core/src/airflow/models/taskmap.py
+++ b/airflow-core/src/airflow/models/taskmap.py
@@ -28,7 +28,6 @@ from opentelemetry import trace
 from sqlalchemy import CheckConstraint, ForeignKeyConstraint, Integer, String, func, or_, select
 from sqlalchemy.orm import Mapped, mapped_column
 
-from airflow._shared.observability.traces import new_task_run_carrier
 from airflow.models.base import COLLATION_ARGS, ID_LEN, TaskInstanceDependencies
 from airflow.models.dag_version import DagVersion
 from airflow.utils.db import exists_query
@@ -141,7 +140,7 @@ class TaskMap(TaskInstanceDependencies):
             order by map index, and the maximum map index value.
         """
         from airflow.models.expandinput import NotFullyPopulated
-        from airflow.models.taskinstance import TaskInstance, _add_and_prime_mapped_ti
+        from airflow.models.taskinstance import TaskInstance, _create_mapped_task_instances
         from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
         from airflow.serialization.definitions.mappedoperator import (
             SerializedMappedOperator,
@@ -241,6 +240,7 @@ class TaskMap(TaskInstanceDependencies):
 
         if unmapped_ti:
             dag_version_id = unmapped_ti.dag_version_id
+            dr = unmapped_ti.dag_run
         elif dag_version := DagVersion.get_latest_version(task.dag_id, session=session):
             dag_version_id = dag_version.id
         else:
@@ -256,22 +256,14 @@ class TaskMap(TaskInstanceDependencies):
                 )
             )
 
-        new_tis: list[TaskInstance] = []
-        for index in indexes_to_map:
-            ti = TaskInstance(
-                task,
-                run_id=run_id,
-                map_index=index,
-                state=state,
-                dag_version_id=dag_version_id,
-            )
-            task.log.debug("Expanding TIs upserted %s", ti)
-            _add_and_prime_mapped_ti(
-                ti, task, dr, session=session, context_carrier=new_task_run_carrier(dr.context_carrier)
-            )
-            new_tis.append(ti)
-        if new_tis:
-            session.flush()
+        new_tis = _create_mapped_task_instances(
+            task,
+            dr,
+            indexes_to_map,
+            dag_version_id=dag_version_id,
+            state=state,
+            session=session,
+        )
         all_expanded_tis.extend(new_tis)
 
         # Coerce the None case to 0 -- these two are almost treated identically,

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -2139,6 +2139,37 @@ def test_mapped_length_increase_at_runtime_adds_additional_tis(dag_maker, sessio
     ]
 
 
+def test_mapped_expansion_defers_some_tis_to_later_scheduler_pass(dag_maker, session):
+    @task
+    def task_1(): ...
+
+    with dag_maker(session=session):
+
+        @task
+        def task_2(arg2): ...
+
+        task_2.expand(arg2=task_1())
+
+    dr: DagRun = dag_maker.create_dagrun()
+    ti = dr.get_task_instance(task_id="task_1", session=session)
+    assert ti
+    ti.state = TaskInstanceState.SUCCESS
+    session.add(TaskMap.from_task_instance_xcom(ti, [1, 2, 3, 4]))
+    session.flush()
+
+    with conf_vars({("scheduler", "max_tis_per_query"): "2"}):
+        decision = dr.task_instance_scheduling_decisions(session=session)
+
+    indices = [(ti.task_id, ti.map_index) for ti in decision.schedulable_tis]
+    assert indices == [("task_2", 0), ("task_2", 1)]
+
+    with conf_vars({("scheduler", "max_tis_per_query"): "2"}):
+        decision = dr.task_instance_scheduling_decisions(session=session)
+
+    indices = [(ti.task_id, ti.map_index) for ti in decision.schedulable_tis]
+    assert indices == [("task_2", 0), ("task_2", 1), ("task_2", 2), ("task_2", 3)]
+
+
 def test_mapped_literal_length_reduction_at_runtime_adds_removed_state(dag_maker, session):
     """
     Test that when the length of mapped literal reduces at runtime, the missing task instances

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -2193,6 +2193,180 @@ def test_mapped_length_increase_at_runtime_adds_additional_tis(dag_maker, sessio
     ]
 
 
+@pytest.mark.parametrize(
+    ("query_limit", "parallelism", "batch_size"),
+    [("2", "32", 2), ("0", "1", 1), ("-1", "1", 1), ("0", "0", 4)],
+)
+def test_mapped_expansion_defers_some_tis_to_later_scheduler_pass(
+    dag_maker, session, query_limit, parallelism, batch_size
+):
+    dag, mapped, dr = _make_mapped_dag_for_expansion(dag_maker, session, dag_id="mapped_budget")
+    upstream = dr.get_task_instance(task_id="op1", session=session)
+    upstream.state = TaskInstanceState.SUCCESS
+    session.add(TaskMap.from_task_instance_xcom(upstream, list(range(4))))
+    session.flush()
+
+    with conf_vars({("scheduler", "max_tis_per_query"): query_limit, ("core", "parallelism"): parallelism}):
+        for start in range(0, 4, batch_size):
+            decision = dr.task_instance_scheduling_decisions(session=session)
+            assert [ti.map_index for ti in decision.schedulable_tis] == list(range(start, start + batch_size))
+            assert dr.state == DagRunState.RUNNING
+            for ti in decision.schedulable_tis:
+                ti.state = TaskInstanceState.SCHEDULED
+            session.flush()
+        assert not dr.task_instance_scheduling_decisions(session=session).schedulable_tis
+
+
+@conf_vars({("scheduler", "max_tis_per_query"): "2"})
+def test_mapped_budget_does_not_defer_unmapped_tasks(dag_maker, session):
+    with dag_maker(session=session, serialized=True):
+        MockOperator.partial(task_id="mapped").expand(arg2=[1, 2, 3])
+        EmptyOperator(task_id="ordinary")
+    dr = dag_maker.create_dagrun()
+    tis = dr.get_task_instances(session=session)
+    for ti in tis:
+        ti.task = dr.dag.get_task(ti.task_id)
+    tis.sort(key=lambda ti: (ti.map_index < 0, ti.map_index))
+    ready, _, _ = dr._get_ready_tis(tis, [], session=session)
+    assert [(ti.task_id, ti.map_index) for ti in ready] == [("mapped", 0), ("mapped", 1), ("ordinary", -1)]
+
+
+@conf_vars({("scheduler", "max_tis_per_query"): "2"})
+def test_revise_map_indexes_defers_some_tis_to_later_scheduler_pass(dag_maker, session):
+    dag, mapped, dr = _make_mapped_dag_for_expansion(dag_maker, session, dag_id="revision_budget")
+    upstream = dr.get_task_instance(task_id="op1", session=session)
+    upstream.state = TaskInstanceState.SUCCESS
+    session.add(TaskMap.from_task_instance_xcom(upstream, [1]))
+    session.flush()
+    dr.task_instance_scheduling_decisions(session=session)
+    session.merge(TaskMap.from_task_instance_xcom(upstream, list(range(5))))
+    session.flush()
+
+    for indexes in ([0, 1], [2, 3], [4]):
+        decision = dr.task_instance_scheduling_decisions(session=session)
+        assert [ti.map_index for ti in decision.schedulable_tis] == indexes
+        for ti in decision.schedulable_tis:
+            ti.state = TaskInstanceState.SCHEDULED
+        session.flush()
+    assert not dr.task_instance_scheduling_decisions(session=session).schedulable_tis
+
+
+@mock.patch.object(TI, "are_dependencies_met", autospec=True)
+def test_revised_mapped_instances_have_dependencies_checked(check_dependencies, dag_maker, session):
+    dag, mapped, dr = _make_mapped_dag_for_expansion(dag_maker, session, dag_id="revision_dependencies")
+    upstream = dr.get_task_instance(task_id="op1", session=session)
+    upstream.state = TaskInstanceState.SUCCESS
+    expand_mapped_task(dag.task_dict[mapped.task_id], dr.run_id, "op1", length=1, session=session)
+    session.merge(TaskMap.from_task_instance_xcom(upstream, [1, 2, 3]))
+    session.flush()
+    check_dependencies.side_effect = lambda ti, **kwargs: ti.map_index != 1
+
+    decision = dr.task_instance_scheduling_decisions(session=session)
+    assert [ti.map_index for ti in decision.schedulable_tis] == [0, 2]
+    assert [call.args[0].map_index for call in check_dependencies.call_args_list] == [0, 1, 2]
+
+
+def test_revise_map_indexes_if_mapped_uses_bulk_insert_when_mutation_hook_is_noop(dag_maker, session) -> None:
+    dag, mapped, dr = _make_mapped_dag_for_expansion(
+        dag_maker, session, dag_id="test_revise_map_indexes_bulk"
+    )
+
+    expand_mapped_task(
+        dag.task_dict[mapped.task_id],
+        dr.run_id,
+        "op1",
+        length=2,
+        session=session,
+    )
+
+    upstream_ti = dr.get_task_instance(task_id="op1", session=session)
+    assert upstream_ti
+    session.merge(TaskMap.from_task_instance_xcom(upstream_ti, [1, 2, 3, 4]))
+    session.flush()
+
+    dag_version_id_row = DagVersion.get_latest_version(dag_id=dr.dag_id, session=session)
+    assert dag_version_id_row is not None
+    dag_version_id = dag_version_id_row.id
+
+    class NoopHook:
+        is_noop = True
+
+        def __call__(self, *_, **__):
+            return None
+
+    with (
+        mock.patch("airflow.settings.task_instance_mutation_hook", NoopHook()),
+        mock.patch.object(
+            session,
+            "bulk_insert_mappings",
+            wraps=session.bulk_insert_mappings,
+            spec=session.bulk_insert_mappings,
+        ) as bulk_insert,
+    ):
+        created_tis = dr._revise_map_indexes_if_mapped(mapped, dag_version_id=dag_version_id, session=session)
+
+    assert bulk_insert.called
+    assert [ti.map_index for ti in created_tis] == [2, 3]
+
+
+def test_revise_map_indexes_if_mapped_calls_mutation_hook_for_new_tis(dag_maker, session) -> None:
+    dag, mapped, dr = _make_mapped_dag_for_expansion(
+        dag_maker, session, dag_id="test_revise_map_indexes_hooked"
+    )
+
+    expand_mapped_task(
+        dag.task_dict[mapped.task_id],
+        dr.run_id,
+        "op1",
+        length=2,
+        session=session,
+    )
+
+    upstream_ti = dr.get_task_instance(task_id="op1", session=session)
+    assert upstream_ti
+    session.merge(TaskMap.from_task_instance_xcom(upstream_ti, [1, 2, 3, 4]))
+    session.flush()
+
+    dag_version_id_row = DagVersion.get_latest_version(dag_id=dr.dag_id, session=session)
+    assert dag_version_id_row is not None
+    dag_version_id = dag_version_id_row.id
+
+    existing_indexes = session.scalars(
+        select(TI.map_index)
+        .where(TI.dag_id == dr.dag_id, TI.task_id == mapped.task_id, TI.run_id == dr.run_id)
+        .order_by(TI.map_index)
+    ).all()
+    assert existing_indexes == [0, 1]
+    called_indexes: list[int] = []
+
+    class MutationHook:
+        is_noop = False
+
+        def __call__(self, task_instance, dag_run=None):
+            called_indexes.append(task_instance.map_index)
+            task_instance.queue = f"q_{task_instance.map_index}"
+
+    mutation_hook = MutationHook()
+
+    with (
+        mock.patch("airflow.settings.task_instance_mutation_hook", mutation_hook),
+        mock.patch("airflow.models.taskinstance.task_instance_mutation_hook", autospec=True) as hook,
+        mock.patch.object(
+            session,
+            "bulk_insert_mappings",
+            wraps=session.bulk_insert_mappings,
+            spec=session.bulk_insert_mappings,
+        ) as bulk_insert,
+    ):
+        hook.side_effect = mutation_hook
+        created_tis = dr._revise_map_indexes_if_mapped(mapped, dag_version_id=dag_version_id, session=session)
+
+    assert set(called_indexes) == {2, 3}
+    assert len(created_tis) == 2
+    assert not bulk_insert.called
+    assert [ti.queue for ti in sorted(created_tis, key=lambda ti: ti.map_index)] == ["q_2", "q_3"]
+
+
 def test_mapped_literal_length_reduction_at_runtime_adds_removed_state(dag_maker, session):
     """
     Test that when the length of mapped literal reduces at runtime, the missing task instances

--- a/airflow-core/tests/unit/models/test_mappedoperator.py
+++ b/airflow-core/tests/unit/models/test_mappedoperator.py
@@ -501,6 +501,47 @@ def test_expand_mapped_task_task_instance_mutation_hook(dag_maker, session, crea
             assert call.args[0].map_index == expected_map_index[index]
 
 
+def test_expand_mapped_task_uses_bulk_insert_when_mutation_hook_is_noop(dag_maker, session) -> None:
+    with dag_maker(session=session, serialized=True) as dag:
+        task1 = BaseOperator(task_id="op1")
+        mapped = MockOperator.partial(task_id="task_2").expand(arg2=task1.output)
+
+    dr = dag_maker.create_dagrun()
+
+    class NoopHook:
+        is_noop = True
+
+        def __call__(self, *_, **__):
+            return None
+
+    noop_hook = NoopHook()
+
+    with (
+        mock.patch("airflow.settings.task_instance_mutation_hook", noop_hook),
+        mock.patch.object(session, "bulk_insert_mappings", wraps=session.bulk_insert_mappings) as bulk_insert,
+    ):
+        expand_mapped_task(
+            dag.task_dict[mapped.task_id],
+            dr.run_id,
+            task1.task_id,
+            length=4,
+            session=session,
+        )
+
+    assert bulk_insert.called
+    mapped_indexes = session.scalars(
+        select(TaskInstance.map_index)
+        .where(
+            TaskInstance.dag_id == dag.dag_id,
+            TaskInstance.task_id == mapped.task_id,
+            TaskInstance.run_id == dr.run_id,
+            TaskInstance.map_index >= 0,
+        )
+        .order_by(TaskInstance.map_index)
+    ).all()
+    assert mapped_indexes == [0, 1, 2, 3]
+
+
 class TestMappedSetupTeardown:
     @staticmethod
     def get_states(dr):

--- a/airflow-core/tests/unit/models/test_mappedoperator.py
+++ b/airflow-core/tests/unit/models/test_mappedoperator.py
@@ -501,6 +501,52 @@ def test_expand_mapped_task_task_instance_mutation_hook(dag_maker, session, crea
             assert call.args[0].map_index == expected_map_index[index]
 
 
+def test_expand_mapped_task_uses_bulk_insert_when_mutation_hook_is_noop(dag_maker, session) -> None:
+    with dag_maker(session=session, serialized=True) as dag:
+        task1 = BaseOperator(task_id="op1")
+        mapped = MockOperator.partial(task_id="task_2").expand(arg2=task1.output)
+
+    dr = dag_maker.create_dagrun()
+
+    class NoopHook:
+        is_noop = True
+
+        def __call__(self, *_, **__):
+            return None
+
+    noop_hook = NoopHook()
+
+    with (
+        mock.patch("airflow.settings.task_instance_mutation_hook", noop_hook),
+        mock.patch.object(
+            session,
+            "bulk_insert_mappings",
+            wraps=session.bulk_insert_mappings,
+            spec=session.bulk_insert_mappings,
+        ) as bulk_insert,
+    ):
+        expand_mapped_task(
+            dag.task_dict[mapped.task_id],
+            dr.run_id,
+            task1.task_id,
+            length=4,
+            session=session,
+        )
+
+    assert bulk_insert.called
+    mapped_indexes = session.scalars(
+        select(TaskInstance.map_index)
+        .where(
+            TaskInstance.dag_id == dag.dag_id,
+            TaskInstance.task_id == mapped.task_id,
+            TaskInstance.run_id == dr.run_id,
+            TaskInstance.map_index >= 0,
+        )
+        .order_by(TaskInstance.map_index)
+    ).all()
+    assert mapped_indexes == [0, 1, 2, 3]
+
+
 class TestMappedSetupTeardown:
     @staticmethod
     def get_states(dr):

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -35,12 +35,13 @@ import uuid6
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
-from sqlalchemy import delete, func, inspect as sa_inspect, select, update
+from sqlalchemy import delete, event, func, inspect as sa_inspect, select, update
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import load_only
+from sqlalchemy.orm import Session, load_only
 from sqlalchemy.orm.attributes import set_committed_value
 
-from airflow import settings
+from airflow import policies, settings
+from airflow._shared.observability import traces
 from airflow._shared.observability.metrics.base_stats_logger import StatsLogger
 from airflow._shared.observability.traces import new_dagrun_trace_carrier, new_task_run_carrier
 from airflow._shared.timezones import timezone
@@ -67,6 +68,7 @@ from airflow.models.taskinstance import (
     TaskInstance,
     TaskInstance as TI,
     TaskInstanceNote,
+    _create_mapped_task_instances,
     clear_task_instances,
     find_relevant_relatives,
 )
@@ -101,6 +103,7 @@ from airflow.serialization.definitions.baseoperator import SerializedBaseOperato
 from airflow.serialization.definitions.dag import SerializedDAG
 from airflow.serialization.encoders import ensure_serialized_asset
 from airflow.serialization.serialized_objects import OperatorSerialization, create_scheduler_operator
+from airflow.task.priority_strategy import _AbsolutePriorityWeightStrategy
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_deps import REQUEUEABLE_DEPS, RUNNING_DEPS
 from airflow.ti_deps.dependencies_states import RUNNABLE_STATES
@@ -109,6 +112,7 @@ from airflow.ti_deps.deps.ready_to_reschedule import ReadyToRescheduleDep
 from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep, _UpstreamTIStates
 from airflow.timetables.simple import PartitionedAtRuntime
 from airflow.utils.session import create_session, provide_session
+from airflow.utils.sqlalchemy import prohibit_commit
 from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
@@ -124,8 +128,6 @@ from tests_common.test_utils.taskinstance import (
 from unit.models import DEFAULT_DATE
 
 if TYPE_CHECKING:
-    from sqlalchemy.orm import Session
-
     from tests_common.pytest_plugin import DagMaker
 
 pytestmark = [pytest.mark.db_test, pytest.mark.need_serialized_dag, pytest.mark.want_activate_assets]
@@ -4531,4 +4533,140 @@ class TestTaskInstanceStatsTagsTeamName:
             "task.scheduled_duration",
             mock.ANY,
             tags=expected_tags,
+        )
+
+
+@pytest.mark.parametrize("with_hook", [False, True])
+@pytest.mark.parametrize("state", [None, TaskInstanceState.UP_FOR_RETRY])
+def test_create_mapped_task_instances_batches_preserve_mutations(
+    dag_maker, session, monkeypatch, with_hook, state
+):
+    monkeypatch.setattr(traces, "tracer", TracerProvider().get_tracer(__name__))
+    with dag_maker(session=session, serialized=True):
+        upstream = BaseOperator(task_id="upstream")
+        MockOperator.partial(task_id="mapped").expand(arg2=upstream.output)
+    dr = dag_maker.create_dagrun(conf={"queue": "policy_queue"})
+    task = dr.dag.get_task("mapped")
+    indexes = [0, 1, 3, 5, 6]
+    flush_sizes = []
+    hook_indexes = []
+    monkeypatch.setattr(session, "autoflush", True)
+
+    class Policy:
+        @policies.hookimpl
+        def task_instance_mutation_hook(self, task_instance, dag_run):
+            hook_indexes.append(task_instance.map_index)
+            attached_session = sa_inspect(task_instance).session
+            if attached_session is None:
+                return
+            assert (
+                attached_session.scalar(
+                    select(DagRun.id).where(DagRun.dag_id == dr.dag_id, DagRun.run_id == dr.run_id)
+                )
+                == dr.id
+            )
+            task_instance.queue = dag_run.conf["queue"]
+            task_instance.pool_slots = task_instance.map_index + 1
+            task_instance.priority_weight = 100 + task_instance.map_index
+            task_instance.note = f"policy-{task_instance.map_index}"
+            if task_instance.map_index == 3:
+                task_instance.state = TaskInstanceState.SKIPPED
+
+    def record_flush(session, flush_context, instances):
+        flush_sizes.append(
+            sum(isinstance(ti, TaskInstance) and ti.task_id == task.task_id for ti in session.new)
+        )
+
+    manager = settings.get_policy_plugin_manager()
+    plugin = Policy()
+    if with_hook:
+        manager.register(plugin)
+    monkeypatch.setattr(settings.task_instance_mutation_hook, "is_noop", True)
+    event.listen(session, "before_flush", record_flush)
+    try:
+        with (
+            prohibit_commit(session),
+            mock.patch.object(
+                session,
+                "bulk_insert_mappings",
+                wraps=session.bulk_insert_mappings,
+                spec=session.bulk_insert_mappings,
+            ) as bulk_insert,
+            mock.patch.object(
+                TaskInstance,
+                "insert_mapping",
+                wraps=TaskInstance.insert_mapping,
+                spec=TaskInstance.insert_mapping,
+            ) as build_mapping,
+        ):
+            tis = _create_mapped_task_instances(
+                task,
+                dr,
+                iter(indexes),
+                dag_version_id=dr.created_dag_version_id,
+                state=state,
+                session=session,
+                batch_size=2,
+            )
+        assert [ti.map_index for ti in tis] == indexes
+        assert all(sa_inspect(ti).persistent and ti.task is task and ti.dag_run is dr for ti in tis)
+        assert len({ti.id for ti in tis}) == len(indexes)
+        assert len({ti.context_carrier["traceparent"] for ti in tis}) == len(indexes)
+        if with_hook:
+            bulk_insert.assert_not_called()
+            assert flush_sizes == [2, 2, 1]
+            assert hook_indexes == [index for index in indexes for _ in range(2)]
+        else:
+            assert [len(call.args[1]) for call in bulk_insert.call_args_list] == [2, 2, 1]
+            build_mapping.assert_called_once()
+        session.expire_all()
+        for ti in tis:
+            assert ti.dag_version_id == dr.created_dag_version_id
+            if with_hook:
+                assert ti.queue == "policy_queue"
+                assert ti.pool_slots == ti.map_index + 1
+                assert ti.priority_weight == 100 + ti.map_index
+                assert ti.note == f"policy-{ti.map_index}"
+                assert ti.state == (TaskInstanceState.SKIPPED if ti.map_index == 3 else state)
+            else:
+                assert ti.queue == task.queue
+                assert ti.state == state
+    finally:
+        event.remove(session, "before_flush", record_flush)
+        if with_hook:
+            manager.unregister(plugin)
+
+
+def test_create_mapped_task_instances_preserves_custom_priority_strategy(dag_maker, session, monkeypatch):
+    class IndexWeight(_AbsolutePriorityWeightStrategy):
+        def get_weight(self, ti):
+            return 10 + ti.map_index
+
+    with dag_maker(session=session, serialized=True):
+        upstream = BaseOperator(task_id="upstream")
+        MockOperator.partial(task_id="mapped").expand(arg2=upstream.output)
+    dr = dag_maker.create_dagrun()
+    task = dr.dag.get_task("mapped")
+    monkeypatch.setattr(type(task), "weight_rule", property(lambda self: IndexWeight()))
+    tis = _create_mapped_task_instances(
+        task,
+        dr,
+        range(3),
+        dag_version_id=dr.created_dag_version_id,
+        session=session,
+        batch_size=2,
+    )
+    assert [ti.priority_weight for ti in tis] == [10, 11, 12]
+
+
+@pytest.mark.parametrize("batch_size", [0, -1])
+def test_create_mapped_task_instances_rejects_invalid_batch_size(batch_size):
+    with pytest.raises(ValueError, match="batch_size must be positive"):
+        _create_mapped_task_instances(
+            mock.Mock(spec=BaseOperator),
+            mock.Mock(spec=DagRun),
+            (),
+            dag_version_id=None,
+            session=mock.Mock(spec=Session),
+            batch_size=batch_size,
         )


### PR DESCRIPTION
Large runtime maps concentrate task-instance writes in scheduler transactions while many Dags are active. The objective is to reduce database pressure and lock waits. This PR currently batches task-instance creation and limits mapped readiness, preserving custom `task_instance_mutation_hook` policies. It does not yet provide bounded expansion transactions or demonstrate reduced database contention.

For a runtime map of 10,000 instances with `[scheduler] max_tis_per_query = 16`:

| Behavior | Main | This PR |
| --- | --- | --- |
| Creation of task-instance rows | All instances are created during expansion. | All instances are still created during expansion, using batches of 1,000 in the same transaction. |
| Visibility in the UI/API | Rows become visible when the caller commits. | The same: batches are not committed separately, and row creation is not deferred to later heartbeats. |
| Mapped readiness | This stage can make all eligible mapped instances ready in one pass. | At most 16 mapped instances become ready per Dag run per pass; the rest are considered in subsequent passes. |

This readiness limit is shared by the mapped tasks within a Dag run. Ordinary tasks remain eligible in the same pass. A zero `max_tis_per_query` uses `[core] parallelism`; if both are zero, the added limit is disabled. Pools, concurrency limits, and executor capacity still determine when ready tasks actually start. Large maps may take more scheduling passes to become fully scheduled, so a small limit can increase scheduling latency or constrain mapped-task throughput. There is no fixed delay between batches of ready instances.

The creation optimization is shared by runtime expansion and map-index revision. Confirmed no-op hooks use bulk insertion and bounded retrieval, reusing a mapping template for built-in priority strategies. Custom priorities retain per-index evaluation. Real mutation hooks receive ordinary ORM instances, preserving attached-session queries, column changes, and related-object mutations. Hook detection checks registered policies as well as the no-op marker. Newly revised indexes receive normal dependency checks.

Creation still completes in the current transaction, and all created instances are retained in memory. This does not bound total expansion time, distribute creation across heartbeats, or cap dependency checks for blocked instances. Literal mapping during initial Dag-run creation is a separate path. The scheduling behavior is documented in the dynamic mapping guide and configuration reference.

A PostgreSQL 14.24 contention diagnostic claimed two running Dags using the scheduler's normal claim query, then attempted a conflicting update on one run while creating 10,000 mapped TIs for the other. The update remained in `Lock / transactionid` wait through all ten insert batches and the final flush, completing only after commit. The scheduler currently commits after processing the claimed group of Dag runs. This reproduces an existing transaction-boundary problem that this PR does not change; it is not a diagnosis of a particular production lock wait.

Meeting the database-pressure objective requires bounded expansion work per transaction with durable progress and safe scheduler ownership across commits. The budget must account for all Dag runs being processed, and subsequent passes must avoid repeatedly loading the entire map. A readiness cap alone can add scheduling passes without reducing the initial write burst. Acceptance should be based on lock-wait duration, transaction duration, peak database load, and latency for other Dags under concurrent activity, alongside throughput and correctness. Creation elapsed time is a secondary measurement.

Creation-only benchmarks for 10,000 instances without a mutation hook:

| Local backend | Main ORM loop | This PR |
| --- | ---: | ---: |
| SQLite | 1.935 s | 0.898 s |
| PostgreSQL, with SQL tracing | 2.274 s | 1.099 s |

These are medians of three runs in a local ARM Breeze environment with Python 3.10, using savepoint rollback. The PostgreSQL trace records one driver INSERT call with 10,000 parameter sets on main, versus ten INSERT calls with 1,000 sets each and ten SELECT calls here. These are DBAPI execution events, not server statement or network-round-trip counts. Median time inside those driver calls increased from 0.282 s to 0.362 s even though total creation time decreased. The result supports reduced overhead outside driver execution; it does not establish lower database load. Custom-hook timings were mixed, and these measurements do not establish end-to-end scheduler latency or production throughput.

Validation includes mapping, readiness, and mutation-hook regressions on SQLite, plus 37 selected tests each on PostgreSQL and MySQL. Fast and manual prek checks passed. Broader API (3,949), CLI (930), serialization (593), and other core (2,016) tests passed. Local validation limitations: the full Core process exceeded the 2 GB VM after the changed model tests; its unfinished portion passed in a fresh process (986 passed, 19 skipped). The Always suite had 2,082 passes and 18 failures caused by missing Apache Beam and IBM Db2 providers in the cached image.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5) and Codex (GPT-6)

Generated-by: Codex (GPT-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

Drafted-by: Codex (GPT-6) (no human review before posting)
