### PR TITLE
Document that `airflow db downgrade` does not revert serialized row content

### DIFF
--- a/airflow-core/docs/installation/upgrading.rst
+++ b/airflow-core/docs/installation/upgrading.rst
@@ -67,6 +67,65 @@ In order to manually migrate the database you should run the ``airflow db migrat
 environment. It can be run either in your virtual environment or in the containers that give
 you access to Airflow ``CLI`` :doc:`/howto/usage-cli` and the database.
 
+Downgrading to an earlier version
+=================================
+
+``airflow db downgrade`` reverses **schema** migrations. It does not rewrite the contents of
+rows that a newer version of Airflow already wrote. Alembic downgrade scripts restore tables,
+columns and the ``alembic_version`` marker, but any serialized payload written while the newer
+version was running stays on disk in the newer version's format.
+
+This matters because Airflow ships forward-compatibility shims and not backward-compatibility
+ones. A newer version generally knows how to read rows an older version wrote; an older version
+has no way to know about a format that did not exist when it was released.
+
+.. warning::
+
+    Downgrading between minor versions is not a supported rollback path once the newer version
+    has run against your metadata database. Restoring a backup taken **before** the upgrade is
+    the only reliable way back.
+
+What can go wrong
+.................
+
+Airflow 3.2 moved trigger keyword arguments from the legacy ``BaseSerialization`` envelope to
+the Task SDK serializer. The two envelopes do not share a shape:
+
+.. code-block:: text
+
+    legacy (3.1.x and earlier)   {"__type": ..., "__var": ...}
+    Task SDK serde (3.2 onward)  {"__classname__": ..., "__version__": ..., "__data__": ...}
+
+Airflow 3.2 reads both: ``Trigger._decrypt_kwargs`` tries the Task SDK deserializer first and
+falls back to ``BaseSerialization`` when that raises. Airflow 3.1.x calls ``BaseSerialization``
+directly, with no fallback, so a row written by 3.2 makes it index a key that isn't there:
+
+.. code-block:: text
+
+    File ".../airflow/serialization/serialized_objects.py", line 652, in deserialize
+        var = encoded_var[Encoding.VAR]
+    KeyError: <Encoding.VAR: '__var'>
+
+The schema downgrade reports success, so the database looks healthy while the scheduler and
+triggerer crash-loop on startup as soon as they load an affected row.
+
+Rolling back safely
+...................
+
+1. Take a backup of the metadata database **before** you upgrade, not after you decide to roll
+   back. See ``Upgrade preparation - make a backup of DB`` above.
+2. If you need to roll back, stop all Airflow components, restore that backup, and redeploy the
+   older Airflow image. Any DAG runs, task instances and triggers created after the backup are
+   lost - that is the trade-off, and there is no way to keep them in a format the older version
+   can read.
+3. If you have no pre-upgrade backup, expect manual repair rather than a clean rollback. Rows
+   in the newer format have to be deleted or rewritten by hand, which loses the work they
+   represent and risks leaving the database internally inconsistent.
+
+The interactive prompt shown by ``airflow db downgrade`` says it is about to "reverse schema
+migrations for the airflow metastore". Read that literally: schema only. Passing ``--yes``
+skips the prompt entirely.
+
 Offline SQL migration scripts
 =============================
 If you want to run the upgrade script offline, you can use the ``-s`` or ``--show-sql-only`` flag


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.
-->

Related: #68317

## What this documents

`airflow db downgrade` reverses **schema** migrations. It does not rewrite the contents of rows a newer Airflow already wrote. The upgrade guide currently says nothing about downgrading at all — the word doesn't appear in `upgrading.rst` — so users reasonably read a successful downgrade as "the database is now compatible with the old version". It isn't.

This adds a `Downgrading to an earlier version` section covering what the command reverts, what it doesn't, the symptom when it bites, and the fact that restoring a pre-upgrade backup is the only reliable rollback.

## Verification

The interesting part is that Airflow's compatibility shim runs in exactly one direction, which is what turns a downgrade into a crash-loop.

**3.1.8** — `Trigger._decrypt_kwargs` calls `BaseSerialization` directly, with nothing to fall back to:

```python
from airflow.serialization.serialized_objects import BaseSerialization
...
return BaseSerialization.deserialize(decrypted_kwargs)
```

**3.2.1** — the same method reads the Task SDK format first and falls back to the legacy one:

```python
from airflow.sdk.serde import deserialize
...
try:
    result = deserialize(decrypted_kwargs)
    ...
except (ImportError, KeyError, AttributeError, TypeError):
    # Backward compatibility: fall back to BaseSerialization for old format
    from airflow.serialization.serialized_objects import BaseSerialization
    return BaseSerialization.deserialize(decrypted_kwargs)
```

So 3.2 reads 3.1's rows, and 3.1 cannot read 3.2's. The envelopes have no keys in common — `shared/serialization/src/airflow_shared/serialization/__init__.py` names them, and calls the legacy pair `OLD_`:

```python
CLASSNAME = "__classname__"
VERSION   = "__version__"
DATA      = "__data__"
...
OLD_TYPE  = "__type"
OLD_DATA  = "__var"
```

`BaseSerialization.deserialize` subscripts that key unguarded at `serialized_objects.py:652`, which produces the `KeyError: <Encoding.VAR: '__var'>` from the issue:

```python
var = encoded_var[Encoding.VAR]
```

## One correction to the issue as filed

#68317 lists `dag_run.conf` and "related serialized columns" as affected by the 3.2 serde move. I don't think that part holds. `ExtendedJSON` — the `TypeDecorator` behind `dag_run.conf`, `taskmap`, `taskinstance` and friends, and the frame that appears in the reporter's traceback — still uses `BaseSerialization` in **both** versions:

```python
# airflow-core/src/airflow/utils/sqlalchemy.py, identical in 3.1.8 and 3.2.1
def process_result_value(self, value, dialect):
    from airflow.serialization.serialized_objects import BaseSerialization
    ...
    return BaseSerialization.deserialize(value)
```

The serde change is confined to call sites that explicitly import `airflow.sdk.serde`, and `trigger.kwargs` is the one on this path. I've scoped the docs to trigger kwargs rather than repeating the broader claim. That does leave the reporter's `_schedule_all_dag_runs` frame unexplained, so if a committer knows of a second 3.2 write path into an `ExtendedJSON` column I'm happy to widen the section.

## Deliberately not changed

The `airflow db downgrade` help text and the interactive prompt both already say "schema" — accurate, but easy to skim past:

> Warning: About to reverse schema migrations for the airflow metastore.

I kept this PR to documentation. If you'd like a pointer to the new section added to `cli_config.py`'s `description`, say the word and I'll add it here.

## Newsfragment

Happy to add `{pr}.doc.rst` under `airflow-core/newsfragments` once this has a number, since the CI check validates the filename against it. Let me know if you want one for a docs-only change.

---

<!-- Please keep an empty line above the dashes. -->
^ Add meaningful description above
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines) for more information.
