### PR TITLE
UI: Stop list pages jumping while a filter loads

### DIFF
--- a/airflow-core/newsfragments/72005.bugfix.rst
+++ b/airflow-core/newsfragments/72005.bugfix.rst
@@ -1,0 +1,1 @@
+Stop list pages shifting while a filter loads. The row count heading no longer disappears mid-load, so the search and filter controls beneath it stay put, and the Dags and Assets lists keep their current rows on screen until the filtered ones arrive.

--- a/airflow-core/newsfragments/72005.bugfix.rst
+++ b/airflow-core/newsfragments/72005.bugfix.rst
@@ -1,1 +1,0 @@
-Stop list pages shifting while a filter loads. The row count heading no longer disappears mid-load, so the search and filter controls beneath it stay put, and the Dags and Assets lists keep their current rows on screen until the filtered ones arrive.

--- a/airflow-core/src/airflow/ui/src/components/DataTable/DataTable.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/DataTable.test.tsx
@@ -289,12 +289,12 @@ describe("DataTable", () => {
     expect(screen.getByRole("heading")).toHaveTextContent("50,000+ task");
   });
 
-  it("does not render row count heading during the initial load", () => {
+  it("keeps the row count heading during the initial load", () => {
     render(<DataTable columns={columns} data={[]} isLoading modelName="task" total={0} />, {
       wrapper: ChakraWrapper,
     });
 
-    expect(screen.queryByRole("heading")).toBeNull();
+    expect(screen.getByRole("heading")).toHaveTextContent(/^task_other$/u);
   });
 
   it("does not render row count heading when hideRowCountHeading is set", () => {
@@ -469,7 +469,7 @@ describe("DataTable", () => {
   });
 
   // Each slot needs its own entry in the header row condition, or its content vanishes whenever
-  // nothing else occupies the row — including while loading, when the row count is suppressed.
+  // nothing else occupies the row — as it does on tables that hide the row count heading.
   const actionSlots = [
     ["filterActions", { filterActions: <button type="button">slot content</button> }],
     ["presentationActions", { presentationActions: <button type="button">slot content</button> }],
@@ -481,14 +481,6 @@ describe("DataTable", () => {
       <DataTable columns={columns} data={[]} hideRowCountHeading modelName="task" total={0} {...slot} />,
       { wrapper: ChakraWrapper },
     );
-
-    expect(screen.getByText("slot content")).toBeInTheDocument();
-  });
-
-  it.each(actionSlots)("keeps %s visible while loading", (_name, slot) => {
-    render(<DataTable columns={columns} data={[]} isLoading modelName="task" {...slot} />, {
-      wrapper: ChakraWrapper,
-    });
 
     expect(screen.queryByRole("heading")).toBeNull();
     expect(screen.getByText("slot content")).toBeInTheDocument();

--- a/airflow-core/src/airflow/ui/src/components/DataTable/DataTable.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/DataTable.tsx
@@ -206,8 +206,6 @@ export const DataTable = <TData,>({
     (pageIndex !== 0 || rows.length !== rowTotal);
 
   const translateModelName = (count: number) => translate(modelName, { count });
-  // During the initial load there is nothing to count yet
-  const showRowCount = !Boolean(hideRowCountHeading) && !Boolean(isLoading);
   const noRowsNode = noRowsMessage ?? translate("noItemsFound", { modelName: translateModelName(0) });
   // i18next derives the plural form from the count, but in some languages (Russian) no integer count
   // ever selects `_other`, so read the count-free plural key directly instead of passing a stand-in.
@@ -221,15 +219,18 @@ export const DataTable = <TData,>({
     display === "table" &&
     (showColumnsMenu ?? columns.length > 5) &&
     table.getAllLeafColumns().some((column) => column.getCanHide());
-  const headingNode = showRowCount ? (
+  const hasRowCount = total !== undefined && !Boolean(isLoading);
+  // `filterActions` sits directly below this heading, so unmounting it while the count is unknown
+  // drags the filter controls up and drops them back once results arrive.
+  const headingNode = Boolean(hideRowCountHeading) ? undefined : (
     <Heading py={1} size="md">
-      {total === undefined
-        ? pluralModelName
-        : `${total.toLocaleString(i18n.language)}${isCapped ? "+" : ""} ${translateModelName(total)}`}
+      {hasRowCount
+        ? `${total.toLocaleString(i18n.language)}${isCapped ? "+" : ""} ${translateModelName(total)}`
+        : pluralModelName}
     </Heading>
-  ) : undefined;
+  );
   // Every slot has to be listed here, or its content disappears whenever nothing else occupies
-  // the row — including every render where the row count is hidden while loading.
+  // the row — including tables that hide the row count heading entirely.
   const renderHeaderRow =
     headingNode !== undefined ||
     headingExtra !== undefined ||

--- a/airflow-core/src/airflow/ui/src/pages/AssetsList/AssetsList.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/AssetsList/AssetsList.test.tsx
@@ -17,10 +17,23 @@
  * under the License.
  */
 import "@testing-library/jest-dom";
-import { render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { delay, http, HttpResponse } from "msw";
+import { setupServer, type SetupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
+import { handlers } from "src/mocks/handlers";
 import { AppWrapper } from "src/utils/AppWrapper";
+
+let server: SetupServer;
+
+beforeAll(() => {
+  server = setupServer(...handlers);
+  server.listen({ onUnhandledRequest: "bypass" });
+});
+
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
 
 // The assets mock handler (see src/mocks/handlers/assets.ts) returns a single asset
 // with one consuming task, one alias and one watcher.
@@ -39,5 +52,28 @@ describe("AssetsList columns", () => {
     await waitFor(() => expect(screen.getByRole("button", { name: "1 alias" })).toBeInTheDocument());
 
     expect(screen.getByRole("button", { name: "1 watcher" })).toBeInTheDocument();
+  });
+});
+
+describe("AssetsList filtering", () => {
+  it("keeps the listed assets on screen while a filter change is still loading", async () => {
+    render(<AppWrapper initialEntries={["/assets"]} />);
+
+    await waitFor(() => expect(screen.getByText("asset_with_dependencies")).toBeInTheDocument());
+
+    server.use(
+      http.get("/ui/assets", async () => {
+        await delay("infinite");
+
+        return HttpResponse.json({ assets: [], total_entries: 0 });
+      }),
+    );
+
+    fireEvent.change(screen.getByTestId("search-dags"), { target: { value: "plain" } });
+
+    await waitFor(() => expect(screen.getByRole("progressbar")).toBeVisible());
+
+    expect(screen.getByText("asset_with_dependencies")).toBeInTheDocument();
+    expect(screen.queryAllByTestId("skeleton")).toHaveLength(0);
   });
 });

--- a/airflow-core/src/airflow/ui/src/pages/AssetsList/AssetsList.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/AssetsList/AssetsList.tsx
@@ -152,15 +152,19 @@ export const AssetsList = () => {
     value: searchParams.get(SearchParamsKeys.GROUP_PATTERN),
   });
 
-  const { data, error, isLoading } = useAssetServiceGetAssetsUi({
-    ...groupArg,
-    lastAssetEventTimestampGte: lastAssetEventTimestampGte ?? undefined,
-    lastAssetEventTimestampLte: lastAssetEventTimestampLte ?? undefined,
-    limit: pagination.pageSize,
-    ...(advancedSearch.enabled ? { namePattern } : { namePrefixPattern: namePattern }),
-    offset: pagination.pageIndex * pagination.pageSize,
-    orderBy,
-  });
+  const { data, error, isFetching, isLoading } = useAssetServiceGetAssetsUi(
+    {
+      ...groupArg,
+      lastAssetEventTimestampGte: lastAssetEventTimestampGte ?? undefined,
+      lastAssetEventTimestampLte: lastAssetEventTimestampLte ?? undefined,
+      limit: pagination.pageSize,
+      ...(advancedSearch.enabled ? { namePattern } : { namePrefixPattern: namePattern }),
+      offset: pagination.pageIndex * pagination.pageSize,
+      orderBy,
+    },
+    undefined,
+    { placeholderData: (prev) => prev },
+  );
 
   const columns = createColumns(translate);
   const totalEntries = data?.total_entries ?? 0;
@@ -200,6 +204,7 @@ export const AssetsList = () => {
         </VStack>
       }
       initialState={tableURLState}
+      isFetching={isFetching}
       isLoading={isLoading}
       modelName="common:asset"
       onStateChange={setTableURLState}

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.test.tsx
@@ -18,12 +18,26 @@
  */
 import "@testing-library/jest-dom";
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { delay, http, HttpResponse } from "msw";
+import { setupServer, type SetupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
 import { DAGS_LIST_DISPLAY_KEY } from "src/constants/localStorage";
+import { handlers } from "src/mocks/handlers";
 import { AppWrapper } from "src/utils/AppWrapper";
 
-afterEach(() => localStorage.clear());
+let server: SetupServer;
+
+beforeAll(() => {
+  server = setupServer(...handlers);
+  server.listen({ onUnhandledRequest: "bypass" });
+});
+
+afterEach(() => {
+  server.resetHandlers();
+  localStorage.clear();
+});
+afterAll(() => server.close());
 
 describe("Dag Filters", () => {
   it("Filter by selected last run state", async () => {
@@ -42,6 +56,32 @@ describe("Dag Filters", () => {
     await waitFor(() => screen.getByTestId("last_dag_run_state-filter").click());
     await waitFor(() => screen.getByTestId("last_dag_run_state-filter-failed").click());
     await waitFor(() => expect(screen.getByText("tutorial_taskflow_api_failed")).toBeInTheDocument());
+  });
+
+  it("keeps the listed Dags on screen while a newly added filter is still loading", async () => {
+    render(<AppWrapper initialEntries={["/dags"]} />);
+
+    await waitFor(() => expect(screen.getByText("tutorial_taskflow_api_failed")).toBeInTheDocument());
+
+    server.use(
+      http.get("/ui/dags", async () => {
+        await delay("infinite");
+
+        return HttpResponse.json({ dags: [], total_entries: 0 });
+      }),
+    );
+
+    fireEvent.click(screen.getByTestId("add-filter-button"));
+    fireEvent.click(await screen.findByTestId("add-filter-last_dag_run_state"));
+    await waitFor(() => screen.getByTestId("last_dag_run_state-filter-success").click());
+
+    await waitFor(() => {
+      expect(screen.getByTestId("last_dag_run_state-pill")).toBeInTheDocument();
+      expect(screen.getByRole("progressbar")).toBeVisible();
+    });
+
+    expect(screen.getByText("tutorial_taskflow_api_failed")).toBeInTheDocument();
+    expect(screen.queryAllByTestId("skeleton")).toHaveLength(0);
   });
 });
 

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -309,7 +309,7 @@ export const DagsList = () => {
     pendingHitl = false;
   }
 
-  const { data, error, isLoading } = useDags({
+  const { data, error, isFetching, isLoading } = useDags({
     advancedSearch: advancedSearch.enabled,
     dagDisplayNamePattern: Boolean(dagDisplayNamePattern) ? dagDisplayNamePattern : undefined,
     dagRunsLimit,
@@ -377,6 +377,7 @@ export const DagsList = () => {
           }
           headingExtra={<DagImportErrors iconOnly />}
           initialState={tableURLState}
+          isFetching={isFetching}
           isLoading={isLoading}
           modelName="common:dag"
           onDisplayToggleChange={setDisplay}

--- a/airflow-core/src/airflow/ui/src/queries/useDags.tsx
+++ b/airflow-core/src/airflow/ui/src/queries/useDags.tsx
@@ -84,6 +84,8 @@ export const useDags = ({
     },
     undefined,
     {
+      // Filter changes swap the query key, which would otherwise drop the list to skeletons
+      placeholderData: (prev) => prev,
       refetchInterval: (query) =>
         refetchInterval === false
           ? false


### PR DESCRIPTION
## Summary

List pages place their search and filter controls directly below the shared table's row count heading. When a filter changes, a new query starts and the heading temporarily disappears, causing the controls to shift up and then back down when the results arrive.

The heading now keeps its space while the count is loading, showing the model name without a number, consistent with tables that do not have a total count.

The Dags and Assets lists now keep their previous results while filtered results load instead of switching to skeletons. This keeps column widths stable, matching the existing behavior of `DagRuns` and `TaskInstances`, while the progress bar indicates that new results are loading.

## Before / after

before:

https://github.com/user-attachments/assets/2b42d4f6-2771-4a74-ac3e-be7691bb90a4

after:

https://github.com/user-attachments/assets/f8cf1b10-2fb7-41b2-ab9d-c8c93e432c9a


## Scope

The heading fix is implemented in the shared table, so it applies to all list pages.

Keeping previous results is handled per query and currently covers Dags, Assets, DagRuns, and TaskInstances. Other lists still switch to skeletons while loading. Some of them also key their queries on route parameters, so retaining the previous entity's rows requires a per-page decision.

Column widths are content-driven, so tables may still reflow between skeletons and real rows on the initial load. Keeping previous results removes that reflow when filters change, which is the case this change targets.

closes: #71979

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
