### PR TITLE
Preserve Decimal precision through XCom serialization

### DIFF
--- a/task-sdk/src/airflow/sdk/serde/serializers/bignum.py
+++ b/task-sdk/src/airflow/sdk/serde/serializers/bignum.py
@@ -42,9 +42,10 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
     _, _, exponent = o.as_tuple()
     if isinstance(exponent, int) and exponent >= 0:  # No digits after the decimal point.
         return int(o), name, __version__, True
-    # Technically lossy due to floating point errors, but the best we
-    # can do without implementing a custom encode function.
-    return float(o), name, __version__, True
+    # ``str`` keeps every significant digit where ``float`` would round to 53 bits
+    # of mantissa. The version stays at 1 because ``deserialize`` has always gone
+    # through ``Decimal(str(data))``, so older readers accept this payload too.
+    return str(o), name, __version__, True
 
 
 def deserialize(cls: type, version: int, data: object) -> decimal.Decimal:

--- a/task-sdk/tests/task_sdk/serde/test_serializers.py
+++ b/task-sdk/tests/task_sdk/serde/test_serializers.py
@@ -166,7 +166,16 @@ class TestSerializers:
 
     @pytest.mark.parametrize(
         ("expr", "expected"),
-        [("1", "1"), ("52e4", "520000"), ("2e0", "2"), ("12e-2", "0.12"), ("12.34", "12.34")],
+        [
+            ("1", "1"),
+            ("52e4", "520000"),
+            ("2e0", "2"),
+            ("12e-2", "0.12"),
+            ("12.34", "12.34"),
+            ("3.14159265358979323846", "3.14159265358979323846"),
+            ("12345678901234567.89", "12345678901234567.89"),
+            ("0.1234567890123456789", "0.1234567890123456789"),
+        ],
     )
     def test_encode_decimal(self, expr, expected):
         assert deserialize(serialize(decimal.Decimal(expr))) == decimal.Decimal(expected)


### PR DESCRIPTION
A task that returns a `decimal.Decimal` hands the next task a different number. The serde encoder converts the value to a float before storing it, so any Decimal that needs more than 53 bits of mantissa is silently rounded on its way through XCom. The same encoder handles deferred-task trigger kwargs, so a `Decimal` passed to `defer()` is rounded too.

`str` keeps every significant digit, so the encoder now uses it for values that have digits after the decimal point. Whole numbers keep their existing integer encoding.

**Repro on main**

```python
from decimal import Decimal

from airflow.sdk.serde import deserialize, serialize

for value in (Decimal("3.14159265358979323846"), Decimal("12345678901234567.89")):
    encoded = serialize(value)
    print(value, "->", encoded["__data__"], "->", deserialize(encoded))

# 3.14159265358979323846 -> 3.141592653589793      -> 3.141592653589793
# 12345678901234567.89   -> 1.2345678901234568e+16 -> 12345678901234568
```

With this change both values come back unchanged.

**Compatibility**

The serializer version deliberately stays at 1. `deserialize` has rebuilt the value with `Decimal(str(data))` ever since the serializer was added in #28067, so every released Airflow reads a string payload as happily as a float one. Bumping the version would do the opposite of helping, because an older reader raises on any version above its own. Existing XCom rows written as floats keep deserializing exactly as they do today.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
