### PR TITLE
Add tests for Hive plugin registration

### DIFF
--- a/airflow-core/tests/unit/always/test_project_structure.py
+++ b/airflow-core/tests/unit/always/test_project_structure.py
@@ -81,7 +81,6 @@ class TestProjectStructure:
             "providers/amazon/tests/unit/amazon/aws/waiters/test_base_waiter.py",
             "providers/apache/hdfs/tests/unit/apache/hdfs/hooks/test_hdfs.py",
             "providers/apache/hdfs/tests/unit/apache/hdfs/sensors/test_hdfs.py",
-            "providers/apache/hive/tests/unit/apache/hive/plugins/test_hive.py",
             "providers/celery/tests/unit/celery/executors/test_celery_executor_utils.py",
             "providers/celery/tests/unit/celery/executors/test_default_celery.py",
             "providers/cloudant/tests/unit/cloudant/test_cloudant_fake.py",

--- a/providers/apache/hive/tests/unit/apache/hive/plugins/__init__.py
+++ b/providers/apache/hive/tests/unit/apache/hive/plugins/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/apache/hive/tests/unit/apache/hive/plugins/test_hive.py
+++ b/providers/apache/hive/tests/unit/apache/hive/plugins/test_hive.py
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from airflow.providers.apache.hive.macros.hive import closest_ds_partition, max_partition
+from airflow.providers.apache.hive.plugins.hive import HivePlugin
+
+
+def test_hive_plugin_registers_macros():
+    plugin = HivePlugin()
+
+    assert plugin.name == "hive"
+    assert plugin.macros == [max_partition, closest_ds_partition]


### PR DESCRIPTION
Add focused coverage for `HivePlugin` to verify that it keeps the expected plugin name and registers the Hive macros.

Remove the corresponding entry from `OVERLOOKED_TESTS` now that the test module exists.

related: #35442

Testing:

- `breeze run pytest providers/apache/hive/tests/unit/apache/hive/plugins/test_hive.py -xvs`
- `breeze run pytest airflow-core/tests/unit/always/test_project_structure.py::TestProjectStructure::test_providers_modules_should_have_tests -xvs`
- Airflow pre-commit and commit-message hooks

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Codex)

Generated-by: Codex following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

Drafted-by: Codex GPT-5; reviewed by @zhangxinyao88 before posting