### PR TITLE
Render the database ERD as a searchable Mermaid diagram instead of an image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,9 @@ airflow.db
 # Airflow temporary artifacts
 airflow-core/src/airflow/git_version
 # ERD diagrams (generated at doc build time)
-airflow-core/docs/img/airflow_erd.svg
-providers/fab/docs/img/fab_erd.svg
-providers/edge3/docs/img/edge3_erd.svg
+airflow-core/docs/img/airflow_erd.mmd
+providers/fab/docs/img/fab_erd.mmd
+providers/edge3/docs/img/edge3_erd.mmd
 airflow-core/src/airflow/ui/coverage/
 # and legacy ones
 airflow/git_version

--- a/airflow-core/docs/database-erd-ref.rst
+++ b/airflow-core/docs/database-erd-ref.rst
@@ -33,6 +33,6 @@ Here is the current Database schema diagram.
    `db command <cli-and-env-variables-ref.html#db>`_ for the commands that you can use to manage
    the migrations.
 
-.. This image is automatically generated during documentation build by the ``generate_erd`` Sphinx extension.
+.. This diagram is automatically generated during documentation build by the ``generate_erd`` Sphinx extension.
 
-.. image:: img/airflow_erd.svg
+.. mermaid:: img/airflow_erd.mmd

--- a/contributing-docs/14_metadata_database_updates.rst
+++ b/contributing-docs/14_metadata_database_updates.rst
@@ -84,7 +84,7 @@ To resolve these conflicts:
 
 .. note::
 
-    The ERD diagram (``airflow_erd.svg``) is no longer committed to the repository. It is
+    The ERD diagram (``airflow_erd.mmd``) is no longer committed to the repository. It is
     automatically generated during the documentation build by the ``generate_erd`` Sphinx extension.
 
 Running migration CI tests locally

--- a/devel-common/src/sphinx_exts/generate_erd.py
+++ b/devel-common/src/sphinx_exts/generate_erd.py
@@ -17,7 +17,8 @@
 """Sphinx extension to generate Airflow database ERD diagrams at doc build time.
 
 Detects which package is being built via the ``AIRFLOW_PACKAGE_NAME`` environment
-variable and generates the appropriate ERD:
+variable and generates the appropriate ERD as Mermaid ER-diagram markup, consumed
+by the ``.. mermaid::`` directive from ``sphinxcontrib-mermaid``:
 
 * ``apache-airflow`` — core Airflow models only
 * ``apache-airflow-providers-fab`` — FAB auth-manager models only
@@ -27,31 +28,23 @@ variable and generates the appropriate ERD:
 from __future__ import annotations
 
 import os
-import shutil
-import sys
 from pathlib import Path
 
 from sphinx.util import logging
 
 log = logging.getLogger(__name__)
 
-PLACEHOLDER_SVG = """\
-<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="800" height="100">
-  <rect width="800" height="100" fill="#fff3cd" stroke="#ffc107" stroke-width="2" rx="8"/>
-  <text x="400" y="40" text-anchor="middle" font-family="sans-serif" font-size="16" fill="#856404">
-    ERD diagram not generated: eralchemy or graphviz system package is not available.
-  </text>
-  <text x="400" y="70" text-anchor="middle" font-family="sans-serif" font-size="14" fill="#856404">
-    Install graphviz (e.g. "brew install graphviz") and eralchemy, then rebuild the docs.
-  </text>
-</svg>
+PLACEHOLDER_MERMAID = """\
+erDiagram
+  ERD_NOT_GENERATED {
+    string reason "eralchemy is not available"
+  }
 """
 
 
-def _write_placeholder(svg_path: str) -> None:
-    """Write a placeholder SVG so the doc build does not break with a missing image."""
-    Path(svg_path).write_text(PLACEHOLDER_SVG)
+def _write_placeholder(mmd_path: str) -> None:
+    """Write placeholder Mermaid markup so the doc build does not break with missing content."""
+    Path(mmd_path).write_text(PLACEHOLDER_MERMAID)
 
 
 def _collect_core_metadata():
@@ -102,14 +95,14 @@ def _collect_edge3_metadata():
 
 # Map package names to their metadata collector and output filename.
 _PACKAGE_ERD_CONFIG: dict[str, tuple] = {
-    "apache-airflow": (_collect_core_metadata, "airflow_erd.svg"),
-    "apache-airflow-providers-fab": (_collect_fab_metadata, "fab_erd.svg"),
-    "apache-airflow-providers-edge3": (_collect_edge3_metadata, "edge3_erd.svg"),
+    "apache-airflow": (_collect_core_metadata, "airflow_erd.mmd"),
+    "apache-airflow-providers-fab": (_collect_fab_metadata, "fab_erd.mmd"),
+    "apache-airflow-providers-edge3": (_collect_edge3_metadata, "edge3_erd.mmd"),
 }
 
 
 def builder_inited(app):
-    """Generate the ERD diagram SVG from SQLAlchemy metadata during doc build."""
+    """Generate the ERD diagram Mermaid markup from SQLAlchemy metadata during doc build."""
     package_name = os.environ.get("AIRFLOW_PACKAGE_NAME", "")
     config = _PACKAGE_ERD_CONFIG.get(package_name)
     if config is None:
@@ -119,52 +112,35 @@ def builder_inited(app):
 
     src_dir = app.srcdir
     img_dir = os.path.join(src_dir, "img")
-    svg_path = os.path.join(img_dir, filename)
+    mmd_path = os.path.join(img_dir, filename)
 
     os.makedirs(img_dir, exist_ok=True)
 
     try:
-        from eralchemy import render_er
+        from eralchemy.main import _intermediary_to_mermaid_er, all_to_intermediary, filter_resources
     except ImportError:
         log.warning("eralchemy is not installed, skipping ERD diagram generation")
-        _write_placeholder(svg_path)
+        _write_placeholder(mmd_path)
         return
 
-    # eralchemy needs either pygraphviz or graphviz Python package, and both need
-    # the graphviz system package (the ``dot`` binary) to render SVG output.
-    if not shutil.which("dot"):
-        hint = (
-            "On macOS, install it with: brew install graphviz"
-            if sys.platform == "darwin"
-            else "Install graphviz via your system package manager."
-        )
-        log.warning(
-            "graphviz system package is not installed — the 'dot' command is not on PATH. "
-            "Skipping ERD diagram generation. %s",
-            hint,
-        )
-        _write_placeholder(svg_path)
-        return
-
-    log.info("Generating ERD diagram for %s at %s", package_name, svg_path)
+    log.info("Generating ERD diagram for %s at %s", package_name, mmd_path)
 
     try:
         metadata = collector()
     except ImportError:
         log.warning("Could not import models for %s, skipping ERD generation", package_name)
-        _write_placeholder(svg_path)
+        _write_placeholder(mmd_path)
         return
 
-    render_er(
-        metadata,
-        svg_path,
-        exclude_tables=["sqlite_sequence"],
+    # Bypass eralchemy's `render_er`/`intermediary_to_mermaid_er`: those wrap the markup in an
+    # HTML comment plus a `mermaid.ink` image link, meant for GitHub-flavored markdown READMEs.
+    # The `.. mermaid::` Sphinx directive needs the raw `erDiagram ...` markup instead.
+    tables, relationships = all_to_intermediary(metadata)
+    tables, relationships = filter_resources(
+        tables, relationships, exclude_tables=["sqlite_sequence"], sort_mode="alphabetical"
     )
-
-    if not os.path.exists(svg_path):
-        log.warning("ERD diagram was not generated (eralchemy/graphviz error), writing placeholder")
-        _write_placeholder(svg_path)
-        return
+    markup = _intermediary_to_mermaid_er(tables, relationships)
+    Path(mmd_path).write_text(markup)
 
     log.info("ERD diagram generated successfully")
 

--- a/providers/edge3/docs/database-erd-ref.rst
+++ b/providers/edge3/docs/database-erd-ref.rst
@@ -28,6 +28,6 @@ Here is the current database schema diagram for the Edge3 provider tables.
    The main purpose of this diagram is to help with troubleshooting and understanding of the
    internal Edge3 DB architecture in case you have any problems with the database.
 
-.. This image is automatically generated during documentation build by the ``generate_erd`` Sphinx extension.
+.. This diagram is automatically generated during documentation build by the ``generate_erd`` Sphinx extension.
 
-.. image:: img/edge3_erd.svg
+.. mermaid:: img/edge3_erd.mmd

--- a/providers/fab/docs/database-erd-ref.rst
+++ b/providers/fab/docs/database-erd-ref.rst
@@ -30,6 +30,6 @@ Here is the current database schema diagram for the FAB auth manager provider ta
    when dealing with problems with migrations. See also :doc:`migrations-ref` for
    list of detailed database migrations.
 
-.. This image is automatically generated during documentation build by the ``generate_erd`` Sphinx extension.
+.. This diagram is automatically generated during documentation build by the ``generate_erd`` Sphinx extension.
 
-.. image:: img/fab_erd.svg
+.. mermaid:: img/fab_erd.mmd


### PR DESCRIPTION
### Sumarry

Render the database ERD reference pages (core, FAB, Edge3) as a Mermaid `erDiagram` instead of an SVG image, so table and column names are indexed by search engines and in-page search instead of being locked inside a picture.

closes: #36842

### Before / after

**Before** — the current production docs (`apache-airflow` 3.4.0) embed the ERD as a flat SVG image. On a schema this size (57 core tables) the image is dense and hard to read even at full screen, and none of the table/column text is selectable or searchable:

<img width="1859" height="731" alt="image" src="https://github.com/user-attachments/assets/ce7706ee-07c3-406f-9767-a5068abfb9ff" />

**After** — same page, rendered as a Mermaid diagram from this branch. Every table/column name is now real page text: here the browser's in-page search (`Cmd+F`) for "INTEGER" finds 50 matches on the FAB provider's ERD page:

<img width="1774" height="932" alt="image" src="https://github.com/user-attachments/assets/79643b70-abc1-446c-946c-39c24b59e259" />

Same on the Edge3 provider's ERD page (a much smaller schema, so also easier to read as a bonus) — 7 matches for "INTEGER":

<img width="1272" height="828" alt="image" src="https://github.com/user-attachments/assets/c81b5db9-595c-4a72-9e28-df250f1db0a4" />

### What changed

- `generate_erd` (the Sphinx extension that (re)builds the diagram from the live SQLAlchemy models on every doc build) now writes Mermaid ER-diagram markup (`.mmd`) instead of an SVG.
- The three `database-erd-ref.rst` pages (`airflow-core`, `providers/fab`, `providers/edge3`) use the `.. mermaid::` directive (already available via `sphinxcontrib-mermaid`, already used elsewhere in the docs) instead of `.. image::`.
- Dropped the graphviz/`dot` availability check and its SVG placeholder — Mermaid markup is emitted directly by `eralchemy` without shelling out to graphviz, so that whole fallback path no longer applies.
- Updated `.gitignore` and `contributing-docs/14_metadata_database_updates.rst` for the new generated filename.

### Why this wasn't done sooner

An earlier attempt (#42323) stalled because it tried to introduce a new tool (`paracelsus`) and wasn't sure whether generating from live models vs. the post-migration database would let the diagram drift out of sync with the models. Both concerns are now moot: `generate_erd` already regenerates from the live SQLAlchemy `MetaData` on every doc build (introduced after that PR), and the `eralchemy` version already pinned in `devel-common` (`eralchemy==1.7.0`) can emit Mermaid ER-diagram markup directly — no new dependency needed.

Note: `eralchemy`'s own `render_er(..., mode="mermaid_er")` wraps its output in an HTML comment plus a `mermaid.ink`-hosted image link (meant for GitHub-flavored markdown READMEs), which isn't right for a Sphinx `.. mermaid::` directive and would reintroduce an external-image dependency. This PR calls eralchemy's lower-level `all_to_intermediary`/`filter_resources`/`_intermediary_to_mermaid_er` functions directly to get the raw `erDiagram ...` markup instead.

### Testing

- Ran the extension against the real core/FAB/Edge3 SQLAlchemy models and confirmed clean Mermaid markup is produced (57 core tables).
- Built all three affected packages with `breeze build-docs --package-filter apache-airflow --package-filter apache-airflow-providers-fab --package-filter apache-airflow-providers-edge3` — build and spellcheck succeeded for all three, and the rendered HTML contains the ERD text (e.g. `dag_run`) directly in the page rather than in an image, with no `mermaid.ink` reference.
- `prek run --stage pre-commit` passes on the changed files, including `mypy` for `devel-common`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)