### PR TITLE
Use non-deprecated user_agent_entry param in DatabricksSqlHook

### DIFF
--- a/providers/databricks/src/airflow/providers/databricks/hooks/databricks_sql.py
+++ b/providers/databricks/src/airflow/providers/databricks/hooks/databricks_sql.py
@@ -241,7 +241,7 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
                 "catalog": self.catalog,
                 "session_configuration": session_config or None,
                 "http_headers": self.http_headers,
-                "_user_agent_entry": self.user_agent_value,
+                "user_agent_entry": self.user_agent_value,
                 **self._get_extra_config(),
                 **self.additional_params,
             }


### PR DESCRIPTION
closes: #72102

`databricks-sql-connector`'s `Session` renamed `_user_agent_entry` to
`user_agent_entry` and only keeps the old name for backward compatibility,
logging a deprecation warning on every connection opened through
`DatabricksSqlHook.get_conn()`. This switches the hook to the current
parameter name.

No behavior change: `user_agent_entry` is supported by every
databricks-sql-connector version this provider currently allows
(>=4.4.0).

##### Was generative AI tooling used to co-author this PR?

- [X] Yes, Claude Code

<!-- Generated-by: Claude Code following the guidelines -->