### PR TITLE
Enforce execution_timeout in deferrable DataprocSubmitJobOperator

### DIFF
--- a/generated/known_airflow_exceptions.txt
+++ b/generated/known_airflow_exceptions.txt
@@ -256,7 +256,7 @@ providers/google/src/airflow/providers/google/cloud/operators/compute.py::19
 providers/google/src/airflow/providers/google/cloud/operators/dataflow.py::16
 providers/google/src/airflow/providers/google/cloud/operators/datafusion.py::2
 providers/google/src/airflow/providers/google/cloud/operators/dataplex.py::54
-providers/google/src/airflow/providers/google/cloud/operators/dataproc.py::32
+providers/google/src/airflow/providers/google/cloud/operators/dataproc.py::33
 providers/google/src/airflow/providers/google/cloud/operators/dataproc_metastore.py::2
 providers/google/src/airflow/providers/google/cloud/operators/datastore.py::2
 providers/google/src/airflow/providers/google/cloud/operators/functions.py::6

--- a/providers/google/src/airflow/providers/google/cloud/operators/dataproc.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/dataproc.py
@@ -1925,7 +1925,9 @@ class DataprocSubmitJobOperator(GoogleCloudBaseOperator):
     :param asynchronous: Flag to return after submitting the job to the Dataproc API.
         This is useful for submitting long-running jobs and
         waiting on them asynchronously using the DataprocJobSensor
-    :param deferrable: Run operator in the deferrable mode
+    :param deferrable: Run operator in the deferrable mode. ``execution_timeout`` is enforced
+        while the task is deferred: on expiry the Dataproc job is cancelled (unless
+        ``cancel_on_kill`` is False) and the task fails.
     :param polling_interval_seconds: time in seconds between polling for job completion.
         The value is considered only when running in deferrable mode. Must be greater than 0.
     :param cancel_on_kill: Flag which indicates whether cancel the hook's job or not, when on_kill is called
@@ -2060,6 +2062,19 @@ class DataprocSubmitJobOperator(GoogleCloudBaseOperator):
                 raise AirflowException(f"Job failed:\n{job}")
             if state == JobStatus.State.CANCELLED:
                 raise AirflowException(f"Job was cancelled:\n{job}")
+            execution_deadline = None
+            trigger_timeout = None
+            if self.execution_timeout:
+                # Anchor on ti.start_date so the deadline stays stable across
+                # re-deferrals, matching non-deferrable execution_timeout semantics.
+                start_date = context["ti"].start_date
+                anchor = start_date.timestamp() if start_date else time.time()
+                execution_deadline = anchor + self.execution_timeout.total_seconds()
+                # Framework backstop only: one extra poll interval of slack so the
+                # trigger's own deadline handling (which cancels the job) fires first.
+                trigger_timeout = timedelta(
+                    seconds=max(execution_deadline - time.time(), 0) + self.polling_interval_seconds
+                )
             self.defer(
                 trigger=DataprocSubmitTrigger(
                     job_id=self.job_id,
@@ -2069,8 +2084,10 @@ class DataprocSubmitJobOperator(GoogleCloudBaseOperator):
                     impersonation_chain=self.impersonation_chain,
                     polling_interval_seconds=self.polling_interval_seconds,
                     cancel_on_kill=self.cancel_on_kill,
+                    execution_deadline=execution_deadline,
                 ),
                 method_name="execute_complete",
+                timeout=trigger_timeout,
             )
         elif not self.asynchronous:
             self.log.info("Waiting for job %s to complete", new_job_id)
@@ -2089,6 +2106,10 @@ class DataprocSubmitJobOperator(GoogleCloudBaseOperator):
         """
         job_state = event["job_state"]
         job_id = event["job_id"]
+        if job_state == "TIMED_OUT":
+            raise AirflowException(
+                event.get("message") or f"Job {job_id} exceeded the task's execution_timeout while deferred."
+            )
         job = event["job"]
         if job_state == JobStatus.State.ERROR.name:  # type: ignore
             raise AirflowException(f"Job {job_id} failed:\n{job}")

--- a/providers/google/src/airflow/providers/google/cloud/triggers/dataproc.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/dataproc.py
@@ -103,10 +103,14 @@ class DataprocSubmitTrigger(DataprocBaseTrigger):
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
     :param polling_interval_seconds: polling period in seconds to check for the status
+    :param execution_deadline: Optional absolute timestamp (in seconds since the epoch) after
+        which the task is considered timed out. On expiry the trigger cancels the Dataproc job
+        (unless ``cancel_on_kill`` is False) and emits a ``TIMED_OUT`` event.
     """
 
-    def __init__(self, job_id: str, **kwargs):
+    def __init__(self, job_id: str, execution_deadline: float | None = None, **kwargs):
         self.job_id = job_id
+        self.execution_deadline = execution_deadline
         super().__init__(**kwargs)
 
     def serialize(self):
@@ -120,6 +124,7 @@ class DataprocSubmitTrigger(DataprocBaseTrigger):
                 "impersonation_chain": self.impersonation_chain,
                 "polling_interval_seconds": self.polling_interval_seconds,
                 "cancel_on_kill": self.cancel_on_kill,
+                "execution_deadline": self.execution_deadline,
             },
         )
 
@@ -213,6 +218,24 @@ class DataprocSubmitTrigger(DataprocBaseTrigger):
                 self.log.info("Dataproc job: %s is in state: %s", self.job_id, state)
                 if state in (JobStatus.State.DONE, JobStatus.State.CANCELLED, JobStatus.State.ERROR):
                     break
+                if self.execution_deadline is not None and time.time() >= self.execution_deadline:
+                    if self.cancel_on_kill:
+                        self.log.info("Job %s exceeded execution_timeout; cancelling it.", self.job_id)
+                        try:
+                            await sync_to_async(self.get_sync_hook().cancel_job)(
+                                job_id=self.job_id, project_id=self.project_id, region=self.region
+                            )
+                        except Exception:
+                            self.log.exception("Failed to cancel job %s after execution timeout", self.job_id)
+                    yield TriggerEvent(
+                        {
+                            "job_id": self.job_id,
+                            "job_state": "TIMED_OUT",
+                            "message": f"Job {self.job_id} exceeded the task's execution_timeout "
+                            "while deferred.",
+                        }
+                    )
+                    return
                 await asyncio.sleep(self.polling_interval_seconds)
             yield TriggerEvent(
                 {"job_id": self.job_id, "job_state": JobStatus.State(state).name, "job": Job.to_dict(job)}

--- a/providers/google/tests/unit/google/cloud/operators/test_dataproc.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_dataproc.py
@@ -1868,6 +1868,48 @@ class TestDataprocSubmitJobOperator(DataprocJobTestBase):
         assert exc.value.method_name == GOOGLE_DEFAULT_DEFERRABLE_METHOD_NAME
 
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
+    @mock.patch(DATAPROC_TRIGGERS_PATH.format("DataprocAsyncHook"))
+    def test_execute_deferrable_with_execution_timeout(self, mock_trigger_hook, mock_hook):
+        mock_hook.return_value.submit_job.return_value.reference.job_id = TEST_JOB_ID
+
+        op = DataprocSubmitJobOperator(
+            task_id=TASK_ID,
+            region=GCP_REGION,
+            project_id=GCP_PROJECT,
+            job={},
+            gcp_conn_id=GCP_CONN_ID,
+            deferrable=True,
+            execution_timeout=dt.timedelta(hours=1),
+        )
+        start_date = dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc)
+        self.mock_ti.start_date = start_date
+
+        with pytest.raises(TaskDeferred) as exc:
+            op.execute(self.mock_context)
+
+        expected_deadline = start_date.timestamp() + 3600
+        assert exc.value.trigger.execution_deadline == expected_deadline
+        assert exc.value.timeout is not None
+
+    @mock.patch(DATAPROC_PATH.format("DataprocHook"))
+    def test_execute_complete_timed_out_raises(self, mock_hook):
+        op = DataprocSubmitJobOperator(
+            task_id=TASK_ID,
+            region=GCP_REGION,
+            project_id=GCP_PROJECT,
+            job={},
+            gcp_conn_id=GCP_CONN_ID,
+            deferrable=True,
+        )
+        event = {
+            "job_id": TEST_JOB_ID,
+            "job_state": "TIMED_OUT",
+            "message": f"Job {TEST_JOB_ID} exceeded the task's execution_timeout while deferred.",
+        }
+        with pytest.raises(AirflowException, match="execution_timeout"):
+            op.execute_complete(context=self.mock_context, event=event)
+
+    @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     @mock.patch(DATAPROC_PATH.format("DataprocSubmitJobOperator.defer"))
     @mock.patch(DATAPROC_PATH.format("DataprocHook.submit_job"))
     def test_dataproc_operator_execute_async_done_before_defer(self, mock_submit_job, mock_defer, mock_hook):

--- a/providers/google/tests/unit/google/cloud/triggers/test_dataproc.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_dataproc.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import time
 from asyncio import CancelledError, Future, sleep
 from unittest import mock
 
@@ -635,6 +636,7 @@ class TestDataprocSubmitTrigger:
             "polling_interval_seconds": TEST_POLL_INTERVAL,
             "cancel_on_kill": True,
             "impersonation_chain": None,
+            "execution_deadline": None,
         }
 
     @pytest.mark.asyncio
@@ -669,6 +671,61 @@ class TestDataprocSubmitTrigger:
             {"job_id": TEST_JOB_ID, "job_state": JobStatus.State.ERROR.name, "job": Job.to_dict(mock_job)}
         )
         assert event.payload == expected_event.payload
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.google.cloud.triggers.dataproc.DataprocSubmitTrigger.get_sync_hook")
+    @mock.patch("airflow.providers.google.cloud.triggers.dataproc.DataprocSubmitTrigger.get_async_hook")
+    async def test_submit_trigger_run_execution_deadline_cancels_job(
+        self, mock_get_async_hook, mock_get_sync_hook
+    ):
+        """Test the trigger cancels a still-running job once the execution deadline passes."""
+        trigger = DataprocSubmitTrigger(
+            job_id=TEST_JOB_ID,
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            polling_interval_seconds=TEST_POLL_INTERVAL,
+            execution_deadline=time.time() - 1,
+        )
+        mock_job = Job(status=JobStatus(state=JobStatus.State.RUNNING))
+        mock_get_async_hook.return_value.get_job_client = mock.AsyncMock()
+        mock_get_async_hook.return_value.get_job = mock.AsyncMock(return_value=mock_job)
+        mock_get_sync_hook.return_value.cancel_job = mock.MagicMock()
+
+        event = await trigger.run().asend(None)
+
+        mock_get_sync_hook.return_value.cancel_job.assert_called_once_with(
+            job_id=TEST_JOB_ID,
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+        )
+        assert event.payload["job_id"] == TEST_JOB_ID
+        assert event.payload["job_state"] == "TIMED_OUT"
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.google.cloud.triggers.dataproc.DataprocSubmitTrigger.get_sync_hook")
+    @mock.patch("airflow.providers.google.cloud.triggers.dataproc.DataprocSubmitTrigger.get_async_hook")
+    async def test_submit_trigger_run_execution_deadline_respects_cancel_on_kill_false(
+        self, mock_get_async_hook, mock_get_sync_hook
+    ):
+        """Test the deadline event is emitted without cancelling when cancel_on_kill is False."""
+        trigger = DataprocSubmitTrigger(
+            job_id=TEST_JOB_ID,
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            polling_interval_seconds=TEST_POLL_INTERVAL,
+            cancel_on_kill=False,
+            execution_deadline=time.time() - 1,
+        )
+        mock_job = Job(status=JobStatus(state=JobStatus.State.RUNNING))
+        mock_get_async_hook.return_value.get_job_client = mock.AsyncMock()
+        mock_get_async_hook.return_value.get_job = mock.AsyncMock(return_value=mock_job)
+
+        event = await trigger.run().asend(None)
+
+        mock_get_sync_hook.return_value.cancel_job.assert_not_called()
+        assert event.payload["job_state"] == "TIMED_OUT"
 
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.google.cloud.triggers.dataproc.DataprocSubmitTrigger.get_sync_hook")


### PR DESCRIPTION
# Why

`DataprocSubmitJobOperator(deferrable=True)` does not enforce `execution_timeout`. Once the operator defers, the synchronous `execute()` returns, and nothing bounds the deferral: `self.defer()` is called without a `timeout`, so the trigger polls the job forever. Even when a user passes `defer(timeout=...)` through a subclass, a framework-level trigger timeout resumes the task only to fail it — the Dataproc job itself keeps running, because the triggerer does not run the trigger's `on_kill` for a timeout resume.

In non-deferrable mode, exceeding `execution_timeout` raises `AirflowTaskTimeout` and `on_kill()` cancels the job. Deferrable mode silently loses both behaviors. The framework gap is acknowledged by `# TODO: handle timeout in case of deferral` in `task-sdk/src/airflow/sdk/execution_time/task_runner.py`.

This is the same class of issue already fixed for `DbtCloudRunJobOperator` (#61467 → #66449), `AirbyteTriggerSyncOperator` (#64048 → #64051), and `KubernetesPodOperator` (#67227 → #67229).

# What

Mirrors the approach merged in #67229:

- **Operator** (`dataproc.py`): when `execution_timeout` is set, derive an absolute deadline anchored on `ti.start_date` (stable across re-deferrals) and pass it to `DataprocSubmitTrigger` as `execution_deadline`. Also pass `timeout=` to `self.defer()` as a framework backstop, with one polling interval of slack so the trigger's own deadline handling (which cancels the job) fires first.
- **Trigger** (`triggers/dataproc.py`): `DataprocSubmitTrigger` accepts an optional `execution_deadline` (epoch seconds). When the deadline passes while the job is still running, the trigger cancels the Dataproc job (unless `cancel_on_kill=False`) and emits a `TIMED_OUT` event.
- **`execute_complete`**: raises `AirflowException` on the `TIMED_OUT` event, failing the task.

`generated/known_airflow_exceptions.txt` is bumped for the one new `raise AirflowException` (only the dataproc line; the file has unrelated drift on main that a full `--generate` would also pick up).

Behavior is unchanged when `execution_timeout` is not set (`execution_deadline=None`, no defer timeout).

`DataprocSubmitJobDirectTrigger` (start-from-trigger path) has the same gap and could be handled in a follow-up.

# Tests

- Trigger: deadline expiry cancels the job and yields `TIMED_OUT`; `cancel_on_kill=False` skips the cancel; serialization includes `execution_deadline`.
- Operator: deferral carries the computed deadline and a defer timeout; `execute_complete` raises on `TIMED_OUT`.

```
providers/google/tests/unit/google/cloud/triggers/test_dataproc.py -k TestDataprocSubmitTrigger: 7 passed, 2 skipped
providers/google/tests/unit/google/cloud/operators/test_dataproc.py -k TestDataprocSubmitJobOperator: 22 passed
```

---

^ Add meaningful description above
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in `airflow-core/newsfragments`.
