### PR TITLE
Fix DeadlockImminentError in async Connection resolution

### DIFF
--- a/task-sdk/src/airflow/sdk/definitions/connection.py
+++ b/task-sdk/src/airflow/sdk/definitions/connection.py
@@ -291,6 +291,82 @@ class Connection:
             cls._handle_connection_error(e, conn_id)
 
     @property
+    async def aextra_dejson(self) -> dict:
+        """Async version: Returns the extra property by deserializing json and masking secrets."""
+        from airflow.sdk.log import amask_secret
+
+        extra = {}
+        if self.extra:
+            try:
+                import json
+                extra = json.loads(self.extra)
+            except Exception:
+                log.exception("Failed to deserialize extra property `extra`, returning empty dictionary")
+            else:
+                await amask_secret(extra)
+        return extra
+
+    async def aget_uri(self) -> str:
+        """Async version: Generate and return connection in URI format."""
+        from urllib.parse import parse_qsl, quote, urlencode
+
+        if self.conn_type:
+            uri = f"{self.conn_type.lower().replace('_', '-')}://"
+        else:
+            uri = "//"
+        host_to_use: str | None
+        if self.host and "://" in self.host:
+            protocol, host = self.host.split("://", 1)
+            # If the protocol in host matches the connection type, don't add it again
+            if protocol == self.conn_type:
+                host_to_use = self.host
+                protocol_to_add = None
+            else:
+                # Different protocol, add it to the URI
+                host_to_use = host
+                protocol_to_add = protocol
+        else:
+            host_to_use = self.host
+            protocol_to_add = None
+
+        if protocol_to_add:
+            uri += f"{protocol_to_add}://"
+
+        authority_block = ""
+        if self.login is not None:
+            authority_block += quote(self.login, safe="")
+        if self.password is not None:
+            authority_block += ":" + quote(self.password, safe="")
+        if authority_block > "":
+            authority_block += "@"
+            uri += authority_block
+
+        host_block = ""
+        if host_to_use:
+            host_block += quote(host_to_use, safe="")
+        if self.port:
+            if host_block == "" and authority_block == "":
+                host_block += f"@:{self.port}"
+            else:
+                host_block += f":{self.port}"
+        if self.schema:
+            host_block += f"/{quote(self.schema, safe='')}"
+        uri += host_block
+
+        if self.extra:
+            try:
+                extra_dejson = await self.aextra_dejson()
+                query: str | None = urlencode(extra_dejson)
+            except TypeError:
+                query = None
+            if query and extra_dejson == dict(parse_qsl(query, keep_blank_values=True)):
+                uri += ("?" if self.schema else "/?") + query
+            else:
+                uri += ("?" if self.schema else "/?") + urlencode({self.EXTRA_KEY: self.extra})
+
+        return uri
+
+    @property
     def extra_dejson(self) -> dict:
         """Returns the extra property by deserializing json."""
         from airflow.sdk.log import mask_secret

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -297,7 +297,7 @@ async def _async_get_connection(conn_id: str) -> Connection:
                 conn = await sync_to_async(secrets_backend.get_connection)(conn_id)  # type: ignore[assignment]
 
             if conn:
-                SecretCache.save_connection_uri(conn_id, conn.get_uri())
+                SecretCache.save_connection_uri(conn_id, await conn.aget_uri())
                 await _amask_connection_secrets(conn)
                 return conn
         except AirflowSecretsBackendAccessDenied:


### PR DESCRIPTION
Closes #71891.

### Motivation

A `DeadlockImminentError` is raised in Airflow 3 when resolving a connection inside an async task (e.g. via `await BaseHook.aget_hook(...)`). The `Connection.async_get()` method resolves the connection and saves it to `SecretCache`. The cache attempts to save the URI via the synchronous `get_uri()` method, which deserializes `extra` using `extra_dejson`.

The `extra_dejson` property iteratively loops over the dict and masks secrets using `mask_secret`, which triggers a synchronous IPC call (`comms.send()`) to the task supervisor. Since this executes inside the asyncio event-loop thread, it throws `DeadlockImminentError` and crashes the loop.

### Changes

- Implemented `aextra_dejson` and `aget_uri` on `Connection` to do the same but natively await the existing async masking utility (`amask_secret`).
- Updated `_async_get_connection` in the execution environment's context to `await conn.aget_uri()` when saving to the SecretCache.