### PR TITLE
UI: Show duration chart tooltips in the selected timezone

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DurationChart.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DurationChart.test.tsx
@@ -1,0 +1,65 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render } from "@testing-library/react";
+import { Bar } from "react-chartjs-2";
+import { describe, expect, it, vi } from "vitest";
+
+import type { GridRunsResponse } from "openapi/requests/types.gen";
+import { TimezoneContext } from "src/context/timezone";
+import { Wrapper } from "src/utils/Wrapper";
+
+import { DurationChart } from "./DurationChart";
+
+const makeRun = (runAfter: string): GridRunsResponse => ({
+  dag_id: "tutorial_dag",
+  duration: 60,
+  end_date: `${runAfter.slice(0, -1)}:01:00Z`,
+  has_missed_deadline: false,
+  has_note: false,
+  queued_at: runAfter,
+  run_after: runAfter,
+  run_id: runAfter,
+  run_type: "scheduled",
+  start_date: runAfter,
+  state: "success",
+});
+
+// A Dag scheduled twice a day: the two runs land 12 hours apart on the same date.
+const entries = [makeRun("2026-08-20T08:30:00Z"), makeRun("2026-08-20T20:30:00Z")];
+
+const renderChart = (selectedTimezone: string) => {
+  render(
+    <TimezoneContext.Provider value={{ selectedTimezone, setSelectedTimezone: vi.fn() }}>
+      <DurationChart entries={entries} kind="Dag Run" />
+    </TimezoneContext.Provider>,
+    { wrapper: Wrapper },
+  );
+
+  return vi.mocked(Bar).mock.calls.at(-1)?.[0].data.labels;
+};
+
+describe("DurationChart", () => {
+  it.each([
+    { expected: ["2026-08-20 08:30:00", "2026-08-20 20:30:00"], timezone: "UTC" },
+    { expected: ["2026-08-20 17:30:00", "2026-08-21 05:30:00"], timezone: "Asia/Tokyo" },
+    { expected: ["2026-08-20 04:30:00", "2026-08-20 16:30:00"], timezone: "America/New_York" },
+  ])("labels each bar in the $timezone timezone", ({ expected, timezone }) => {
+    expect(renderChart(timezone)).toEqual(expected);
+  });
+});

--- a/airflow-core/src/airflow/ui/src/components/DurationChart.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DurationChart.tsx
@@ -38,7 +38,6 @@ import type { TaskInstanceResponse, GridRunsResponse } from "openapi/requests/ty
 import { useTimezone } from "src/context/timezone";
 import { getComputedCSSVariableValue } from "src/theme";
 import {
-  DEFAULT_DATETIME_FORMAT,
   formatDate,
   getDurationTickStep,
   renderCompactDuration,
@@ -195,9 +194,7 @@ export const DurationChart = ({
                 label: translate("durationChart.runDuration"),
               },
             ],
-            labels: entries.map((entry: RunResponse) =>
-              dayjs(entry.run_after).format(DEFAULT_DATETIME_FORMAT),
-            ),
+            labels: entries.map((entry: RunResponse) => formatDate(entry.run_after, selectedTimezone)),
           }}
           datasetIdKey="id"
           options={{


### PR DESCRIPTION
## Summary

The duration chart on the Dag and Task overview pages formatted its bar labels — which Chart.js reuses as the tooltip title — in the browser's local timezone, while the x-axis ticks and every other timestamp in the UI follow the timezone selected in the header. With the browser in `Europe/Warsaw` and `Asia/Tokyo` selected, a run at `2026-08-20T08:30:00Z` is labeled 17:30:00 on the axis and 10:30:00 in the tooltip, so the tooltip no longer identifies the bar under the cursor. Labels now use the same `formatDate` call with the selected timezone that the axis already did.

## Tests

The component had no tests; this adds one asserting the label text across three timezones.

related: #72018

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
