### PR TITLE
use secrets for fab users --use-random-password generation

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/cli_commands/user_command.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/cli_commands/user_command.py
@@ -22,8 +22,8 @@ import functools
 import getpass
 import json
 import os
-import random
 import re
+import secrets
 import string
 from typing import Any
 
@@ -113,7 +113,8 @@ def user_reset_password(args):
 
 def _create_password(args):
     if args.use_random_password:
-        password = "".join(random.choices(string.printable, k=16))
+        characters = string.ascii_letters + string.digits + string.punctuation
+        password = "".join(secrets.choice(characters) for _ in range(16))
     elif args.password:
         password = args.password
     else:

--- a/providers/fab/tests/unit/fab/auth_manager/cli_commands/test_user_command.py
+++ b/providers/fab/tests/unit/fab/auth_manager/cli_commands/test_user_command.py
@@ -16,13 +16,17 @@
 # under the License.
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import re
+import secrets
+import string
 import tempfile
 from contextlib import redirect_stdout
 from importlib import reload
 from io import StringIO
+from unittest import mock
 
 import pytest
 
@@ -37,6 +41,18 @@ pytestmark = pytest.mark.db_test
 TEST_USER1_EMAIL = "test-user1@example.com"
 TEST_USER2_EMAIL = "test-user2@example.com"
 TEST_USER3_EMAIL = "test-user3@example.com"
+
+
+@mock.patch(
+    "airflow.providers.fab.auth_manager.cli_commands.user_command.secrets.choice",
+    side_effect=secrets.choice,
+)
+def test_create_password_uses_csprng_without_whitespace(mock_choice):
+    args = argparse.Namespace(use_random_password=True, password=None)
+    password = user_command._create_password(args)
+    assert mock_choice.call_count == 16
+    assert len(password) == 16
+    assert not any(char in string.whitespace for char in password)
 
 
 def _does_user_belong_to_role(appbuilder, email, rolename):


### PR DESCRIPTION
_create_password builds the --use-random-password value with random.choices, the Mersenne Twister PRNG that Python documents as unfit for security use, so the generated web-login credential comes from a reconstructable stream, and string.printable also seeds it with whitespace and control characters that land in the stored password (roughly 63% of generated values). Switch to secrets.choice over the printable non-whitespace alphabet, matching the generation already used in the teradata provider's encryption_utils and the kubernetes and ssh helpers. Added a regression test asserting the CSPRNG is used and that no whitespace reaches the password.

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.