### PR TITLE
Fix Publish Docs to S3 failing for ts-sdk and java-sdk

### DIFF
--- a/.github/workflows/publish-docs-to-s3.yml
+++ b/.github/workflows/publish-docs-to-s3.yml
@@ -152,8 +152,9 @@ jobs:
         # Tracked at #66436.
         run: |
           # Keep the non-provider list in sync with NON_PROVIDER_TOKENS in
-          # dev/registry/derive_wave_providers.py.
-          NON_PROVIDER_TOKENS=("apache-airflow" "apache-airflow-ctl" "apache-airflow-mypy" "task-sdk" "helm-chart" "docker-stack")
+          # dev/registry/derive_wave_providers.py, which documents why.
+          # dev/registry/tests/test_derive_wave_providers.py pins the two together.
+          NON_PROVIDER_TOKENS=("apache-airflow" "apache-airflow-ctl" "apache-airflow-mypy" "task-sdk" "java-sdk" "ts-sdk" "helm-chart" "docker-stack")
           has_provider=false
           for token in $INCLUDE_DOCS; do
             is_non_provider=false

--- a/.github/workflows/registry-tests.yml
+++ b/.github/workflows/registry-tests.yml
@@ -26,6 +26,10 @@ on:  # yamllint disable-line rule:truthy
       - 'providers/*/provider.yaml'
       - 'providers/*/*/provider.yaml'
       - '.github/workflows/registry-tests.yml'
+      # test_derive_wave_providers.py pins NON_PROVIDER_TOKENS to the copies in
+      # these two files, so a PR touching only them still has to run the guard.
+      - '.github/workflows/publish-docs-to-s3.yml'
+      - 'dev/breeze/src/airflow_breeze/global_constants.py'
   push:
     branches: [main]
     paths:

--- a/dev/registry/derive_wave_providers.py
+++ b/dev/registry/derive_wave_providers.py
@@ -53,6 +53,11 @@ PROVIDER_TAG_RE = re.compile(r"^providers-(?P<id>.+?)/(?P<ver>.+)$")
 RC_SUFFIX_RE = re.compile(r"rc[0-9]+$")
 
 META_TOKENS = frozenset({"all", "all-providers", "apache-airflow-providers"})
+# Every doc distribution that is not a provider. Must stay equal to
+# REGULAR_DOC_PACKAGES in dev/breeze/src/airflow_breeze/global_constants.py minus
+# META_TOKENS -- that constant is the source of truth for what `include-docs`
+# accepts, and a token missing here is treated as a provider ID, which fails the
+# registry extraction. tests/test_derive_wave_providers.py pins the two together.
 NON_PROVIDER_TOKENS = frozenset(
     {
         "apache-airflow",
@@ -61,6 +66,8 @@ NON_PROVIDER_TOKENS = frozenset(
         "apache-airflow-ctl",
         "apache-airflow-mypy",
         "task-sdk",
+        "java-sdk",
+        "ts-sdk",
     }
 )
 PROVIDER_PREFIX = "apache-airflow-providers-"

--- a/dev/registry/tests/test_derive_wave_providers.py
+++ b/dev/registry/tests/test_derive_wave_providers.py
@@ -18,8 +18,19 @@
 
 from __future__ import annotations
 
+import ast
+import re
+from pathlib import Path
+
 import pytest
-from derive_wave_providers import derive
+from derive_wave_providers import META_TOKENS, NON_PROVIDER_TOKENS, derive
+
+AIRFLOW_ROOT = Path(__file__).parents[3]
+GLOBAL_CONSTANTS = AIRFLOW_ROOT / "dev" / "breeze" / "src" / "airflow_breeze" / "global_constants.py"
+PUBLISH_DOCS_WORKFLOW = AIRFLOW_ROOT / ".github" / "workflows" / "publish-docs-to-s3.yml"
+PUBLISH_DOCS_TO_S3 = (
+    AIRFLOW_ROOT / "dev" / "breeze" / "src" / "airflow_breeze" / "utils" / "publish_docs_to_s3.py"
+)
 
 
 def fake_git(wave_tags=None, provider_tags=None):
@@ -95,6 +106,13 @@ WAVE_PROVIDER_TAGS = [
         ("amazon amazon google", "any", "amazon google", False, ""),
         # Empty.
         ("", "any", "", False, ""),
+        # Language-SDK doc packages are distributions, not providers. Passing one
+        # through as a provider ID fails registry extraction (`provider(s) not found
+        # in provider.yaml files`) and blocks the docs publish.
+        ("ts-sdk", "any", "", False, ""),
+        ("java-sdk ts-sdk task-sdk", "any", "", False, ""),
+        # A real provider alongside an SDK token still rebuilds, minus the SDK.
+        ("ts-sdk amazon", "any", "amazon", False, ""),
     ],
 )
 def test_derive(include_docs, ref, expected_providers, expected_full_build, log_substr):
@@ -167,3 +185,64 @@ def test_glob_matches_non_wave_tag_is_filtered_out():
     assert providers == "amazon"
     assert full_build is False
     assert "providers/2026-02-10 -> providers/2026-02-20" in log
+
+
+def _string_collection_constant(path: Path, name: str) -> set[str]:
+    """Parse a collection-of-strings constant out of a Python file via AST.
+
+    `derive_wave_providers.py` runs under bare `python3` on the runner, where
+    breeze is not installed, so these constants are parsed rather than imported.
+
+    Anything but a flat literal of string constants raises. Skipping an element
+    we cannot read would shrink both sides of the comparisons below in step, so
+    the guard would pass vacuously on exactly the drift it exists to catch.
+    """
+    tree = ast.parse(path.read_text(), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            targets: list[ast.expr] = list(node.targets)
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        else:
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == name for target in targets):
+            continue
+        if not isinstance(node.value, (ast.List, ast.Tuple, ast.Set)):
+            raise AssertionError(f"{name} in {path} is not a list/tuple/set literal")
+        values = set()
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Constant) or not isinstance(elt.value, str):
+                raise AssertionError(f"{name} in {path} has a non-literal element: {ast.unparse(elt)}")
+            values.add(elt.value)
+        return values
+    raise AssertionError(f"{name} not found in {path}")
+
+
+def _workflow_non_provider_tokens() -> set[str]:
+    """The NON_PROVIDER_TOKENS bash array from publish-docs-to-s3.yml."""
+    match = re.search(
+        r"^\s*NON_PROVIDER_TOKENS=\((.*?)\)\s*$",
+        PUBLISH_DOCS_WORKFLOW.read_text(),
+        re.MULTILINE | re.DOTALL,
+    )
+    if not match:
+        raise AssertionError(f"NON_PROVIDER_TOKENS array not found in {PUBLISH_DOCS_WORKFLOW}")
+    return set(re.findall(r'"([^"]+)"', match.group(1)))
+
+
+def test_non_provider_tokens_match_breeze_doc_packages():
+    # A doc package added to breeze but not here is parsed as a provider ID and
+    # fails registry extraction, which is how ts-sdk (#70812) broke docs publishing.
+    regular_doc_packages = _string_collection_constant(GLOBAL_CONSTANTS, "REGULAR_DOC_PACKAGES")
+    assert regular_doc_packages - META_TOKENS == NON_PROVIDER_TOKENS
+
+
+def test_workflow_non_provider_list_matches_script():
+    assert _workflow_non_provider_tokens() == NON_PROVIDER_TOKENS
+
+
+def test_breeze_publish_docs_non_short_names_match_script():
+    # A third copy, with the same "not in the list means expand to
+    # apache-airflow-providers-{}" semantics. In sync today; pinned so it stays that way.
+    non_short_name_packages = _string_collection_constant(PUBLISH_DOCS_TO_S3, "NON_SHORT_NAME_PACKAGES")
+    assert non_short_name_packages == NON_PROVIDER_TOKENS


### PR DESCRIPTION
- related: #70812, #66100
- failing run: https://github.com/apache/airflow/actions/runs/32948512400

## Why

Dispatching **Publish Docs to S3** with `include-docs=ts-sdk` fails: `ts-sdk` is passed to the registry as a provider ID, extraction exits 1 with `provider(s) not found in provider.yaml files: ['ts-sdk']`, and that blocks the publish. `java-sdk` has the same latent bug.

## How

The non-provider token list is hand-copied in three places, and two were missing both SDK tokens:

- `.github/workflows/publish-docs-to-s3.yml` (bash array), stale
- `dev/registry/derive_wave_providers.py` (`NON_PROVIDER_TOKENS`), stale
- `dev/breeze/src/airflow_breeze/utils/publish_docs_to_s3.py` (`NON_SHORT_NAME_PACKAGES`), in sync but unpinned

The duplication is deliberate (the bash copy lets release tags predating #66100 still publish), so rather than removing it, tests pin all three to breeze's `REGULAR_DOC_PACKAGES`:

```
NON_PROVIDER_TOKENS == set(REGULAR_DOC_PACKAGES) - META_TOKENS
```

Anchoring to `REGULAR_DOC_PACKAGES` is the point: #70812 added `ts-sdk` there and to the workflow but never touched `dev/registry/`, so only this direction catches that drift. `registry-tests.yml` also only triggered on `dev/registry/**`, so such a PR ran no check at all.

## What

- Add `java-sdk` and `ts-sdk` to both stale copies.
- Add three drift guards in `dev/registry/tests/test_derive_wave_providers.py`, one per copy. They raise rather than silently pass if their pattern stops matching, and the AST helper rejects non-literal elements, which would otherwise shrink both sides of the comparison in step and pass vacuously.
- Add `test_derive` cases `ts-sdk`, `java-sdk ts-sdk task-sdk`, and `ts-sdk amazon` (a real provider alongside an SDK token must still rebuild).
- Widen `registry-tests.yml` `pull_request` paths to cover `publish-docs-to-s3.yml` and `global_constants.py`.
---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code Opus 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
