### PR TITLE
Test Kerberos startup probe overrides in Worker Sets

### DIFF
--- a/chart/tests/helm_tests/airflow_core/test_worker_sets.py
+++ b/chart/tests/helm_tests/airflow_core/test_worker_sets.py
@@ -1589,6 +1589,68 @@ class TestWorkerSets:
         )
 
     @pytest.mark.parametrize(
+        ("startup_probe", "worker_set_startup_probe", "expected"),
+        [
+            (
+                {"enabled": False},
+                {"enabled": True},
+                {
+                    "exec": {"command": ["klist", "-s"]},
+                    "timeoutSeconds": 5,
+                    "initialDelaySeconds": 0,
+                    "periodSeconds": 10,
+                    "failureThreshold": 6,
+                },
+            ),
+            ({"enabled": True}, {"enabled": False}, None),
+            (
+                {
+                    "timeoutSeconds": 1,
+                    "initialDelaySeconds": 2,
+                    "periodSeconds": 3,
+                    "failureThreshold": 4,
+                },
+                {"timeoutSeconds": 11},
+                {
+                    "exec": {"command": ["klist", "-s"]},
+                    "timeoutSeconds": 11,
+                    "initialDelaySeconds": 2,
+                    "periodSeconds": 3,
+                    "failureThreshold": 4,
+                },
+            ),
+        ],
+        ids=["enabled", "disabled", "custom"],
+    )
+    def test_overwrite_kerberos_sidecar_startup_probe(
+        self, startup_probe, worker_set_startup_probe, expected
+    ):
+        docs = render_chart(
+            values={
+                "workers": {
+                    "celery": {
+                        "enableDefault": False,
+                        "kerberosSidecar": {"enabled": True, "startupProbe": startup_probe},
+                        "sets": [
+                            {
+                                "name": "test",
+                                "kerberosSidecar": {"startupProbe": worker_set_startup_probe},
+                            }
+                        ],
+                    }
+                }
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        assert (
+            jmespath.search(
+                "spec.template.spec.containers[?name=='worker-kerberos'] | [0].startupProbe", docs[0]
+            )
+            == expected
+        )
+
+    @pytest.mark.parametrize(
         "values",
         [
             {


### PR DESCRIPTION
related: #71221
related: #71682

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)