### PR TITLE
Consume all mapped asset events on the next triggered run

### DIFF
--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -6461,6 +6461,7 @@ class TestSchedulerJob:
             select(AssetDagRunQueue).where(AssetDagRunQueue.target_dag_id == consumer_dag_id)
         ).all()
         assert created_run.state == State.QUEUED
+        assert len(created_run.consumed_asset_events) == len(items)
         assert {e.source_map_index for e in created_run.consumed_asset_events} == set(extras)
         assert {e.source_map_index: e.extra for e in created_run.consumed_asset_events} == extras
         assert leftover_adrq == []
@@ -6488,6 +6489,12 @@ class TestSchedulerJob:
         assert len(first_runs) == 1
         assert {e.source_map_index for e in first_runs[0].consumed_asset_events} == {0}
         assert {e.extra["item"] for e in first_runs[0].consumed_asset_events} == {1}
+        assert (
+            session.scalars(
+                select(AssetDagRunQueue).where(AssetDagRunQueue.target_dag_id == consumer_dag_id)
+            ).all()
+            == []
+        )
 
         mapped_tis = session.scalars(
             select(TaskInstance)
@@ -6502,6 +6509,18 @@ class TestSchedulerJob:
         self._register_mapped_outlet(mapped_tis[2], asset, {"item": 3}, session)
         session.flush()
 
+        queued_events = session.scalars(
+            select(AssetEvent).where(AssetEvent.source_dag_id == "mapped-asset-leftover-producer")
+        ).all()
+        leftover_adrq = session.scalars(
+            select(AssetDagRunQueue).where(AssetDagRunQueue.target_dag_id == consumer_dag_id)
+        ).all()
+        assert {e.source_map_index for e in queued_events} == {0, 1, 2}
+        assert {row.asset_event_id for row in leftover_adrq} == {
+            e.id for e in queued_events if e.source_map_index in {1, 2}
+        }
+        assert len(session.scalars(select(DagRun).where(DagRun.dag_id == consumer_dag_id)).all()) == 1
+
         self._tick_asset_runs(session)
         session.expire_all()
 
@@ -6511,6 +6530,12 @@ class TestSchedulerJob:
         assert len(runs) == 2
         assert {e.source_map_index for e in runs[1].consumed_asset_events} == {1, 2}
         assert {e.extra["item"] for e in runs[1].consumed_asset_events} == {2, 3}
+        assert {
+            e.source_map_index
+            for e in session.scalars(
+                select(AssetEvent).where(AssetEvent.source_dag_id == "mapped-asset-leftover-producer")
+            )
+        } == {0, 1, 2}
         assert (
             session.scalars(
                 select(AssetDagRunQueue).where(AssetDagRunQueue.target_dag_id == consumer_dag_id)
@@ -6529,6 +6554,13 @@ class TestSchedulerJob:
             consumer_dag_id=consumer_dag_id,
             producer_dag_id="mapped-asset-failed-producer",
         )
+        mapped_tis[1].state = TaskInstanceState.FAILED
+        TaskInstance.register_asset_changes_in_db(
+            ti=mapped_tis[1],
+            task_outlets=[],
+            outlet_events=[],
+            session=session,
+        )
         self._register_mapped_outlet(mapped_tis[0], asset, {"item": 1}, session)
         self._register_mapped_outlet(mapped_tis[2], asset, {"item": 3}, session)
         session.flush()
@@ -6537,6 +6569,10 @@ class TestSchedulerJob:
         session.expire_all()
 
         created_run = session.scalars(select(DagRun).where(DagRun.dag_id == consumer_dag_id)).one()
+        events = session.scalars(
+            select(AssetEvent).where(AssetEvent.source_dag_id == "mapped-asset-failed-producer")
+        ).all()
+        assert {e.source_map_index for e in events} == {0, 2}
         assert {e.source_map_index for e in created_run.consumed_asset_events} == {0, 2}
         assert {e.extra["item"] for e in created_run.consumed_asset_events} == {1, 3}
         assert (
@@ -6570,6 +6606,7 @@ class TestSchedulerJob:
 
         created_run = session.scalars(select(DagRun).where(DagRun.dag_id == consumer_dag_id)).one()
         extras = {e.extra["from"] for e in created_run.consumed_asset_events}
+        assert len(created_run.consumed_asset_events) == 2
         assert extras == {"a", "b"}
         assert {e.source_dag_id for e in created_run.consumed_asset_events} == {
             "same-second-prod-a",
@@ -6617,12 +6654,15 @@ class TestSchedulerJob:
         session.expire_all()
 
         created_run = session.scalars(select(DagRun).where(DagRun.dag_id == consumer_dag_id)).one()
-        assert {e.extra["item"] for e in created_run.consumed_asset_events} == {1, 2, 3}
-        assert {e.asset.uri for e in created_run.consumed_asset_events} == {
+        events = created_run.consumed_asset_events
+        assert len(events) == 3
+        assert {e.extra["item"] for e in events} == {1, 2, 3}
+        assert {e.asset.uri for e in events} == {
             "test://dyn-1",
             "test://dyn-2",
             "test://dyn-3",
         }
+        assert {source_alias.name for e in events for source_alias in e.source_aliases} == {alias.name}
         assert (
             session.scalars(
                 select(AssetDagRunQueue).where(AssetDagRunQueue.target_dag_id == consumer_dag_id)
@@ -6658,7 +6698,8 @@ class TestSchedulerJob:
         assert len(adrqs) == 3
         assert {row.asset_id for row in adrqs} == {asset1_id}
 
-    def test_mapped_asset_or_condition_consumes_fan_out(self, session, dag_maker):
+    @mock.patch("airflow.jobs.scheduler_job_runner.with_row_locks", autospec=True)
+    def test_mapped_asset_or_condition_consumes_fan_out(self, mock_with_row_locks, session, dag_maker):
         asset1 = Asset(name="or-asset-1", uri="test://or-asset-1")
         asset2 = Asset(name="or-asset-2", uri="test://or-asset-2")
         consumer_dag_id = "or-consumer"
@@ -6671,22 +6712,37 @@ class TestSchedulerJob:
             consumer_dag_id=consumer_dag_id,
             producer_dag_id="or-producer",
         )
+        with dag_maker(dag_id="or-producer-2", schedule=None, serialized=True, session=session):
+            EmptyOperator(task_id="pub", outlets=[asset2])
+        ti_asset2 = dag_maker.create_dagrun(session=session).get_task_instance("pub", session=session)
         for ti in mapped_tis:
             self._register_mapped_outlet(ti, asset1, {"item": ti.map_index + 1}, session)
+        self._register_mapped_outlet(ti_asset2, asset2, {"from": "asset2"}, session)
         session.flush()
 
+        asset1_id = session.scalar(select(AssetModel.id).where(AssetModel.uri == asset1.uri))
+        asset2_id = session.scalar(select(AssetModel.id).where(AssetModel.uri == asset2.uri))
+
+        def _lock_only_asset1(query, session, **kwargs):
+            locked = with_row_locks(query, session, **kwargs)
+            entity = query.column_descriptions[0]["entity"]
+            if entity is AssetDagRunQueue:
+                return locked.where(AssetDagRunQueue.asset_id == asset1_id)
+            return locked
+
+        mock_with_row_locks.side_effect = _lock_only_asset1
         self._tick_asset_runs(session)
         session.expire_all()
 
         created_run = session.scalars(select(DagRun).where(DagRun.dag_id == consumer_dag_id)).one()
+        leftover_adrq = session.scalars(
+            select(AssetDagRunQueue).where(AssetDagRunQueue.target_dag_id == consumer_dag_id)
+        ).all()
         assert {e.source_map_index for e in created_run.consumed_asset_events} == {0, 1, 2}
         assert {e.extra["item"] for e in created_run.consumed_asset_events} == {1, 2, 3}
-        assert (
-            session.scalars(
-                select(AssetDagRunQueue).where(AssetDagRunQueue.target_dag_id == consumer_dag_id)
-            ).all()
-            == []
-        )
+        assert {e.asset.uri for e in created_run.consumed_asset_events} == {asset1.uri}
+        assert len(leftover_adrq) == 1
+        assert leftover_adrq[0].asset_id == asset2_id
 
     @pytest.mark.parametrize("catchup", [False, True])
     def test_mapped_asset_catchup_keeps_queued_events(self, catchup, session, dag_maker):
@@ -6710,6 +6766,7 @@ class TestSchedulerJob:
 
         created_run = session.scalars(select(DagRun).where(DagRun.dag_id == consumer_dag_id)).one()
         assert {e.source_map_index for e in created_run.consumed_asset_events} == {0, 1, 2}
+        assert {e.extra["item"] for e in created_run.consumed_asset_events} == {1, 2, 3}
         assert (
             session.scalars(
                 select(AssetDagRunQueue).where(AssetDagRunQueue.target_dag_id == consumer_dag_id)

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -47,6 +47,7 @@ from airflow._shared.module_loading import qualname
 from airflow._shared.observability.metrics.base_stats_logger import StatsLogger
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.auth.tokens import JWTGenerator
+from airflow.api_fastapi.execution_api.datamodels.asset import AssetProfile
 from airflow.assets.manager import AssetManager
 from airflow.callbacks.callback_requests import (
     DagCallbackRequest,
@@ -6343,6 +6344,378 @@ class TestSchedulerJob:
         ).one_or_none()
         # ADRQ is deleted even when no DagRun is created, to prevent stale rows accumulating.
         assert _adrq is None
+
+    def _create_mapped_outlet_dags(
+        self,
+        dag_maker,
+        session,
+        *,
+        items: list,
+        asset: Asset,
+        schedule=None,
+        catchup: bool = False,
+        consumer_dag_id: str = "mapped-asset-consumer",
+        producer_dag_id: str = "mapped-asset-producer",
+    ) -> list[TaskInstance]:
+        with dag_maker(
+            dag_id=consumer_dag_id, schedule=schedule or [asset], catchup=catchup, session=session
+        ):
+            EmptyOperator(task_id="consume")
+
+        with dag_maker(dag_id=producer_dag_id, schedule=None, serialized=True, session=session):
+
+            @task(outlets=[asset])
+            def publish(item):
+                return item
+
+            publish.expand(item=items)
+
+        dag_maker.create_dagrun(session=session)
+        return session.scalars(
+            select(TaskInstance)
+            .where(
+                TaskInstance.dag_id == producer_dag_id,
+                TaskInstance.task_id == "publish",
+                TaskInstance.map_index >= 0,
+            )
+            .order_by(TaskInstance.map_index)
+        ).all()
+
+    def _register_mapped_outlet(
+        self,
+        ti: TaskInstance,
+        asset: Asset,
+        extra: dict,
+        session: Session,
+    ) -> None:
+        TaskInstance.register_asset_changes_in_db(
+            ti=ti,
+            task_outlets=[ensure_serialized_asset(asset).asprofile()],
+            outlet_events=[{"dest_asset_key": {"name": asset.name, "uri": asset.uri}, "extra": extra}],
+            session=session,
+        )
+
+    def _tick_asset_runs(self, session):
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
+        self.job_runner._create_dagruns_for_dags(session, session)
+        return scheduler_job
+
+    def test_mapped_asset_empty_expand_creates_no_run(self, session, dag_maker):
+        asset = Asset(name="mapped-outlet-empty", uri="test://mapped-outlet-empty")
+        consumer_dag_id = "mapped-asset-empty-consumer"
+        mapped_tis = self._create_mapped_outlet_dags(
+            dag_maker,
+            session,
+            items=[],
+            asset=asset,
+            consumer_dag_id=consumer_dag_id,
+            producer_dag_id="mapped-asset-empty-producer",
+        )
+        session.flush()
+
+        self._tick_asset_runs(session)
+        session.expire_all()
+
+        assert mapped_tis == []
+        assert (
+            session.scalars(
+                select(AssetEvent).where(AssetEvent.source_dag_id == "mapped-asset-empty-producer")
+            ).all()
+            == []
+        )
+        assert session.scalars(select(DagRun).where(DagRun.dag_id == consumer_dag_id)).all() == []
+        assert (
+            session.scalars(
+                select(AssetDagRunQueue).where(AssetDagRunQueue.target_dag_id == consumer_dag_id)
+            ).all()
+            == []
+        )
+
+    @pytest.mark.parametrize(
+        ("items", "same_extras"),
+        [
+            pytest.param([1], False, id="single-item"),
+            pytest.param([1, 2, 3], False, id="three-distinct-extras"),
+            pytest.param([1, 2, 3], True, id="three-same-extras"),
+        ],
+    )
+    def test_mapped_asset_events_consumed_together(self, items, same_extras, session, dag_maker):
+        asset = Asset(name="mapped-outlet", uri="test://mapped-outlet")
+        consumer_dag_id = "mapped-asset-consumer"
+        mapped_tis = self._create_mapped_outlet_dags(
+            dag_maker, session, items=items, asset=asset, consumer_dag_id=consumer_dag_id
+        )
+        extras = {
+            ti.map_index: {"item": 1} if same_extras else {"item": items[ti.map_index]} for ti in mapped_tis
+        }
+        for ti in mapped_tis:
+            self._register_mapped_outlet(ti, asset, extras[ti.map_index], session)
+        session.flush()
+
+        self._tick_asset_runs(session)
+        session.expire_all()
+
+        created_run = session.scalars(select(DagRun).where(DagRun.dag_id == consumer_dag_id)).one()
+        leftover_adrq = session.scalars(
+            select(AssetDagRunQueue).where(AssetDagRunQueue.target_dag_id == consumer_dag_id)
+        ).all()
+        assert created_run.state == State.QUEUED
+        assert {e.source_map_index for e in created_run.consumed_asset_events} == set(extras)
+        assert {e.source_map_index: e.extra for e in created_run.consumed_asset_events} == extras
+        assert leftover_adrq == []
+
+    def test_mapped_asset_leftovers_consumed_on_next_tick(self, session, dag_maker):
+        asset = Asset(name="mapped-outlet-leftover", uri="test://mapped-outlet-leftover")
+        consumer_dag_id = "mapped-asset-leftover-consumer"
+        mapped_tis = self._create_mapped_outlet_dags(
+            dag_maker,
+            session,
+            items=[1, 2, 3],
+            asset=asset,
+            consumer_dag_id=consumer_dag_id,
+            producer_dag_id="mapped-asset-leftover-producer",
+        )
+        self._register_mapped_outlet(mapped_tis[0], asset, {"item": 1}, session)
+        session.flush()
+
+        self._tick_asset_runs(session)
+        session.expire_all()
+
+        first_runs = session.scalars(
+            select(DagRun).where(DagRun.dag_id == consumer_dag_id).order_by(DagRun.id)
+        ).all()
+        assert len(first_runs) == 1
+        assert {e.source_map_index for e in first_runs[0].consumed_asset_events} == {0}
+        assert {e.extra["item"] for e in first_runs[0].consumed_asset_events} == {1}
+
+        mapped_tis = session.scalars(
+            select(TaskInstance)
+            .where(
+                TaskInstance.dag_id == "mapped-asset-leftover-producer",
+                TaskInstance.task_id == "publish",
+                TaskInstance.map_index >= 0,
+            )
+            .order_by(TaskInstance.map_index)
+        ).all()
+        self._register_mapped_outlet(mapped_tis[1], asset, {"item": 2}, session)
+        self._register_mapped_outlet(mapped_tis[2], asset, {"item": 3}, session)
+        session.flush()
+
+        self._tick_asset_runs(session)
+        session.expire_all()
+
+        runs = session.scalars(
+            select(DagRun).where(DagRun.dag_id == consumer_dag_id).order_by(DagRun.id)
+        ).all()
+        assert len(runs) == 2
+        assert {e.source_map_index for e in runs[1].consumed_asset_events} == {1, 2}
+        assert {e.extra["item"] for e in runs[1].consumed_asset_events} == {2, 3}
+        assert (
+            session.scalars(
+                select(AssetDagRunQueue).where(AssetDagRunQueue.target_dag_id == consumer_dag_id)
+            ).all()
+            == []
+        )
+
+    def test_mapped_asset_failed_index_not_queued(self, session, dag_maker):
+        asset = Asset(name="mapped-outlet-failed", uri="test://mapped-outlet-failed")
+        consumer_dag_id = "mapped-asset-failed-consumer"
+        mapped_tis = self._create_mapped_outlet_dags(
+            dag_maker,
+            session,
+            items=[1, 2, 3],
+            asset=asset,
+            consumer_dag_id=consumer_dag_id,
+            producer_dag_id="mapped-asset-failed-producer",
+        )
+        self._register_mapped_outlet(mapped_tis[0], asset, {"item": 1}, session)
+        self._register_mapped_outlet(mapped_tis[2], asset, {"item": 3}, session)
+        session.flush()
+
+        self._tick_asset_runs(session)
+        session.expire_all()
+
+        created_run = session.scalars(select(DagRun).where(DagRun.dag_id == consumer_dag_id)).one()
+        assert {e.source_map_index for e in created_run.consumed_asset_events} == {0, 2}
+        assert {e.extra["item"] for e in created_run.consumed_asset_events} == {1, 3}
+        assert (
+            session.scalars(
+                select(AssetDagRunQueue).where(AssetDagRunQueue.target_dag_id == consumer_dag_id)
+            ).all()
+            == []
+        )
+
+    @time_machine.travel(DEFAULT_DATE, tick=False)
+    def test_mapped_asset_two_producers_same_second(self, session, dag_maker):
+        asset = Asset(name="shared-outlet", uri="test://shared-outlet")
+        consumer_dag_id = "same-second-consumer"
+        with dag_maker(dag_id=consumer_dag_id, schedule=[asset], session=session):
+            EmptyOperator(task_id="consume")
+
+        with dag_maker(dag_id="same-second-prod-a", schedule=None, serialized=True, session=session):
+            EmptyOperator(task_id="pub", outlets=[asset])
+        ti_a = dag_maker.create_dagrun(session=session).get_task_instance("pub", session=session)
+
+        with dag_maker(dag_id="same-second-prod-b", schedule=None, serialized=True, session=session):
+            EmptyOperator(task_id="pub", outlets=[asset])
+        ti_b = dag_maker.create_dagrun(session=session).get_task_instance("pub", session=session)
+
+        self._register_mapped_outlet(ti_a, asset, {"from": "a"}, session)
+        self._register_mapped_outlet(ti_b, asset, {"from": "b"}, session)
+        session.flush()
+
+        self._tick_asset_runs(session)
+        session.expire_all()
+
+        created_run = session.scalars(select(DagRun).where(DagRun.dag_id == consumer_dag_id)).one()
+        extras = {e.extra["from"] for e in created_run.consumed_asset_events}
+        assert extras == {"a", "b"}
+        assert {e.source_dag_id for e in created_run.consumed_asset_events} == {
+            "same-second-prod-a",
+            "same-second-prod-b",
+        }
+        assert {e.timestamp for e in created_run.consumed_asset_events} == {DEFAULT_DATE}
+        assert (
+            session.scalars(
+                select(AssetDagRunQueue).where(AssetDagRunQueue.target_dag_id == consumer_dag_id)
+            ).all()
+            == []
+        )
+
+    def test_mapped_asset_alias_yields_consumed_together(self, session, dag_maker):
+        alias = AssetAlias("mapped-alias")
+        consumer_dag_id = "alias-yield-consumer"
+        with dag_maker(dag_id=consumer_dag_id, schedule=[alias], session=session):
+            EmptyOperator(task_id="consume")
+
+        with dag_maker(dag_id="alias-yield-producer", schedule=None, serialized=True, session=session):
+
+            @task(outlets=[alias])
+            def produce():
+                return None
+
+            produce()
+
+        ti = dag_maker.create_dagrun(session=session).get_task_instance("produce", session=session)
+        TaskInstance.register_asset_changes_in_db(
+            ti=ti,
+            task_outlets=[AssetProfile(name=alias.name, type="AssetAlias")],
+            outlet_events=[
+                {
+                    "dest_asset_key": {"name": f"dyn-{item}", "uri": f"test://dyn-{item}"},
+                    "source_alias_name": alias.name,
+                    "extra": {"item": item},
+                }
+                for item in (1, 2, 3)
+            ],
+            session=session,
+        )
+        session.flush()
+
+        self._tick_asset_runs(session)
+        session.expire_all()
+
+        created_run = session.scalars(select(DagRun).where(DagRun.dag_id == consumer_dag_id)).one()
+        assert {e.extra["item"] for e in created_run.consumed_asset_events} == {1, 2, 3}
+        assert {e.asset.uri for e in created_run.consumed_asset_events} == {
+            "test://dyn-1",
+            "test://dyn-2",
+            "test://dyn-3",
+        }
+        assert (
+            session.scalars(
+                select(AssetDagRunQueue).where(AssetDagRunQueue.target_dag_id == consumer_dag_id)
+            ).all()
+            == []
+        )
+
+    def test_mapped_asset_and_condition_keeps_adrq(self, session, dag_maker):
+        asset1 = Asset(name="and-asset-1", uri="test://and-asset-1")
+        asset2 = Asset(name="and-asset-2", uri="test://and-asset-2")
+        consumer_dag_id = "and-consumer"
+        mapped_tis = self._create_mapped_outlet_dags(
+            dag_maker,
+            session,
+            items=[1, 2, 3],
+            asset=asset1,
+            schedule=asset1 & asset2,
+            consumer_dag_id=consumer_dag_id,
+            producer_dag_id="and-producer",
+        )
+        for ti in mapped_tis:
+            self._register_mapped_outlet(ti, asset1, {"item": ti.map_index + 1}, session)
+        session.flush()
+
+        self._tick_asset_runs(session)
+        session.expire_all()
+
+        assert session.scalars(select(DagRun).where(DagRun.dag_id == consumer_dag_id)).one_or_none() is None
+        adrqs = session.scalars(
+            select(AssetDagRunQueue).where(AssetDagRunQueue.target_dag_id == consumer_dag_id)
+        ).all()
+        asset1_id = session.scalar(select(AssetModel.id).where(AssetModel.uri == asset1.uri))
+        assert len(adrqs) == 3
+        assert {row.asset_id for row in adrqs} == {asset1_id}
+
+    def test_mapped_asset_or_condition_consumes_fan_out(self, session, dag_maker):
+        asset1 = Asset(name="or-asset-1", uri="test://or-asset-1")
+        asset2 = Asset(name="or-asset-2", uri="test://or-asset-2")
+        consumer_dag_id = "or-consumer"
+        mapped_tis = self._create_mapped_outlet_dags(
+            dag_maker,
+            session,
+            items=[1, 2, 3],
+            asset=asset1,
+            schedule=asset1 | asset2,
+            consumer_dag_id=consumer_dag_id,
+            producer_dag_id="or-producer",
+        )
+        for ti in mapped_tis:
+            self._register_mapped_outlet(ti, asset1, {"item": ti.map_index + 1}, session)
+        session.flush()
+
+        self._tick_asset_runs(session)
+        session.expire_all()
+
+        created_run = session.scalars(select(DagRun).where(DagRun.dag_id == consumer_dag_id)).one()
+        assert {e.source_map_index for e in created_run.consumed_asset_events} == {0, 1, 2}
+        assert {e.extra["item"] for e in created_run.consumed_asset_events} == {1, 2, 3}
+        assert (
+            session.scalars(
+                select(AssetDagRunQueue).where(AssetDagRunQueue.target_dag_id == consumer_dag_id)
+            ).all()
+            == []
+        )
+
+    @pytest.mark.parametrize("catchup", [False, True])
+    def test_mapped_asset_catchup_keeps_queued_events(self, catchup, session, dag_maker):
+        asset = Asset(name="mapped-outlet-catchup", uri="test://mapped-outlet-catchup")
+        consumer_dag_id = "mapped-asset-catchup-consumer"
+        mapped_tis = self._create_mapped_outlet_dags(
+            dag_maker,
+            session,
+            items=[1, 2, 3],
+            asset=asset,
+            catchup=catchup,
+            consumer_dag_id=consumer_dag_id,
+            producer_dag_id="mapped-asset-catchup-producer",
+        )
+        for ti in mapped_tis:
+            self._register_mapped_outlet(ti, asset, {"item": ti.map_index + 1}, session)
+        session.flush()
+
+        self._tick_asset_runs(session)
+        session.expire_all()
+
+        created_run = session.scalars(select(DagRun).where(DagRun.dag_id == consumer_dag_id)).one()
+        assert {e.source_map_index for e in created_run.consumed_asset_events} == {0, 1, 2}
+        assert (
+            session.scalars(
+                select(AssetDagRunQueue).where(AssetDagRunQueue.target_dag_id == consumer_dag_id)
+            ).all()
+            == []
+        )
 
     @time_machine.travel(DEFAULT_DATE + datetime.timedelta(days=1, seconds=9), tick=False)
     @mock.patch("airflow._shared.observability.metrics.stats._get_backend")

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -173,7 +173,7 @@ from tests_common.test_utils.db import (
 )
 from tests_common.test_utils.mock_executor import MockExecutor
 from tests_common.test_utils.mock_operators import CustomOperator
-from tests_common.test_utils.taskinstance import create_task_instance, run_task_instance
+from tests_common.test_utils.taskinstance import create_task_instance, get_template_context, run_task_instance
 from unit.listeners import dag_listener
 from unit.models import TEST_DAGS_FOLDER
 
@@ -6356,11 +6356,12 @@ class TestSchedulerJob:
         catchup: bool = False,
         consumer_dag_id: str = "mapped-asset-consumer",
         producer_dag_id: str = "mapped-asset-producer",
-    ) -> list[TaskInstance]:
+    ) -> tuple[list[TaskInstance], object]:
         with dag_maker(
             dag_id=consumer_dag_id, schedule=schedule or [asset], catchup=catchup, session=session
         ):
             EmptyOperator(task_id="consume")
+        consume_task = dag_maker.dag.get_task("consume")
 
         with dag_maker(dag_id=producer_dag_id, schedule=None, serialized=True, session=session):
 
@@ -6371,7 +6372,7 @@ class TestSchedulerJob:
             publish.expand(item=items)
 
         dag_maker.create_dagrun(session=session)
-        return session.scalars(
+        mapped_tis = session.scalars(
             select(TaskInstance)
             .where(
                 TaskInstance.dag_id == producer_dag_id,
@@ -6380,6 +6381,7 @@ class TestSchedulerJob:
             )
             .order_by(TaskInstance.map_index)
         ).all()
+        return mapped_tis, consume_task
 
     def _register_mapped_outlet(
         self,
@@ -6401,10 +6403,18 @@ class TestSchedulerJob:
         self.job_runner._create_dagruns_for_dags(session, session)
         return scheduler_job
 
+    @staticmethod
+    def _triggering_asset_events(dag_run, task, asset, session):
+        # Access the relationship first so model_validate includes consumed events instead of [].
+        _ = dag_run.consumed_asset_events
+        ti = dag_run.get_task_instance(task.task_id, session=session)
+        context = get_template_context(ti, task, session=session)
+        return list(context["triggering_asset_events"][asset])
+
     def test_mapped_asset_empty_expand_creates_no_run(self, session, dag_maker):
         asset = Asset(name="mapped-outlet-empty", uri="test://mapped-outlet-empty")
         consumer_dag_id = "mapped-asset-empty-consumer"
-        mapped_tis = self._create_mapped_outlet_dags(
+        mapped_tis, _ = self._create_mapped_outlet_dags(
             dag_maker,
             session,
             items=[],
@@ -6443,7 +6453,7 @@ class TestSchedulerJob:
     def test_mapped_asset_events_consumed_together(self, items, same_extras, session, dag_maker):
         asset = Asset(name="mapped-outlet", uri="test://mapped-outlet")
         consumer_dag_id = "mapped-asset-consumer"
-        mapped_tis = self._create_mapped_outlet_dags(
+        mapped_tis, consume_task = self._create_mapped_outlet_dags(
             dag_maker, session, items=items, asset=asset, consumer_dag_id=consumer_dag_id
         )
         extras = {
@@ -6464,12 +6474,47 @@ class TestSchedulerJob:
         assert len(created_run.consumed_asset_events) == len(items)
         assert {e.source_map_index for e in created_run.consumed_asset_events} == set(extras)
         assert {e.source_map_index: e.extra for e in created_run.consumed_asset_events} == extras
+        trig = self._triggering_asset_events(created_run, consume_task, asset, session)
+        assert {e.source_map_index for e in trig} == set(extras)
+        assert {e.source_map_index: e.extra for e in trig} == extras
         assert leftover_adrq == []
+
+    def test_mapped_asset_run_ti_consumes_all_outlets(self, session, dag_maker):
+        asset = Asset(name="mapped-outlet-run-ti", uri="test://mapped-outlet-run-ti")
+        consumer_dag_id = "mapped-asset-run-ti-consumer"
+        producer_dag_id = "mapped-asset-run-ti-producer"
+        mapped_tis, consume_task = self._create_mapped_outlet_dags(
+            dag_maker,
+            session,
+            items=[1, 2, 3],
+            asset=asset,
+            consumer_dag_id=consumer_dag_id,
+            producer_dag_id=producer_dag_id,
+        )
+        producer_run = session.scalar(select(DagRun).where(DagRun.dag_id == producer_dag_id))
+        assert len(mapped_tis) == 3
+        for map_index in range(3):
+            dag_maker.run_ti("publish", dag_run=producer_run, map_index=map_index, session=session)
+        session.flush()
+
+        self._tick_asset_runs(session)
+        session.expire_all()
+
+        created_run = session.scalars(select(DagRun).where(DagRun.dag_id == consumer_dag_id)).one()
+        assert {e.source_map_index for e in created_run.consumed_asset_events} == {0, 1, 2}
+        trig = self._triggering_asset_events(created_run, consume_task, asset, session)
+        assert {e.source_map_index for e in trig} == {0, 1, 2}
+        assert (
+            session.scalars(
+                select(AssetDagRunQueue).where(AssetDagRunQueue.target_dag_id == consumer_dag_id)
+            ).all()
+            == []
+        )
 
     def test_mapped_asset_leftovers_consumed_on_next_tick(self, session, dag_maker):
         asset = Asset(name="mapped-outlet-leftover", uri="test://mapped-outlet-leftover")
         consumer_dag_id = "mapped-asset-leftover-consumer"
-        mapped_tis = self._create_mapped_outlet_dags(
+        mapped_tis, consume_task = self._create_mapped_outlet_dags(
             dag_maker,
             session,
             items=[1, 2, 3],
@@ -6489,6 +6534,8 @@ class TestSchedulerJob:
         assert len(first_runs) == 1
         assert {e.source_map_index for e in first_runs[0].consumed_asset_events} == {0}
         assert {e.extra["item"] for e in first_runs[0].consumed_asset_events} == {1}
+        trig_first = self._triggering_asset_events(first_runs[0], consume_task, asset, session)
+        assert {e.source_map_index for e in trig_first} == {0}
         assert (
             session.scalars(
                 select(AssetDagRunQueue).where(AssetDagRunQueue.target_dag_id == consumer_dag_id)
@@ -6530,6 +6577,8 @@ class TestSchedulerJob:
         assert len(runs) == 2
         assert {e.source_map_index for e in runs[1].consumed_asset_events} == {1, 2}
         assert {e.extra["item"] for e in runs[1].consumed_asset_events} == {2, 3}
+        trig_second = self._triggering_asset_events(runs[1], consume_task, asset, session)
+        assert {e.source_map_index for e in trig_second} == {1, 2}
         assert {
             e.source_map_index
             for e in session.scalars(
@@ -6546,7 +6595,7 @@ class TestSchedulerJob:
     def test_mapped_asset_failed_index_not_queued(self, session, dag_maker):
         asset = Asset(name="mapped-outlet-failed", uri="test://mapped-outlet-failed")
         consumer_dag_id = "mapped-asset-failed-consumer"
-        mapped_tis = self._create_mapped_outlet_dags(
+        mapped_tis, _ = self._create_mapped_outlet_dags(
             dag_maker,
             session,
             items=[1, 2, 3],
@@ -6674,7 +6723,7 @@ class TestSchedulerJob:
         asset1 = Asset(name="and-asset-1", uri="test://and-asset-1")
         asset2 = Asset(name="and-asset-2", uri="test://and-asset-2")
         consumer_dag_id = "and-consumer"
-        mapped_tis = self._create_mapped_outlet_dags(
+        mapped_tis, _ = self._create_mapped_outlet_dags(
             dag_maker,
             session,
             items=[1, 2, 3],
@@ -6698,12 +6747,36 @@ class TestSchedulerJob:
         assert len(adrqs) == 3
         assert {row.asset_id for row in adrqs} == {asset1_id}
 
+        asset2_id = session.scalar(select(AssetModel.id).where(AssetModel.uri == asset2.uri))
+        event_b = AssetEvent(asset_id=asset2_id, timestamp=timezone.utcnow())
+        session.add(event_b)
+        session.flush()
+        session.add(
+            AssetDagRunQueue(asset_id=asset2_id, target_dag_id=consumer_dag_id, asset_event_id=event_b.id)
+        )
+        session.flush()
+
+        self._tick_asset_runs(session)
+        session.expire_all()
+
+        created_run = session.scalars(select(DagRun).where(DagRun.dag_id == consumer_dag_id)).one()
+        consumed = list(created_run.consumed_asset_events)
+        assert len(consumed) == 4
+        assert {e.source_map_index for e in consumed if e.asset_id != asset2_id} == {0, 1, 2}
+        assert event_b.id in {e.id for e in consumed}
+        assert (
+            session.scalars(
+                select(AssetDagRunQueue).where(AssetDagRunQueue.target_dag_id == consumer_dag_id)
+            ).all()
+            == []
+        )
+
     @mock.patch("airflow.jobs.scheduler_job_runner.with_row_locks", autospec=True)
     def test_mapped_asset_or_condition_consumes_fan_out(self, mock_with_row_locks, session, dag_maker):
         asset1 = Asset(name="or-asset-1", uri="test://or-asset-1")
         asset2 = Asset(name="or-asset-2", uri="test://or-asset-2")
         consumer_dag_id = "or-consumer"
-        mapped_tis = self._create_mapped_outlet_dags(
+        mapped_tis, _ = self._create_mapped_outlet_dags(
             dag_maker,
             session,
             items=[1, 2, 3],
@@ -6748,7 +6821,7 @@ class TestSchedulerJob:
     def test_mapped_asset_catchup_keeps_queued_events(self, catchup, session, dag_maker):
         asset = Asset(name="mapped-outlet-catchup", uri="test://mapped-outlet-catchup")
         consumer_dag_id = "mapped-asset-catchup-consumer"
-        mapped_tis = self._create_mapped_outlet_dags(
+        mapped_tis, _ = self._create_mapped_outlet_dags(
             dag_maker,
             session,
             items=[1, 2, 3],


### PR DESCRIPTION
## What is the change?

Tests only. Ten regression tests in `airflow-core/tests/unit/jobs/test_scheduler_job.py` pin that a mapped producer's asset events are all consumed on the next triggered run, covering empty expand, a failed map index, leftovers on the next tick, AND and OR schedules, alias yields, catchup, and two producers in the same second. No production change, no newsfragment.

## Why did I do it?

closes: #54659

Three mapped outlets finishing together left the consumer with only a subset of events in `triggering_asset_events`. Consume-by-event-id is already on main, but the existing tests insert asset Dag run queue rows by hand, so the real emit path from mapped task instances was never covered.

## How did I do it?

Emit goes through `register_asset_changes_in_db` after mapped SUCCESS, plus one `dag_maker.run_ti(..., map_index=N)` case. Consume runs through `SchedulerJobRunner._create_dagruns_for_dags`, and `get_template_context` is checked after loading `consumed_asset_events`. The AND case waits for the second asset, then consumes the leftover queue. One tick batches all visible events; that is the default, not a bug.

## What's the impact?

None at runtime. If consume-by-id or the mapped emit path regresses, these tests fail instead of events being dropped silently.

## What's the test plan?

`uv run --project airflow-core pytest airflow-core/tests/unit/jobs/test_scheduler_job.py -k mapped_asset_ -q` runs all ten tests.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (Grok 4.6)

Generated-by: Grok 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
