### PR TITLE
fix(metrics): report DogStatsD timer durations in milliseconds

### DIFF
--- a/shared/observability/src/airflow_shared/observability/metrics/datadog_logger.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/datadog_logger.py
@@ -139,6 +139,11 @@ class SafeDogStatsdLogger:
         """Timer metric that can be cancelled."""
         tags_list = self._build_tags_list(tags)
         if stat and self.metrics_validator.test(stat):
+            # datadog's ``timed()`` context manager defaults to ``use_ms=False``, which reports
+            # the elapsed time in seconds even though the metric is sent with the ``|ms`` type.
+            # Airflow's ``Timer`` measures in milliseconds, so keep the units consistent and
+            # report milliseconds (see GH issue #72110).
+            kwargs.setdefault("use_ms", True)
             return Timer(self.dogstatsd.timed(stat, tags=tags_list, **kwargs))
         return Timer()
 

--- a/shared/observability/tests/observability/metrics/test_stats.py
+++ b/shared/observability/tests/observability/metrics/test_stats.py
@@ -257,7 +257,7 @@ class TestDogStats:
     def test_timer(self, time_mock):
         with self.dogstatsd.timer("empty_timer") as timer:
             pass
-        self.dogstatsd_client.timed.assert_called_once_with("empty_timer", tags=[])
+        self.dogstatsd_client.timed.assert_called_once_with("empty_timer", tags=[], use_ms=True)
         expected_duration = 1000.0 * 100.0
         assert expected_duration == timer.duration
         assert time_mock.call_count == 2


### PR DESCRIPTION
closes #72110

## Problem
With `[metrics] statsd_datadog_enabled = True`, every metric emitted via `Stats.timer()` is under-reported by 1000x. `Stats.timing()` metrics are unaffected, so units become inconsistent on the same backend.

`datadog`'s `timed()` context manager defaults to `use_ms=False`, so it reports the elapsed time in **seconds** even though the metric is sent with the `|ms` type. Airflow's `Timer` measures in **milliseconds** (`1000.0 * (time.perf_counter() - start)`).

## Fix
Pass `use_ms=True` to `dogstatsd.timed()` in `SafeDogStatsdLogger.timer()` so elapsed times are reported in milliseconds, consistent with `Stats.timing()` and Airflow's own `Timer.duration`.

## Tests
Updated the existing `TestDogStats.test_timer` assertion to expect `use_ms=True`.