### PR TITLE
Helm: Point flower extraNetworkPolicies deprecation at the real key

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -108,7 +108,7 @@ https://airflow.apache.org/docs/helm-chart/stable/production-guide.html#knownhos
 {{- if .Values.flower.extraNetworkPolicies }}
 
 DEPRECATION WARNING:
-   `flower.extraNetworkPolicies` has been renamed to `flower.networkPolicy.peers`.
+   `flower.extraNetworkPolicies` has been renamed to `flower.networkPolicy.ingress.from`.
    Please change your values as support for the old name will be dropped in a future release.
 
 {{- end }}


### PR DESCRIPTION
The chart's post-install `NOTES.txt` tells anyone still on the deprecated
`flower.extraNetworkPolicies` to migrate to `flower.networkPolicy.peers`.
That key does not exist. The parameter that actually replaced it is
`flower.networkPolicy.ingress.from` — what the template reads, and what
`values.yaml`, `values.schema.json` and `RELEASE_NOTES.rst` all document.

It is not just a wrong name in a message. `flower.networkPolicy` is declared
with `additionalProperties: false`, so following the warning fails the install
outright:

```console
$ helm template rn chart -f peers.yaml
Error: values don't meet the specifications of the schema(s) in the following chart(s):
airflow:
- at '/flower/networkPolicy': additional properties 'peers' not allowed
```

while the corrected key renders as intended:

```console
$ helm template rn chart -f ingress-from.yaml \
    --show-only templates/flower/flower-networkpolicy.yaml
...
  ingress:
    - from:
      - namespaceSelector:
          matchLabels:
            release: myrelease
      ports:
        - port: 5555
```

The warning is gated on `.Values.flower.extraNetworkPolicies` being set, so it
reaches exactly the users who are mid-migration — and sends them to a key Helm
rejects.

The wrong spelling dates back to #16619, which renamed the parameter to
`networkPolicy.ingress.from` during review but left the `NOTES.txt` strings on
the earlier `networkPolicy.peers` name. That commit introduced the identical
bug in the `webserver` notice too; that one disappeared with the Airflow 3
webserver removal, leaving only flower's.

### On testing

No test is added.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)