### PR TITLE
Skip atexit in forked task children rather than running post-fork handlers

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -19,7 +19,6 @@
 
 from __future__ import annotations
 
-import atexit
 import contextlib
 import functools
 import io
@@ -442,17 +441,12 @@ def _fork_main(
             os.close(requests.fileno())
         os._exit(n)
 
-    if hasattr(atexit, "_clear"):
-        # Since we're in a fork we want to try and clear them. If we can't do it cleanly, then we won't try
-        # and run new atexit handlers.
-        with suppress(Exception):
-            atexit._clear()
-            base_exit = exit
-
-            def exit(n: int) -> NoReturn:
-                # This will only run any atexit funcs registered after we've forked.
-                atexit._run_exitfuncs()
-                base_exit(n)
+    # We deliberately never run atexit handlers registered post-fork (used to via
+    # atexit._run_exitfuncs() here). A library's atexit handler that isn't fork-safe -- holds a
+    # native lock or thread that didn't survive the fork -- can block forever, which means this
+    # forked task child, and the pod hosting it, never exits (e.g. pyarrow's S3 client finalizer
+    # deadlocking in its AWS-CRT teardown). There's no way to tell a safe handler from an unsafe
+    # one in advance, so os._exit() skips all of them rather than risk running an unknown one.
 
     try:
         block_orm_access()

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -386,6 +386,41 @@ class TestWatchedSubprocess:
             ]
         )
 
+    def test_fork_main_never_runs_post_fork_atexit_handlers(self, tmp_path, client_with_ti_start):
+        """A fork-unsafe library's atexit handler must never run in the forked task child. If it
+        did and it blocked (e.g. pyarrow's S3 client finalizer deadlocking in AWS-CRT teardown),
+        the child -- and the pod hosting it -- would never exit."""
+        marker = tmp_path / "atexit-ran"
+
+        def subprocess_main():
+            # This is run in the subprocess!
+            CommsDecoder()._get_response()
+
+            import atexit
+
+            atexit.register(marker.write_text, "atexit ran")
+
+        proc = ActivitySubprocess.start(
+            dag_rel_path=os.devnull,
+            bundle_info=FAKE_BUNDLE,
+            what=TaskInstance(
+                id="4d828a62-a417-4936-a7a6-2b3fabacecab",
+                task_id="b",
+                dag_id="c",
+                run_id="d",
+                try_number=1,
+                dag_version_id=uuid7(),
+                queue="default",
+            ),
+            client=client_with_ti_start,
+            target=subprocess_main,
+        )
+
+        rc = proc.wait()
+
+        assert rc == 0
+        assert not marker.exists()
+
     @pytest.mark.flaky(reruns=3)
     def test_reopen_log_fd(self, captured_logs, client_with_ti_start):
         def subprocess_main():


### PR DESCRIPTION
A forked task child could hang forever if any library registered an atexit handler that isn't fork-safe -- one that holds a native lock or thread that doesn't survive `fork()`.

Task-SDK's custom exit path in `_fork_main` clears any atexit handlers inherited from the parent immediately after forking (`atexit._clear()`), then runs whatever gets registered during the child's own subsequent execution via `atexit._run_exitfuncs()` before calling `os._exit()`. That's the actual gap: a library imported for the first time inside the forked child -- after the clear already ran -- re-registers its own atexit handler into what is by then an empty-then-repopulated registry, and that fresh, post-fork registration is what `_run_exitfuncs()` executes. The `_clear()` correctly protects against anything inherited from the parent; it does nothing to protect against a fork-unsafe handler the child registers on its own a moment later.

This was hit in production exactly that way: `pyiceberg` imports `pyarrow.fs` for the first time inside `target()` (task execution, i.e. after the clear), which calls `atexit.register(ensure_s3_finalized)` into the now-repopulating registry. When `_run_exitfuncs()` later runs it, `ensure_s3_finalized` deadlocks in pyarrow's AWS-CRT teardown -- confirmed via a symbolized gdb backtrace on a live wedged production process (`atexit._run_exitfuncs() -> ensure_s3_finalized -> EnsureS3Finalized -> ... -> futex_wait` forever).

The same failure mode applies to any fork-unsafe atexit handler registered by any library during the child's post-fork execution, not just pyarrow's. This skips atexit entirely in the forked child rather than trying to special-case known offenders -- there's no way to tell a safe handler from an unsafe one in advance.

The prior post-fork-atexit behavior was a deliberate choice (see discussion on the internal tracking ticket) to let task code tidy up after the process finishes. This PR trades that intentional cleanup opportunity for guaranteed exit -- happy to discuss alternatives (e.g. running atexit with a timeout) if that tradeoff needs more thought.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes -- Claude Code (Sonnet 5)

Generated-by: Claude Code (Sonnet 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)