### PR TITLE
Make Dags list e2e filters wait on the request that actually fires

### DIFF
--- a/airflow-core/src/airflow/ui/tests/e2e/pages/DagsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/DagsPage.ts
@@ -87,21 +87,13 @@ export class DagsPage extends BasePage {
    * Clear the search input and wait for list to reset
    */
   public async clearSearch(): Promise<void> {
-    const responsePromise = this.page
-      .waitForResponse((resp: Response) => resp.url().includes("/api/v2/dags") && resp.status() === 200, {
-        timeout: 10_000,
-      })
-      .catch((error: unknown) => {
-        if (error instanceof Error && !error.message.includes("Timeout")) {
-          throw error;
-        }
-      });
-
     // Click the clear button instead of programmatically clearing the input.
     // The SearchBar component uses a 200ms debounce on keystroke changes,
     // but the clear button calls onChange("") directly, bypassing the debounce.
     await this.page.getByTestId("clear-search").click();
-    await responsePromise;
+    // Clearing goes back to a query the page already holds, which react-query answers from cache
+    // instead of refetching, so the dropped search param is the only signal there is.
+    await expect(this.page).not.toHaveURL(/name_pattern=/u);
     await this.waitForDagList();
   }
 
@@ -119,23 +111,33 @@ export class DagsPage extends BasePage {
   public async filterByStatus(
     status: "failed" | "needs_review" | "queued" | "running" | "success",
   ): Promise<void> {
-    // Set up response listener before the click so we don't miss a fast response.
-    const responsePromise = this.page
-      .waitForResponse((resp: Response) => resp.url().includes("/api/v2/dags") && resp.status() === 200, {
-        timeout: 10_000,
-      })
-      .catch((error: unknown) => {
-        if (error instanceof Error && !error.message.includes("Timeout")) {
-          throw error;
-        }
-      });
+    // Set up response listener before the click so we don't miss a fast response. /ui/dags shares
+    // its prefix with the page's other endpoints and is refetched on a poll interval, so only the
+    // filters a request carries tell this fetch from one that predates it.
+    const responsePromise = this.page.waitForResponse(
+      (response: Response) => {
+        const url = new URL(response.url());
+        const filters = url.searchParams;
+
+        return (
+          url.pathname.endsWith("/ui/dags") &&
+          (status === "needs_review"
+            ? filters.get("has_pending_actions") === "true"
+            : filters.get("last_dag_run_state") === status) &&
+          response.status() === 200
+        );
+      },
+      { timeout: 10_000 },
+    );
 
     if (status === "needs_review") {
       // A boolean filter is active the moment it is picked from the menu.
       await this.openAddFilterMenu();
       await this.needsReviewFilter.click();
     } else {
-      if (await this.lastRunStatePill.isVisible().catch(() => false)) {
+      // A pill is only in the DOM once it collapses out of edit mode, so sampling its
+      // visibility races that. The URL carries the same fact and never animates.
+      if (new URL(this.page.url()).searchParams.has("last_dag_run_state")) {
         // An existing pill already holds a value, so re-opening it leaves the menu shut.
         await this.lastRunStatePill.click();
         await this.lastRunStateFilter.click();
@@ -145,8 +147,8 @@ export class DagsPage extends BasePage {
         await this.page.getByTestId("add-filter-last_dag_run_state").click();
       }
       await this.page.getByTestId(`last_dag_run_state-filter-${status}`).click();
-      // Selecting blurs the pill, which collapses it ~150ms later. Wait for that so a
-      // follow-up call sees the pill rather than racing it and reopening the menu.
+      // Selecting blurs the pill, which collapses it ~150ms later. Hand back a settled bar
+      // instead of one mid-transition.
       await expect(this.lastRunStatePill).toBeVisible({ timeout: 5000 });
     }
     await responsePromise;


### PR DESCRIPTION
## Summary

The status-filter helper on the Dags list waits for a response from `/api/v2/dags`, but the list is served by `/ui/dags`, and the timeout that follows is swallowed. The test passes with the filtered list request returning 500 — verified by forcing that response locally — so it is blind to a regression in the endpoint it exists to cover.

`filterByStatus` now waits on the fetch carrying the filter it just applied, which also keeps the wait off the sibling `/ui/dags/*` endpoints and the list's own refresh poll. Clearing the search has no request to wait for: it returns to a query react-query still holds, so the dropped search param is the signal instead.

Its branch also came from the run-state pill's visibility, and that pill is absent from the DOM while its filter is being edited; the search param carries the same fact without animating.

## Tests

Chromium against a local Airflow built from these sources, `--retries=0`: both affected tests pass 10 repeats each, at 13.4s and 12.7s against 23.2s and 19.9s before.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)