### PR TITLE
fix(db_cleanup): remove invalid dag_id column for task_reschedule

### DIFF
--- a/airflow-core/src/airflow/utils/db_cleanup.py
+++ b/airflow-core/src/airflow/utils/db_cleanup.py
@@ -202,7 +202,7 @@ config_list: list[_TableConfig] = [
         recency_column_name="expires_at",
         dag_id_column_name="dag_id",
     ),
-    _TableConfig(table_name="task_reschedule", recency_column_name="start_date", dag_id_column_name="dag_id"),
+    _TableConfig(table_name="task_reschedule", recency_column_name="start_date"),
     _TableConfig(table_name="xcom", recency_column_name="timestamp", dag_id_column_name="dag_id"),
     _TableConfig(table_name="_xcom_archive", recency_column_name="timestamp", dag_id_column_name="dag_id"),
     _TableConfig(table_name="callback_request", recency_column_name="created_at"),


### PR DESCRIPTION
The `TaskReschedule` table was migrated in Airflow 3.0 (migration `0063`) from `dag_id`/`task_id`/`run_id` to `ti_id` (UUID FK to `task_instance.id`). The `dag_id` column was dropped.

However, `db_cleanup.py`'s `_TableConfig` for `task_reschedule` still specified `dag_id_column_name="dag_id"`, causing the `_build_query` function to generate:

```sql
SELECT count(*) FROM (SELECT base.* FROM task_reschedule AS base
WHERE base.start_date < ... AND base.dag_id IN (...)) AS anon_1
```

This fails with `column base.dag_id does not exist` on PostgreSQL (and similar errors on other databases) when `airflow db clean` is run with a `--dag-id` filter.

**Fix:** Remove the `dag_id_column_name` from `task_reschedule`'s config, since the table no longer has a `dag_id` column and cannot be directly filtered by DAG ID.

Other tables without a `dag_id` column (e.g., `import_error`, `callback_request`, `trigger`, `celery_taskmeta`) already omit this parameter — this fix makes `task_reschedule` consistent with them.

Fixes #72020