### PR TITLE
Fix TypeScript coordinator hanging forever without a supervisor greeting

### DIFF
--- a/ts-sdk/src/coordinator/comm-channel.ts
+++ b/ts-sdk/src/coordinator/comm-channel.ts
@@ -51,6 +51,10 @@ export interface RequestOptions {
   timeoutMs?: number;
 }
 
+export interface ConnectOptions {
+  timeoutMs?: number;
+}
+
 export const COORDINATOR_REQUEST_TIMEOUT_MS = 30_000;
 
 export class CommChannel {
@@ -81,11 +85,22 @@ export class CommChannel {
     sock.on("error", (err) => this.handleClose(err));
   }
 
-  /** Connect and wait for the supervisor's greeting; rejects if the
-   *  socket dies before it arrives. */
-  static async connect(addr: string, logs: LogChannel | null = null): Promise<CommConnection> {
+  /** Connect and wait for the supervisor's greeting; rejects if the socket dies, or no greeting
+   *  arrives within `timeoutMs`, before it arrives. A timeout destroys the socket so the runtime
+   *  never waits on a wedged or misbehaving supervisor forever. */
+  static async connect(
+    addr: string,
+    logs: LogChannel | null = null,
+    opts: ConnectOptions = {},
+  ): Promise<CommConnection> {
     const sock = await connectTcp(addr);
     const channel = new CommChannel(sock, logs);
+    const timeoutMs = opts.timeoutMs ?? COORDINATOR_REQUEST_TIMEOUT_MS;
+    channel.greeting.rejectAfter(timeoutMs, () => {
+      const err = new Error(`Timed out waiting for supervisor greeting after ${timeoutMs} ms`);
+      sock.destroy(err);
+      return err;
+    });
     const firstFrame = await channel.greeting.promise;
     return { channel, firstFrame };
   }

--- a/ts-sdk/tests/coordinator/comm-channel.test.ts
+++ b/ts-sdk/tests/coordinator/comm-channel.test.ts
@@ -18,9 +18,15 @@
  */
 
 import { EventEmitter } from "node:events";
+import type { Socket } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CommChannel, COORDINATOR_REQUEST_TIMEOUT_MS } from "../../src/coordinator/comm-channel.js";
 import { encodeResponse } from "../../src/coordinator/frames.js";
+import { connectTcp } from "../../src/coordinator/tcp-connect.js";
+
+vi.mock("../../src/coordinator/tcp-connect.js", () => ({
+  connectTcp: vi.fn(),
+}));
 
 class FakeSocket extends EventEmitter {
   writeCallback: ((err?: Error) => void) | undefined;
@@ -148,6 +154,59 @@ describe("CommChannel", () => {
 
     await expect(request).rejects.toThrow("write failed");
     await vi.advanceTimersByTimeAsync(10);
+  });
+
+  it("times out waiting for the supervisor greeting and destroys the socket", async () => {
+    vi.useFakeTimers();
+    const sock = new FakeSocket();
+    vi.mocked(connectTcp).mockResolvedValue(sock as unknown as Socket);
+
+    const connection = CommChannel.connect("127.0.0.1:0", null, { timeoutMs: 10 });
+    const assertion = expect(connection).rejects.toThrow(
+      "Timed out waiting for supervisor greeting after 10 ms",
+    );
+    await vi.advanceTimersByTimeAsync(10);
+
+    await assertion;
+    expect(sock.destroy).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it("uses the default request timeout for the greeting when no override is given", async () => {
+    vi.useFakeTimers();
+    const sock = new FakeSocket();
+    vi.mocked(connectTcp).mockResolvedValue(sock as unknown as Socket);
+
+    const connection = CommChannel.connect("127.0.0.1:0", null);
+    const rejection = vi.fn();
+    connection.catch(rejection);
+    const assertion = expect(connection).rejects.toThrow(
+      `Timed out waiting for supervisor greeting after ${COORDINATOR_REQUEST_TIMEOUT_MS} ms`,
+    );
+
+    await vi.advanceTimersByTimeAsync(COORDINATOR_REQUEST_TIMEOUT_MS - 1);
+    expect(rejection).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+
+    await assertion;
+    expect(rejection).toHaveBeenCalledOnce();
+  });
+
+  it("clears the greeting timeout once the greeting arrives", async () => {
+    vi.useFakeTimers();
+    const sock = new FakeSocket();
+    vi.mocked(connectTcp).mockResolvedValue(sock as unknown as Socket);
+
+    const connection = CommChannel.connect("127.0.0.1:0", null, { timeoutMs: 10 });
+    // Let the mocked connectTcp() promise settle and the "data" listener attach
+    // before the greeting frame arrives.
+    await vi.advanceTimersByTimeAsync(0);
+    sock.emit("data", encodeResponse(0, { type: "StartupDetails" }));
+
+    await expect(connection).resolves.toMatchObject({
+      firstFrame: { body: { type: "StartupDetails" } },
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    expect(sock.destroy).not.toHaveBeenCalled();
   });
 
   it("does not log clean close events", async () => {


### PR DESCRIPTION
### Summary

`CommChannel.connect()` (`ts-sdk/src/coordinator/comm-channel.ts`) opens the comm TCP socket and then awaits `channel.greeting.promise` — the supervisor's first frame (`StartupDetails` or `DagFileParseRequest`) — with no timeout of its own. Once the TCP connection succeeds, nothing bounds how long the Node coordinator process will wait for that first frame: if the socket stays open but the supervisor never writes the greeting (a wedged or misbehaving supervisor, a stuck process on the Python side, a protocol bug), `connect()` never resolves and never rejects, and the coordinator subprocess hangs indefinitely with no way to recover on its own.

This is inconsistent with the rest of the same class: every subsequent `request()` call on the channel already times out after `COORDINATOR_REQUEST_TIMEOUT_MS` (30 seconds, `ts-sdk/src/coordinator/comm-channel.ts:54`) via `Deferred.rejectAfter()`, and `sendResponse()` supports an equivalent optional timeout that destroys the socket when a terminal write wedges. The greeting wait — which happens once, at startup, before any request/response traffic — was the one gap left uncovered.

### Change

- Added `ConnectOptions` (`{ timeoutMs?: number }`) and a third parameter on `CommChannel.connect()`.
- `connect()` now arms `channel.greeting.rejectAfter(timeoutMs, ...)` right after opening the socket, defaulting `timeoutMs` to the existing `COORDINATOR_REQUEST_TIMEOUT_MS` (30s) for consistency with the rest of the channel. This reuses the same self-clearing-timer `Deferred` mechanism already used by `request()` and `sendResponse()` — no new timer bookkeeping.
- On timeout, the socket is destroyed (`sock.destroy(err)`) with a descriptive error, mirroring the existing `sendResponse` timeout pattern, so a wedged supervisor connection is actually torn down instead of left dangling.
- A normal greeting arrival still resolves `connect()` immediately and clears the timer, so there's no behavior change on the working path.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)