### PR TITLE
Fix docs omitting asset from the Dag discovery safe-mode heuristic

### DIFF
--- a/airflow-core/docs/core-concepts/dags.rst
+++ b/airflow-core/docs/core-concepts/dags.rst
@@ -164,14 +164,14 @@ While both Dag constructors get called when the file is accessed, only ``dag_1``
 
 .. note::
 
-    When searching for Dags inside the Dag bundle, Airflow only considers Python files that contain the strings ``airflow`` and ``dag`` (case-insensitively) as an optimization.
+    When searching for Dags inside the Dag bundle, Airflow only considers Python files that contain ``airflow`` and at least one of ``dag`` or ``asset`` (all matched case-insensitively) as an optimization.
 
     To consider all Python files instead, set the ``[core] dag_discovery_safe_mode`` configuration flag to ``False``. This is the setting to use when your Dags are defined through a wrapper or abstraction whose source does not contain those strings. The flag is read by the Dag file processor, so set it on that component (and on anything that runs ``airflow dags reserialize``) and restart it for the change to take effect -- otherwise Dags may appear after a manual reserialize and then disappear again on the next processor scan.
 
 You can also provide an ``.airflowignore`` file inside your Dag bundle, or any of its subfolders, which describes patterns of files for the loader to ignore. It covers the directory it's in plus all subfolders underneath it. See  :ref:`.airflowignore <concepts:airflowignore>` below for details of the file syntax.
 
 In the case where the ``.airflowignore`` does not meet your needs and you want a more flexible way to control if a python file needs to be parsed by airflow, you can plug your callable by setting ``might_contain_dag_callable`` in the config file.
-Note, this callable will replace the default Airflow heuristic, i.e. checking if the strings ``airflow`` and ``dag`` (case-insensitively) are present in the python file.
+Note, this callable will replace the default Airflow heuristic, i.e. checking if the python file contains ``airflow`` and at least one of ``dag`` or ``asset`` (all matched case-insensitively).
 
 .. code-block::
 

--- a/airflow-core/docs/faq.rst
+++ b/airflow-core/docs/faq.rst
@@ -36,10 +36,10 @@ There are very many reasons why your task might not be getting scheduled. Here a
   may want to confirm that this works both where the scheduler runs as well
   as where the worker runs.
 
-- Does the file containing your Dag contain the string ``airflow`` and ``DAG`` somewhere
-  in the contents? When searching the Dag directory, Airflow ignores files not containing
-  ``airflow`` and ``DAG`` in order to prevent the DagBag parsing from importing all python
-  files collocated with user's Dags.
+- Does the file containing your Dag contain ``airflow`` and at least one of ``dag`` or
+  ``asset`` somewhere in the contents (all matched case-insensitively)? When searching the
+  Dag directory, Airflow skips files that do not match, in order to prevent the DagBag
+  parsing from importing all python files collocated with user's Dags.
 
 - Is your ``start_date`` set properly? For time-based Dags, the task won't be triggered until the
   the first schedule interval following the start date has passed.

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -320,9 +320,10 @@ core:
       default: "True"
     dag_discovery_safe_mode:
       description: |
-        If enabled, Airflow only scans files containing both ``DAG`` and ``airflow`` (case-insensitive)
-        when looking for Dags. Set this to ``False`` to scan every Python file instead -- required when
-        your Dags are defined through a wrapper or abstraction whose source does not contain those strings.
+        If enabled, Airflow only scans files containing ``airflow`` and at least one of ``dag`` or
+        ``asset`` (all matched case-insensitively) when looking for Dags. Set this to ``False`` to scan
+        every Python file instead -- required when your Dags are defined through a wrapper or abstraction
+        whose source does not contain those strings.
 
         This setting is read by the Dag file processor, so it must be configured for that component. In a
         separate-process deployment (for example the Helm chart) set it on the ``dag-processor`` as well as

--- a/airflow-core/tests/unit/utils/test_file.py
+++ b/airflow-core/tests/unit/utils/test_file.py
@@ -29,6 +29,7 @@ from airflow.utils import file as file_utils
 from airflow.utils.file import (
     correct_maybe_zipped,
     list_py_file_paths,
+    might_contain_dag_via_default_heuristic,
     open_maybe_zipped,
 )
 
@@ -229,3 +230,22 @@ def test_get_unique_dag_module_name(edge_filename, expected_modification):
         mocked_sha1.return_value.hexdigest.return_value = "mocked_path_hash_sha1"
         modify_module_name = file_utils.get_unique_dag_module_name(edge_filename)
         assert modify_module_name == expected_modification
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        pytest.param(b"from airflow.sdk import DAG", True, id="airflow-and-dag"),
+        pytest.param(b"from airflow.sdk import asset", True, id="airflow-and-asset"),
+        pytest.param(b"from airflow.sdk import Asset", True, id="mixed-case-asset"),
+        pytest.param(
+            b"DAG_DEFAULTS = {'asset_bucket': 's3://data-lake'}", False, id="keywords-without-airflow"
+        ),
+        pytest.param(b"from airflow.configuration import conf", False, id="airflow-without-dag-or-asset"),
+    ],
+)
+def test_might_contain_dag_via_default_heuristic(tmp_path, content, expected):
+    candidate = tmp_path / "candidate.py"
+    candidate.write_bytes(content)
+
+    assert might_contain_dag_via_default_heuristic(file_path=str(candidate)) is expected


### PR DESCRIPTION
## Why

- The default safe-mode heuristic has matched `airflow` AND (`dag` OR `asset`) since #41325 (Airflow 3.0.0), but document still describes an `airflow` AND `dag` check.

## How

- Reword document to: `airflow` and at least one of `dag` or `asset`, matched case-insensitively.

# Verification

- `uv run --project airflow-core pytest airflow-core/tests/unit/utils/test_file.py`

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
