### PR TITLE
Allow Variable.get_variable_from_secrets to reuse session

### DIFF
--- a/airflow-core/src/airflow/models/variable.py
+++ b/airflow-core/src/airflow/models/variable.py
@@ -459,7 +459,7 @@ class Variable(Base, LoggingMixin):
         return None
 
     @staticmethod
-    def get_variable_from_secrets(key: str, team_name: str | None = None) -> str | None:
+    def get_variable_from_secrets(key: str, team_name: str | None = None, *, session: Session | None = None) -> str | None:
         """
         Get Airflow Variable by iterating over all Secret Backends.
 
@@ -480,8 +480,12 @@ class Variable(Base, LoggingMixin):
         # iterate over backends if not in cache (or expired)
         for secrets_backend in ensure_secrets_loaded():
             try:
+                kwargs = {"team_name": team_name, "key": key}
+                if type(secrets_backend).__name__ == "MetastoreBackend" and session is not None:
+                    kwargs["session"] = session
+
                 var_val = call_secrets_backend_method(
-                    secrets_backend.get_variable, team_name=team_name, key=key
+                    secrets_backend.get_variable, **kwargs
                 )
                 if var_val is not None:
                     break


### PR DESCRIPTION
Closes #71801.

### Motivation

When resolving `VariableInterval` deadlines (such as in `_process_dagrun_deadline_alerts`), the scheduler operates under `prohibit_commit`. However, querying `MetastoreBackend.get_variable` through `Variable.get_variable_from_secrets` does not pass down the session, which triggers `@provide_session` to create a scoped session that automatically commits upon exiting, thus tripping `UNEXPECTED COMMIT` guards.

Because of this, callers had to duplicate the secrets backend iteration loop directly in `dag.py` (see #68917) instead of utilizing `get_variable_from_secrets`.

### Changes

- Add `session=None` keyword-only argument to `Variable.get_variable_from_secrets`.
- Explicitly check if the `secrets_backend` is `MetastoreBackend`, and if `session` is provided, forward it in the `call_secrets_backend_method` arguments.
- This allows the caller's session to be reused across the metadata DB lookup without triggering unexpected commits, clearing the way for deduplicating the `dag.py` loop.