### PR TITLE
Fix common.ai Vertex model example to use a valid pydantic-ai prefix

### DIFF
--- a/providers/common/ai/tests/unit/common/ai/hooks/test_pydantic_ai.py
+++ b/providers/common/ai/tests/unit/common/ai/hooks/test_pydantic_ai.py
@@ -24,6 +24,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pydantic_ai.models import Model
 from pydantic_ai.models.test import TestModel
+from pydantic_ai.providers import infer_provider_class
 
 from airflow.models.connection import Connection
 from airflow.providers.common.ai.hooks.pydantic_ai import (
@@ -722,7 +723,7 @@ class TestPydanticAIVertexHook:
             None,
             None,
             {
-                "model": "google-vertex:gemini-2.0-flash",
+                "model": "google-cloud:gemini-2.0-flash",
                 "project": "my-project",
                 "location": "us-central1",
             },
@@ -739,7 +740,7 @@ class TestPydanticAIVertexHook:
         result = hook._get_provider_kwargs(
             None,
             None,
-            {"model": "google-gla:gemini-2.0-flash", "api_key": "gla-key"},
+            {"model": "google:gemini-2.0-flash", "api_key": "gla-key"},
         )
         assert result["api_key"] == "gla-key"
 
@@ -758,7 +759,7 @@ class TestPydanticAIVertexHook:
             None,
             None,
             {
-                "model": "google-vertex:gemini-2.0-flash",
+                "model": "google-cloud:gemini-2.0-flash",
                 "project": "my-project",
                 "location": "us-central1",
                 "vertexai": vertexai_value,
@@ -792,7 +793,7 @@ class TestPydanticAIVertexHook:
                 None,
                 None,
                 {
-                    "model": "google-vertex:gemini-2.0-flash",
+                    "model": "google-cloud:gemini-2.0-flash",
                     "service_account_info": sa_info_dict,
                 },
             )
@@ -807,7 +808,7 @@ class TestPydanticAIVertexHook:
     def test_get_provider_kwargs_returns_empty_for_adc(self):
         """When no keys are in extra, return {} so ADC path is taken."""
         hook = PydanticAIVertexHook.__new__(PydanticAIVertexHook)
-        result = hook._get_provider_kwargs(None, None, {"model": "google-vertex:gemini-2.0-flash"})
+        result = hook._get_provider_kwargs(None, None, {"model": "google-cloud:gemini-2.0-flash"})
         assert result == {}
 
     @patch("airflow.providers.common.ai.hooks.pydantic_ai.infer_model", autospec=True)
@@ -817,12 +818,12 @@ class TestPydanticAIVertexHook:
         conn = Connection(
             conn_id="vertex_test",
             conn_type="pydanticai-vertex",
-            extra=json.dumps({"model": "google-vertex:gemini-2.0-flash"}),
+            extra=json.dumps({"model": "google-cloud:gemini-2.0-flash"}),
         )
         with patch.object(hook, "get_connection", return_value=conn):
             hook.get_conn()
 
-        mock_infer_model.assert_called_once_with("google-vertex:gemini-2.0-flash")
+        mock_infer_model.assert_called_once_with("google-cloud:gemini-2.0-flash")
 
     @patch("airflow.providers.common.ai.hooks.pydantic_ai.infer_model", autospec=True)
     @patch("airflow.providers.common.ai.hooks.pydantic_ai.infer_provider_class", autospec=True)
@@ -837,7 +838,7 @@ class TestPydanticAIVertexHook:
             conn_type="pydanticai-vertex",
             extra=json.dumps(
                 {
-                    "model": "google-vertex:gemini-2.0-flash",
+                    "model": "google-cloud:gemini-2.0-flash",
                     "project": "my-project",
                     "location": "europe-west4",
                 }
@@ -847,7 +848,7 @@ class TestPydanticAIVertexHook:
             hook.get_conn()
 
         factory = mock_infer_model.call_args[1]["provider_factory"]
-        factory("google-vertex")
+        factory("google-cloud")
         mock_provider_cls.assert_called_with(project="my-project", location="europe-west4")
 
     @patch("airflow.providers.common.ai.hooks.pydantic_ai.infer_model", autospec=True)
@@ -913,3 +914,19 @@ class TestPydanticAIVertexHook:
         assert provider.kwargs["location"] == "us-central1"
         # The TypeError fallback must never have been reached.
         mock_infer_provider.assert_not_called()
+
+    def test_documented_model_prefix_is_a_valid_pydantic_ai_provider(self):
+        """Regression test: the model-prefix documented in the connection form and
+        docstrings must be a provider id pydantic-ai actually recognizes (see
+        pydantic/pydantic-ai#5336, which renamed the old Vertex provider id shortly
+        before Airflow's docstrings/placeholders were written).
+        """
+        try:
+            infer_provider_class("google-cloud")
+        except ValueError as exc:
+            pytest.fail(f"Documented prefix 'google-cloud' is not a recognized provider: {exc}")
+        except ImportError:
+            # The optional `google-genai` dependency isn't installed in the test
+            # environment; failing past provider-name resolution is enough to
+            # prove "google-cloud" is recognized.
+            pass


### PR DESCRIPTION
The documented model-identifier example for the Google Vertex AI connection ("google-vertex:gemini-2.0-flash") is not a provider prefix pydantic-ai recognizes; calling infer_provider_class with it raises ValueError: Unknown provider. Users who copy the connection form placeholder, docstring example, or hook default verbatim hit an immediate, confusing failure instead of an expected credentials error.

pydantic-ai renamed this provider id to "google-cloud:" when it split GoogleProvider(vertexai=True) into separate GoogleProvider and GoogleCloudProvider classes (pydantic/pydantic-ai#5336), shortly before these examples were written. Update the connection-form placeholder, hook docstrings, and tests to the working prefix, and add a regression test that exercises the real (unmocked) provider resolution so the example string can't silently drift again.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)


Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
