### PR TITLE
Show a notice when the Calendar view cuts off planned runs

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/calendar.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/calendar.py
@@ -42,6 +42,8 @@ class CalendarTimeRangeCollectionResponse(BaseModel):
 
     total_entries: int
     dag_runs: list[CalendarTimeRangeResponse]
+    # True when the planned-run scan hit its iteration cap before the end of the year
+    planned_runs_capped: bool = False
 
 
 class CalendarDeadlineResponse(BaseModel):

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -2802,6 +2802,10 @@ components:
             $ref: '#/components/schemas/CalendarTimeRangeResponse'
           type: array
           title: Dag Runs
+        planned_runs_capped:
+          type: boolean
+          title: Planned Runs Capped
+          default: false
       type: object
       required:
       - total_entries

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/calendar.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/calendar.py
@@ -49,7 +49,9 @@ log = structlog.get_logger(logger_name=__name__)
 class CalendarService:
     """Service class for calendar-related operations."""
 
-    MAX_PLANNED_RUNS: int = 2000
+    # High enough to cover a full year of hourly runs (8784); the iteration cost per
+    # request stays bounded well below a second even for seconds-resolution crons.
+    MAX_PLANNED_RUNS: int = 10000
 
     def get_calendar_data(
         self,
@@ -82,12 +84,15 @@ class CalendarService:
             granularity,
         )
 
-        planned_data = self._get_planned_dag_runs(dag, raw_dag_states, date_filter, granularity)
+        planned_data, planned_capped = self._get_planned_dag_runs(
+            dag, raw_dag_states, date_filter, granularity
+        )
 
         all_data = historical_data + planned_data
         return CalendarTimeRangeCollectionResponse(
             total_entries=len(all_data),
             dag_runs=all_data,
+            planned_runs_capped=planned_capped,
         )
 
     def _get_historical_dag_runs(
@@ -139,10 +144,10 @@ class CalendarService:
         raw_dag_states: Sequence[Row],
         date_filter: RangeFilter,
         granularity: Literal["hourly", "daily"],
-    ) -> list[CalendarTimeRangeResponse]:
-        """Get planned Dag runs based on the Dag's timetable."""
+    ) -> tuple[list[CalendarTimeRangeResponse], bool]:
+        """Get planned Dag runs based on the Dag's timetable, and whether the cap cut them off."""
         if not self._should_calculate_planned_runs(dag, raw_dag_states):
-            return []
+            return [], False
 
         last_state = raw_dag_states[-1]
 
@@ -150,7 +155,7 @@ class CalendarService:
             last_run_after = timezone.coerce_datetime(last_state.run_after)
             last_partition_date = timezone.coerce_datetime(last_state.partition_date)
             if not last_run_after or not last_partition_date:
-                return []
+                return [], False
             year = last_partition_date.year
             last_info = DagRunInfo(
                 run_after=last_run_after,
@@ -161,7 +166,7 @@ class CalendarService:
         else:
             last_data_interval = self._get_last_data_interval(raw_dag_states)
             if not last_data_interval:
-                return []
+                return [], False
             year = last_data_interval.end.year
             if isinstance(dag.timetable, CronMixin):
                 return self._calculate_cron_planned_runs(
@@ -212,9 +217,10 @@ class CalendarService:
         year: int,
         date_filter: RangeFilter,
         granularity: Literal["hourly", "daily"],
-    ) -> list[CalendarTimeRangeResponse]:
+    ) -> tuple[list[CalendarTimeRangeResponse], bool]:
         """Calculate planned runs for cron-based timetables."""
         dates: dict[datetime, int] = collections.Counter()
+        capped = False
 
         dates_iter: Iterator[datetime | None] = croniter(
             cast("CronMixin", dag.timetable)._expression,
@@ -234,10 +240,14 @@ class CalendarService:
                 continue
 
             dates[self._truncate_datetime_for_granularity(dt, granularity)] += 1
+        else:
+            # croniter iterates forever, so exhausting the islice means the cap cut the scan
+            # short of the year boundary.
+            capped = True
 
         return [
             CalendarTimeRangeResponse(date=dt, state="planned", count=count) for dt, count in dates.items()
-        ]
+        ], capped
 
     def _calculate_timetable_planned_runs(
         self,
@@ -247,7 +257,7 @@ class CalendarService:
         restriction: TimeRestriction,
         date_filter: RangeFilter,
         granularity: Literal["hourly", "daily"],
-    ) -> list[CalendarTimeRangeResponse]:
+    ) -> tuple[list[CalendarTimeRangeResponse], bool]:
         """Calculate planned runs for generic timetables."""
         dates: dict[datetime, int] = collections.Counter()
         prev_run_after = last_info.run_after
@@ -284,7 +294,7 @@ class CalendarService:
 
         return [
             CalendarTimeRangeResponse(date=dt, state="planned", count=count) for dt, count in dates.items()
-        ]
+        ], total_planned >= self.MAX_PLANNED_RUNS
 
     def _get_time_truncation_expression(
         self,

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -9295,6 +9295,11 @@ export const $CalendarTimeRangeCollectionResponse = {
             },
             type: 'array',
             title: 'Dag Runs'
+        },
+        planned_runs_capped: {
+            type: 'boolean',
+            title: 'Planned Runs Capped',
+            default: false
         }
     },
     type: 'object',

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -2308,6 +2308,7 @@ export type CalendarDeadlineResponse = {
 export type CalendarTimeRangeCollectionResponse = {
     total_entries: number;
     dag_runs: Array<CalendarTimeRangeResponse>;
+    planned_runs_capped?: boolean;
 };
 
 /**

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
@@ -22,6 +22,7 @@
     "noData": "No data available",
     "noFailedRuns": "No failed runs",
     "noRuns": "No runs",
+    "plannedRunsCapped": "This Dag has too many planned runs to display; only the earliest are shown.",
     "totalRuns": "Total Runs",
     "week": "Week {{weekNumber}}",
     "weekdays": {

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/Calendar.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/Calendar.tsx
@@ -34,7 +34,7 @@ import {
   useDagServiceGetDagDetails,
 } from "openapi/queries";
 
-import { IconButton, ButtonGroupToggle } from "src/system-components";
+import { Alert, IconButton, ButtonGroupToggle } from "src/system-components";
 
 import { ErrorAlert } from "src/components/ErrorAlert";
 
@@ -121,6 +121,9 @@ export const Calendar = () => {
   return (
     <Box data-testid="dag-calendar-root" p={6}>
       <ErrorAlert error={error} />
+      {Boolean(data?.planned_runs_capped) && data?.dag_runs.some((run) => run.state === "planned") ? (
+        <Alert mb={4} status="info" title={translate("calendar.plannedRunsCapped")} />
+      ) : undefined}
       <HStack data-testid="calendar-header" justify="space-between" mb={6}>
         <HStack gap={4} mb={4}>
           {granularity === "daily" ? (

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_calendar.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_calendar.py
@@ -17,10 +17,11 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pendulum
 import pytest
+import time_machine
 from sqlalchemy.orm import Session
 
 from airflow._shared.timezones import timezone
@@ -80,6 +81,7 @@ class TestCalendar:
                 {},
                 {
                     "total_entries": 5,
+                    "planned_runs_capped": False,
                     "dag_runs": [
                         {"date": "2025-01-01T00:00:00Z", "state": "failed", "count": 1},
                         {"date": "2025-01-01T00:00:00Z", "state": "success", "count": 1},
@@ -93,6 +95,7 @@ class TestCalendar:
                 {"logical_date_gte": "2025-01-01T00:00:00Z", "logical_date_lte": "2025-01-01T23:23:59Z"},
                 {
                     "total_entries": 2,
+                    "planned_runs_capped": False,
                     "dag_runs": [
                         {"date": "2025-01-01T00:00:00Z", "state": "failed", "count": 1},
                         {"date": "2025-01-01T00:00:00Z", "state": "success", "count": 1},
@@ -103,6 +106,7 @@ class TestCalendar:
                 {"logical_date_gte": "2025-01-02T00:00:00Z", "logical_date_lte": "2025-01-02T23:23:59Z"},
                 {
                     "total_entries": 2,
+                    "planned_runs_capped": False,
                     "dag_runs": [
                         {"date": "2025-01-02T00:00:00Z", "state": "running", "count": 1},
                         {"date": "2025-01-02T00:00:00Z", "state": "planned", "count": 1},
@@ -127,6 +131,7 @@ class TestCalendar:
                 {"granularity": "hourly"},
                 {
                     "total_entries": 6,
+                    "planned_runs_capped": False,
                     "dag_runs": [
                         {"date": "2025-01-01T00:00:00Z", "state": "failed", "count": 1},
                         {"date": "2025-01-01T01:00:00Z", "state": "success", "count": 1},
@@ -145,6 +150,7 @@ class TestCalendar:
                 },
                 {
                     "total_entries": 2,
+                    "planned_runs_capped": False,
                     "dag_runs": [
                         {"date": "2025-01-02T00:00:00Z", "state": "running", "count": 1},
                         {"date": "2025-01-02T01:00:00Z", "state": "planned", "count": 1},
@@ -161,6 +167,7 @@ class TestCalendar:
                 },
                 {
                     "total_entries": 0,
+                    "planned_runs_capped": False,
                     "dag_runs": [],
                 },
             ),
@@ -174,6 +181,7 @@ class TestCalendar:
                 },
                 {
                     "total_entries": 2,
+                    "planned_runs_capped": False,
                     "dag_runs": [
                         {"date": "2025-01-02T00:00:00Z", "state": "running", "count": 1},
                         {"date": "2025-01-02T01:00:00Z", "state": "planned", "count": 1},
@@ -253,6 +261,7 @@ class TestPartitionedCalendar:
                 {},
                 {
                     "total_entries": 4,
+                    "planned_runs_capped": False,
                     "dag_runs": [
                         {"date": "2025-01-01T00:00:00Z", "state": "success", "count": 1},
                         {"date": "2025-01-02T00:00:00Z", "state": "failed", "count": 1},
@@ -265,6 +274,7 @@ class TestPartitionedCalendar:
                 {"partition_date_gte": "2025-01-02T00:00:00Z", "partition_date_lte": "2025-01-03T23:59:59Z"},
                 {
                     "total_entries": 2,
+                    "planned_runs_capped": False,
                     "dag_runs": [
                         {"date": "2025-01-02T00:00:00Z", "state": "failed", "count": 1},
                         {"date": "2025-01-03T00:00:00Z", "state": "success", "count": 1},
@@ -275,6 +285,7 @@ class TestPartitionedCalendar:
                 {"logical_date_gte": "2025-01-01T00:00:00Z", "logical_date_lte": "2025-01-04T23:59:59Z"},
                 {
                     "total_entries": 1,
+                    "planned_runs_capped": False,
                     "dag_runs": [
                         {"date": "2025-01-04T00:00:00Z", "state": "running", "count": 1},
                     ],
@@ -296,6 +307,7 @@ class TestPartitionedCalendar:
                 {"granularity": "hourly"},
                 {
                     "total_entries": 4,
+                    "planned_runs_capped": False,
                     "dag_runs": [
                         {"date": "2025-01-01T00:00:00Z", "state": "success", "count": 1},
                         {"date": "2025-01-02T00:00:00Z", "state": "failed", "count": 1},
@@ -312,6 +324,7 @@ class TestPartitionedCalendar:
                 },
                 {
                     "total_entries": 1,
+                    "planned_runs_capped": False,
                     "dag_runs": [
                         {"date": "2025-01-01T00:00:00Z", "state": "success", "count": 1},
                     ],
@@ -328,18 +341,18 @@ class TestPartitionedCalendar:
 
 
 class TestCalendarPlannedRunsCap:
-    """A high-frequency cron must stop at MAX_PLANNED_RUNS instead of iterating to the year boundary."""
+    """A high-frequency schedule must stop at MAX_PLANNED_RUNS instead of iterating to the year boundary."""
 
     DAG_NAME = "test_minutely_dag"
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture(autouse=True, params=["* * * * *", timedelta(minutes=1)], ids=["cron", "timedelta"])
     @provide_session
-    def setup_dag_runs(self, dag_maker, *, session: Session = NEW_SESSION) -> None:
+    def setup_dag_runs(self, request, dag_maker, *, session: Session = NEW_SESSION) -> None:
         clear_db_runs()
         clear_db_dags()
         with dag_maker(
             self.DAG_NAME,
-            schedule="* * * * *",
+            schedule=request.param,
             start_date=datetime(2025, 6, 1),
             catchup=False,
             serialized=True,
@@ -358,11 +371,16 @@ class TestCalendarPlannedRunsCap:
         clear_db_runs()
         clear_db_dags()
 
-    def test_planned_runs_capped_for_high_frequency_cron(self, test_client):
+    # The generic-timetable path plans from "now" when catchup is disabled, so pin the
+    # clock to the year the fixture's Dag run lives in.
+    @time_machine.travel("2025-06-02T00:00:00+00:00", tick=False)
+    def test_planned_runs_capped_for_high_frequency_schedule(self, test_client):
         response = test_client.get(f"/calendar/{self.DAG_NAME}")
         assert response.status_code == 200
-        planned = [r for r in response.json()["dag_runs"] if r["state"] == "planned"]
+        body = response.json()
+        planned = [r for r in body["dag_runs"] if r["state"] == "planned"]
         assert sum(r["count"] for r in planned) == CalendarService.MAX_PLANNED_RUNS
+        assert body["planned_runs_capped"] is True
 
 
 _CALLBACK_PATH = "tests.unit.api_fastapi.core_api.routes.ui.test_calendar._noop_callback"


### PR DESCRIPTION
Follow-up to #71263, implementing the reviewer's suggestions there: the planned-run cap silently truncates the Calendar for Dags with high-frequency schedules, which reads as the schedule stopping partway through the year.

- The calendar response now includes `planned_runs_capped`, set when the planned-run scan hits `MAX_PLANNED_RUNS` before reaching the year boundary (both the cron fast path and the generic timetable path).
- The Calendar view shows an info banner when planned cells were cut off: "This Dag has too many planned runs to display; only the earliest are shown."
- `MAX_PLANNED_RUNS` is raised from 2000 to 10000, so a full year of hourly runs (8784) fits without truncation; the per-request scan cost stays well under a second even for seconds-resolution crons.

related: #71263

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)