### PR TITLE
Document custom OTel metrics endpoint path support

### DIFF
--- a/airflow-core/docs/administration-and-deployment/logging-monitoring/metrics.rst
+++ b/airflow-core/docs/administration-and-deployment/logging-monitoring/metrics.rst
@@ -136,6 +136,15 @@ Add the Collector details to your configuration file e.g. ``airflow.cfg``
     The OpenTelemetry SDK should be configured using standard OpenTelemetry environment variables
     such as ``OTEL_EXPORTER_OTLP_ENDPOINT``, ``OTEL_EXPORTER_OTLP_PROTOCOL``, etc.
 
+    To send metrics to an endpoint with a non-default path, set
+    ``OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`` to the complete metrics endpoint. This takes precedence
+    over ``OTEL_EXPORTER_OTLP_ENDPOINT`` and avoids applying the default ``/v1/metrics`` suffix:
+
+    .. code-block:: bash
+
+        export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT="https://metrics.example.com/opentelemetry/api/v1/push"
+        export OTEL_EXPORTER_OTLP_METRICS_PROTOCOL="http/protobuf"
+
     See the OpenTelemetry `exporter protocol specification <https://opentelemetry.io/docs/specs/otel/protocol/exporter/#configuration-options>`_  and
     `SDK environment variable documentation <https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#periodic-exporting-metricreader>`_ for more information.
 

--- a/shared/observability/tests/observability/metrics/test_otel_logger.py
+++ b/shared/observability/tests/observability/metrics/test_otel_logger.py
@@ -448,15 +448,15 @@ class TestOtelMetrics:
             pytest.param(
                 {
                     "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:1234",
-                    "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://localhost:2222",
+                    "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://localhost:2222/custom/metrics",
                     "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
-                    "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": "grpc",
+                    "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": "http/protobuf",
                 },
                 None,
                 None,
-                "localhost:2222",
-                "grpc",
-                id="type_specific_vars_take_precedence",
+                "http://localhost:2222/custom/metrics",
+                "http",
+                id="type_specific_http_endpoint_with_custom_path_takes_precedence",
             ),
             pytest.param(
                 {},


### PR DESCRIPTION
### Summary

Issue #42492 reports that Airflow's OTel metrics exporter can't send metrics to a non-default path (e.g. VictoriaMetrics' `/opentelemetry/api/v1/push`), and asks for a new `otel_path` Airflow config option to fix it — mirroring how `otel_host`/`otel_port` already work.

Looking at `get_otel_data_exporter()` in `shared/observability/src/airflow_shared/observability/common.py`, the `/v1/metrics` suffix is only ever appended in the legacy fallback branch, when neither `OTEL_EXPORTER_OTLP_ENDPOINT` nor `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` is set and the code falls back to the deprecated `otel_host`/`otel_port` Airflow config keys. As soon as either of those standard OTel endpoint env vars is set, the code calls `OTLPMetricExporter()` with no endpoint argument at all and lets the OpenTelemetry SDK read the env var itself — which means a full custom-path URL in `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` already passes through completely untouched today. Verified this against the real `opentelemetry-exporter-otlp-proto-http` package.

So the capability the issue asks for already exists -- it's just undocumented.

While writing the doc, found that the one existing test that covered "type-specific endpoint env var takes precedence over the base one" (`test_config_priorities[type_specific_vars_take_precedence]`) used the gRPC protocol for its type-specific case. gRPC targets are always `host:port` — there's no path component in a gRPC target — so that test could not have caught a regression in path handling no matter what URL was fed into it; it only proved precedence, not path preservation, despite the surrounding docs claim it would be backing. Updated it to use the HTTP protocol with a path-bearing endpoint, which is the same shape as the example in the new docs section, so the test actually guards the behavior being documented.

### Changes

- `airflow-core/docs/administration-and-deployment/logging-monitoring/metrics.rst`: added a note under the deprecated `otel_*` config keys explaining that `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` can be set to a complete custom-path endpoint, that it takes precedence over `OTEL_EXPORTER_OTLP_ENDPOINT`, and that doing so avoids the default `/v1/metrics` suffix — with a runnable example matching a VictoriaMetrics-style push path.
- `shared/observability/tests/observability/metrics/test_otel_logger.py`: replaced the gRPC-protocol precedence case with an HTTP-protocol case whose endpoint carries a custom path, so the test actually exercises and locks in the path-preservation behavior described in the new docs.

closes: #42492

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)