### PR TITLE
Rename Legacy{Foo} to TeamUnaware{Foo} where appropriate

### DIFF
--- a/airflow-core/tests/unit/always/test_secrets.py
+++ b/airflow-core/tests/unit/always/test_secrets.py
@@ -230,7 +230,7 @@ class TestVariableFromSecrets:
         assert Variable.get_variable_from_secrets(key="_team___myvar") is None
 
 
-class _LegacyGetConnectionBackend(BaseSecretsBackend):
+class _TeamUnawareGetConnectionBackend(BaseSecretsBackend):
     """Backend overriding ``get_connection`` with the pre-3.2 ``(self, conn_id)`` signature (e.g. Vault)."""
 
     def __init__(self, conns: dict[str, Connection]):
@@ -240,7 +240,7 @@ class _LegacyGetConnectionBackend(BaseSecretsBackend):
         return self._conns.get(conn_id)
 
 
-class _LegacyGetVariableBackend(BaseSecretsBackend):
+class _TeamUnawareGetVariableBackend(BaseSecretsBackend):
     """Backend overriding ``get_variable`` with the pre-3.2 ``(self, key)`` signature."""
 
     def __init__(self, variables: dict[str, str]):
@@ -251,7 +251,7 @@ class _LegacyGetVariableBackend(BaseSecretsBackend):
 
 
 @skip_if_force_lowest_dependencies_marker
-class TestLegacyBackendSignatureCompat:
+class TestTeamUnawareBackendSignatureCompat:
     """Backends whose overrides predate the ``team_name`` keyword must keep working (issue #1333)."""
 
     def setup_method(self) -> None:
@@ -260,21 +260,21 @@ class TestLegacyBackendSignatureCompat:
     @pytest.mark.parametrize("team_name", [None, "team_a"])
     @conf_vars({("core", "multi_team"): "True"})
     @mock.patch.dict("sys.modules", {"airflow.sdk.execution_time.task_runner": None})
-    def test_get_connection_with_legacy_get_connection_override(self, team_name):
-        backend = _LegacyGetConnectionBackend(
-            {"legacy_conn": Connection(conn_id="legacy_conn", conn_type="mysql", host="h")}
+    def test_get_connection_with_team_unaware_override(self, team_name):
+        backend = _TeamUnawareGetConnectionBackend(
+            {"team_unaware_conn": Connection(conn_id="team_unaware_conn", conn_type="mysql", host="h")}
         )
         with mock.patch("airflow.configuration.ensure_secrets_loaded", return_value=[backend]):
-            conn = Connection.get_connection_from_secrets("legacy_conn", team_name=team_name)
+            conn = Connection.get_connection_from_secrets("team_unaware_conn", team_name=team_name)
 
-        assert conn.conn_id == "legacy_conn"
+        assert conn.conn_id == "team_unaware_conn"
         assert conn.conn_type == "mysql"
 
     @pytest.mark.parametrize("team_name", [None, "team_a"])
-    def test_get_variable_with_legacy_get_variable_override(self, team_name):
-        backend = _LegacyGetVariableBackend({"legacy_var": "secret_value"})
+    def test_get_variable_with_team_unaware_override(self, team_name):
+        backend = _TeamUnawareGetVariableBackend({"team_unaware_var": "secret_value"})
         with mock.patch("airflow.models.variable.ensure_secrets_loaded", return_value=[backend]):
-            value = Variable.get_variable_from_secrets("legacy_var", team_name=team_name)
+            value = Variable.get_variable_from_secrets("team_unaware_var", team_name=team_name)
 
         assert value == "secret_value"
 

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/test_base_auth_manager.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/test_base_auth_manager.py
@@ -175,15 +175,15 @@ class TestBaseAuthManager:
             access_view=AccessView.DOCS, user=None, team_name="team_a"
         )
 
-    def test_authorize_view_drops_team_name_and_warns_for_legacy_manager(self):
+    def test_authorize_view_drops_team_name_and_warns_for_team_unaware_manager(self):
         # A manager whose is_authorized_view predates team_name (out-of-tree, or a provider
         # released before the argument existed) must keep working: authorize_view falls back
         # to a global check and warns that some views are not team-restricted.
-        class LegacyAuthManager(EmptyAuthManager):
+        class TeamUnawareAuthManager(EmptyAuthManager):
             def is_authorized_view(self, *, access_view, user=None):  # old signature, no team_name
                 return True
 
-        manager = LegacyAuthManager()
+        manager = TeamUnawareAuthManager()
 
         with pytest.warns(RemovedInAirflow4Warning, match="not team-aware"):
             result = manager.authorize_view(access_view=AccessView.DOCS, user=None, team_name="team_a")

--- a/shared/secrets_backend/tests/secrets_backend/test_base.py
+++ b/shared/secrets_backend/tests/secrets_backend/test_base.py
@@ -150,7 +150,7 @@ class TestBaseSecretsBackend:
         assert conn.uri == sample_conn_uri
 
 
-class _LegacyConnValueBackend(BaseSecretsBackend):
+class _TeamUnawareConnValueBackend(BaseSecretsBackend):
     """Backend overriding ``get_conn_value`` with the pre-3.2 ``(self, conn_id)`` signature."""
 
     def __init__(self, conn_values: dict[str, str]):
@@ -203,8 +203,8 @@ class TestTeamNameBackwardCompat:
     """``get_connection`` must not forward ``team_name`` to overrides that predate it (issue #1333)."""
 
     @pytest.mark.parametrize("team_name", [None, "team_a"])
-    def test_legacy_get_conn_value_signature_does_not_break(self, sample_conn_uri, team_name):
-        backend = _LegacyConnValueBackend(conn_values={"test_conn": sample_conn_uri})
+    def test_team_unaware_get_conn_value_signature_does_not_break(self, sample_conn_uri, team_name):
+        backend = _TeamUnawareConnValueBackend(conn_values={"test_conn": sample_conn_uri})
 
         conn = backend.get_connection(conn_id="test_conn", team_name=team_name)
 
@@ -239,7 +239,7 @@ class TestTeamNameBackwardCompat:
         assert backend.call_count == 1
 
     @pytest.mark.parametrize("team_name", [None, "team_a"])
-    def test_legacy_backend_missing_conn_returns_none(self, team_name):
-        backend = _LegacyConnValueBackend(conn_values={})
+    def test_team_unaware_backend_missing_conn_returns_none(self, team_name):
+        backend = _TeamUnawareConnValueBackend(conn_values={})
 
         assert backend.get_connection(conn_id="missing", team_name=team_name) is None


### PR DESCRIPTION
"Legacy" only makes sense if you know the context and what it is comparing to.  The mirrors in these files were already named TeamAware{Foo} (_TeamAwareConnValueBackend, _TeamAwareRaisingBackend), so this makes the pair readable without a docstring explaining which change "legacy" refers to.