### PR TITLE
Fix missing HTTP access logs when api-server omits the core app

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/app.py
+++ b/airflow-core/src/airflow/api_fastapi/app.py
@@ -29,6 +29,7 @@ from starlette.middleware import Middleware
 
 from airflow.api_fastapi.common.dagbag import create_dag_bag
 from airflow.api_fastapi.common.exceptions import init_error_handlers
+from airflow.api_fastapi.common.http_access_log import HttpAccessLogMiddleware
 from airflow.api_fastapi.core_api.app import (
     init_config,
     init_flask_plugins,
@@ -152,6 +153,8 @@ def create_app(apps: str = "all") -> FastAPI:
         init_error_handlers(app)
         init_middlewares(app)
 
+    init_access_logging(app)
+
     init_config(app)
 
     return app
@@ -217,6 +220,11 @@ def get_auth_manager() -> BaseAuthManager:
             "The `init_auth_manager` method needs to be called first."
         )
     return _AuthManagerState.instance
+
+
+def init_access_logging(app: FastAPI) -> None:
+    """Install the access log middleware, the only producer of access records."""
+    app.add_middleware(HttpAccessLogMiddleware)
 
 
 def init_plugins(app: FastAPI) -> None:

--- a/airflow-core/src/airflow/api_fastapi/core_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/app.py
@@ -184,6 +184,6 @@ def init_middlewares(app: FastAPI) -> None:
     # GZipMiddleware must be inside HttpAccessLogMiddleware so that access logs capture
     # the full end-to-end duration including compression time. HttpAccessLogMiddleware is
     # installed by ``init_access_logging`` in ``create_app``, which runs after this
-    # function — do not reorder those calls, and do not add another outer middleware here.
+    # function — do not reorder those calls.
     # See https://github.com/apache/airflow/issues/60165
     app.add_middleware(GZipMiddleware, minimum_size=1024, compresslevel=5)

--- a/airflow-core/src/airflow/api_fastapi/core_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/app.py
@@ -175,7 +175,6 @@ def init_config(app: FastAPI) -> None:
 def init_middlewares(app: FastAPI) -> None:
     from airflow.api_fastapi.app import get_auth_manager
     from airflow.api_fastapi.auth.middlewares.refresh_token import JWTRefreshMiddleware
-    from airflow.api_fastapi.common.http_access_log import HttpAccessLogMiddleware
 
     app.add_middleware(JWTRefreshMiddleware)
 
@@ -186,6 +185,3 @@ def init_middlewares(app: FastAPI) -> None:
     # the full end-to-end duration including compression time.
     # See https://github.com/apache/airflow/issues/60165
     app.add_middleware(GZipMiddleware, minimum_size=1024, compresslevel=5)
-    # HttpAccessLogMiddleware must be outermost (added last) so it times the full
-    # request lifecycle including all inner middleware.
-    app.add_middleware(HttpAccessLogMiddleware)

--- a/airflow-core/src/airflow/api_fastapi/core_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/app.py
@@ -182,6 +182,8 @@ def init_middlewares(app: FastAPI) -> None:
         app.add_middleware(middleware_cls, **middleware_kwargs)
 
     # GZipMiddleware must be inside HttpAccessLogMiddleware so that access logs capture
-    # the full end-to-end duration including compression time.
+    # the full end-to-end duration including compression time. HttpAccessLogMiddleware is
+    # installed by ``init_access_logging`` in ``create_app``, which runs after this
+    # function — do not reorder those calls, and do not add another outer middleware here.
     # See https://github.com/apache/airflow/issues/60165
     app.add_middleware(GZipMiddleware, minimum_size=1024, compresslevel=5)

--- a/airflow-core/tests/unit/api_fastapi/test_app.py
+++ b/airflow-core/tests/unit/api_fastapi/test_app.py
@@ -24,6 +24,7 @@ from fastapi import FastAPI
 
 import airflow.api_fastapi.app as app_module
 import airflow.plugins_manager as plugins_manager
+from airflow.api_fastapi.common.http_access_log import HttpAccessLogMiddleware
 
 from tests_common.test_utils.config import conf_vars
 
@@ -86,6 +87,15 @@ def test_all_apps(mock_create_task_exec_api, mock_init_plugins, mock_init_views,
 
     # Assert that execution-related functions were also called
     mock_create_task_exec_api.assert_called_once_with()
+
+
+@pytest.mark.parametrize("apps", ["all", "core", "execution"])
+def test_access_log_middleware_installed_for_every_apps_selection(apps, client):
+    """Both server backends disable their own access logger, so a selection that skips this
+    middleware has no access logging at all."""
+    installed = [m.cls for m in client(apps=apps).app.user_middleware]
+
+    assert installed.count(HttpAccessLogMiddleware) == 1
 
 
 def test_catch_all_route_last(client):

--- a/airflow-core/tests/unit/api_fastapi/test_app.py
+++ b/airflow-core/tests/unit/api_fastapi/test_app.py
@@ -90,12 +90,15 @@ def test_all_apps(mock_create_task_exec_api, mock_init_plugins, mock_init_views,
 
 
 @pytest.mark.parametrize("apps", ["all", "core", "execution"])
-def test_access_log_middleware_installed_for_every_apps_selection(apps, client):
+def test_access_log_middleware_installed_outermost_for_every_apps_selection(apps, client):
     """Both server backends disable their own access logger, so a selection that skips this
-    middleware has no access logging at all."""
+    middleware has no access logging at all. It must also stay outermost so it times the full
+    request including inner middlewares (GZip compression in particular — see #60165); the
+    test default config has no CORS so index 0 is HttpAccessLogMiddleware."""
     installed = [m.cls for m in client(apps=apps).app.user_middleware]
 
     assert installed.count(HttpAccessLogMiddleware) == 1
+    assert installed[0] is HttpAccessLogMiddleware
 
 
 def test_catch_all_route_last(client):


### PR DESCRIPTION
An `api-server` started without the core app — for example `--apps execution`, the shape used to run
the Task Execution API as its own deployment — serves requests normally but emits no access log
lines at all.

Three separate places disable the built-in access loggers, all resting on the premise that
`HttpAccessLogMiddleware` handles access logging:

- `AirflowUvicornWorker.CONFIG_KWARGS` — `access_log: False`
- the uvicorn kwargs built in `api_server_command`
- `uvicorn.access` / `gunicorn.access` muted (`handlers: []`, `propagate: False`) in `logging_config`

That premise only held while the middleware was installed inside the `"core" in apps_list` branch of
`create_app`, so an `--apps` selection without `core` had no access-log producer at all — and because
the loggers are muted at the logging-config level too, no configuration could bring the records back.

This installs the middleware for every `apps` selection, which makes the premise true again rather
than adding a fourth conditional. The alternative — enabling uvicorn's own access log when `core` is
absent — needs three coordinated conditionals across three files and would give execution-only
deployments a different log format from every other deployment.

For anyone running the Task Execution API as its own deployment, this restores per-request telemetry
(latency, status codes, endpoint counts) for the component every running task depends on for
heartbeats, state transitions and XComs.

### Verification

Started a real `api-server` and issued a marked request, before and after the change:

| `--apps` | uvicorn | gunicorn |
| --- | --- | --- |
| `execution` | no record → logged | no record → logged |
| `core` | logged | logged |
| `all` | logged | logged |

- Middleware order for `core`/`all` is unchanged: `[HttpAccessLogMiddleware, GZipMiddleware, JWTRefreshMiddleware]`.
- The generated OpenAPI specs are byte-identical with and without the change.
- The added test fails on `[execution]` without the fix and passes with it.
- `airflow-core/tests/unit/api_fastapi` (3750), `providers/fab` (536) and `providers/common/compat`
  (197) pass. The `test_hitl.py` and example-Dag failures seen locally also fail on unmodified
  `main`, so they are unrelated.

Note for reviewers: #64523 (open) also edits `init_middlewares` to add a metrics middleware, so the
two may conflict textually.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)