### PR TITLE
Fix mismatched XCom values when a dynamically mapped task has a gap

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -179,20 +179,27 @@ def get_mapped_xcom_by_index(
         )
 
     if mapped_length is not None:
-        map_index = offset if offset >= 0 else mapped_length + offset
-        if not (0 <= map_index < mapped_length):
-            raise not_found()
-        xcom_query = XComModel.get_many(
+        any_pushed = XComModel.get_many(
             run_id=run_id,
             key=key,
             task_ids=task_id,
             dag_ids=dag_id,
-            map_indexes=map_index,
-        )
-        result: tuple[XComModel] | None = session.scalars(xcom_query.order_by(None)).first()
-        if result is None:
-            return XComSequenceIndexResponse(None)
-        return XComSequenceIndexResponse((result[0] if isinstance(result, tuple) else result).value)
+        ).order_by(None)
+        if session.execute(any_pushed.limit(1)).first() is not None:
+            map_index = offset if offset >= 0 else mapped_length + offset
+            if not (0 <= map_index < mapped_length):
+                raise not_found()
+            xcom_query = XComModel.get_many(
+                run_id=run_id,
+                key=key,
+                task_ids=task_id,
+                dag_ids=dag_id,
+                map_indexes=map_index,
+            )
+            result: tuple[XComModel] | None = session.scalars(xcom_query.order_by(None)).first()
+            if result is None:
+                return XComSequenceIndexResponse(None)
+            return XComSequenceIndexResponse((result[0] if isinstance(result, tuple) else result).value)
 
     xcom_query = XComModel.get_many(
         run_id=run_id,
@@ -245,9 +252,13 @@ def get_mapped_xcom_by_slice(
     ).order_by(None)
 
     # Only fall back to fetching every XCom row (needed to place each value at its true
-    # map_index) when there's an actual gap. The common case -- every mapped instance has
-    # pushed its XCom -- keeps the cheaper SQL-side OFFSET/LIMIT/slice() below.
-    if mapped_length is not None and get_query_count(base_query, session=session) < mapped_length:
+    # map_index) when there's an actual gap for this key -- i.e. some, but not all, of the
+    # mapped instances have pushed it. If none have (e.g. the key doesn't exist at all),
+    # that's not a gap to fill with None; it's an empty/not-found result, handled below by
+    # the unchanged SQL-side path. The common case -- every instance has pushed -- also
+    # keeps that cheaper OFFSET/LIMIT/slice() path.
+    existing_count = get_query_count(base_query, session=session) if mapped_length is not None else 0
+    if mapped_length is not None and 0 < existing_count < mapped_length:
         by_map_index = {
             row.map_index: row.value
             for row in session.execute(base_query.with_only_columns(XComModel.map_index, XComModel.value))

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -22,7 +22,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Request, Response, status
 from pydantic import JsonValue
-from sqlalchemy import delete
+from sqlalchemy import delete, func, select
 from sqlalchemy.sql.selectable import Select
 
 from airflow.api_fastapi.common.db.common import SessionDep
@@ -33,6 +33,7 @@ from airflow.api_fastapi.execution_api.datamodels.xcom import (
     XComSequenceSliceResponse,
 )
 from airflow.api_fastapi.execution_api.security import CurrentTIToken
+from airflow.models.taskinstance import TaskInstance
 from airflow.models.taskmap import TaskMap
 from airflow.models.xcom import XComModel
 from airflow.utils.db import get_query_count
@@ -133,6 +134,27 @@ async def xcom_query(
     return query
 
 
+def _get_mapped_length(dag_id: str, run_id: str, task_id: str, *, session: SessionDep) -> int | None:
+    """
+    Get the number of mapped task instances ``task_id`` expands into for this run.
+
+    Returns *None* if ``task_id`` is not a mapped task in this run (no task instance
+    with ``map_index >= 0`` exists), in which case callers should fall back to treating
+    the XCom rows as an unmapped/non-sparse sequence.
+    """
+    max_map_index = session.scalar(
+        select(func.max(TaskInstance.map_index)).where(
+            TaskInstance.dag_id == dag_id,
+            TaskInstance.run_id == run_id,
+            TaskInstance.task_id == task_id,
+            TaskInstance.map_index >= 0,
+        )
+    )
+    if max_map_index is None:
+        return None
+    return max_map_index + 1
+
+
 @router.get(
     "/{dag_id}/{run_id}/{task_id}/{key:path}/item/{offset}",
     description="Get a single XCom value from a mapped task by sequence index",
@@ -145,6 +167,33 @@ def get_mapped_xcom_by_index(
     offset: int,
     session: SessionDep,
 ) -> XComSequenceIndexResponse:
+    mapped_length = _get_mapped_length(dag_id, run_id, task_id, session=session)
+
+    def not_found() -> HTTPException:
+        message = (
+            f"XCom with {key=} {offset=} not found for task {task_id!r} in DAG run {run_id!r} of {dag_id!r}"
+        )
+        return HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"reason": "not_found", "message": message},
+        )
+
+    if mapped_length is not None:
+        map_index = offset if offset >= 0 else mapped_length + offset
+        if not (0 <= map_index < mapped_length):
+            raise not_found()
+        xcom_query = XComModel.get_many(
+            run_id=run_id,
+            key=key,
+            task_ids=task_id,
+            dag_ids=dag_id,
+            map_indexes=map_index,
+        )
+        result: tuple[XComModel] | None = session.scalars(xcom_query.order_by(None)).first()
+        if result is None:
+            return XComSequenceIndexResponse(None)
+        return XComSequenceIndexResponse((result[0] if isinstance(result, tuple) else result).value)
+
     xcom_query = XComModel.get_many(
         run_id=run_id,
         key=key,
@@ -157,15 +206,9 @@ def get_mapped_xcom_by_index(
     else:
         xcom_query = xcom_query.order_by(XComModel.map_index.desc()).offset(-1 - offset)
 
-    result: tuple[XComModel] | None
-    if (result := session.scalars(xcom_query).first()) is None:
-        message = (
-            f"XCom with {key=} {offset=} not found for task {task_id!r} in DAG run {run_id!r} of {dag_id!r}"
-        )
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={"reason": "not_found", "message": message},
-        )
+    result = session.scalars(xcom_query).first()
+    if result is None:
+        raise not_found()
     return XComSequenceIndexResponse((result[0] if isinstance(result, tuple) else result).value)
 
 
@@ -190,6 +233,23 @@ def get_mapped_xcom_by_slice(
     params: Annotated[GetXComSliceFilterParams, Query()],
     session: SessionDep,
 ) -> XComSequenceSliceResponse:
+    mapped_length = (
+        None if params.include_prior_dates else _get_mapped_length(dag_id, run_id, task_id, session=session)
+    )
+    if mapped_length is not None:
+        query = XComModel.get_many(
+            run_id=run_id,
+            key=key,
+            task_ids=task_id,
+            dag_ids=dag_id,
+        ).order_by(None)
+        by_map_index = {
+            row.map_index: row.value
+            for row in session.execute(query.with_only_columns(XComModel.map_index, XComModel.value))
+        }
+        values = [by_map_index.get(i) for i in range(mapped_length)]
+        return XComSequenceSliceResponse(values[params.start : params.stop : params.step])
+
     query = XComModel.get_many(
         run_id=run_id,
         key=key,
@@ -276,6 +336,9 @@ def get_mapped_xcom_by_slice(
     description="Returns the count of mapped XCom values found in the `Content-Range` response header",
 )
 def head_xcom(
+    dag_id: str,
+    run_id: str,
+    task_id: str,
     response: Response,
     session: SessionDep,
     xcom_query: Annotated[Select, Depends(xcom_query)],
@@ -288,7 +351,10 @@ def head_xcom(
             detail={"reason": "invalid_request", "message": "Cannot specify map_index in a HEAD request"},
         )
 
-    count = get_query_count(xcom_query, session=session)
+    if (mapped_length := _get_mapped_length(dag_id, run_id, task_id, session=session)) is not None:
+        count = mapped_length
+    else:
+        count = get_query_count(xcom_query, session=session)
     # Tell the caller how many items in this query. We define a custom range unit (HTTP spec only defines
     # "bytes" but we can add our own)
     response.headers["Content-Range"] = f"map_indexes {count}"

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -236,28 +236,26 @@ def get_mapped_xcom_by_slice(
     mapped_length = (
         None if params.include_prior_dates else _get_mapped_length(dag_id, run_id, task_id, session=session)
     )
-    if mapped_length is not None:
-        query = XComModel.get_many(
-            run_id=run_id,
-            key=key,
-            task_ids=task_id,
-            dag_ids=dag_id,
-        ).order_by(None)
-        by_map_index = {
-            row.map_index: row.value
-            for row in session.execute(query.with_only_columns(XComModel.map_index, XComModel.value))
-        }
-        values = [by_map_index.get(i) for i in range(mapped_length)]
-        return XComSequenceSliceResponse(values[params.start : params.stop : params.step])
-
-    query = XComModel.get_many(
+    base_query = XComModel.get_many(
         run_id=run_id,
         key=key,
         task_ids=task_id,
         dag_ids=dag_id,
         include_prior_dates=params.include_prior_dates,
-    )
-    query = query.order_by(None)
+    ).order_by(None)
+
+    # Only fall back to fetching every XCom row (needed to place each value at its true
+    # map_index) when there's an actual gap. The common case -- every mapped instance has
+    # pushed its XCom -- keeps the cheaper SQL-side OFFSET/LIMIT/slice() below.
+    if mapped_length is not None and get_query_count(base_query, session=session) < mapped_length:
+        by_map_index = {
+            row.map_index: row.value
+            for row in session.execute(base_query.with_only_columns(XComModel.map_index, XComModel.value))
+        }
+        values = [by_map_index.get(i) for i in range(mapped_length)]
+        return XComSequenceSliceResponse(values[params.start : params.stop : params.step])
+
+    query = base_query
 
     step = params.step or 1
 

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
@@ -244,6 +244,44 @@ class TestXComsGetEndpoint:
         assert response.status_code == 200
         assert response.json() == "f"
 
+    def test_xcom_get_with_offset_mapped_task_wrong_key_not_found(self, client, dag_maker, session):
+        """
+        A mapped task with no XCom rows at all for the requested key (e.g. the key is
+        wrong, or nothing has been pushed yet) must 404, not be treated as a sparse
+        sequence and resolve every offset to None.
+        """
+
+        class MyOperator(EmptyOperator):
+            def __init__(self, *, x, **kwargs):
+                super().__init__(**kwargs)
+                self.x = x
+
+        with dag_maker(dag_id="dag"):
+            MyOperator.partial(task_id="task").expand(x=["f", "o", "o", "b"])
+        dag_maker.create_dagrun(run_id="runid")
+
+        response = client.get("/execution/xcoms/dag/runid/task/non_existent_key/item/0")
+        assert response.status_code == 404
+
+    def test_xcom_get_with_slice_mapped_task_wrong_key_not_found(self, client, dag_maker, session):
+        """
+        Same as above, but for the slice endpoint: no XCom rows at all for the key means
+        an empty result, not a full-length list of None.
+        """
+
+        class MyOperator(EmptyOperator):
+            def __init__(self, *, x, **kwargs):
+                super().__init__(**kwargs)
+                self.x = x
+
+        with dag_maker(dag_id="dag"):
+            MyOperator.partial(task_id="task").expand(x=["f", "o", "o", "b"])
+        dag_maker.create_dagrun(run_id="runid")
+
+        response = client.get("/execution/xcoms/dag/runid/task/non_existent_key/slice")
+        assert response.status_code == 200
+        assert response.json() == []
+
     @pytest.mark.parametrize(
         "key",
         [

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
@@ -373,6 +373,44 @@ class TestXComsGetEndpoint:
         assert slice_response.status_code == 200
         assert slice_response.json() == ["f", None, "o", "b"]
 
+    def test_xcom_get_with_slice_mapped_task_without_gap_uses_sql_pagination(
+        self, client, dag_maker, session
+    ):
+        """
+        When every mapped instance has already pushed an XCom, the slice endpoint must
+        not fall into the gap-filling branch that loads every row into memory -- it should
+        keep using SQL-side OFFSET/LIMIT/slice() pagination.
+        """
+
+        class MyOperator(EmptyOperator):
+            def __init__(self, *, x, **kwargs):
+                super().__init__(**kwargs)
+                self.x = x
+
+        with dag_maker(dag_id="dag"):
+            MyOperator.partial(task_id="task").expand(x=["f", "o", "o", "b"])
+        dag_run = dag_maker.create_dagrun(run_id="runid")
+        tis = {ti.map_index: ti for ti in dag_run.task_instances}
+
+        for map_index, value in enumerate(["f", "o", "o", "b"]):
+            ti = tis[map_index]
+            session.add(
+                XComModel(
+                    key="xcom_1",
+                    value=value,
+                    dag_run_id=ti.dag_run.id,
+                    run_id=ti.run_id,
+                    task_id=ti.task_id,
+                    dag_id=ti.dag_id,
+                    map_index=map_index,
+                )
+            )
+        session.commit()
+
+        response = client.get("/execution/xcoms/dag/runid/task/xcom_1/slice")
+        assert response.status_code == 200
+        assert response.json() == ["f", "o", "o", "b"]
+
     @pytest.mark.parametrize(
         ("include_prior_dates", "expected_xcoms"),
         [[True, ["earlier_value", "later_value"]], [False, ["later_value"]]],

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
@@ -35,7 +35,7 @@ from airflow.models.xcom import XComModel
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.sdk.serde import deserialize, serialize
 from airflow.utils.session import create_session
-from airflow.utils.state import DagRunState
+from airflow.utils.state import DagRunState, TaskInstanceState
 
 from tests_common.test_utils.config import conf_vars
 
@@ -142,38 +142,40 @@ class TestXComsGetEndpoint:
         ("offset", "expected_status", "expected_json"),
         [
             pytest.param(
-                -4,
+                -5,
                 404,
                 {
                     "detail": {
                         "reason": "not_found",
                         "message": (
-                            "XCom with key='xcom_1' offset=-4 not found "
+                            "XCom with key='xcom_1' offset=-5 not found "
                             "for task 'task' in DAG run 'runid' of 'dag'"
                         ),
                     },
                 },
-                id="-4",
+                id="-5",
             ),
-            pytest.param(-3, 200, "f", id="-3"),
+            pytest.param(-4, 200, "f", id="-4"),
+            pytest.param(-3, 200, None, id="-3"),
             pytest.param(-2, 200, "o", id="-2"),
             pytest.param(-1, 200, "b", id="-1"),
             pytest.param(0, 200, "f", id="0"),
-            pytest.param(1, 200, "o", id="1"),
-            pytest.param(2, 200, "b", id="2"),
+            pytest.param(1, 200, None, id="1"),
+            pytest.param(2, 200, "o", id="2"),
+            pytest.param(3, 200, "b", id="3"),
             pytest.param(
-                3,
+                4,
                 404,
                 {
                     "detail": {
                         "reason": "not_found",
                         "message": (
-                            "XCom with key='xcom_1' offset=3 not found "
+                            "XCom with key='xcom_1' offset=4 not found "
                             "for task 'task' in DAG run 'runid' of 'dag'"
                         ),
                     },
                 },
-                id="3",
+                id="4",
             ),
         ],
     )
@@ -217,6 +219,30 @@ class TestXComsGetEndpoint:
         response = client.get(f"/execution/xcoms/dag/runid/task/xcom_1/item/{offset}")
         assert response.status_code == expected_status
         assert response.json() == expected_json
+
+    def test_xcom_get_with_offset_unmapped_task_falls_back_to_position(
+        self, client, create_task_instance, session
+    ):
+        """
+        An unmapped task (map_index=-1) has no logical map_index range to key a sparse
+        array off of, so offset access falls back to indexing by position among existing
+        XCom rows, same as before this endpoint gained sparse-index resolution.
+        """
+        ti = create_task_instance()
+        x = XComModel(
+            key="xcom_1",
+            value="f",
+            dag_run_id=ti.dag_run.id,
+            run_id=ti.run_id,
+            task_id=ti.task_id,
+            dag_id=ti.dag_id,
+        )
+        session.add(x)
+        session.commit()
+
+        response = client.get(f"/execution/xcoms/{ti.dag_id}/{ti.run_id}/{ti.task_id}/xcom_1/item/0")
+        assert response.status_code == 200
+        assert response.json() == "f"
 
     @pytest.mark.parametrize(
         "key",
@@ -278,7 +304,74 @@ class TestXComsGetEndpoint:
 
         response = client.get(f"/execution/xcoms/dag/runid/task/xcom_1/slice?{urllib.parse.urlencode(qs)}")
         assert response.status_code == 200
-        assert response.json() == ["f", "o", "b"][key]
+        assert response.json() == xcom_values[key]
+
+    def test_xcom_get_with_slice_unmapped_task_falls_back_to_compaction(
+        self, client, create_task_instance, session
+    ):
+        """
+        An unmapped task (map_index=-1) has no logical map_index range to key a sparse
+        array off of, so slicing falls back to the existing XCom rows in map_index order,
+        same as before this endpoint gained sparse-index resolution.
+        """
+        ti = create_task_instance()
+        x = XComModel(
+            key="xcom_1",
+            value="f",
+            dag_run_id=ti.dag_run.id,
+            run_id=ti.run_id,
+            task_id=ti.task_id,
+            dag_id=ti.dag_id,
+        )
+        session.add(x)
+        session.commit()
+
+        response = client.get(f"/execution/xcoms/{ti.dag_id}/{ti.run_id}/{ti.task_id}/xcom_1/slice")
+        assert response.status_code == 200
+        assert response.json() == ["f"]
+
+    def test_xcom_get_with_slice_and_count_unfinished_mapped_task(self, client, dag_maker, session):
+        """
+        Regression test for a mapped task instance that hasn't pushed any XCom yet (e.g.
+        still up_for_reschedule), as opposed to one that pushed a None value.
+
+        Both the slice and count (HEAD) endpoints must reflect the full logical
+        map_index range, not just the map indexes that have an XCom row.
+        """
+
+        class MyOperator(EmptyOperator):
+            def __init__(self, *, x, **kwargs):
+                super().__init__(**kwargs)
+                self.x = x
+
+        with dag_maker(dag_id="dag"):
+            MyOperator.partial(task_id="task").expand(x=["f", "o", "o", "b"])
+        dag_run = dag_maker.create_dagrun(run_id="runid")
+        tis = {ti.map_index: ti for ti in dag_run.task_instances}
+
+        tis[1].state = TaskInstanceState.UP_FOR_RESCHEDULE
+        for map_index, value in {0: "f", 2: "o", 3: "b"}.items():
+            ti = tis[map_index]
+            session.add(
+                XComModel(
+                    key="xcom_1",
+                    value=value,
+                    dag_run_id=ti.dag_run.id,
+                    run_id=ti.run_id,
+                    task_id=ti.task_id,
+                    dag_id=ti.dag_id,
+                    map_index=map_index,
+                )
+            )
+        session.commit()
+
+        head_response = client.head("/execution/xcoms/dag/runid/task/xcom_1")
+        assert head_response.status_code == 200
+        assert head_response.headers["Content-Range"] == "map_indexes 4"
+
+        slice_response = client.get("/execution/xcoms/dag/runid/task/xcom_1/slice")
+        assert slice_response.status_code == 200
+        assert slice_response.json() == ["f", None, "o", "b"]
 
     @pytest.mark.parametrize(
         ("include_prior_dates", "expected_xcoms"),

--- a/task-sdk/tests/task_sdk/execution_time/test_lazy_sequence.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_lazy_sequence.py
@@ -139,6 +139,15 @@ def test_getitem_calls_correct_deserialise(monkeypatch, mock_supervisor_comms, l
     )
 
 
+def test_getitem_index_sparse_gap_returns_none(mock_supervisor_comms, lazy_sequence):
+    """
+    A mapped task instance that hasn't pushed an XCom yet (still within the logical
+    map_index range, e.g. up_for_reschedule or skipped) resolves to None, not IndexError.
+    """
+    mock_supervisor_comms.send.return_value = XComSequenceIndexResult(root=None)
+    assert lazy_sequence[4] is None
+
+
 def test_getitem_indexerror(mock_supervisor_comms, lazy_sequence):
     mock_supervisor_comms.send.return_value = ErrorResponse(
         error=ErrorType.XCOM_NOT_FOUND,


### PR DESCRIPTION
### Sumarry

Fix the Execution API's XCom sequence-read endpoints so a mapped task/task-group instance that hasn't pushed an XCom yet (still `up_for_reschedule`, or skipped) doesn't shift the values of every mapped instance after it.

closes: #40321

### The bug

`get_mapped_xcom_by_index`, `get_mapped_xcom_by_slice`, and `head_xcom` (in `airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py`) all built their result by querying XCom rows ordered by `map_index` and then using the *position in that result set* as if it were the `map_index` itself (via SQL `OFFSET`/`LIMIT`/`slice()`, with `map_index` dropped from the response).

That's correct only when every mapped instance has already pushed an XCom. If one hasn't — e.g. a sensor inside a dynamically mapped `@task_group` is still `up_for_reschedule` — there's no row for its `map_index`, so the query silently returns one fewer row and every later `map_index`'s value shifts down by one position. A downstream task reading `mapped_group.output[i]` (or iterating over it) can get another instance's value instead of the one it asked for, or hit an `IndexError` reading past the (now short) end.

This is the same root cause reported in #40321 in 2024 against the Airflow 2.x `LazyXComSelectSequence` implementation. The AIP-72 rewrite reimplemented the same "position == map_index" assumption in the new task-sdk/execution-API code path instead of fixing it, so it's still present on `main` today.

### Confirming the bug is still there, and that the fix resolves it

Before writing the fix, I reproduced the bug against current `main` with a test scenario matching the issue: a task mapped over 4 values, where `map_index=1` never gets an XCom row (simulating a mapped instance that's still `up_for_reschedule` and hasn't pushed anything). Querying the slice endpoint for all 4 values returned only 3 — `["f", "o", "b"]` — with the value that actually belongs to `map_index=3` silently shifted into `map_index=1`'s position. The `HEAD` endpoint's count also undercounted (3 instead of 4). This matches exactly what the issue reports: values read by a downstream task line up with the wrong `map_index`, and the reported length is wrong too.

Two of the existing tests in `test_xcoms.py` (`test_xcom_get_with_offset`, `test_xcom_get_with_slice`) already built this exact gapped scenario, but asserted the *compacted* 3-item result as the expected outcome — meaning the buggy behavior was pinned as correct by the test suite rather than being an untested gap.

After the fix, I reran the same scenario: the slice endpoint now returns the full 4-item `["f", None, "o", "b"]`, with `map_index=3`'s value correctly in position 3, and `HEAD`'s count correctly reports 4. I updated the two pinning tests to assert this corrected behavior and added `test_xcom_get_with_slice_and_count_unfinished_mapped_task` as an explicit regression test for the issue's scenario (a task instance that never pushed an XCom at all, as opposed to one whose pushed value happened to be `None` — those are different situations that both need to resolve correctly).

### The fix

Added `_get_mapped_length()`, which resolves the *logical* number of mapped instances for `(dag_id, run_id, task_id)` from the `TaskInstance` table (every mapped instance gets a row at expansion time, whether or not it has run yet — see `TaskMap.expand_mapped_task`), independent of how many XCom rows exist.

When a task is mapped in this run, the three endpoints now key results by the *actual* `map_index` instead of result position, filling in `None` for any `map_index` that has no XCom row yet:

- `get_mapped_xcom_by_index`: `offset` resolves against the logical `0..mapped_length-1` range; a valid-but-missing index returns `None` (200), not a 404 — only an out-of-range index 404s.
- `get_mapped_xcom_by_slice`: builds a `map_index -> value` dict, fills gaps with `None`, then applies the slice with plain Python slicing.
- `head_xcom`: reports the logical mapped length in `Content-Range`, not the XCom row count.

Two cases are deliberately left on the old (pre-fix) behavior, since there's no well-defined "logical length" for them:

- `include_prior_dates=True` on the slice endpoint can span multiple dag runs, each with its own (potentially different) mapped length.
- An unmapped task (`map_index=-1`, no expansion) has no mapped-length concept at all — it falls through to the original row-position logic unchanged.

`get_xcom`'s `offset` query-parameter branch (a separate, older code path) is intentionally untouched — no task-sdk client currently calls it with `offset` set, and it has its own pre-existing "skip None values" semantics that aren't part of this bug.

### Blast radius: what else calls these endpoints, and what changes for callers

I checked who actually consumes these three routes and what the response-shape change means for them, since this touches a fairly central part of the Execution API.

**Consumers.** `task-sdk`'s `LazyXComSequence` (`task-sdk/src/airflow/sdk/execution_time/lazy_sequence.py`) is the only real consumer, reached through `XComOperations` in `task-sdk/src/airflow/sdk/api/client.py`. I grepped the rest of the repo (`providers/`, the UI, everywhere else) for these route paths and the relevant symbol names and found no other caller — nothing outside task-sdk talks to these three endpoints directly. `client.py` itself is a thin pass-through and doesn't assume anything about the old semantics, so it needed no changes.

**User-visible behavior change.** This is the one worth calling out explicitly: a mapped task's `.output` used to silently compact away gaps when iterated, sliced, or expanded over downstream (`for v in t.output`, `.expand(x=t.output)`, etc.) — a missing map_index just meant the list was shorter than the actual mapped count, with everything after it shifted into the wrong position. After this fix, `.output` is the correct length and gaps show up explicitly as `None` at their true position. This is the intended correctness fix, but it's a behavior change any DAG author relying (knowingly or not) on the old compaction would notice — e.g. `.expand(x=t.output)` now creates an instance with `x=None` for the gap instead of one fewer instance. Flagging this for review since it's a semantic change, not just a bugfix that's invisible from the outside.

**Performance.** The original version of this fix always fetched every XCom row for the task into a Python dict once a task was detected as mapped, even when there was no gap at all — regressing the existing SQL-side `OFFSET`/`LIMIT`/`slice()` pagination for the common case. Since XCom values are stored in an unbounded JSON column (only the *count* of mapped instances is capped, by `core.max_map_length`, default 1024), that could mean loading a large number of large payloads into API-server memory for a single-item slice request. Fixed by adding one cheap `COUNT` query to detect whether a gap actually exists before falling into the full-fetch path — the common case (no gaps) keeps the original SQL pagination; only a genuinely sparse sequence pays the cost of loading every row, which is unavoidable since placing values at their true `map_index` requires knowing all of them. Added `test_xcom_get_with_slice_mapped_task_without_gap_uses_sql_pagination` to cover the no-gap path explicitly, since the existing gap-scenario tests wouldn't have caught a regression here.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)