### PR TITLE
Reject unknown update mask fields

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -226,6 +226,12 @@ def patch_dag_run(
     fields_to_update = patch_body.model_fields_set
 
     if update_mask:
+        unknown_fields = set(update_mask) - set(DAGRunPatchBody.model_fields)
+        if unknown_fields:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                f"Unknown update_mask field(s): {sorted(unknown_fields)}",
+            )
         fields_to_update = fields_to_update.intersection(update_mask)
     else:
         try:

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/variables.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/variables.py
@@ -67,6 +67,13 @@ def update_orm_from_pydantic(
         )
 
     if update_mask:
+        valid_update_fields = set(VariableBody.model_fields) - {"key"}
+        unknown_fields = set(update_mask) - valid_update_fields - {"key"}
+        if unknown_fields:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                f"Unknown update_mask field(s): {sorted(unknown_fields)}",
+            )
         fields_to_update = patch_body.model_fields_set & set(update_mask)
         try:
             VariableBodyPartial(**patch_body.model_dump(include=fields_to_update))

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -1737,11 +1737,11 @@ class TestPatchDagRun:
                 {"user_id": "test", "content": None},
             ),
             (
-                {"update_mask": ["random"]},
-                {"state": DagRunState.FAILED},
-                {"state": "success", "note": "test_note"},
+                {"update_mask": ["state", "note"]},
+                {"state": DagRunState.FAILED, "note": "updated note"},
+                {"state": "failed", "note": "updated note"},
                 200,
-                {"user_id": "not_test", "content": "test_note"},
+                {"user_id": "test", "content": "updated note"},
             ),
         ],
     )
@@ -1759,6 +1759,20 @@ class TestPatchDagRun:
         for key, value in response_body.items():
             assert response_json.get(key) == value
         _check_dag_run_note(session, DAG1_RUN1_ID, note_data)
+
+    @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
+    def test_patch_dag_run_with_unknown_update_mask_rejects_request(self, test_client, session):
+        response = test_client.patch(
+            f"/dags/{DAG1_ID}/dagRuns/{DAG1_RUN1_ID}",
+            params={"update_mask": ["random"]},
+            json={"state": DagRunState.FAILED, "note": "should not be saved"},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Unknown update_mask field(s): ['random']"
+        dag_run = session.scalar(select(DagRun).filter_by(dag_id=DAG1_ID, run_id=DAG1_RUN1_ID))
+        assert dag_run.state == DagRunState.SUCCESS
+        assert dag_run.note == "test_note"
 
     def test_patch_dag_run_not_found(self, test_client):
         response = test_client.patch(

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
@@ -633,6 +633,37 @@ class TestPatchVariable(TestVariableEndpoint):
         assert response.json()["description"] == "updated description"
         assert response.json()["key"] == TEST_VARIABLE_KEY
 
+    def test_patch_with_comma_joined_update_mask_rejects_unknown_field(self, test_client):
+        self.create_variables()
+        response = test_client.patch(
+            f"/variables/{TEST_VARIABLE_KEY}",
+            json={
+                "key": TEST_VARIABLE_KEY,
+                "value": "new value",
+                "description": "new description",
+            },
+            params={"update_mask": ["value,description"]},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Unknown update_mask field(s): ['value,description']"
+        variable = Variable.get(TEST_VARIABLE_KEY)
+        assert variable.val == TEST_VARIABLE_VALUE
+        assert variable.description == TEST_VARIABLE_DESCRIPTION
+
+    def test_patch_with_update_mask_key_rejects_immutable_field(self, test_client):
+        self.create_variables()
+        response = test_client.patch(
+            f"/variables/{TEST_VARIABLE_KEY}",
+            json={"key": TEST_VARIABLE_KEY, "value": "new value", "description": None},
+            params={"update_mask": ["key"]},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == (
+            "Update not allowed: the following fields are immutable and cannot be modified: {'key'}"
+        )
+
 
 class TestPostVariable(TestVariableEndpoint):
     @pytest.mark.enable_redact


### PR DESCRIPTION
Unknown fields in Variable and Dag Run update masks now return HTTP 400 instead of silently succeeding. Regression tests verify rejection and that records remain unchanged.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — OpenAI Codex (GPT-5)

Generated-by: OpenAI Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---
Drafted-by: OpenAI Codex (GPT-5) (no human review before posting)
