### PR TITLE
Add unit tests for common AI provider exceptions

### DIFF
--- a/airflow-core/tests/unit/always/test_project_structure.py
+++ b/airflow-core/tests/unit/always/test_project_structure.py
@@ -99,7 +99,6 @@ class TestProjectStructure:
             "providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_k8s_hashlib_wrapper.py",
             "providers/common/sql/tests/unit/common/sql/datafusion/test_base.py",
             "providers/common/sql/tests/unit/common/sql/datafusion/test_exceptions.py",
-            "providers/common/ai/tests/unit/common/ai/test_exceptions.py",
             "providers/common/compat/tests/unit/common/compat/lineage/test_entities.py",
             "providers/common/compat/tests/unit/common/compat/standard/test_operators.py",
             "providers/common/compat/tests/unit/common/compat/standard/test_triggers.py",

--- a/providers/common/ai/tests/unit/common/ai/test_exceptions.py
+++ b/providers/common/ai/tests/unit/common/ai/test_exceptions.py
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow.providers.common.ai.exceptions import (
+    HITLMaxIterationsError,
+    LLMFileAnalysisError,
+    LLMFileAnalysisLimitExceededError,
+    LLMFileAnalysisMultimodalRequiredError,
+    LLMFileAnalysisUnsupportedFormatError,
+    ManagedAgentInvocationError,
+)
+from airflow.providers.common.compat.sdk import AirflowException
+
+EXCEPTION_CASES = [
+    (HITLMaxIterationsError, AirflowException),
+    (LLMFileAnalysisError, ValueError),
+    (LLMFileAnalysisUnsupportedFormatError, LLMFileAnalysisError),
+    (LLMFileAnalysisLimitExceededError, LLMFileAnalysisError),
+    (LLMFileAnalysisMultimodalRequiredError, LLMFileAnalysisUnsupportedFormatError),
+    (ManagedAgentInvocationError, RuntimeError),
+]
+
+
+@pytest.mark.parametrize(("exc_cls", "expected_base"), EXCEPTION_CASES)
+def test_exception_bases_and_message(exc_cls, expected_base):
+    message = "test-message"
+    exc = exc_cls(message)
+
+    assert isinstance(exc, expected_base)
+    assert str(exc) == message
+
+
+def test_llm_file_analysis_exception_chain():
+    exc = LLMFileAnalysisMultimodalRequiredError("need multimodal")
+
+    assert isinstance(exc, LLMFileAnalysisUnsupportedFormatError)
+    assert isinstance(exc, LLMFileAnalysisError)
+    assert isinstance(exc, ValueError)


### PR DESCRIPTION
## What is the change?

I added unit tests for the six exception classes in the common AI provider, and I removed that test path from the `OVERLOOKED_TESTS` list in the project-structure guard.

## Why did I change this?

The project-structure test expects every provider source file to have a matching test module. `exceptions.py` in the common AI provider was still on the skip list, which is one of the gaps tracked in #35442. I wanted that module covered instead of remaining an exemption.

## How did I change it?

I added `providers/common/ai/tests/unit/common/ai/test_exceptions.py`. Each test builds the exception with a message and checks the parent class, including the file-analysis inheritance chain (`LLMFileAnalysisMultimodalRequiredError` -> `LLMFileAnalysisUnsupportedFormatError` -> `LLMFileAnalysisError` -> `ValueError`). I then deleted the matching line from `OVERLOOKED_TESTS` in `airflow-core/tests/unit/always/test_project_structure.py`. Production `exceptions.py` is unchanged.

## What's the impact?

No runtime behavior changes. The exception types and messages stay the same. What changes is coverage: those classes now have tests, and CI will fail if the test file disappears without putting the exemption back. This is one slice of #35442, not the whole backlog, so I used `related:` rather than `closes:`.

## How did I test?

I ran the new tests locally with:

```bash
uv run --project providers/common/ai pytest providers/common/ai/tests/unit/common/ai/test_exceptions.py -xvs
```

All 7 passed: one check per exception type, plus the inheritance-chain test.

I also ran the project-structure guard, which is the test that used to skip this file:

```bash
uv run --project airflow-core pytest airflow-core/tests/unit/always/test_project_structure.py::TestProjectStructure::test_providers_modules_should_have_tests -xvs
```

That passed as well, so removing the exemption was safe. I did not run the full provider suite; this change is only those tests.

## Reviewers

Please review, common AI provider code owners: @gopidesupavan @kaxil @Lee-W @ashb

related: #35442

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Cursor Grok 4.6

Generated-by: Cursor Grok 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
