### PR TITLE
Continuously service DAG processor IPC while parsers are active

### DIFF
--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import functools
 import gc
 import inspect
@@ -28,6 +29,7 @@ import random
 import selectors
 import signal
 import sys
+import threading
 import time
 import zipfile
 from collections import OrderedDict, defaultdict
@@ -209,6 +211,53 @@ class _StubSelector(selectors.BaseSelector):
     def get_map(self): ...
 
 
+class _LockedSelector(selectors.BaseSelector):
+    """Serialize selector operations so the IPC thread and the parsing loop do not race."""
+
+    def __init__(self, inner: selectors.BaseSelector | None = None) -> None:
+        super().__init__()
+        self._inner = inner or selectors.DefaultSelector()
+        self._lock = threading.Lock()
+
+    def register(self, fileobj, events, data=None):
+        with self._lock:
+            return self._inner.register(fileobj, events, data)
+
+    def unregister(self, fileobj):
+        with self._lock:
+            return self._inner.unregister(fileobj)
+
+    def modify(self, fileobj, events, data=None):
+        with self._lock:
+            return self._inner.modify(fileobj, events, data)
+
+    def select(self, timeout=None):
+        # Do not hold ``_lock`` across the blocking wait. The IPC thread is the
+        # only select() caller (kill uses wait=False); register/unregister from
+        # the parsing thread must proceed while we wait, and holding the lock
+        # here also meant os.fork() could copy a held lock into parser children.
+        return self._inner.select(timeout)
+
+    def close(self):
+        with self._lock:
+            return self._inner.close()
+
+    def get_map(self):
+        with self._lock:
+            return self._inner.get_map()
+
+    def get_key(self, fileobj):
+        with self._lock:
+            return self._inner.get_key(fileobj)
+
+
+class _IpcThreadControl(NamedTuple):
+    stop: threading.Event
+    pause: threading.Event
+    parked: threading.Event
+    thread: threading.Thread
+
+
 @attrs.define(kw_only=True)
 class DagFileProcessorManager(LoggingMixin):
     """
@@ -293,6 +342,7 @@ class DagFileProcessorManager(LoggingMixin):
     """Last time we checked if any bundles are ready to be refreshed"""
     _force_refresh_bundles: set[str] = attrs.field(factory=set, init=False)
     """List of bundles that need to be force refreshed in the next loop"""
+    _ipc_control: _IpcThreadControl | None = attrs.field(default=None, init=False)
 
     _file_parsing_sort_mode: str = attrs.field(
         factory=_config_get_factory("dag_processor", "file_parsing_sort_mode")
@@ -401,7 +451,9 @@ class DagFileProcessorManager(LoggingMixin):
         """Initialize transport-neutral process state (selector, stats) before the parsing loop starts."""
         # Initialization is delayed until here to avoid fork issues in some
         # selector implementations. Also see _StubSelector documentation.
-        self.selector = selectors.DefaultSelector()
+        # The lock wrapper lets the IPC service thread and the parsing loop
+        # share the selector without concurrent select/register/unregister.
+        self.selector = _LockedSelector()
 
         stats.initialize(
             factory=stats_utils.get_stats_factory(),
@@ -561,55 +613,148 @@ class DagFileProcessorManager(LoggingMixin):
         # needs to be done before this process is forked to create the DAG parsing processes.
         SecretCache.init()
 
-        poll_time = 0.0
-
         known_files: dict[str, set[DagFileInfo]] = {}
 
-        while True:
-            loop_start_time = time.monotonic()
+        with self._ipc_service_thread():
+            while True:
+                loop_start_time = time.monotonic()
 
-            self.heartbeat()
+                self.heartbeat()
 
-            self._kill_timed_out_processors()
+                self._kill_timed_out_processors()
 
-            self._queue_requested_files_for_parsing()
+                self._queue_requested_files_for_parsing()
 
-            self._refresh_dag_bundles(known_files=known_files)
+                self._refresh_dag_bundles(known_files=known_files)
 
-            if not self._file_queue:
-                # Generate more file paths to process if we processed all the files already. Note for this to
-                # clear down, we must have cleared all files found from scanning the dags dir _and_ have
-                # cleared all files added as a result of callbacks
-                self.prepare_file_queue(known_files=known_files)
+                if not self._file_queue:
+                    # Generate more file paths to process if we processed all the files already. Note for this to
+                    # clear down, we must have cleared all files found from scanning the dags dir _and_ have
+                    # cleared all files added as a result of callbacks
+                    self.prepare_file_queue(known_files=known_files)
 
-            self._start_new_processes()
+                self._start_new_processes()
 
-            self._service_processor_sockets(timeout=poll_time)
+                self._collect_results()
 
-            self._collect_results()
+                for callback in self.fetch_callbacks():
+                    self._add_callback_to_queue(callback)
+                self._scan_stale_dags()
+                self._cleanup_stale_bundle_versions()
+                self.purge_inactive_dag_warnings()
 
-            for callback in self.fetch_callbacks():
-                self._add_callback_to_queue(callback)
-            self._scan_stale_dags()
-            self._cleanup_stale_bundle_versions()
-            self.purge_inactive_dag_warnings()
+                # Update number of loop iteration.
+                self._num_run += 1
 
-            # Update number of loop iteration.
-            self._num_run += 1
+                self.print_stats(known_files=known_files)
 
-            self.print_stats(known_files=known_files)
+                if self.max_runs_reached():
+                    self.log.info(
+                        "Exiting dag parsing loop as all files have been processed %s times", self.max_runs
+                    )
+                    break
 
-            if self.max_runs_reached():
-                self.log.info(
-                    "Exiting dag parsing loop as all files have been processed %s times", self.max_runs
-                )
-                break
+                self._wait_between_loop_iterations(loop_start_time)
+                if self.max_runs_reached():
+                    self.log.info(
+                        "Exiting dag parsing loop as all files have been processed %s times", self.max_runs
+                    )
+                    break
 
-            loop_duration = time.monotonic() - loop_start_time
-            if loop_duration < 1:
-                poll_time = 1 - loop_duration
-            else:
-                poll_time = 0.0
+        # max_runs can be reached while collecting in-flight results, before the
+        # next empty-queue prepare_file_queue() call that used to emit this.
+        self._emit_parse_cycle_metrics()
+
+    def _wait_between_loop_iterations(self, loop_start_time: float) -> None:
+        """
+        Rate-limit the parsing loop without delaying in-flight result collection.
+
+        The pre-thread loop waited inside ``_service_processor_sockets`` and woke
+        as soon as a child closed its sockets. Replacing that with a blind
+        ``sleep(1)`` made ``max_runs=1`` manager runs take several extra seconds
+        and trip CI ``execution_timeout`` (see ``test_dag_with_system_exit``).
+        """
+        remaining = 1.0 - (time.monotonic() - loop_start_time)
+        if remaining <= 0:
+            return
+
+        if not self._processors and not self._file_queue:
+            time.sleep(remaining)
+            return
+
+        deadline = time.monotonic() + remaining
+        while time.monotonic() < deadline:
+            if self._processors:
+                self._collect_results()
+            if self.max_runs_reached() or not self._processors:
+                return
+            time.sleep(0.05)
+
+    @contextlib.contextmanager
+    def _ipc_service_thread(self):
+        """
+        Run ``_service_processor_sockets`` in a background thread until the context exits.
+
+        Parser children that call ``Variable.get()`` / ``xcom_push()`` block on
+        ``socket.recv()`` until the parent replies. Servicing sockets only once
+        per parsing-loop iteration leaves those children stuck while the parent
+        is in ``_refresh_dag_bundles`` or other long work.
+
+        The thread parks before ``os.fork()`` (see ``_pause_ipc_for_fork``) so
+        Linux parser children are not created from a multi-threaded parent.
+        """
+        stop_event = threading.Event()
+        pause_event = threading.Event()
+        parked = threading.Event()
+
+        def _service_loop():
+            while not stop_event.is_set():
+                if pause_event.is_set():
+                    parked.set()
+                    while pause_event.is_set() and not stop_event.is_set():
+                        stop_event.wait(timeout=0.05)
+                    parked.clear()
+                    continue
+                try:
+                    self._service_processor_sockets(timeout=0.1)
+                except Exception:
+                    self.log.exception("Error servicing processor sockets")
+
+        thread = threading.Thread(target=_service_loop, name="dag-processor-ipc")
+        self._ipc_control = _IpcThreadControl(
+            stop=stop_event, pause=pause_event, parked=parked, thread=thread
+        )
+        thread.start()
+        try:
+            yield
+        finally:
+            stop_event.set()
+            pause_event.clear()
+            thread.join(timeout=2.0)
+            if thread.is_alive():
+                self.log.warning("IPC service thread did not stop within 2s")
+            self._ipc_control = None
+
+    @contextlib.contextmanager
+    def _pause_ipc_for_fork(self):
+        """
+        Park the IPC thread so ``os.fork()`` does not copy a live extra thread.
+
+        Linux parser children use a bare fork (no exec). Forking while
+        ``dag-processor-ipc`` is in ``select()`` or holding library locks can
+        leave the child deadlocked, so ``is_ready`` never becomes true.
+        """
+        ctl = self._ipc_control
+        if ctl is None or not ctl.thread.is_alive():
+            yield
+            return
+        ctl.pause.set()
+        if not ctl.parked.wait(timeout=1.0):
+            self.log.warning("IPC thread did not pause before fork")
+        try:
+            yield
+        finally:
+            ctl.pause.clear()
 
     def _service_processor_sockets(self, timeout: float | None = 1.0):
         """
@@ -1237,7 +1382,7 @@ class DagFileProcessorManager(LoggingMixin):
                         }
                     ),
                 )
-                processor.kill(signal.SIGKILL)
+                processor.kill(signal.SIGKILL, wait=False)
                 processor.close()
                 self._file_stats.pop(file, None)
 
@@ -1450,28 +1595,33 @@ class DagFileProcessorManager(LoggingMixin):
 
     def _start_new_processes(self):
         """Start more processors if we have enough slots and files to process."""
+        if not (self._parallelism > len(self._processors) and self._file_queue):
+            return
+
         bundle_to_team = self._get_team_names({file.bundle_name for file in self._file_queue})
 
-        while self._parallelism > len(self._processors) and self._file_queue:
-            file, _ = self._file_queue.popitem(last=False)
-            # Stop creating duplicate processor i.e. processor with the same filepath
-            if file in self._processors:
-                continue
+        # Forking with the IPC thread running is not safe on Linux (bare fork).
+        with self._pause_ipc_for_fork():
+            while self._parallelism > len(self._processors) and self._file_queue:
+                file, _ = self._file_queue.popitem(last=False)
+                # Stop creating duplicate processor i.e. processor with the same filepath
+                if file in self._processors:
+                    continue
 
-            processor = self._create_process(file)
-            stats.incr(
-                "dag_processing.processes",
-                tags=prune_dict(
-                    {
-                        "file_path": file.normalized_file_path_for_stats,
-                        "action": "start",
-                        "team_name": bundle_to_team.get(file.bundle_name),
-                    }
-                ),
-            )
+                processor = self._create_process(file)
+                stats.incr(
+                    "dag_processing.processes",
+                    tags=prune_dict(
+                        {
+                            "file_path": file.normalized_file_path_for_stats,
+                            "action": "start",
+                            "team_name": bundle_to_team.get(file.bundle_name),
+                        }
+                    ),
+                )
 
-            self._processors[file] = processor
-            stats.gauge("dag_processing.file_path_queue_size", len(self._file_queue))
+                self._processors[file] = processor
+                stats.gauge("dag_processing.file_path_queue_size", len(self._file_queue))
 
     def _add_new_files_to_queue(self, known_files: dict[str, set[DagFileInfo]]):
         """
@@ -1564,12 +1714,7 @@ class DagFileProcessorManager(LoggingMixin):
         """
         # We only emit metrics after processing all files in the queue. If `self._parsing_start_time` is None
         # when this method is called, no files have yet been added to the queue so we shouldn't emit metrics.
-        if self._parsing_start_time is not None:
-            emit_metrics(
-                parse_time=time.perf_counter() - self._parsing_start_time,
-                dag_file_stats=list(self._file_stats.values()),
-            )
-            self._parsing_start_time = None
+        self._emit_parse_cycle_metrics()
 
         # If the file path is already being processed, or if a file was
         # processed recently, wait until the next batch
@@ -1658,7 +1803,7 @@ class DagFileProcessorManager(LoggingMixin):
                     "dag_processing.processor_timeouts",
                     tags=prune_dict({"file_path": file_path_tag, "team_name": team_name}),
                 )
-                processor.kill(signal.SIGKILL)
+                processor.kill(signal.SIGKILL, wait=False)
 
                 processors_to_remove.append(file)
 
@@ -1707,6 +1852,16 @@ class DagFileProcessorManager(LoggingMixin):
             self._parsing_start_time = time.perf_counter()
 
         stats.gauge("dag_processing.file_path_queue_size", len(self._file_queue))
+
+    def _emit_parse_cycle_metrics(self) -> None:
+        """Emit ``total_parse_time`` for the current file-queue cycle, if one is in progress."""
+        if self._parsing_start_time is None:
+            return
+        emit_metrics(
+            parse_time=time.perf_counter() - self._parsing_start_time,
+            dag_file_stats=list(self._file_stats.values()),
+        )
+        self._parsing_start_time = None
 
     def max_runs_reached(self):
         """:return: whether all file paths have been processed max_runs times."""

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -26,6 +26,7 @@ import re
 import shutil
 import signal
 import textwrap
+import threading
 import time
 import zipfile
 from collections import Counter, OrderedDict, defaultdict, namedtuple
@@ -678,7 +679,7 @@ class TestDagFileProcessorManager:
             "dag_processing.processes",
             tags={"file_path": "callbacks_with_spaces.py", "action": "stop"},
         )
-        processor.kill.assert_called_once_with(signal.SIGKILL)
+        processor.kill.assert_called_once_with(signal.SIGKILL, wait=False)
 
     def test_terminate_orphan_processes_tolerates_stale_file_handle_on_close(self):
         """A stale NFS file handle on close (e.g. OpenShift) must not crash the manager."""
@@ -1539,7 +1540,7 @@ class TestDagFileProcessorManager:
             mock.patch("airflow.dag_processing.manager.stats.incr") as stats_incr_mock,
         ):
             manager._kill_timed_out_processors()
-        mock_kill.assert_called_once_with(signal.SIGKILL)
+        mock_kill.assert_called_once_with(signal.SIGKILL, wait=False)
         stats_decr_mock.assert_called_once_with(
             "dag_processing.processes",
             tags={"file_path": "folder_abc_txt.py", "action": "timeout"},
@@ -1587,6 +1588,75 @@ class TestDagFileProcessorManager:
         with mock.patch.object(type(processor), "kill") as mock_kill:
             manager._kill_timed_out_processors()
         mock_kill.assert_not_called()
+
+    def test_ipc_service_thread_starts_and_stops(self):
+        manager = DagFileProcessorManager(max_runs=1)
+        manager.prepare_process_context()
+
+        with manager._ipc_service_thread():
+            ipc_threads = [t for t in threading.enumerate() if t.name == "dag-processor-ipc"]
+            assert len(ipc_threads) == 1
+            assert ipc_threads[0].is_alive()
+
+        ipc_threads = [t for t in threading.enumerate() if t.name == "dag-processor-ipc"]
+        assert ipc_threads == []
+
+    def test_ipc_service_thread_polls_while_caller_is_blocked(self):
+        manager = DagFileProcessorManager(max_runs=1)
+        manager.prepare_process_context()
+        calls: list[float] = []
+        original = manager._service_processor_sockets
+
+        def _track(timeout=1.0):
+            calls.append(timeout)
+            return original(timeout=timeout)
+
+        with mock.patch.object(manager, "_service_processor_sockets", side_effect=_track):
+            with manager._ipc_service_thread():
+                time.sleep(0.35)
+
+        assert calls
+        assert all(timeout == 0.1 for timeout in calls)
+
+    def test_ipc_thread_pauses_around_process_start(self):
+        manager = DagFileProcessorManager(max_runs=1)
+        manager.prepare_process_context()
+        dag_file = DagFileInfo(bundle_name="testing", rel_path=Path("abc.py"), bundle_path=TEST_DAGS_FOLDER)
+        manager._file_queue = OrderedDict([(dag_file, None)])
+        paused_at_create: list[bool] = []
+
+        def _fake_create(file):
+            ctl = manager._ipc_control
+            paused_at_create.append(bool(ctl and ctl.parked.is_set()))
+            processor, _ = self.mock_processor()
+            return processor
+
+        with manager._ipc_service_thread():
+            with mock.patch.object(manager, "_create_process", side_effect=_fake_create):
+                manager._start_new_processes()
+
+        assert paused_at_create == [True]
+        assert dag_file in manager._processors
+
+    def test_wait_between_loop_iterations_collects_ready_processors(self):
+        manager = DagFileProcessorManager(max_runs=1)
+        dag_file = DagFileInfo(bundle_name="testing", rel_path=Path("abc.py"), bundle_path=TEST_DAGS_FOLDER)
+        processor, _ = self.mock_processor()
+        manager._processors[dag_file] = processor
+        manager._file_stats[dag_file] = DagFileStat()
+        manager._num_run = 1
+
+        def _handle(file, proc):
+            manager._file_stats[file] = DagFileStat(run_count=1)
+
+        with (
+            mock.patch.object(type(processor), "is_ready", new_callable=mock.PropertyMock, return_value=True),
+            mock.patch.object(manager, "handle_parsing_result", side_effect=_handle),
+        ):
+            manager._wait_between_loop_iterations(loop_start_time=time.monotonic())
+
+        assert manager._processors == {}
+        assert manager.max_runs_reached()
 
     def test_terminate_normalizes_file_path_stats_tag(self):
         manager = DagFileProcessorManager(max_runs=1)

--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -22,6 +22,7 @@ import logging
 import pathlib
 import sys
 import textwrap
+import time
 import typing
 import uuid
 from collections.abc import Callable, Iterable
@@ -192,6 +193,51 @@ class TestDagFileProcessor:
             proc._service_subprocess(0.1)
 
         result = proc.parsing_result
+        assert result is not None
+        assert result.import_errors == {}
+        assert result.serialized_dags[0].dag_id == "test_abc"
+
+    def test_variable_get_serviced_while_manager_is_busy(
+        self,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+        inprocess_client,
+    ):
+        logger = MagicMock(spec=FilteringBoundLogger)
+        logger_filehandle = MagicMock(spec=BinaryIO)
+
+        def dag_in_a_fn():
+            from airflow.sdk import DAG, Variable
+
+            with DAG(f"test_{Variable.get('myvar')}"):
+                ...
+
+        path = write_dag_in_a_fn_to_file(dag_in_a_fn, tmp_path)
+        monkeypatch.setenv("AIRFLOW_VAR_MYVAR", "abc")
+
+        manager = DagFileProcessorManager(max_runs=1)
+        manager.prepare_process_context()
+        proc = DagFileProcessorProcess.start(
+            id=1,
+            path=path,
+            bundle_path=tmp_path,
+            bundle_name="testing",
+            dag_file_rel_path=str(path.relative_to(tmp_path)),
+            callbacks=[],
+            logger=logger,
+            logger_filehandle=logger_filehandle,
+            client=inprocess_client,
+            selector=manager.selector,
+        )
+
+        # Main thread does not call _service_processor_sockets; the IPC thread must.
+        with manager._ipc_service_thread():
+            deadline = time.monotonic() + 15
+            while not proc.is_ready and time.monotonic() < deadline:
+                time.sleep(0.05)
+
+        result = proc.parsing_result
+        assert proc.is_ready
         assert result is not None
         assert result.import_errors == {}
         assert result.serialized_dags[0].dag_id == "test_abc"

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -950,6 +950,17 @@ class WatchedSubprocess:
                 msg = self.decoder.validate_python(self._deserialize_request(request.body))
             except Exception:
                 log.exception("Unable to decode message", body=request.body)
+                # Always reply — a silent continue leaves the child blocked on
+                # socket.recv() until the process times out (see issue #65369).
+                with suppress(Exception):
+                    self.send_msg(
+                        msg=None,
+                        request_id=request.id,
+                        error=ErrorResponse(
+                            error=ErrorType.GENERIC_ERROR,
+                            detail={"status_code": 400, "message": "Unable to decode message"},
+                        ),
+                    )
                 continue
 
             # Restore the task runner's trace context so that any outbound HTTP calls made while
@@ -1067,6 +1078,7 @@ class WatchedSubprocess:
         signal_to_send: signal.Signals = signal.SIGINT,
         escalation_delay: float = 5.0,
         force: bool = False,
+        wait: bool = True,
     ):
         """
         Attempt to terminate the subprocess with a given signal.
@@ -1078,6 +1090,8 @@ class WatchedSubprocess:
         :param signal_to_send: The signal to send initially (default is SIGINT).
         :param escalation_delay: Time in seconds to wait for the process to exit after each signal.
         :param force: If True, escalate through the remaining signals instead of sending only `signal_to_send`.
+        :param wait: If False, send the signal and return immediately without polling the shared
+            selector. Used by DagFileProcessorManager while an IPC thread owns socket servicing.
         """
         if self._exit_code is not None:
             return
@@ -1094,6 +1108,8 @@ class WatchedSubprocess:
         for sig in escalation_path:
             try:
                 self._signal_subprocess(sig)
+                if not wait:
+                    return
 
                 start = time.monotonic()
                 end = start + escalation_delay

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -3572,6 +3572,33 @@ class TestHandleRequest:
         # Should not raise StopIteration (which would mean the loop crashed).
         generator.send(req2)
 
+    def test_handle_requests_undecodable_message_sends_error(self, watched_subprocess, mocker):
+        """An unknown IPC body must get an ErrorResponse so the child does not hang on recv()."""
+        watched_subprocess, read_socket = watched_subprocess
+
+        generator = watched_subprocess.handle_requests(log=mocker.Mock())
+        next(generator)
+
+        req_frame = _RequestFrame(id=randint(1, 2**32 - 1), body={"type": "NotARealMessage"})
+        generator.send(req_frame)
+
+        read_socket.settimeout(0.5)
+        frame_len = int.from_bytes(read_socket.recv(4), "big")
+        frame = msgspec.msgpack.Decoder(_ResponseFrame).decode(read_socket.recv(frame_len))
+
+        assert frame.id == req_frame.id
+        assert frame.error is not None
+        assert frame.error["error"] == "GENERIC_ERROR"
+        assert frame.error["detail"]["message"] == "Unable to decode message"
+
+        # Generator must stay alive for a subsequent valid request.
+        watched_subprocess.client.task_instances.succeed = mocker.Mock()
+        req2 = _RequestFrame(
+            id=randint(1, 2**32 - 1),
+            body=SucceedTask(end_date=timezone.parse("2024-10-31T12:00:00Z")).model_dump(),
+        )
+        generator.send(req2)
+
     @pytest.mark.parametrize(
         ("msg", "api_method", "expected_state"),
         [


### PR DESCRIPTION
Continuously service DAG processor IPC while parsers are active

Parser children that call `Variable.get()` or `Connection.get()` during parse or callbacks can pin a Dag-processor slot until `dag_file_processor_timeout`. This PR services IPC continuously while parsers are active, and always replies to undecodable requests so a child cannot hang with no response.


## Problem

Two related gaps produce the same symptom: a parser child blocks on `socket.recv()` and occupies a slot so other Dags go stale.

### 1. Supported IPC is serviced too slowly

When a Dag file calls `Variable.get()` or `Connection.get()` during parse, the forked child sends an IPC request and waits for the parent. The parent only called `_service_processor_sockets()` once per `_run_parsing_loop()` iteration. While the parent is in `_refresh_dag_bundles()`, `_collect_results()`, stale-Dag scans, or other long work, children wait.

Airflow 2 did a direct metadata-DB read for those lookups, so this is a 3.x regression. Profiling of the Dag processor shows `_parse_file()` time dominated by a single `socket.recv()` inside `CommsDecoder._get_response()`.

### 2. Unsupported IPC never gets a reply

A production failure callback called `ti.xcom_push()`. The child sent `SetXCom`, which is not in the Dag processor `ToManager` union. `WatchedSubprocess.handle_requests` logged `Unable to decode message` and continued **without sending a reply**. The child hung until `dag_file_processor_timeout` (default 1200s), pinning a parser slot so other Dags stayed stale.

Any unsupported type (`SetXCom`, `DeleteXCom`, `SucceedTask`, `DeferTask`, …) has the same hang-with-no-reply failure mode. This PR does not add handling for any of those message types — it only makes sure a child sending one fails fast instead of hanging. `SetXCom` handling itself is split out to #72297 per review feedback, since it needs review of its own xcom-persistence semantics separately from the IPC-threading change here.


## Proposed solution

Two layers, both required to close the hang:

1. **Continuous IPC service.** A dedicated `dag-processor-ipc` thread polls processor sockets for the entire parsing loop, so children get replies while the main thread is busy. The in-loop `_service_processor_sockets()` call is removed. `_LockedSelector` serializes `select` / `register` / `unregister` on the shared selector so this thread and the main thread don't race over it; timeout and orphan kills use `kill(..., wait=False)` so they send the signal without stealing that selector.
2. **Always reply.** Any request that fails to decode (including for currently-unsupported types like `SetXCom`) gets an `ErrorResponse` with the request id, so the child's `CommsDecoder` raises immediately instead of hanging.

`SetXCom`, `DeleteXCom`, and other task-lifecycle messages stay unsupported here on purpose; they now fail fast rather than pin a slot.


## Test plan

- [x] `TestHandleRequest.test_handle_requests_undecodable_message_sends_error` — decode failure sends `ErrorResponse` instead of dropping the frame
- [x] `TestDagFileProcessor.test_variable_get_serviced_while_manager_is_busy` — child `Variable.get()` is answered while the main thread is not polling
- [x] `TestDagFileProcessorManager.test_ipc_service_thread_starts_and_stops` / `test_ipc_service_thread_polls_while_caller_is_blocked`
- [x] Timeout / orphan kill paths assert `kill(SIGKILL, wait=False)`
- [ ] CI: airflow-core + task-sdk unit tests selected by selective-checks
