### PR TITLE
Support Anthropic SDK 1.x in Anthropic provider

### DIFF
--- a/providers/anthropic/README.rst
+++ b/providers/anthropic/README.rst
@@ -57,7 +57,7 @@ PIP package                                 Version required
 ==========================================  ====================
 ``apache-airflow``                          ``>=3.0.0``
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
-``anthropic``                               ``>=0.121.0,<1.0.0``
+``anthropic``                               ``>=1.0.0``
 ==========================================  ====================
 
 Optional dependencies
@@ -66,9 +66,9 @@ Optional dependencies
 ===========  ===============================
 Extra        Dependencies
 ===========  ===============================
-``bedrock``  ``anthropic[bedrock]>=0.121.0``
-``vertex``   ``anthropic[vertex]>=0.121.0``
-``aws``      ``anthropic[aws]>=0.121.0``
+``bedrock``  ``anthropic[bedrock]>=1.0.0``
+``vertex``   ``anthropic[vertex]>=1.0.0``
+``aws``      ``anthropic[aws]>=1.0.0``
 ===========  ===============================
 
 The changelog for the provider package can be found in the

--- a/providers/anthropic/docs/connections.rst
+++ b/providers/anthropic/docs/connections.rst
@@ -49,7 +49,8 @@ Extra (optional)
       ``model`` (e.g. ``hook.create_message(...)``, ``hook.create_agent(...)``). Set it here
       to change the model without editing Dags; falls back to the provider default
       (``claude-opus-4-8``).
-    * ``aws_region`` — AWS region for the ``bedrock`` and ``aws`` platforms.
+    * ``aws_region`` — AWS region for the ``bedrock`` and ``aws`` platforms; defaults
+      to ``us-east-1`` when omitted.
     * ``project_id`` / ``region`` — GCP project and region for the ``vertex`` platform.
     * ``resource`` — Azure resource name for the ``foundry`` platform.
     * ``anthropic_client_kwargs`` — a nested dictionary forwarded verbatim to the client

--- a/providers/anthropic/docs/index.rst
+++ b/providers/anthropic/docs/index.rst
@@ -138,7 +138,7 @@ PIP package                                 Version required
 ==========================================  ====================
 ``apache-airflow``                          ``>=3.0.0``
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
-``anthropic``                               ``>=0.121.0,<1.0.0``
+``anthropic``                               ``>=1.0.0``
 ==========================================  ====================
 
 Optional dependencies
@@ -152,13 +152,13 @@ Install them when installing from PyPI. For example:
     pip install apache-airflow-providers-anthropic[bedrock]
 
 
-===========  ======================================
+===========  ===============================
 Extra        Dependencies
-===========  ======================================
-``bedrock``  ``anthropic[bedrock]>=0.121.0,<1.0.0``
-``vertex``   ``anthropic[vertex]>=0.121.0,<1.0.0``
-``aws``      ``anthropic[aws]>=0.121.0,<1.0.0``
-===========  ======================================
+===========  ===============================
+``bedrock``  ``anthropic[bedrock]>=1.0.0``
+``vertex``   ``anthropic[vertex]>=1.0.0``
+``aws``      ``anthropic[aws]>=1.0.0``
+===========  ===============================
 
 Downloading official packages
 -----------------------------

--- a/providers/anthropic/provider.yaml
+++ b/providers/anthropic/provider.yaml
@@ -104,7 +104,7 @@ connection-types:
           type:
             - string
             - 'null'
-        description: AWS region for the bedrock platform (for example us-east-1).
+        description: AWS region for the bedrock and aws platforms. Defaults to us-east-1.
       project_id:
         label: GCP Project ID
         schema:

--- a/providers/anthropic/pyproject.toml
+++ b/providers/anthropic/pyproject.toml
@@ -61,24 +61,15 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=3.0.0",
     "apache-airflow-providers-common-compat>=1.12.0",
-    # 0.121.0 is the first release whose ``sessions.create`` accepts ``budget``, which is
-    # how the guide tells users to set a session ceiling. Reading a ``budget_reached`` stop
-    # reason happens to work further back -- older clients mis-build the discriminated
-    # union into the wrong variant class while preserving ``.type`` -- but only with
-    # response validation left non-strict, so it is not something to depend on.
-    # anthropic 1.0.0 replaces httpx with httpx2 and is a major release the provider
-    # has not been validated against. Remove the <1.0.0 cap (here and in the extras
-    # below) after migrating to the 1.x SDK;
-    # tracked at https://github.com/apache/airflow/issues/72071
-    "anthropic>=0.121.0,<1.0.0",
+    "anthropic>=1.0.0",
 ]
 
 # The optional dependencies should be modified in place in the generated file
 # Any change in the dependencies is preserved when the file is regenerated
 [project.optional-dependencies]
-"bedrock" = ["anthropic[bedrock]>=0.121.0,<1.0.0"]
-"vertex" = ["anthropic[vertex]>=0.121.0,<1.0.0"]
-"aws" = ["anthropic[aws]>=0.121.0,<1.0.0"]
+"bedrock" = ["anthropic[bedrock]>=1.0.0"]
+"vertex" = ["anthropic[vertex]>=1.0.0"]
+"aws" = ["anthropic[aws]>=1.0.0"]
 
 [dependency-groups]
 dev = [

--- a/providers/anthropic/src/airflow/providers/anthropic/get_provider_info.py
+++ b/providers/anthropic/src/airflow/providers/anthropic/get_provider_info.py
@@ -85,7 +85,7 @@ def get_provider_info():
                     "aws_region": {
                         "label": "AWS Region",
                         "schema": {"type": ["string", "null"]},
-                        "description": "AWS region for the bedrock platform (for example us-east-1).",
+                        "description": "AWS region for the bedrock and aws platforms. Defaults to us-east-1.",
                     },
                     "project_id": {
                         "label": "GCP Project ID",

--- a/providers/anthropic/src/airflow/providers/anthropic/hooks/anthropic.py
+++ b/providers/anthropic/src/airflow/providers/anthropic/hooks/anthropic.py
@@ -70,6 +70,8 @@ if TYPE_CHECKING:
 #: a provider release when this model ID is retired.
 DEFAULT_MODEL = "claude-opus-4-8"
 
+DEFAULT_AWS_REGION = "us-east-1"
+
 #: Platforms that serve the first-party-only endpoints (Message Batches, token
 #: counting, the Models API). Amazon Bedrock, Google Vertex AI and Microsoft
 #: Foundry do not serve these, so the hook fails fast rather than surfacing a
@@ -295,7 +297,8 @@ class AnthropicHook(BaseHook):
     - ``platform``: one of ``anthropic`` (default), ``bedrock``, ``vertex``, ``aws``, ``foundry``.
     - ``model``: default model id used when an operator/hook call omits ``model`` (lets you
       change the model without editing Dags); falls back to :data:`DEFAULT_MODEL`.
-    - ``aws_region``: region for the ``bedrock`` and ``aws`` platforms.
+    - ``aws_region``: region for the ``bedrock`` and ``aws`` platforms; defaults to
+      :data:`DEFAULT_AWS_REGION` when omitted.
     - ``project_id`` / ``region``: project and region for the ``vertex`` platform.
     - ``resource``: Azure resource name for the ``foundry`` platform.
     - ``anthropic_client_kwargs``: extra keyword arguments forwarded to the client
@@ -349,14 +352,15 @@ class AnthropicHook(BaseHook):
         client_kwargs = dict(extras.get("anthropic_client_kwargs", {}))
         platform = self.platform
         self.log.debug("Building Anthropic client for platform %r (conn_id=%s)", platform, self.conn_id)
+        aws_region = extras.get("aws_region") or DEFAULT_AWS_REGION
         if platform == "bedrock":
-            return AnthropicBedrock(aws_region=extras.get("aws_region"), **client_kwargs)
+            return AnthropicBedrock(aws_region=aws_region, **client_kwargs)
         if platform == "vertex":
             return AnthropicVertex(
                 project_id=extras.get("project_id"), region=extras.get("region"), **client_kwargs
             )
         if platform == "aws":
-            return AnthropicAWS(aws_region=extras.get("aws_region"), **client_kwargs)
+            return AnthropicAWS(aws_region=aws_region, **client_kwargs)
         if platform == "foundry":
             api_key = client_kwargs.pop("api_key", None) or conn.password
             return AnthropicFoundry(api_key=api_key, resource=extras.get("resource"), **client_kwargs)

--- a/providers/anthropic/tests/unit/anthropic/hooks/test_anthropic.py
+++ b/providers/anthropic/tests/unit/anthropic/hooks/test_anthropic.py
@@ -31,6 +31,7 @@ from airflow.providers.anthropic.exceptions import (
     AnthropicTriggerEventError,
 )
 from airflow.providers.anthropic.hooks.anthropic import (
+    DEFAULT_AWS_REGION,
     DEFAULT_MODEL,
     MAX_CONSECUTIVE_POLL_FAILURES,
     AnthropicHook,
@@ -45,7 +46,7 @@ from airflow.providers.anthropic.hooks.anthropic import (
 
 pytest.importorskip("anthropic")
 
-import httpx
+import httpx2
 from anthropic import BadRequestError
 from anthropic.types import BetaMonetaryAmount
 from anthropic.types.beta import BetaManagedAgentsServerToolUsage, BetaManagedAgentsSessionUsage
@@ -283,8 +284,8 @@ class TestBuildBudget:
 
 def _make_bad_request(message="cannot be archived while its status is running") -> BadRequestError:
     """A real SDK BadRequestError -- archive_session only interrupts on this, not on any error."""
-    request = httpx.Request("POST", "https://api.anthropic.com/v1/sessions/sess_1/archive")
-    return BadRequestError(message, response=httpx.Response(400, request=request), body=None)
+    request = httpx2.Request("POST", "https://api.anthropic.com/v1/sessions/sess_1/archive")
+    return BadRequestError(message, response=httpx2.Response(400, request=request), body=None)
 
 
 class TestArchiveSession:
@@ -660,6 +661,13 @@ class TestAnthropicHookGetConn:
         mock_bedrock.assert_called_once_with(aws_region="us-east-1")
         assert client is mock_bedrock.return_value
 
+    @mock.patch(f"{HOOK_PATH}.AnthropicBedrock")
+    @mock.patch.object(AnthropicHook, "get_connection")
+    def test_bedrock_platform_without_region(self, mock_get_connection, mock_bedrock):
+        mock_get_connection.return_value = _conn(extra={"platform": "bedrock"})
+        AnthropicHook().get_conn()
+        mock_bedrock.assert_called_once_with(aws_region=DEFAULT_AWS_REGION)
+
     @mock.patch(f"{HOOK_PATH}.AnthropicVertex")
     @mock.patch.object(AnthropicHook, "get_connection")
     def test_vertex_platform(self, mock_get_connection, mock_vertex):
@@ -679,10 +687,9 @@ class TestAnthropicHookGetConn:
     @mock.patch(f"{HOOK_PATH}.AnthropicAWS", autospec=True)
     @mock.patch.object(AnthropicHook, "get_connection")
     def test_aws_platform_without_region(self, mock_get_connection, mock_aws):
-        # No aws_region configured -> pass None so the SDK falls back to its own resolution.
         mock_get_connection.return_value = _conn(extra={"platform": "aws"})
         AnthropicHook().get_conn()
-        mock_aws.assert_called_once_with(aws_region=None)
+        mock_aws.assert_called_once_with(aws_region=DEFAULT_AWS_REGION)
 
     @mock.patch(f"{HOOK_PATH}.AnthropicFoundry")
     @mock.patch.object(AnthropicHook, "get_connection")

--- a/uv.lock
+++ b/uv.lock
@@ -1097,21 +1097,20 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.125.0"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "distro" },
     { name = "docstring-parser" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/f8/6f0560884b5363848347bd640b6c1d04abc25e7aa61787a232f790c6b60a/anthropic-0.125.0.tar.gz", hash = "sha256:e0cdd336580cb7411c1cdab69f80973e9bf4bff7f8e08141811d46307d45c682", size = 1112593, upload-time = "2026-08-19T22:00:42.837Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/aa/4978e58035bd6c638c7b483450a68b7ef2d732ab78885e27bb9db0cff1a2/anthropic-1.0.0.tar.gz", hash = "sha256:42be3c97604af7252c5898413aee076ace6c46e9bca0d0d90ceb77c7d3719027", size = 1077769, upload-time = "2026-08-20T19:59:00.565Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/1a/b1bd30cda3790557e8791bec5922a6ec8fabb6fa8b008c76a39cf7be6152/anthropic-0.125.0-py3-none-any.whl", hash = "sha256:3486013602eca76d8b12540764e53654f02cf4951110bca86cf06e67428a9f21", size = 1184067, upload-time = "2026-08-19T22:00:44.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/5b/db4a854aebf5d33a5ab714c46af6eb85ee44f390ed29b7b325c00b9f11ed/anthropic-1.0.0-py3-none-any.whl", hash = "sha256:32dd52e9e1d774393b27182f451398ba4262287a4d0eab30887f89f1481b3ae4", size = 1171725, upload-time = "2026-08-20T19:58:58.725Z" },
 ]
 
 [package.optional-dependencies]
@@ -3205,7 +3204,7 @@ docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "d
 
 [[package]]
 name = "apache-airflow-providers-amazon"
-version = "9.35.0"
+version = "9.35.1"
 source = { editable = "providers/amazon" }
 dependencies = [
     { name = "apache-airflow" },
@@ -3442,10 +3441,10 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = ">=0.121.0,<1.0.0" },
-    { name = "anthropic", extras = ["aws"], marker = "extra == 'aws'", specifier = ">=0.121.0,<1.0.0" },
-    { name = "anthropic", extras = ["bedrock"], marker = "extra == 'bedrock'", specifier = ">=0.121.0,<1.0.0" },
-    { name = "anthropic", extras = ["vertex"], marker = "extra == 'vertex'", specifier = ">=0.121.0,<1.0.0" },
+    { name = "anthropic", specifier = ">=1.0.0" },
+    { name = "anthropic", extras = ["aws"], marker = "extra == 'aws'", specifier = ">=1.0.0" },
+    { name = "anthropic", extras = ["bedrock"], marker = "extra == 'bedrock'", specifier = ">=1.0.0" },
+    { name = "anthropic", extras = ["vertex"], marker = "extra == 'vertex'", specifier = ">=1.0.0" },
     { name = "apache-airflow", editable = "." },
     { name = "apache-airflow-providers-common-compat", editable = "providers/common/compat" },
 ]
@@ -6587,7 +6586,7 @@ docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "d
 
 [[package]]
 name = "apache-airflow-providers-microsoft-azure"
-version = "15.0.0"
+version = "15.0.1"
 source = { editable = "providers/microsoft/azure" }
 dependencies = [
     { name = "adlfs" },


### PR DESCRIPTION
# Support Anthropic SDK 1.x in Anthropic provider

This updates the Anthropic provider for the Anthropic Python SDK 1.x release and removes the need for the temporary `<1.0.0` cap.

Anthropic 1.0 changed the SDK's underlying HTTP package from `httpx` to `httpx2`. That made the provider checks fail in a unit test that builds a real SDK `BadRequestError` using the old response object. The test helper now builds `httpx2` request/response objects to match the SDK 1.x error types.

The provider now requires `anthropic>=1.0.0`, updates the optional extras to the same floor, and refreshes `uv.lock` so tests run against `anthropic==1.0.0`.

This also keeps existing Bedrock and Claude Platform on AWS connections working when `aws_region` is not set. Older SDK versions defaulted that case to `us-east-1`, but SDK 1.x raises an error if `None` is passed. The provider now applies the same `us-east-1` default itself and documents that behavior.

closes: #72071

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes - Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)