### PR TITLE
Fix connection port validation

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
@@ -29,6 +29,8 @@ from airflow._shared.secrets_masker import redact, should_hide_value_for_key
 from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel, make_partial_model
 from airflow.configuration import conf
 
+PortNumber = Annotated[int, Field(ge=0, le=65535)]
+
 
 # Response Models
 class ConnectionResponse(BaseModel):
@@ -191,7 +193,7 @@ class ConnectionBody(StrictBaseModel):
     host: str | None = Field(default=None)
     login: str | None = Field(default=None)
     schema_: str | None = Field(None, alias="schema")
-    port: int | None = Field(default=None)
+    port: PortNumber | None = Field(default=None)
     password: str | None = Field(default=None)
     extra: str | None = Field(default=None)
     team_name: str | None = Field(max_length=50, default=None)

--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -28,7 +28,7 @@ from typing import Any
 from urllib.parse import parse_qsl, quote, unquote, urlencode, urlsplit
 
 from sqlalchemy import ForeignKey, Integer, String, Text, select
-from sqlalchemy.orm import Mapped, mapped_column, reconstructor
+from sqlalchemy.orm import Mapped, mapped_column, reconstructor, validates
 
 from airflow._shared.module_loading import import_string
 from airflow._shared.secrets_backend.base import call_secrets_backend_method
@@ -60,6 +60,8 @@ log = logging.getLogger(__name__)
 #
 # You can try the regex here: https://regex101.com/r/69033B/1
 RE_SANITIZE_CONN_ID = re.compile(r"^[\w#!()\-.:/\\]{1,}$")
+PORT_MIN = 0
+PORT_MAX = 65535
 # the conn ID max len should be 250
 CONN_ID_MAX_LEN: int = 250
 
@@ -219,6 +221,33 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
             raise ValueError(f"Encountered non-JSON in `extra` field for connection {conn_id!r}.")
         return None
 
+    @staticmethod
+    def _validate_port(port: int | None) -> int | None:
+        if port is None:
+            return None
+        if type(port) is not int:
+            raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.")
+        if not PORT_MIN <= port <= PORT_MAX:
+            raise ValueError(
+                f"Expected value for `port` in the range {PORT_MIN}-{PORT_MAX}, but got {port!r} instead."
+            )
+        return port
+
+    @classmethod
+    def _coerce_port(cls, port) -> int | None:
+        if port is None or port == "":
+            return None
+        if isinstance(port, str):
+            try:
+                port = int(port)
+            except ValueError:
+                raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.") from None
+        return cls._validate_port(port)
+
+    @validates("port")
+    def _validate_port_assignment(self, _, port: int | None) -> int | None:
+        return self._validate_port(port)
+
     @reconstructor
     def on_db_load(self):
         if self.password:
@@ -335,7 +364,7 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
         if host_to_use:
             host_block += quote(host_to_use, safe="")
 
-        if self.port:
+        if self.port is not None:
             if host_block == "" and authority_block == "":
                 host_block += f"@:{self.port}"
             else:
@@ -586,11 +615,8 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
         if conn_type:
             kwargs["conn_type"] = cls._normalize_conn_type(conn_type)
         port = kwargs.pop("port", None)
-        if port:
-            try:
-                kwargs["port"] = int(port)
-            except ValueError:
-                raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.")
+        if port is not None:
+            kwargs["port"] = cls._coerce_port(port)
         return Connection(conn_id=conn_id, **kwargs)
 
     def as_json(self) -> str:

--- a/airflow-core/tests/unit/always/test_connection.py
+++ b/airflow-core/tests/unit/always/test_connection.py
@@ -620,14 +620,22 @@ class TestConnection:
     @pytest.mark.parametrize(
         ("val", "expected"),
         [
+            ('{"port": 0}', 0),
             ('{"port": 1}', 1),
             ('{"port": "1"}', 1),
+            ('{"port": "0"}', 0),
+            ('{"port": ""}', None),
             ('{"port": null}', None),
         ],
     )
     def test_from_json_port(self, val, expected):
         """Two conn_type normalizations are applied: replace - with _ and postgresql with postgres"""
         assert Connection.from_json(val).port == expected
+
+    @pytest.mark.parametrize("val", ['{"port": -1}', '{"port": 65536}', '{"port": 1.5}', '{"port": "1.5"}'])
+    def test_from_json_rejects_invalid_port(self, val):
+        with pytest.raises(ValueError, match="port"):
+            Connection.from_json(val)
 
     @pytest.mark.parametrize(
         ("val", "expected"),

--- a/airflow-core/tests/unit/api_fastapi/core_api/datamodels/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/datamodels/test_connections.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from airflow.api_fastapi.core_api.datamodels.connections import ConnectionResponse
+from airflow.api_fastapi.core_api.datamodels.connections import ConnectionBody, ConnectionResponse
 
 
 def _payload(**overrides):
@@ -56,3 +56,15 @@ def test_redact_extra_rejects_non_json(extra):
     """
     with pytest.raises(ValidationError):
         ConnectionResponse.model_validate(_payload(extra=extra))
+
+
+@pytest.mark.parametrize("port", [0, 65535, None])
+def test_connection_body_allows_valid_port_boundaries(port):
+    body = ConnectionBody(connection_id="test_conn", conn_type="http", port=port)
+    assert body.port == port
+
+
+@pytest.mark.parametrize("port", [-1, 65536])
+def test_connection_body_rejects_invalid_port_boundaries(port):
+    with pytest.raises(ValidationError):
+        ConnectionBody(connection_id="test_conn", conn_type="http", port=port)

--- a/airflow-core/tests/unit/models/test_connection.py
+++ b/airflow-core/tests/unit/models/test_connection.py
@@ -320,6 +320,16 @@ class TestConnection:
                 f"RFC3986 warning not expected for connection '{connection.conn_id}'."
             )
 
+    @pytest.mark.parametrize("port", [0, 65535, None])
+    def test_allows_valid_port_boundaries(self, port):
+        conn = Connection(conn_id="test-port", conn_type="http", port=port)
+        assert conn.port == port
+
+    @pytest.mark.parametrize("port", [-1, 65536, "123", 1.5, ""])
+    def test_rejects_invalid_direct_port_values(self, port):
+        with pytest.raises(ValueError, match="port"):
+            Connection(conn_id="test-port", conn_type="http", port=port)
+
     @pytest.mark.parametrize(
         ("connection", "expected_conn_id"),
         [

--- a/task-sdk/src/airflow/sdk/definitions/connection.py
+++ b/task-sdk/src/airflow/sdk/definitions/connection.py
@@ -29,6 +29,19 @@ from airflow.sdk.exceptions import AirflowException, AirflowNotFoundException, A
 from airflow.sdk.providers_manager_runtime import ProvidersManagerTaskRuntime
 
 log = logging.getLogger(__name__)
+PORT_MIN = 0
+PORT_MAX = 65535
+
+
+def _validate_port(_, __, value: int | None) -> None:
+    if value is None:
+        return
+    if type(value) is not int:
+        raise ValueError(f"Expected integer value for `port`, but got {value!r} instead.")
+    if not PORT_MIN <= value <= PORT_MAX:
+        raise ValueError(
+            f"Expected value for `port` in the range {PORT_MIN}-{PORT_MAX}, but got {value!r} instead."
+        )
 
 
 def _parse_netloc_to_hostname(uri_parts):
@@ -118,7 +131,7 @@ class Connection:
     schema: str | None = None
     login: str | None = None
     password: str | None = None
-    port: int | None = None
+    port: int | None = attrs.field(default=None, validator=attrs.validators.optional(_validate_port))
     extra: str | None = None
 
     EXTRA_KEY = "__extra__"
@@ -152,6 +165,18 @@ class Connection:
             self.__attrs_init__(conn_id=conn_id, **kwargs)  # type: ignore[attr-defined]
         else:
             self.__dict__.update(attrs.asdict(self.from_uri(uri, conn_id=conn_id), recurse=False))
+
+    @classmethod
+    def _coerce_port(cls, port) -> int | None:
+        if port is None or port == "":
+            return None
+        if isinstance(port, str):
+            try:
+                port = int(port)
+            except ValueError:
+                raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.") from None
+        _validate_port(None, None, port)
+        return port
 
     def get_uri(self) -> str:
         """Generate and return connection in URI format."""
@@ -191,7 +216,7 @@ class Connection:
         host_block = ""
         if host_to_use:
             host_block += quote(host_to_use, safe="")
-        if self.port:
+        if self.port is not None:
             if host_block == "" and authority_block == "":
                 host_block += f"@:{self.port}"
             else:
@@ -355,11 +380,8 @@ class Connection:
         if conn_type:
             kwargs["conn_type"] = cls._normalize_conn_type(conn_type)
         port = kwargs.pop("port", None)
-        if port:
-            try:
-                kwargs["port"] = int(port)
-            except ValueError:
-                raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.")
+        if port is not None:
+            kwargs["port"] = cls._coerce_port(port)
         return cls(conn_id=conn_id, **kwargs)
 
     def as_json(self) -> str:

--- a/task-sdk/tests/task_sdk/definitions/test_connection.py
+++ b/task-sdk/tests/task_sdk/definitions/test_connection.py
@@ -198,6 +198,34 @@ class TestConnections:
         assert connection.host == "localhost"
         assert connection.port == 5432
 
+    @pytest.mark.parametrize(
+        ("payload", "expected_port"),
+        [
+            ({"port": 0}, 0),
+            ({"port": "0"}, 0),
+            ({"port": 65535}, 65535),
+            ({"port": ""}, None),
+        ],
+    )
+    def test_from_json_port_boundaries(self, payload, expected_port):
+        connection = Connection.from_json(json.dumps(payload), conn_id="test_conn")
+        assert connection.port == expected_port
+
+    @pytest.mark.parametrize("payload", [{"port": -1}, {"port": 65536}, {"port": 1.5}, {"port": "1.5"}])
+    def test_from_json_rejects_invalid_port(self, payload):
+        with pytest.raises(ValueError, match="port"):
+            Connection.from_json(json.dumps(payload), conn_id="test_conn")
+
+    @pytest.mark.parametrize("port", [0, 65535, None])
+    def test_direct_constructor_allows_valid_port_boundaries(self, port):
+        connection = Connection(conn_id="test_conn", conn_type="http", port=port)
+        assert connection.port == port
+
+    @pytest.mark.parametrize("port", [-1, 65536, "123", 1.5, ""])
+    def test_direct_constructor_rejects_invalid_port_values(self, port):
+        with pytest.raises(ValueError, match="port"):
+            Connection(conn_id="test_conn", conn_type="http", port=port)
+
     def test_from_json_without_conn_type(self):
         """Test that from_json works without conn_type (backward compatibility with AF 2)."""
         json_data = {


### PR DESCRIPTION
Closes #68382

Connection port validation was inconsistent across model construction, JSON deserialization, the Task SDK, and the public API schema.

This change validates ports as integers in the inclusive `0..65535` range, preserves numeric JSON strings and empty ports, serializes port `0`, and adds focused boundary coverage.

Tests:
- `python -m py_compile` on changed source and test files
- `git diff --check`
