### PR TITLE
Fix flaky test_connection_form_widgets timeout

### DIFF
--- a/airflow-core/tests/unit/always/test_providers_manager.py
+++ b/airflow-core/tests/unit/always/test_providers_manager.py
@@ -246,6 +246,10 @@ class TestProviderManager:
         assert "bad" not in providers_manager._remote_logging_by_scheme
         assert providers_manager._remote_logging_info_list == []
 
+    # The first test in the suite's order to hit _import_info_from_all_hooks() pays the one-time
+    # cost of cold-importing every provider hook module, which can exceed the default 60s
+    # execution timeout on slower or loaded runners.
+    @pytest.mark.execution_timeout(120)
     def test_connection_form_widgets(self, yaml_ui_metadata_counts):
         yaml_widgets, _ = yaml_ui_metadata_counts
         provider_manager = ProvidersManager()


### PR DESCRIPTION
Every test in TestProviderManager resets the ProvidersManager singleton, but sys.modules stays warm across tests. The first test in the suite's order to trigger _import_info_from_all_hooks() therefore pays the one-time cost of cold-importing every provider hook module, and that test is test_connection_form_widgets. That cost sits right at the 60s default per-test execution timeout, so the test flakes on slower or loaded runners (observed roughly 1 in 6 runs of core-tests on 8-vCPU runners in a downstream CI). The sibling test_field_behaviours, which runs the same sweep against a warm module cache, takes about 3s.

Raising the marker to 120s matches the existing precedent in tests/unit/cli/commands/test_connection_command.py and test_task_command.py.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (Claude Fable 5)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
