### PR TITLE
Fix mypy httpx/httpx2 type mismatch in anthropic provider tests

### DIFF
--- a/providers/anthropic/tests/unit/anthropic/hooks/test_anthropic.py
+++ b/providers/anthropic/tests/unit/anthropic/hooks/test_anthropic.py
@@ -284,7 +284,11 @@ class TestBuildBudget:
 def _make_bad_request(message="cannot be archived while its status is running") -> BadRequestError:
     """A real SDK BadRequestError -- archive_session only interrupts on this, not on any error."""
     request = httpx.Request("POST", "https://api.anthropic.com/v1/sessions/sess_1/archive")
-    return BadRequestError(message, response=httpx.Response(400, request=request), body=None)
+    # anthropic>=1.0.0 types `response` as httpx2.Response, but BadRequestError only ever
+    # duck-types the response (status_code, headers.get, request), so a plain httpx.Response
+    # works at runtime against anthropic>=0.121.0 too -- the SDK's still-supported lower bound,
+    # which depends on httpx, not httpx2.
+    return BadRequestError(message, response=httpx.Response(400, request=request), body=None)  # type: ignore[arg-type]
 
 
 class TestArchiveSession:


### PR DESCRIPTION
I encountered the CI failure in non-related PR (https://github.com/apache/airflow/actions/runs/32921443404/job/98038017920?pr=71843) and also in the scheduled CI (https://github.com/apache/airflow/actions/runs/32922654770/job/98042562433)

## Why

`prek --stage manual mypy-providers --all-files` fails because `anthropic` 1.0.0 switched its HTTP transport dependency from `httpx` to a new, separate PyPI package named `httpx2`, so `BadRequestError`'s `response` parameter is now typed `httpx2.Response` instead of `httpx.Response`.

## What

- In `test_anthropic.py`'s `_make_bad_request` helper, added a scoped `# type: ignore[arg-type]` (with a comment) on the `BadRequestError(...)` call instead of importing `httpx2`. `BadRequestError` only ever duck-types the response object (`status_code`, `headers.get`, `.request`), so a plain `httpx.Response` still works at runtime. This avoids adding a hard dependency on `httpx2`, which doesn't exist under the provider's still-supported lower bound (`anthropic>=0.121.0`, which depends on `httpx`) and would otherwise break test collection under CI's lowest-direct-dependency job for providers.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code Sonnet 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
