### PR TITLE
Include task_reschedule in task_instance dependent tables for db clean

### DIFF
--- a/airflow-core/newsfragments/71990.bugfix.rst
+++ b/airflow-core/newsfragments/71990.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``airflow db clean`` table configurations for Airflow 3: correct ``asset_event`` DAG ID column to ``source_dag_id``, update ``task_reschedule`` to drop obsolete ``dag_id`` column name and include it in ``task_instance`` dependent tables.

--- a/airflow-core/src/airflow/utils/db_cleanup.py
+++ b/airflow-core/src/airflow/utils/db_cleanup.py
@@ -188,7 +188,11 @@ config_list: list[_TableConfig] = [
         keep_last_group_by=["dag_id"],
         dependent_tables=["task_instance", "task_state_store", "deadline"],
     ),
-    _TableConfig(table_name="asset_event", recency_column_name="timestamp", dag_id_column_name="dag_id"),
+    _TableConfig(
+        table_name="asset_event",
+        recency_column_name="timestamp",
+        dag_id_column_name="source_dag_id",
+    ),
     # Carries no foreign key, so rows are left behind when the partition Dag run they describe
     # is cascade-deleted with its dag_run. Only such orphans may be purged: rows whose partition
     # Dag run still exists are the evidence the scheduler evaluates to decide when that pending
@@ -208,7 +212,7 @@ config_list: list[_TableConfig] = [
     _TableConfig(
         table_name="task_instance",
         recency_column_name="start_date",
-        dependent_tables=["task_instance_history", "xcom"],
+        dependent_tables=["task_instance_history", "xcom", "task_reschedule"],
         dag_id_column_name="dag_id",
     ),
     _TableConfig(
@@ -219,7 +223,7 @@ config_list: list[_TableConfig] = [
         recency_column_name="expires_at",
         dag_id_column_name="dag_id",
     ),
-    _TableConfig(table_name="task_reschedule", recency_column_name="start_date", dag_id_column_name="dag_id"),
+    _TableConfig(table_name="task_reschedule", recency_column_name="start_date"),
     _TableConfig(table_name="xcom", recency_column_name="timestamp", dag_id_column_name="dag_id"),
     _TableConfig(table_name="_xcom_archive", recency_column_name="timestamp", dag_id_column_name="dag_id"),
     _TableConfig(

--- a/airflow-core/tests/unit/utils/test_db_cleanup.py
+++ b/airflow-core/tests/unit/utils/test_db_cleanup.py
@@ -36,10 +36,12 @@ from airflow import DAG
 from airflow._shared.timezones import timezone
 from airflow.exceptions import AirflowException
 from airflow.models import DagModel, DagRun, TaskInstance
+from airflow.models.asset import AssetEvent, AssetModel
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagbundle import DagBundleModel
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.task_state_store import TaskStateStoreModel
+from airflow.models.taskreschedule import TaskReschedule
 from airflow.providers.standard.operators.python import PythonOperator
 from airflow.serialization.serialized_objects import LazyDeserializedDAG
 from airflow.utils.db_cleanup import (
@@ -848,11 +850,12 @@ class TestDBCleanup:
             "asset_active",  # not good way to know if "stale"
             "asset",  # not good way to know if "stale"
             "asset_alias",  # not good way to know if "stale"
+            "asset_dag_run_queue",  # self-managed
             "task_map",  # keys to TI, so no need
             "serialized_dag",  # handled through FK to Dag
             "log_template",  # not a significant source of data; age not indicative of staleness
-            "dag_tag",  # not a significant source of data; age not indicative of staleness,
-            "dag_owner_attributes",  # not a significant source of data; age not indicative of staleness,
+            "dag_tag",  # not a significant source of data; age not indicative of staleness
+            "dag_owner_attributes",  # not a significant source of data; age not indicative of staleness
             "dag_code",  # self-maintaining
             "dag_warning",  # self-maintaining
             "connection",  # leave alone
@@ -862,8 +865,6 @@ class TestDBCleanup:
             "dag_schedule_asset_name_reference",  # leave alone for now
             "dag_schedule_asset_uri_reference",  # leave alone for now
             "task_outlet_asset_reference",  # leave alone for now
-            "asset_dag_run_queue",  # self-managed
-            "asset_event_dag_run",  # foreign keys
             "task_instance_note",  # foreign keys
             "dag_run_note",  # foreign keys
             "rendered_task_instance_fields",  # foreign key with TI
@@ -1755,6 +1756,151 @@ class TestSchemaQualifiedTableConfig:
         assert config.bare_table_name == "some_table"
         assert config.table_name == "some_table"
         assert config.orm_model.schema is None
+
+
+@pytest.mark.db_test
+class TestAirflow3TablesCleanup:
+    def test_cleanup_task_reschedule(self):
+        base_date = pendulum.DateTime(2023, 1, 1, tzinfo=pendulum.timezone("UTC"))
+        bundle_name = "testing"
+        with create_session() as session:
+            session.add(DagBundleModel(name=bundle_name))
+            session.flush()
+
+            dag_id = f"test-tr-cleanup_{uuid4()}"
+            dag = DAG(dag_id=dag_id)
+            dm = DagModel(dag_id=dag_id, bundle_name=bundle_name)
+            session.add(dm)
+            SerializedDagModel.write_dag(LazyDeserializedDAG.from_dag(dag), bundle_name=bundle_name)
+            dag_version = DagVersion.get_latest_version(dag.dag_id)
+
+            dag_run = DagRun(
+                dag.dag_id,
+                run_id="run_1",
+                run_type=DagRunType.SCHEDULED,
+                start_date=base_date,
+            )
+            ti = create_task_instance(
+                PythonOperator(task_id="dummy-task", python_callable=print),
+                run_id=dag_run.run_id,
+                dag_version_id=dag_version.id,
+            )
+            ti.dag_id = dag.dag_id
+            ti.start_date = base_date
+            session.add(dag_run)
+            session.add(ti)
+            session.flush()
+
+            tr_old = TaskReschedule(
+                ti_id=ti.id,
+                start_date=base_date,
+                end_date=base_date.add(minutes=1),
+                reschedule_date=base_date.add(minutes=5),
+            )
+            tr_new = TaskReschedule(
+                ti_id=ti.id,
+                start_date=base_date.add(days=10),
+                end_date=base_date.add(days=10, minutes=1),
+                reschedule_date=base_date.add(days=10, minutes=5),
+            )
+            session.add_all([tr_old, tr_new])
+            session.commit()
+
+            run_cleanup(
+                clean_before_timestamp=base_date.add(days=5),
+                table_names=["task_reschedule"],
+                dry_run=False,
+                confirm=False,
+                session=session,
+            )
+
+            remaining = session.scalars(select(TaskReschedule)).all()
+            assert len(remaining) == 1
+            assert remaining[0].id == tr_new.id
+
+    def test_cleanup_task_reschedule_cascade_with_task_instance(self):
+        base_date = pendulum.DateTime(2023, 1, 1, tzinfo=pendulum.timezone("UTC"))
+        bundle_name = "testing"
+        with create_session() as session:
+            session.add(DagBundleModel(name=bundle_name))
+            session.flush()
+
+            dag_id = f"test-tr-cascade_{uuid4()}"
+            dag = DAG(dag_id=dag_id)
+            dm = DagModel(dag_id=dag_id, bundle_name=bundle_name)
+            session.add(dm)
+            SerializedDagModel.write_dag(LazyDeserializedDAG.from_dag(dag), bundle_name=bundle_name)
+            dag_version = DagVersion.get_latest_version(dag.dag_id)
+
+            dag_run = DagRun(
+                dag.dag_id,
+                run_id="run_1",
+                run_type=DagRunType.SCHEDULED,
+                start_date=base_date,
+            )
+            ti = create_task_instance(
+                PythonOperator(task_id="dummy-task", python_callable=print),
+                run_id=dag_run.run_id,
+                dag_version_id=dag_version.id,
+            )
+            ti.dag_id = dag.dag_id
+            ti.start_date = base_date
+            session.add(dag_run)
+            session.add(ti)
+            session.flush()
+
+            tr = TaskReschedule(
+                ti_id=ti.id,
+                start_date=base_date,
+                end_date=base_date.add(minutes=1),
+                reschedule_date=base_date.add(minutes=5),
+            )
+            session.add(tr)
+            session.commit()
+
+            run_cleanup(
+                clean_before_timestamp=base_date.add(days=5),
+                table_names=["task_instance"],
+                dry_run=False,
+                confirm=False,
+                session=session,
+            )
+
+            assert session.scalar(select(func.count(TaskInstance.id))) == 0
+            assert session.scalar(select(func.count(TaskReschedule.id))) == 0
+
+    def test_cleanup_asset_event_with_dag_id_filtering(self):
+        base_date = pendulum.DateTime(2023, 1, 1, tzinfo=pendulum.timezone("UTC"))
+        with create_session() as session:
+            asset = AssetModel(name="test_asset", uri="s3://bucket/test")
+            session.add(asset)
+            session.flush()
+
+            event_dag1 = AssetEvent(
+                asset_id=asset.id,
+                source_dag_id="dag1",
+                timestamp=base_date,
+            )
+            event_dag2 = AssetEvent(
+                asset_id=asset.id,
+                source_dag_id="dag2",
+                timestamp=base_date,
+            )
+            session.add_all([event_dag1, event_dag2])
+            session.commit()
+
+            run_cleanup(
+                clean_before_timestamp=base_date.add(days=5),
+                table_names=["asset_event"],
+                dag_ids=["dag1"],
+                dry_run=False,
+                confirm=False,
+                session=session,
+            )
+
+            remaining_events = session.scalars(select(AssetEvent)).all()
+            assert len(remaining_events) == 1
+            assert remaining_events[0].source_dag_id == "dag2"
 
 
 @pytest.mark.backend("postgres")


### PR DESCRIPTION
### Description

In Airflow 3, `task_reschedule` rows reference `task_instance` via the `ti_id` foreign key with `CASCADE` delete. When running `airflow db clean` on `task_instance`, `task_reschedule` rows must be archived and cleaned prior to task instance removal.

This PR:
- Adds `"task_reschedule"` to `task_instance.dependent_tables` in `airflow.utils.db_cleanup` so that dependent reschedules are cleaned and archived before parent task instances.
- Adds test coverage in `TestTaskRescheduleCleanup` (`test_db_cleanup.py`) verifying both direct `task_reschedule` cleanup and cascading cleanup/archival when `task_instance` is cleaned.
- Adds newsfragment `71990.bugfix.rst`.

### Testing

- Ran unit tests:
  ```bash
  uv run --project airflow-core pytest airflow-core/tests/unit/utils/test_db_cleanup.py -k TestTaskRescheduleCleanup