### PR TITLE
fix: respect cursor_itersize in psycopg3 server-side cursor path

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/transfers/postgres_to_gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/postgres_to_gcs.py
@@ -61,10 +61,12 @@ class _PostgresServerSideCursorDecorator:
             if self.rows:
                 return self.rows.pop()
             self.initialized = True
-            row = self.cursor.fetchone()
-            if row is None:
+            rows = self.cursor.fetchmany(self.cursor.itersize)
+            if not rows:
                 raise StopIteration
-            return row
+            self.rows = list(rows)
+            self.rows.reverse()
+            return self.rows.pop()
         # psycopg2
         if self.rows:
             return self.rows.pop()


### PR DESCRIPTION
When `USE_PSYCOPG3` is True, `_PostgresServerSideCursorDecorator.__next__`
was using `fetchone()` which issues `FETCH FORWARD 1` per row, ignoring
the configured `cursor_itersize`. This caused a 17x slowdown for large
tables with server-side cursors.

Fix by using `fetchmany(cursor.itersize)` to batch-fetch rows, matching
the psycopg2 behavior which iterates the cursor (respecting itersize).

Closes #72075