### PR TITLE
Honor execute_tasks_new_python_interpreter when the task supervisor forks the task runner

### DIFF
--- a/airflow-core/newsfragments/71995.bugfix.rst
+++ b/airflow-core/newsfragments/71995.bugfix.rst
@@ -1,0 +1,1 @@
+Honor ``[core] execute_tasks_new_python_interpreter`` when the task supervisor forks the task runner, so Linux deployments can opt into fork+exec for tasks and avoid inheriting held C-library locks (e.g. OpenSSL's) from supervisor threads.

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -223,6 +223,11 @@ core:
         * ``False``: Execute via forking of the parent process
         * ``True``: Spawning a new python process, slower than fork, but means plugin changes picked
           up by tasks straight away
+
+        A fresh interpreter also avoids fork-safety hazards of a long-running,
+        multithreaded supervisor: a bare ``fork()`` can inherit C-library locks held
+        by a sibling thread at fork time (e.g. OpenSSL's, taken while building an
+        ``SSLContext``), which deadlocks later TLS setup in the task process.
       default: "False"
       example: ~
       version_added: 2.0.0

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1112,6 +1112,7 @@ mTLS
 multi-cloud
 multimodal
 multiprocess
+multithreaded
 mutex
 mv
 mwaa

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -517,6 +517,18 @@ def _should_use_exec() -> bool:
     return sys.platform in _FORK_EXEC_PLATFORMS
 
 
+def _task_exec_configured() -> bool:
+    """
+    Whether ``[core] execute_tasks_new_python_interpreter`` asks for a fresh interpreter per task.
+
+    Opt-in fork-safety escape hatch: a bare ``os.fork()`` of a multithreaded
+    supervisor can inherit a C-library lock mid-held by a sibling thread
+    (OpenSSL's global lock, taken inside ``SSL_CTX_new``), which then blocks
+    every ``SSLContext`` construction in the child forever.
+    """
+    return conf.getboolean("core", "execute_tasks_new_python_interpreter", fallback=False)
+
+
 def _resolve_child_target(dotted: str) -> Callable[[], None]:
     """
     Resolve a ``module:qualname`` string to the callable the exec'd child runs.
@@ -1412,10 +1424,13 @@ class ActivitySubprocess(WatchedSubprocess):
         **kwargs,
     ) -> Self:
         """Fork and start a new subprocess to execute the given task."""
-        # Opt in to fork+exec on platforms that need it (currently macOS).
+        # Opt in to fork+exec on platforms that need it (currently macOS), or
+        # when a fresh interpreter per task is configured (fork of a
+        # multithreaded supervisor can inherit held C-library locks, e.g.
+        # OpenSSL's, and deadlock the child; see #71707).
         # Tests override `target` with a local stub to exercise the base
         # infrastructure; keep bare fork for those.
-        use_exec = target is _subprocess_main and _should_use_exec()
+        use_exec = target is _subprocess_main and (_should_use_exec() or _task_exec_configured())
         proc: Self = super().start(
             id=what.id,
             client=client,

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -4479,6 +4479,66 @@ def test_api_client_clears_dag_bag_override_when_dag_is_none():
         in_process_api_server.cache_clear()
 
 
+class TestActivitySubprocessExecSelection:
+    """Which launch mode ``ActivitySubprocess.start()`` picks for the task runner."""
+
+    @pytest.fixture
+    def captured_kwargs(self, monkeypatch):
+        captured = {}
+
+        @classmethod
+        def fake_start(cls, **kwargs):
+            captured.update(kwargs)
+            return MagicMock(spec=supervisor.ActivitySubprocess)
+
+        monkeypatch.setattr(supervisor.WatchedSubprocess, "start", fake_start)
+        return captured
+
+    def _start(self, **kwargs):
+        args = {
+            "what": TaskInstance(
+                id="4d828a62-a417-4936-a7a6-2b3fabacecab",
+                task_id="b",
+                dag_id="c",
+                run_id="d",
+                try_number=1,
+                dag_version_id=uuid7(),
+                queue="default",
+            ),
+            "dag_rel_path": os.devnull,
+            "bundle_info": FAKE_BUNDLE,
+            "client": MagicMock(spec=sdk_client.Client),
+        }
+        args.update(kwargs)
+        return ActivitySubprocess.start(**args)
+
+    def test_bare_fork_by_default(self, monkeypatch, captured_kwargs):
+        monkeypatch.setattr(supervisor, "_should_use_exec", lambda: False)
+        with conf_vars({("core", "execute_tasks_new_python_interpreter"): "false"}):
+            self._start()
+        assert captured_kwargs["use_exec"] is False
+
+    def test_exec_when_config_requests_fresh_interpreter(self, monkeypatch, captured_kwargs):
+        """Linux + execute_tasks_new_python_interpreter=True still execs (issue #71707)."""
+        monkeypatch.setattr(supervisor, "_should_use_exec", lambda: False)
+        with conf_vars({("core", "execute_tasks_new_python_interpreter"): "true"}):
+            self._start()
+        assert captured_kwargs["use_exec"] is True
+
+    def test_exec_on_fork_unsafe_platform_regardless_of_config(self, monkeypatch, captured_kwargs):
+        monkeypatch.setattr(supervisor, "_should_use_exec", lambda: True)
+        with conf_vars({("core", "execute_tasks_new_python_interpreter"): "false"}):
+            self._start()
+        assert captured_kwargs["use_exec"] is True
+
+    def test_stub_target_keeps_bare_fork_even_when_config_set(self, monkeypatch, captured_kwargs):
+        """Tests override `target` with local stubs; those can't be rehydrated across exec."""
+        monkeypatch.setattr(supervisor, "_should_use_exec", lambda: False)
+        with conf_vars({("core", "execute_tasks_new_python_interpreter"): "true"}):
+            self._start(target=lambda: None)
+        assert captured_kwargs["use_exec"] is False
+
+
 class TestResolveChildTarget:
     """Test rehydrating the exec'd child's entry point from _AIRFLOW_CHILD_TARGET."""
 


### PR DESCRIPTION
Been digging into #71707 — the case where a task subprocess hangs forever with every thread stuck at `ssl.py:440` building fresh `SSLContext`s. The mechanism there is that `ActivitySubprocess.start()` does a bare `os.fork()` on Linux, and if a sibling thread in the supervisor (OTel exporter, google-auth refresh threads, an OpenLineage listener...) happens to be inside OpenSSL's global lock at that exact moment, the child inherits the held lock with no owner left to release it. Every later `SSLContext` construction in that child then blocks forever.

What surprised me is that `[core] execute_tasks_new_python_interpreter=True` doesn't actually protect you from this. The executor honors the knob when launching the *supervisor* (e.g. celery's `_execute_in_subprocess`), but the supervisor then bare-forks the task runner regardless — the config stops one fork short of the process that actually runs user code. The Edge worker hit the same class of problem and got the config honored for its launch path in #65943; this does the equivalent for the Task SDK's own fork.

The fork+exec machinery itself already exists and isn't macOS-specific (it's what `_should_use_exec()` gates), so the change is small: when the config is set and we're launching the real task entry point, take the exec path too. Test stub targets keep bare fork as before, and the DAG processor / triggerer paths are untouched since the option is task-scoped.

Verified on Linux: with the config set the task child comes up as a fresh interpreter (`_child_exec_main` rehydrating over the dup2'd FDs, supervisor comms working end to end), `ruff`/`mypy` are clean, and the existing supervisor test suite passes (the handful of `test_exit_by_signal`/remote-logging errors fail identically on a clean checkout — missing optional deps locally, unrelated). Added selection tests for default / config-set / fork-unsafe-platform / stub-target combinations.

closes: #71707

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.