### PR TITLE
Fix stale TypeScript SDK docs on bundle metadata and packing setup

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/language-sdks/typescript.rst
+++ b/airflow-core/docs/authoring-and-scheduling/language-sdks/typescript.rst
@@ -53,6 +53,11 @@ Prerequisites
   the worker, under a directory the coordinator scans.
 * The ``apache-airflow-task-sdk`` package (installed with Airflow) provides the coordinator; no additional
   Python packages are needed.
+* In the TypeScript project, install the ``apache-airflow-ts-sdk`` npm package to author task handlers:
+
+  .. code-block:: bash
+
+      npm install apache-airflow-ts-sdk
 
 Quick start
 -----------
@@ -259,8 +264,12 @@ a single self-contained ESM file, ``bundle.mjs``, and embeds the manifest (the `
 map plus the supervisor schema version) as a leading ``//# airflowMetadata=<base64>`` comment — one file to
 deploy, with no separate manifest or ``node_modules``.
 
+``esbuild`` is an optional peer dependency: packing is build-time only, so the runtime install of
+``apache-airflow-ts-sdk`` skips it, and it must be installed separately before running ``airflow-ts-pack``.
+
 .. code-block:: bash
 
+    npm install --save-dev esbuild
     npx airflow-ts-pack src/main.ts --outdir dist
 
 Use ``--outdir <dir>`` to choose the output directory (default ``dist``) and ``--source <name>`` to set the
@@ -290,8 +299,8 @@ All ``kwargs`` in the ``coordinators`` config entry are passed to the
      - Description
    * - ``bundles_root``
      - *(required)*
-     - One or more directories searched, in order, for a ``bundle.mjs`` (with embedded metadata, or with an
-       ``airflow-metadata.yaml`` sidecar). Accepts a string, a path, or a list of strings/paths.
+     - One or more directories searched, in order, for a ``bundle.mjs`` with embedded metadata. Accepts a
+       string, a path, or a list of strings/paths.
    * - ``node_executable``
      - ``"node"``
      - Path to the ``node`` binary. Defaults to ``node`` on ``$PATH``.


### PR DESCRIPTION
### Summary

`airflow-core/docs/authoring-and-scheduling/language-sdks/typescript.rst` still described `NodeCoordinator`'s `bundles_root` as accepting a `bundle.mjs` "with embedded metadata, or with an `airflow-metadata.yaml` sidecar." That sidecar fallback was removed in #70273 (`Remove airflow-metadata.yaml sidecar support from NodeCoordinator`) — `airflow-ts-pack` always embeds the manifest in `bundle.mjs` itself, and `NodeCoordinator` now only reads that embedded metadata; no tool produces the sidecar file, and `_bundle_metadata.py`'s YAML-sidecar parsing helpers are effectively dead code from the doc's point of view. The doc never got updated when the code changed, so it describes a deployment shape (a hand-written `airflow-metadata.yaml` next to the bundle) that Airflow no longer supports.

Separately, the "Building and packaging" section jumped straight to running `npx airflow-ts-pack src/main.ts --outdir dist` without ever showing how to get there: it never mentioned installing the `apache-airflow-ts-sdk` npm package, and it didn't mention that `esbuild` — the bundler `airflow-ts-pack` uses — is an *optional* peer dependency that the runtime install intentionally skips (see `ts-sdk/package.json`'s `peerDependenciesMeta.esbuild.optional`). A user following the doc exactly as written would run `npx airflow-ts-pack` in a project that never had `esbuild` installed and hit a failure with no explanation in the doc of why, or what to install instead. The `ts-sdk/README.md` already has the correct sequence (`npm install --save-dev esbuild` before packing); the RST doc had drifted from it.

### Change

- Removed the stale `airflow-metadata.yaml` sidecar mention from the `NodeCoordinator` configuration table; `bundles_root` now just documents the current, single supported shape (a `bundle.mjs` with embedded metadata).
- Added a "Prerequisites" bullet showing `npm install apache-airflow-ts-sdk` for authoring task handlers.
- Added an explanation plus `npm install --save-dev esbuild` to the "Building and packaging" section, before the `airflow-ts-pack` invocation, so the documented steps actually work end-to-end for a fresh project.

Docs-only change.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)
