### PR TITLE
Upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/airflow-e2e-tests.yml
+++ b/.github/workflows/airflow-e2e-tests.yml
@@ -135,7 +135,7 @@ jobs:
       # arch-specific auto-provisioned JDKs (the example pins a Java 11 toolchain).
       - name: "Setup Java for the Java SDK build"
         if: inputs.e2e_test_mode == 'java_sdk'
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5.7.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c  # v6.0.0
         with:
           distribution: 'temurin'
           java-version: ${{ inputs.java-sdk-version }}

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -115,7 +115,7 @@ jobs:
       - name: "Install SVN"
         run: sudo apt-get update && sudo apt-get install -y subversion
       - name: "Install Java (for Apache RAT)"
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5.7.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c  # v6.0.0
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/ci-amd.yml
+++ b/.github/workflows/ci-amd.yml
@@ -1044,7 +1044,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Java
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5.7.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c  # v6.0.0
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/ci-arm.yml
+++ b/.github/workflows/ci-arm.yml
@@ -1033,7 +1033,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Java
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5.7.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c  # v6.0.0
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -130,7 +130,7 @@ jobs:
 
       - name: Setup Java
         if: matrix.language == 'java'
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5.7.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c  # v6.0.0
         with:
           distribution: 'temurin'
           java-version: '11'

--- a/.github/workflows/java-sdk-dependency-security.yml
+++ b/.github/workflows/java-sdk-dependency-security.yml
@@ -67,7 +67,7 @@ jobs:
       # 17: toolchain for scala_spark_example/
       # 21: runs Gradle itself — the last entry listed is the one that sets JAVA_HOME
       - name: Install JDK toolchains
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5.7.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c  # v6.0.0
         with:
           distribution: temurin
           java-version: |

--- a/.github/workflows/java-sdk-release-verify.yml
+++ b/.github/workflows/java-sdk-release-verify.yml
@@ -76,7 +76,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5.7.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c  # v6.0.0
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
@@ -133,7 +133,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5.7.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c  # v6.0.0
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -203,7 +203,7 @@ jobs:
           restore-keys: |
             lang-sdk-go-v1-${{ runner.os }}-${{ runner.arch }}-
       - name: "Setup Java for lang-SDK build"
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961  # v5.7.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c  # v6.0.0
         with:
           distribution: 'temurin'
           java-version: ${{ inputs.java-sdk-version }}


### PR DESCRIPTION
Upgrade all active workflow references from `actions/setup-java` v5.7.0 to v6.0.0 while retaining digest pinning.

Validation: verified no older references remain in active workflow YAML and ran `git diff --check`. This workflow-only change does not require a newsfragment.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (GitHub Copilot)

Generated-by: GitHub Copilot following the [guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)