### PR TITLE
Add WebSocketSensor and WebSocketTrigger to the standard provider

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -454,6 +454,7 @@ decrypted
 Decrypts
 deduplicate
 deduplicated
+deduplicating
 deduplication
 deepcopy
 DefaultAzureCredential

--- a/providers/standard/docs/index.rst
+++ b/providers/standard/docs/index.rst
@@ -127,6 +127,7 @@ Install them when installing from PyPI. For example:
 Extra            Dependencies
 ===============  ========================================
 ``openlineage``  ``apache-airflow-providers-openlineage``
+``websocket``    ``websockets>=14.0``
 ===============  ========================================
 
 Downloading official packages

--- a/providers/standard/docs/sensors/websocket.rst
+++ b/providers/standard/docs/sensors/websocket.rst
@@ -1,0 +1,43 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+
+.. _howto/operator:WebSocketSensor:
+
+WebSocketSensor
+================
+
+Use the :class:`~airflow.providers.standard.sensors.websocket.WebSocketSensor` to wait for a message on a
+``ws://`` or ``wss://`` WebSocket connection. This is useful when a remote server accepts a long-lived
+connection and replies asynchronously once it has handled the requested work, since a plain HTTP request
+is not well suited to that kind of long-lived connection. Requires the ``websocket`` extra
+(``apache-airflow-providers-standard[websocket]``).
+
+.. exampleinclude:: /../src/airflow/providers/standard/example_dags/example_sensors.py
+    :language: python
+    :dedent: 4
+    :start-after: [START example_websocket_sensor]
+    :end-before: [END example_websocket_sensor]
+
+Also for this job you can use sensor in the deferrable mode:
+
+.. exampleinclude:: /../src/airflow/providers/standard/example_dags/example_sensors.py
+    :language: python
+    :dedent: 4
+    :start-after: [START example_websocket_sensor_async]
+    :end-before: [END example_websocket_sensor_async]

--- a/providers/standard/docs/sensors/websocket.rst
+++ b/providers/standard/docs/sensors/websocket.rst
@@ -41,3 +41,13 @@ Also for this job you can use sensor in the deferrable mode:
     :dedent: 4
     :start-after: [START example_websocket_sensor_async]
     :end-before: [END example_websocket_sensor_async]
+
+A common use case is to send a request over the connection right after it opens (via
+``message_to_send``) and then wait for the remote server's asynchronous reply, optionally
+passing connection headers such as an auth token via ``header``:
+
+.. exampleinclude:: /../src/airflow/providers/standard/example_dags/example_sensors.py
+    :language: python
+    :dedent: 4
+    :start-after: [START example_websocket_sensor_send_message_async]
+    :end-before: [END example_websocket_sensor_send_message_async]

--- a/providers/standard/docs/sensors/websocket.rst
+++ b/providers/standard/docs/sensors/websocket.rst
@@ -51,3 +51,11 @@ passing connection headers such as an auth token via ``header``:
     :dedent: 4
     :start-after: [START example_websocket_sensor_send_message_async]
     :end-before: [END example_websocket_sensor_send_message_async]
+
+.. warning::
+    In deferrable mode, ``message_to_send`` may be sent more than once for a single task
+    run. Airflow triggers are not guaranteed to execute exactly once — a triggerer
+    restart or redistribution to another host re-runs the trigger from scratch, opening
+    a new connection and re-sending ``message_to_send``. If that message has a side
+    effect on the remote server, such as starting a job, the server must treat a resend
+    as safe — for example by deduplicating on a request id embedded in the message.

--- a/providers/standard/provider.yaml
+++ b/providers/standard/provider.yaml
@@ -83,6 +83,7 @@ integrations:
       - /docs/apache-airflow-providers-standard/sensors/datetime.rst
       - /docs/apache-airflow-providers-standard/sensors/file.rst
       - /docs/apache-airflow-providers-standard/sensors/external_task_sensor.rst
+      - /docs/apache-airflow-providers-standard/sensors/websocket.rst
 
 operators:
   - integration-name: Standard
@@ -108,6 +109,7 @@ sensors:
       - airflow.providers.standard.sensors.python
       - airflow.providers.standard.sensors.filesystem
       - airflow.providers.standard.sensors.external_task
+      - airflow.providers.standard.sensors.websocket
 hooks:
   - integration-name: Standard
     python-modules:
@@ -122,6 +124,7 @@ triggers:
       - airflow.providers.standard.triggers.file
       - airflow.providers.standard.triggers.temporal
       - airflow.providers.standard.triggers.hitl
+      - airflow.providers.standard.triggers.websocket
 
 extra-links:
   - airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunLink

--- a/providers/standard/pyproject.toml
+++ b/providers/standard/pyproject.toml
@@ -69,6 +69,9 @@ dependencies = [
 "openlineage" = [
     "apache-airflow-providers-openlineage"
 ]
+"websocket" = [
+    "websockets>=14.0"
+]
 
 [dependency-groups]
 dev = [
@@ -79,6 +82,7 @@ dev = [
     "apache-airflow-providers-openlineage",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "apache-airflow-providers-mysql",
+    "websockets>=14.0",
 ]
 
 # To build docs:

--- a/providers/standard/src/airflow/providers/standard/example_dags/example_sensors.py
+++ b/providers/standard/src/airflow/providers/standard/example_dags/example_sensors.py
@@ -28,6 +28,7 @@ from airflow.providers.standard.sensors.filesystem import FileSensor
 from airflow.providers.standard.sensors.python import PythonSensor
 from airflow.providers.standard.sensors.time import TimeSensor
 from airflow.providers.standard.sensors.time_delta import TimeDeltaSensor
+from airflow.providers.standard.sensors.websocket import WebSocketSensor
 from airflow.providers.standard.sensors.weekday import DayOfWeekSensor
 from airflow.providers.standard.utils.weekday import WeekDay
 from airflow.sdk import DAG
@@ -125,6 +126,22 @@ with DAG(
     )
     # [END example_day_of_week_sensor]
 
+    # [START example_websocket_sensor]
+    t12 = WebSocketSensor(
+        task_id="wait_for_websocket_message", url="wss://example.com/socket", timeout=3, soft_fail=True
+    )
+    # [END example_websocket_sensor]
+
+    # [START example_websocket_sensor_async]
+    t13 = WebSocketSensor(
+        task_id="wait_for_websocket_message_async",
+        url="wss://example.com/socket",
+        deferrable=True,
+        timeout=3,
+        soft_fail=True,
+    )
+    # [END example_websocket_sensor_async]
+
     tx = BashOperator(task_id="print_date_in_bash", bash_command="date")
 
     tx.trigger_rule = TriggerRule.NONE_FAILED
@@ -133,3 +150,4 @@ with DAG(
     t8 >> tx
     [t9, t10] >> tx
     t11 >> tx
+    [t12, t13] >> tx

--- a/providers/standard/src/airflow/providers/standard/example_dags/example_sensors.py
+++ b/providers/standard/src/airflow/providers/standard/example_dags/example_sensors.py
@@ -142,6 +142,18 @@ with DAG(
     )
     # [END example_websocket_sensor_async]
 
+    # [START example_websocket_sensor_send_message_async]
+    t14 = WebSocketSensor(
+        task_id="request_and_wait_for_websocket_reply",
+        url="wss://example.com/socket",
+        message_to_send='{"action": "start_job"}',
+        header={"Authorization": "Bearer my-token"},
+        deferrable=True,
+        timeout=3,
+        soft_fail=True,
+    )
+    # [END example_websocket_sensor_send_message_async]
+
     tx = BashOperator(task_id="print_date_in_bash", bash_command="date")
 
     tx.trigger_rule = TriggerRule.NONE_FAILED
@@ -150,4 +162,4 @@ with DAG(
     t8 >> tx
     [t9, t10] >> tx
     t11 >> tx
-    [t12, t13] >> tx
+    [t12, t13, t14] >> tx

--- a/providers/standard/src/airflow/providers/standard/get_provider_info.py
+++ b/providers/standard/src/airflow/providers/standard/get_provider_info.py
@@ -43,7 +43,6 @@ def get_provider_info():
                     "/docs/apache-airflow-providers-standard/sensors/datetime.rst",
                     "/docs/apache-airflow-providers-standard/sensors/file.rst",
                     "/docs/apache-airflow-providers-standard/sensors/external_task_sensor.rst",
-                    "/docs/apache-airflow-providers-standard/sensors/websocket.rst",
                 ],
             }
         ],
@@ -76,7 +75,6 @@ def get_provider_info():
                     "airflow.providers.standard.sensors.python",
                     "airflow.providers.standard.sensors.filesystem",
                     "airflow.providers.standard.sensors.external_task",
-                    "airflow.providers.standard.sensors.websocket",
                 ],
             }
         ],
@@ -98,7 +96,6 @@ def get_provider_info():
                     "airflow.providers.standard.triggers.file",
                     "airflow.providers.standard.triggers.temporal",
                     "airflow.providers.standard.triggers.hitl",
-                    "airflow.providers.standard.triggers.websocket",
                 ],
             }
         ],

--- a/providers/standard/src/airflow/providers/standard/get_provider_info.py
+++ b/providers/standard/src/airflow/providers/standard/get_provider_info.py
@@ -43,6 +43,7 @@ def get_provider_info():
                     "/docs/apache-airflow-providers-standard/sensors/datetime.rst",
                     "/docs/apache-airflow-providers-standard/sensors/file.rst",
                     "/docs/apache-airflow-providers-standard/sensors/external_task_sensor.rst",
+                    "/docs/apache-airflow-providers-standard/sensors/websocket.rst",
                 ],
             }
         ],
@@ -75,6 +76,7 @@ def get_provider_info():
                     "airflow.providers.standard.sensors.python",
                     "airflow.providers.standard.sensors.filesystem",
                     "airflow.providers.standard.sensors.external_task",
+                    "airflow.providers.standard.sensors.websocket",
                 ],
             }
         ],
@@ -96,6 +98,7 @@ def get_provider_info():
                     "airflow.providers.standard.triggers.file",
                     "airflow.providers.standard.triggers.temporal",
                     "airflow.providers.standard.triggers.hitl",
+                    "airflow.providers.standard.triggers.websocket",
                 ],
             }
         ],

--- a/providers/standard/src/airflow/providers/standard/sensors/websocket.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/websocket.py
@@ -76,16 +76,20 @@ class WebSocketSensor(BaseSensorOperator):
     def execute(self, context: Context) -> None:
         if not self.deferrable:
             super().execute(context=context)
-        if not self.poke(context=context):
-            self.defer(
-                timeout=datetime.timedelta(seconds=self.timeout),
-                trigger=WebSocketTrigger(
-                    url=self.url,
-                    header=self.header,
-                    message_to_send=self.message_to_send,
-                ),
-                method_name="execute_complete",
-            )
+            return
+        # Each poke opens and consumes a WebSocket connection, so the deferrable path must
+        # defer immediately: polling here first would send message_to_send and consume the
+        # reply before handing off, leaving the trigger to open a second connection and
+        # re-send the request.
+        self.defer(
+            timeout=datetime.timedelta(seconds=self.timeout),
+            trigger=WebSocketTrigger(
+                url=self.url,
+                header=self.header,
+                message_to_send=self.message_to_send,
+            ),
+            method_name="execute_complete",
+        )
 
     def execute_complete(self, context: Context, event: Any = None) -> None:
         """Handle the event when the trigger fires and return immediately."""

--- a/providers/standard/src/airflow/providers/standard/sensors/websocket.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/websocket.py
@@ -1,0 +1,92 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import datetime
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+from websockets.sync.client import connect
+
+from airflow.providers.common.compat.sdk import BaseSensorOperator, conf
+from airflow.providers.standard.triggers.websocket import WebSocketTrigger
+
+if TYPE_CHECKING:
+    from airflow.sdk import Context
+
+
+class WebSocketSensor(BaseSensorOperator):
+    """
+    Waits for a message on a WebSocket connection.
+
+    :param url: The ``ws://`` or ``wss://`` URL of the WebSocket server to connect to.
+    :param header: Optional headers sent when opening the connection.
+    :param message_to_send: Optional message sent right after the connection is established.
+    :param deferrable: If waiting for completion, whether to defer the task until done,
+        default is ``False``.
+
+    .. seealso::
+        For more information on how to use this sensor, take a look at the guide:
+        :ref:`howto/operator:WebSocketSensor`
+    """
+
+    template_fields: Sequence[str] = ("url",)
+
+    def __init__(
+        self,
+        *,
+        url: str,
+        header: dict[str, str] | None = None,
+        message_to_send: str | bytes | None = None,
+        deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.url = url
+        self.header = header
+        self.message_to_send = message_to_send
+        self.deferrable = deferrable
+
+    def poke(self, context: Context) -> bool:
+        self.log.info("Poking WebSocket %s", self.url)
+        with connect(self.url, additional_headers=self.header) as websocket:
+            if self.message_to_send is not None:
+                websocket.send(self.message_to_send)
+            try:
+                websocket.recv(timeout=self.poke_interval)
+            except TimeoutError:
+                return False
+        self.log.info("Received message from %s", self.url)
+        return True
+
+    def execute(self, context: Context) -> None:
+        if not self.deferrable:
+            super().execute(context=context)
+        if not self.poke(context=context):
+            self.defer(
+                timeout=datetime.timedelta(seconds=self.timeout),
+                trigger=WebSocketTrigger(
+                    url=self.url,
+                    header=self.header,
+                    message_to_send=self.message_to_send,
+                ),
+                method_name="execute_complete",
+            )
+
+    def execute_complete(self, context: Context, event: Any = None) -> None:
+        """Handle the event when the trigger fires and return immediately."""
+        self.log.info("%s completed successfully with message: %s", self.task_id, event)

--- a/providers/standard/src/airflow/providers/standard/sensors/websocket.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/websocket.py
@@ -20,7 +20,7 @@ import datetime
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
-from websockets.sync.client import ClientConnection, connect
+from websockets.sync.client import connect
 
 from airflow.providers.common.compat.sdk import BaseSensorOperator, conf, poke_mode_only
 from airflow.providers.standard.triggers.websocket import WebSocketTrigger
@@ -36,9 +36,10 @@ class WebSocketSensor(BaseSensorOperator):
 
     WebSocket messages are consumptive: once read, a message cannot be read again, and
     reconnecting can duplicate ``message_to_send`` against the remote server. The
-    non-deferrable path therefore keeps a single connection open across pokes instead of
-    reconnecting and re-sending on every poke, and this sensor will not behave correctly in
-    reschedule mode, since that state would be lost between rescheduled invocations.
+    non-deferrable path therefore opens exactly one connection and blocks on it for up to
+    ``timeout`` seconds instead of reconnecting every ``poke_interval`` (which has no
+    effect on this sensor), and this sensor is marked poke-mode-only since a rescheduled
+    invocation would need a new connection anyway.
 
     :param url: The ``ws://`` or ``wss://`` URL of the WebSocket server to connect to.
     :param header: Optional headers sent when opening the connection.
@@ -51,7 +52,8 @@ class WebSocketSensor(BaseSensorOperator):
         :ref:`howto/operator:WebSocketSensor`
     """
 
-    template_fields: Sequence[str] = ("url",)
+    template_fields: Sequence[str] = ("url", "header", "message_to_send")
+    template_fields_renderers = {"header": "json"}
 
     def __init__(
         self,
@@ -67,31 +69,22 @@ class WebSocketSensor(BaseSensorOperator):
         self.header = header
         self.message_to_send = message_to_send
         self.deferrable = deferrable
-        self._connection: ClientConnection | None = None
 
     def poke(self, context: Context) -> bool:
-        if self._connection is None:
-            self.log.info("Connecting to WebSocket %s", self.url)
-            self._connection = connect(self.url, additional_headers=self.header)
+        self.log.info("Connecting to WebSocket %s", self.url)
+        with connect(self.url, additional_headers=self.header) as websocket:
             if self.message_to_send is not None:
-                self._connection.send(self.message_to_send)
-        try:
-            self._connection.recv(timeout=self.poke_interval)
-        except TimeoutError:
-            return False
+                websocket.send(self.message_to_send)
+            try:
+                websocket.recv(timeout=self.timeout)
+            except TimeoutError:
+                return False
         self.log.info("Received message from %s", self.url)
-        self._connection.close()
-        self._connection = None
         return True
 
     def execute(self, context: Context) -> None:
         if not self.deferrable:
-            try:
-                super().execute(context=context)
-            finally:
-                if self._connection is not None:
-                    self._connection.close()
-                    self._connection = None
+            super().execute(context=context)
             return
         # Each poke opens and consumes a WebSocket connection, so the deferrable path must
         # defer immediately: polling here first would send message_to_send and consume the

--- a/providers/standard/src/airflow/providers/standard/sensors/websocket.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/websocket.py
@@ -20,18 +20,25 @@ import datetime
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
-from websockets.sync.client import connect
+from websockets.sync.client import ClientConnection, connect
 
-from airflow.providers.common.compat.sdk import BaseSensorOperator, conf
+from airflow.providers.common.compat.sdk import BaseSensorOperator, conf, poke_mode_only
 from airflow.providers.standard.triggers.websocket import WebSocketTrigger
 
 if TYPE_CHECKING:
     from airflow.sdk import Context
 
 
+@poke_mode_only
 class WebSocketSensor(BaseSensorOperator):
     """
     Waits for a message on a WebSocket connection.
+
+    WebSocket messages are consumptive: once read, a message cannot be read again, and
+    reconnecting can duplicate ``message_to_send`` against the remote server. The
+    non-deferrable path therefore keeps a single connection open across pokes instead of
+    reconnecting and re-sending on every poke, and this sensor will not behave correctly in
+    reschedule mode, since that state would be lost between rescheduled invocations.
 
     :param url: The ``ws://`` or ``wss://`` URL of the WebSocket server to connect to.
     :param header: Optional headers sent when opening the connection.
@@ -60,22 +67,31 @@ class WebSocketSensor(BaseSensorOperator):
         self.header = header
         self.message_to_send = message_to_send
         self.deferrable = deferrable
+        self._connection: ClientConnection | None = None
 
     def poke(self, context: Context) -> bool:
-        self.log.info("Poking WebSocket %s", self.url)
-        with connect(self.url, additional_headers=self.header) as websocket:
+        if self._connection is None:
+            self.log.info("Connecting to WebSocket %s", self.url)
+            self._connection = connect(self.url, additional_headers=self.header)
             if self.message_to_send is not None:
-                websocket.send(self.message_to_send)
-            try:
-                websocket.recv(timeout=self.poke_interval)
-            except TimeoutError:
-                return False
+                self._connection.send(self.message_to_send)
+        try:
+            self._connection.recv(timeout=self.poke_interval)
+        except TimeoutError:
+            return False
         self.log.info("Received message from %s", self.url)
+        self._connection.close()
+        self._connection = None
         return True
 
     def execute(self, context: Context) -> None:
         if not self.deferrable:
-            super().execute(context=context)
+            try:
+                super().execute(context=context)
+            finally:
+                if self._connection is not None:
+                    self._connection.close()
+                    self._connection = None
             return
         # Each poke opens and consumes a WebSocket connection, so the deferrable path must
         # defer immediately: polling here first would send message_to_send and consume the

--- a/providers/standard/src/airflow/providers/standard/sensors/websocket.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/websocket.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import datetime
+import time
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
@@ -72,13 +73,14 @@ class WebSocketSensor(BaseSensorOperator):
 
     def poke(self, context: Context) -> bool:
         self.log.info("Connecting to WebSocket %s", self.url)
-        with connect(self.url, additional_headers=self.header) as websocket:
-            if self.message_to_send is not None:
-                websocket.send(self.message_to_send)
-            try:
-                websocket.recv(timeout=self.timeout)
-            except TimeoutError:
-                return False
+        deadline = time.monotonic() + self.timeout
+        try:
+            with connect(self.url, additional_headers=self.header, open_timeout=self.timeout) as websocket:
+                if self.message_to_send is not None:
+                    websocket.send(self.message_to_send)
+                websocket.recv(timeout=max(deadline - time.monotonic(), 0))
+        except TimeoutError:
+            return False
         self.log.info("Received message from %s", self.url)
         return True
 

--- a/providers/standard/src/airflow/providers/standard/triggers/websocket.py
+++ b/providers/standard/src/airflow/providers/standard/triggers/websocket.py
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+from websockets.asyncio.client import connect
+
+from airflow.providers.standard.version_compat import AIRFLOW_V_3_0_PLUS
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.triggers.base import BaseEventTrigger, TriggerEvent
+else:
+    from airflow.triggers.base import BaseTrigger as BaseEventTrigger, TriggerEvent  # type: ignore
+
+
+class WebSocketTrigger(BaseEventTrigger):
+    """
+    A trigger that opens a WebSocket connection and fires once a message is received.
+
+    This is meant for deferrable operators that hand off a long-lived request to a remote
+    WebSocket server and resume once that server replies, without occupying a worker slot
+    while waiting.
+
+    :param url: The ``ws://`` or ``wss://`` URL of the WebSocket server to connect to.
+    :param header: Optional headers sent when opening the connection.
+    :param message_to_send: Optional message sent right after the connection is established.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        header: dict[str, str] | None = None,
+        message_to_send: str | bytes | None = None,
+        **kwargs,
+    ):
+        super().__init__()
+        self.url = url
+        self.header = header
+        self.message_to_send = message_to_send
+
+    def serialize(self) -> tuple[str, dict[str, Any]]:
+        """Serialize WebSocketTrigger arguments and classpath."""
+        return (
+            "airflow.providers.standard.triggers.websocket.WebSocketTrigger",
+            {
+                "url": self.url,
+                "header": self.header,
+                "message_to_send": self.message_to_send,
+            },
+        )
+
+    async def run(self) -> AsyncIterator[TriggerEvent]:
+        """Connect to the WebSocket server and wait for the first message."""
+        async with connect(self.url, additional_headers=self.header) as websocket:
+            if self.message_to_send is not None:
+                await websocket.send(self.message_to_send)
+            message = await websocket.recv()
+            self.log.info("Received message from %s", self.url)
+            yield TriggerEvent(message)

--- a/providers/standard/src/airflow/providers/standard/triggers/websocket.py
+++ b/providers/standard/src/airflow/providers/standard/triggers/websocket.py
@@ -21,15 +21,10 @@ from typing import Any
 
 from websockets.asyncio.client import connect
 
-from airflow.providers.standard.version_compat import AIRFLOW_V_3_0_PLUS
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.triggers.base import BaseEventTrigger, TriggerEvent
-else:
-    from airflow.triggers.base import BaseTrigger as BaseEventTrigger, TriggerEvent  # type: ignore
+from airflow.triggers.base import BaseTrigger, TriggerEvent
 
 
-class WebSocketTrigger(BaseEventTrigger):
+class WebSocketTrigger(BaseTrigger):
     """
     A trigger that opens a WebSocket connection and fires once a message is received.
 

--- a/providers/standard/src/airflow/providers/standard/triggers/websocket.py
+++ b/providers/standard/src/airflow/providers/standard/triggers/websocket.py
@@ -32,6 +32,12 @@ class WebSocketTrigger(BaseTrigger):
     WebSocket server and resume once that server replies, without occupying a worker slot
     while waiting.
 
+    Like any Airflow trigger, ``run()`` is not guaranteed to execute only once: a
+    triggerer restart or redistribution to another host re-runs it from scratch. Each
+    execution opens a new connection and re-sends ``message_to_send`` if one is set, so
+    if that message starts a remote job, the remote server must treat a resend as safe —
+    for example by deduplicating on a request id embedded in the message.
+
     :param url: The ``ws://`` or ``wss://`` URL of the WebSocket server to connect to.
     :param header: Optional headers sent when opening the connection.
     :param message_to_send: Optional message sent right after the connection is established.

--- a/providers/standard/tests/unit/standard/sensors/test_websocket.py
+++ b/providers/standard/tests/unit/standard/sensors/test_websocket.py
@@ -70,7 +70,36 @@ class TestWebSocketSensor:
             task_id="poke_timeout_arg", url=URL, timeout=45, poke_interval=5, dag=self.dag
         )
         assert sensor.poke(context={}) is True
-        mock_websocket.recv.assert_called_once_with(timeout=45)
+
+        mock_connect.assert_called_once_with(URL, additional_headers=None, open_timeout=45)
+        (_, kwargs) = mock_websocket.recv.call_args
+        assert kwargs["timeout"] == pytest.approx(45, abs=1)
+
+    @mock.patch("airflow.providers.standard.sensors.websocket.connect", autospec=True)
+    def test_poke_returns_false_when_handshake_times_out(self, mock_connect):
+        """A connect() timeout (slow handshake) must be treated the same as a recv()
+        timeout — including respecting soft_fail — not propagate as a raw TimeoutError
+        that bypasses the sensor's normal timeout handling."""
+        mock_connect.side_effect = TimeoutError("timed out while waiting for handshake response")
+
+        sensor = WebSocketSensor(task_id="handshake_timeout", url=URL, dag=self.dag)
+        assert sensor.poke(context={}) is False
+
+    @mock.patch("airflow.providers.standard.sensors.websocket.time.monotonic")
+    @mock.patch("airflow.providers.standard.sensors.websocket.connect", autospec=True)
+    def test_poke_recv_gets_remaining_time_after_slow_handshake(self, mock_connect, mock_monotonic):
+        """If the handshake itself consumes part of the timeout budget, recv() must only
+        get what's left, not the full timeout again — otherwise total wait time could
+        exceed the sensor's declared timeout."""
+        mock_websocket = mock.MagicMock(spec=ClientConnection)
+        mock_websocket.recv.return_value = "pong"
+        mock_connect.return_value.__enter__.return_value = mock_websocket
+        # deadline computed at t=0 with timeout=10; connect() "takes" 4s, leaving 6s for recv().
+        mock_monotonic.side_effect = [0, 4]
+
+        sensor = WebSocketSensor(task_id="slow_handshake", url=URL, timeout=10, dag=self.dag)
+        assert sensor.poke(context={}) is True
+        mock_websocket.recv.assert_called_once_with(timeout=6)
 
     def test_reschedule_mode_not_allowed(self):
         with pytest.raises(ValueError, match="Cannot set mode to 'reschedule'. Only 'poke' is acceptable"):
@@ -82,7 +111,7 @@ class TestWebSocketSensor:
         trigger is supposed to wait for."""
         sensor = WebSocketSensor(task_id="defer", url=URL, deferrable=True, dag=self.dag)
 
-        with mock.patch.object(WebSocketSensor, "poke") as mock_poke:
+        with mock.patch.object(WebSocketSensor, "poke", autospec=True) as mock_poke:
             with pytest.raises(TaskDeferred) as exc:
                 sensor.execute({})
 
@@ -96,7 +125,7 @@ class TestWebSocketSensor:
         message_to_send."""
         sensor = WebSocketSensor(task_id="sync_timeout", url=URL, timeout=0, dag=self.dag)
 
-        with mock.patch.object(WebSocketSensor, "poke", return_value=False) as mock_poke:
+        with mock.patch.object(WebSocketSensor, "poke", autospec=True, return_value=False) as mock_poke:
             with pytest.raises(AirflowSensorTimeout):
                 sensor.execute({})
 

--- a/providers/standard/tests/unit/standard/sensors/test_websocket.py
+++ b/providers/standard/tests/unit/standard/sensors/test_websocket.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from unittest import mock
 
 import pytest
+from websockets.sync.client import ClientConnection
 
 from airflow.models.dag import DAG
 from airflow.providers.common.compat.sdk import TaskDeferred
@@ -37,9 +38,9 @@ class TestWebSocketSensor:
         args = {"owner": "airflow", "start_date": DEFAULT_DATE}
         cls.dag = DAG("test_websocket_sensor", schedule=None, default_args=args)
 
-    @mock.patch("airflow.providers.standard.sensors.websocket.connect")
+    @mock.patch("airflow.providers.standard.sensors.websocket.connect", autospec=True)
     def test_poke_returns_true_on_message(self, mock_connect):
-        mock_websocket = mock.MagicMock()
+        mock_websocket = mock.MagicMock(spec=ClientConnection)
         mock_websocket.recv.return_value = "pong"
         mock_connect.return_value.__enter__.return_value = mock_websocket
 
@@ -47,21 +48,35 @@ class TestWebSocketSensor:
         assert sensor.poke(context={}) is True
         mock_websocket.send.assert_called_once_with("ping")
 
-    @mock.patch("airflow.providers.standard.sensors.websocket.connect")
+    @mock.patch("airflow.providers.standard.sensors.websocket.connect", autospec=True)
     def test_poke_returns_false_on_timeout(self, mock_connect):
-        mock_websocket = mock.MagicMock()
+        mock_websocket = mock.MagicMock(spec=ClientConnection)
         mock_websocket.recv.side_effect = TimeoutError()
         mock_connect.return_value.__enter__.return_value = mock_websocket
 
         sensor = WebSocketSensor(task_id="poke_false", url=URL, dag=self.dag)
         assert sensor.poke(context={}) is False
 
-    def test_task_defer(self):
+    def test_task_defer_does_not_poke_first(self):
+        """The deferrable path must defer immediately: poke() consumes the connection,
+        so polling before deferring would send message_to_send and lose the reply the
+        trigger is supposed to wait for."""
         sensor = WebSocketSensor(task_id="defer", url=URL, deferrable=True, dag=self.dag)
 
-        with mock.patch.object(WebSocketSensor, "poke", return_value=False):
+        with mock.patch.object(WebSocketSensor, "poke") as mock_poke:
             with pytest.raises(TaskDeferred) as exc:
                 sensor.execute({})
 
+        mock_poke.assert_not_called()
         assert isinstance(exc.value.trigger, WebSocketTrigger)
         assert exc.value.trigger.url == URL
+
+    def test_execute_sync_returns_after_one_poke(self):
+        """The non-deferrable path must return once the sensor loop succeeds, not poke
+        (and consume) a second WebSocket message."""
+        sensor = WebSocketSensor(task_id="sync", url=URL, timeout=0, dag=self.dag)
+
+        with mock.patch.object(WebSocketSensor, "poke", return_value=True) as mock_poke:
+            sensor.execute({})
+
+        mock_poke.assert_called_once()

--- a/providers/standard/tests/unit/standard/sensors/test_websocket.py
+++ b/providers/standard/tests/unit/standard/sensors/test_websocket.py
@@ -42,56 +42,35 @@ class TestWebSocketSensor:
     def test_poke_returns_true_on_message(self, mock_connect):
         mock_websocket = mock.MagicMock(spec=ClientConnection)
         mock_websocket.recv.return_value = "pong"
-        mock_connect.return_value = mock_websocket
+        mock_connect.return_value.__enter__.return_value = mock_websocket
 
         sensor = WebSocketSensor(task_id="poke_true", url=URL, message_to_send="ping", dag=self.dag)
         assert sensor.poke(context={}) is True
         mock_websocket.send.assert_called_once_with("ping")
-        mock_websocket.close.assert_called_once()
-        assert sensor._connection is None
 
     @mock.patch("airflow.providers.standard.sensors.websocket.connect", autospec=True)
     def test_poke_returns_false_on_timeout(self, mock_connect):
         mock_websocket = mock.MagicMock(spec=ClientConnection)
         mock_websocket.recv.side_effect = TimeoutError()
-        mock_connect.return_value = mock_websocket
+        mock_connect.return_value.__enter__.return_value = mock_websocket
 
         sensor = WebSocketSensor(task_id="poke_false", url=URL, dag=self.dag)
         assert sensor.poke(context={}) is False
-        mock_websocket.close.assert_not_called()
 
     @mock.patch("airflow.providers.standard.sensors.websocket.connect", autospec=True)
-    def test_poke_reuses_connection_and_sends_message_once(self, mock_connect):
-        """A second poke() after a timeout must not reopen the connection or re-send
-        message_to_send — WebSocket reads are consumptive, so resending would restart
-        the remote job the sensor is waiting on."""
+    def test_poke_waits_for_the_overall_timeout_not_poke_interval(self, mock_connect):
+        """recv() must be bounded by the sensor's overall timeout, not poke_interval —
+        otherwise a single poke could block past the sensor's declared timeout before
+        that timeout is ever checked."""
         mock_websocket = mock.MagicMock(spec=ClientConnection)
-        mock_websocket.recv.side_effect = [TimeoutError(), "pong"]
-        mock_connect.return_value = mock_websocket
+        mock_websocket.recv.return_value = "pong"
+        mock_connect.return_value.__enter__.return_value = mock_websocket
 
-        sensor = WebSocketSensor(task_id="reuse", url=URL, message_to_send="ping", dag=self.dag)
-        assert sensor.poke(context={}) is False
+        sensor = WebSocketSensor(
+            task_id="poke_timeout_arg", url=URL, timeout=45, poke_interval=5, dag=self.dag
+        )
         assert sensor.poke(context={}) is True
-
-        mock_connect.assert_called_once()
-        mock_websocket.send.assert_called_once_with("ping")
-
-    def test_execute_closes_connection_left_open_on_timeout(self):
-        """If the sensor loop times out, execute() must close whatever connection poke()
-        left open rather than leaking it."""
-        sensor = WebSocketSensor(task_id="timeout", url=URL, timeout=0, dag=self.dag)
-        fake_connection = mock.MagicMock(spec=ClientConnection)
-
-        def fake_poke(context):
-            sensor._connection = fake_connection
-            return False
-
-        with mock.patch.object(WebSocketSensor, "poke", side_effect=fake_poke):
-            with pytest.raises(AirflowSensorTimeout):
-                sensor.execute({})
-
-        fake_connection.close.assert_called_once()
-        assert sensor._connection is None
+        mock_websocket.recv.assert_called_once_with(timeout=45)
 
     def test_reschedule_mode_not_allowed(self):
         with pytest.raises(ValueError, match="Cannot set mode to 'reschedule'. Only 'poke' is acceptable"):
@@ -111,12 +90,30 @@ class TestWebSocketSensor:
         assert isinstance(exc.value.trigger, WebSocketTrigger)
         assert exc.value.trigger.url == URL
 
-    def test_execute_sync_returns_after_one_poke(self):
-        """The non-deferrable path must return once the sensor loop succeeds, not poke
-        (and consume) a second WebSocket message."""
-        sensor = WebSocketSensor(task_id="sync", url=URL, timeout=0, dag=self.dag)
+    def test_execute_sync_calls_poke_exactly_once(self):
+        """Since poke() already blocks for the full sensor timeout, execute() must never
+        call it a second time — a second call would open a new connection and re-send
+        message_to_send."""
+        sensor = WebSocketSensor(task_id="sync_timeout", url=URL, timeout=0, dag=self.dag)
 
-        with mock.patch.object(WebSocketSensor, "poke", return_value=True) as mock_poke:
-            sensor.execute({})
+        with mock.patch.object(WebSocketSensor, "poke", return_value=False) as mock_poke:
+            with pytest.raises(AirflowSensorTimeout):
+                sensor.execute({})
 
         mock_poke.assert_called_once()
+
+    def test_template_fields_are_rendered(self):
+        """url, header, and message_to_send commonly need runtime values (run_id, an
+        idempotency key, an auth token), so all three must be templated."""
+        sensor = WebSocketSensor(
+            task_id="templated",
+            url="wss://example.com/{{ run_id }}",
+            message_to_send='{"run_id": "{{ run_id }}"}',
+            header={"Authorization": "Bearer {{ run_id }}"},
+            dag=self.dag,
+        )
+        sensor.render_template_fields({"run_id": "manual__2024-01-01"})
+
+        assert sensor.url == "wss://example.com/manual__2024-01-01"
+        assert sensor.message_to_send == '{"run_id": "manual__2024-01-01"}'
+        assert sensor.header == {"Authorization": "Bearer manual__2024-01-01"}

--- a/providers/standard/tests/unit/standard/sensors/test_websocket.py
+++ b/providers/standard/tests/unit/standard/sensors/test_websocket.py
@@ -1,0 +1,67 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from airflow.models.dag import DAG
+from airflow.providers.common.compat.sdk import TaskDeferred
+from airflow.providers.standard.sensors.websocket import WebSocketSensor
+from airflow.providers.standard.triggers.websocket import WebSocketTrigger
+
+from tests_common.test_utils.version_compat import timezone
+
+URL = "ws://example.com/socket"
+DEFAULT_DATE = timezone.datetime(2015, 1, 1)
+
+
+class TestWebSocketSensor:
+    @classmethod
+    def setup_class(cls):
+        args = {"owner": "airflow", "start_date": DEFAULT_DATE}
+        cls.dag = DAG("test_websocket_sensor", schedule=None, default_args=args)
+
+    @mock.patch("airflow.providers.standard.sensors.websocket.connect")
+    def test_poke_returns_true_on_message(self, mock_connect):
+        mock_websocket = mock.MagicMock()
+        mock_websocket.recv.return_value = "pong"
+        mock_connect.return_value.__enter__.return_value = mock_websocket
+
+        sensor = WebSocketSensor(task_id="poke_true", url=URL, message_to_send="ping", dag=self.dag)
+        assert sensor.poke(context={}) is True
+        mock_websocket.send.assert_called_once_with("ping")
+
+    @mock.patch("airflow.providers.standard.sensors.websocket.connect")
+    def test_poke_returns_false_on_timeout(self, mock_connect):
+        mock_websocket = mock.MagicMock()
+        mock_websocket.recv.side_effect = TimeoutError()
+        mock_connect.return_value.__enter__.return_value = mock_websocket
+
+        sensor = WebSocketSensor(task_id="poke_false", url=URL, dag=self.dag)
+        assert sensor.poke(context={}) is False
+
+    def test_task_defer(self):
+        sensor = WebSocketSensor(task_id="defer", url=URL, deferrable=True, dag=self.dag)
+
+        with mock.patch.object(WebSocketSensor, "poke", return_value=False):
+            with pytest.raises(TaskDeferred) as exc:
+                sensor.execute({})
+
+        assert isinstance(exc.value.trigger, WebSocketTrigger)
+        assert exc.value.trigger.url == URL

--- a/providers/standard/tests/unit/standard/sensors/test_websocket.py
+++ b/providers/standard/tests/unit/standard/sensors/test_websocket.py
@@ -22,7 +22,7 @@ import pytest
 from websockets.sync.client import ClientConnection
 
 from airflow.models.dag import DAG
-from airflow.providers.common.compat.sdk import TaskDeferred
+from airflow.providers.common.compat.sdk import AirflowSensorTimeout, TaskDeferred
 from airflow.providers.standard.sensors.websocket import WebSocketSensor
 from airflow.providers.standard.triggers.websocket import WebSocketTrigger
 
@@ -42,20 +42,60 @@ class TestWebSocketSensor:
     def test_poke_returns_true_on_message(self, mock_connect):
         mock_websocket = mock.MagicMock(spec=ClientConnection)
         mock_websocket.recv.return_value = "pong"
-        mock_connect.return_value.__enter__.return_value = mock_websocket
+        mock_connect.return_value = mock_websocket
 
         sensor = WebSocketSensor(task_id="poke_true", url=URL, message_to_send="ping", dag=self.dag)
         assert sensor.poke(context={}) is True
         mock_websocket.send.assert_called_once_with("ping")
+        mock_websocket.close.assert_called_once()
+        assert sensor._connection is None
 
     @mock.patch("airflow.providers.standard.sensors.websocket.connect", autospec=True)
     def test_poke_returns_false_on_timeout(self, mock_connect):
         mock_websocket = mock.MagicMock(spec=ClientConnection)
         mock_websocket.recv.side_effect = TimeoutError()
-        mock_connect.return_value.__enter__.return_value = mock_websocket
+        mock_connect.return_value = mock_websocket
 
         sensor = WebSocketSensor(task_id="poke_false", url=URL, dag=self.dag)
         assert sensor.poke(context={}) is False
+        mock_websocket.close.assert_not_called()
+
+    @mock.patch("airflow.providers.standard.sensors.websocket.connect", autospec=True)
+    def test_poke_reuses_connection_and_sends_message_once(self, mock_connect):
+        """A second poke() after a timeout must not reopen the connection or re-send
+        message_to_send — WebSocket reads are consumptive, so resending would restart
+        the remote job the sensor is waiting on."""
+        mock_websocket = mock.MagicMock(spec=ClientConnection)
+        mock_websocket.recv.side_effect = [TimeoutError(), "pong"]
+        mock_connect.return_value = mock_websocket
+
+        sensor = WebSocketSensor(task_id="reuse", url=URL, message_to_send="ping", dag=self.dag)
+        assert sensor.poke(context={}) is False
+        assert sensor.poke(context={}) is True
+
+        mock_connect.assert_called_once()
+        mock_websocket.send.assert_called_once_with("ping")
+
+    def test_execute_closes_connection_left_open_on_timeout(self):
+        """If the sensor loop times out, execute() must close whatever connection poke()
+        left open rather than leaking it."""
+        sensor = WebSocketSensor(task_id="timeout", url=URL, timeout=0, dag=self.dag)
+        fake_connection = mock.MagicMock(spec=ClientConnection)
+
+        def fake_poke(context):
+            sensor._connection = fake_connection
+            return False
+
+        with mock.patch.object(WebSocketSensor, "poke", side_effect=fake_poke):
+            with pytest.raises(AirflowSensorTimeout):
+                sensor.execute({})
+
+        fake_connection.close.assert_called_once()
+        assert sensor._connection is None
+
+    def test_reschedule_mode_not_allowed(self):
+        with pytest.raises(ValueError, match="Cannot set mode to 'reschedule'. Only 'poke' is acceptable"):
+            WebSocketSensor(task_id="reschedule", url=URL, mode="reschedule", dag=self.dag)
 
     def test_task_defer_does_not_poke_first(self):
         """The deferrable path must defer immediately: poke() consumes the connection,

--- a/providers/standard/tests/unit/standard/triggers/test_websocket.py
+++ b/providers/standard/tests/unit/standard/triggers/test_websocket.py
@@ -76,3 +76,24 @@ class TestWebSocketTrigger:
         await trigger.run().__anext__()
 
         mock_websocket.send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.standard.triggers.websocket.connect", autospec=True)
+    async def test_reconstructed_trigger_resends_message_to_send(self, mock_connect):
+        """Documents that a triggerer restart or redistribution — which reconstructs the
+        trigger from its serialize() output and calls run() again — re-sends
+        message_to_send. Airflow does not guarantee a trigger's run() executes only
+        once, so callers whose message starts a remote job must make that job
+        idempotent; this is not something the trigger itself can enforce."""
+        mock_websocket = mock.AsyncMock(spec=ClientConnection)
+        mock_websocket.recv.return_value = "pong"
+        mock_connect.return_value = _FakeConnection(mock_websocket)
+
+        original = WebSocketTrigger(url=self.URL, message_to_send="start_job")
+        _, kwargs = original.serialize()
+        reconstructed = WebSocketTrigger(**kwargs)
+
+        await original.run().__anext__()
+        await reconstructed.run().__anext__()
+
+        assert mock_websocket.send.await_args_list == [mock.call("start_job"), mock.call("start_job")]

--- a/providers/standard/tests/unit/standard/triggers/test_websocket.py
+++ b/providers/standard/tests/unit/standard/triggers/test_websocket.py
@@ -1,0 +1,77 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from airflow.providers.standard.triggers.websocket import WebSocketTrigger
+
+
+class _FakeConnection:
+    """Stands in for the object returned by ``websockets.asyncio.client.connect``."""
+
+    def __init__(self, websocket):
+        self._websocket = websocket
+
+    async def __aenter__(self):
+        return self._websocket
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+
+class TestWebSocketTrigger:
+    URL = "ws://example.com/socket"
+
+    def test_serialization(self):
+        """Asserts that the trigger correctly serializes its arguments and classpath."""
+        trigger = WebSocketTrigger(url=self.URL, header={"Authorization": "token"}, message_to_send="ping")
+        classpath, kwargs = trigger.serialize()
+        assert classpath == "airflow.providers.standard.triggers.websocket.WebSocketTrigger"
+        assert kwargs == {
+            "url": self.URL,
+            "header": {"Authorization": "token"},
+            "message_to_send": "ping",
+        }
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.standard.triggers.websocket.connect")
+    async def test_run_yields_event_with_received_message(self, mock_connect):
+        mock_websocket = mock.AsyncMock()
+        mock_websocket.recv.return_value = "pong"
+        mock_connect.return_value = _FakeConnection(mock_websocket)
+
+        trigger = WebSocketTrigger(url=self.URL, header={"Authorization": "token"}, message_to_send="ping")
+        event = await trigger.run().__anext__()
+
+        mock_connect.assert_called_once_with(self.URL, additional_headers={"Authorization": "token"})
+        mock_websocket.send.assert_awaited_once_with("ping")
+        assert event.payload == "pong"
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.standard.triggers.websocket.connect")
+    async def test_run_does_not_send_without_message_to_send(self, mock_connect):
+        mock_websocket = mock.AsyncMock()
+        mock_websocket.recv.return_value = "pong"
+        mock_connect.return_value = _FakeConnection(mock_websocket)
+
+        trigger = WebSocketTrigger(url=self.URL)
+        await trigger.run().__anext__()
+
+        mock_websocket.send.assert_not_awaited()

--- a/providers/standard/tests/unit/standard/triggers/test_websocket.py
+++ b/providers/standard/tests/unit/standard/triggers/test_websocket.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from unittest import mock
 
 import pytest
+from websockets.asyncio.client import ClientConnection
 
 from airflow.providers.standard.triggers.websocket import WebSocketTrigger
 
@@ -51,9 +52,9 @@ class TestWebSocketTrigger:
         }
 
     @pytest.mark.asyncio
-    @mock.patch("airflow.providers.standard.triggers.websocket.connect")
+    @mock.patch("airflow.providers.standard.triggers.websocket.connect", autospec=True)
     async def test_run_yields_event_with_received_message(self, mock_connect):
-        mock_websocket = mock.AsyncMock()
+        mock_websocket = mock.AsyncMock(spec=ClientConnection)
         mock_websocket.recv.return_value = "pong"
         mock_connect.return_value = _FakeConnection(mock_websocket)
 
@@ -65,9 +66,9 @@ class TestWebSocketTrigger:
         assert event.payload == "pong"
 
     @pytest.mark.asyncio
-    @mock.patch("airflow.providers.standard.triggers.websocket.connect")
+    @mock.patch("airflow.providers.standard.triggers.websocket.connect", autospec=True)
     async def test_run_does_not_send_without_message_to_send(self, mock_connect):
-        mock_websocket = mock.AsyncMock()
+        mock_websocket = mock.AsyncMock(spec=ClientConnection)
         mock_websocket.recv.return_value = "pong"
         mock_connect.return_value = _FakeConnection(mock_websocket)
 

--- a/uv.lock
+++ b/uv.lock
@@ -3205,7 +3205,7 @@ docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "d
 
 [[package]]
 name = "apache-airflow-providers-amazon"
-version = "9.35.0"
+version = "9.35.1"
 source = { editable = "providers/amazon" }
 dependencies = [
     { name = "apache-airflow" },
@@ -6587,7 +6587,7 @@ docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "d
 
 [[package]]
 name = "apache-airflow-providers-microsoft-azure"
-version = "15.0.0"
+version = "15.0.1"
 source = { editable = "providers/microsoft/azure" }
 dependencies = [
     { name = "adlfs" },

--- a/uv.lock
+++ b/uv.lock
@@ -3205,7 +3205,7 @@ docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "d
 
 [[package]]
 name = "apache-airflow-providers-amazon"
-version = "9.35.1"
+version = "9.35.0"
 source = { editable = "providers/amazon" }
 dependencies = [
     { name = "apache-airflow" },
@@ -6587,7 +6587,7 @@ docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "d
 
 [[package]]
 name = "apache-airflow-providers-microsoft-azure"
-version = "15.0.1"
+version = "15.0.0"
 source = { editable = "providers/microsoft/azure" }
 dependencies = [
     { name = "adlfs" },

--- a/uv.lock
+++ b/uv.lock
@@ -3205,7 +3205,7 @@ docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "d
 
 [[package]]
 name = "apache-airflow-providers-amazon"
-version = "9.35.0"
+version = "9.35.1"
 source = { editable = "providers/amazon" }
 dependencies = [
     { name = "apache-airflow" },
@@ -6587,7 +6587,7 @@ docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "d
 
 [[package]]
 name = "apache-airflow-providers-microsoft-azure"
-version = "15.0.0"
+version = "15.0.1"
 source = { editable = "providers/microsoft/azure" }
 dependencies = [
     { name = "adlfs" },
@@ -8272,6 +8272,9 @@ dependencies = [
 openlineage = [
     { name = "apache-airflow-providers-openlineage" },
 ]
+websocket = [
+    { name = "websockets" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -8281,6 +8284,7 @@ dev = [
     { name = "apache-airflow-providers-mysql" },
     { name = "apache-airflow-providers-openlineage" },
     { name = "apache-airflow-task-sdk" },
+    { name = "websockets" },
 ]
 docs = [
     { name = "apache-airflow-devel-common", extra = ["docs"] },
@@ -8291,8 +8295,9 @@ requires-dist = [
     { name = "apache-airflow", editable = "." },
     { name = "apache-airflow-providers-common-compat", editable = "providers/common/compat" },
     { name = "apache-airflow-providers-openlineage", marker = "extra == 'openlineage'", editable = "providers/openlineage" },
+    { name = "websockets", marker = "extra == 'websocket'", specifier = ">=14.0" },
 ]
-provides-extras = ["openlineage"]
+provides-extras = ["openlineage", "websocket"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -8302,6 +8307,7 @@ dev = [
     { name = "apache-airflow-providers-mysql", editable = "providers/mysql" },
     { name = "apache-airflow-providers-openlineage", editable = "providers/openlineage" },
     { name = "apache-airflow-task-sdk", editable = "task-sdk" },
+    { name = "websockets", specifier = ">=14.0" },
 ]
 docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "devel-common" }]
 


### PR DESCRIPTION
## Summary

Deferrable operators that hand a long-lived request off to a remote server currently have no built-in way to resume once that server replies over a WebSocket connection. This closes #21139, which asked for exactly this: a trigger that opens a WebSocket connection, hands off the wait to the triggerer, and fires once the remote server replies.

## Why we need this

Without this, the only options today are a plain HTTP-based deferrable sensor/trigger that polls, or a non-deferrable operator that blocks synchronously, and both have real costs for a long-running, unknown-duration remote job. Polling means repeated API calls against the remote server for the entire duration of the job — on a `poke_interval` of a few seconds that adds up fast over a job that can run for hours, and it puts avoidable load on a server that has no way to tell Airflow "I'm still working" other than answering yet another request. Polling also caps how quickly Airflow finds out the job is done: the result only surfaces on the next poll, so the effective latency is bounded by `poke_interval`, not by when the server actually finished. A synchronous, non-deferrable wait avoids the polling cost but instead ties up a full worker slot for the whole duration, which does not scale when many such jobs run concurrently. A WebSocket trigger avoids all three: the remote server pushes the reply the moment it is ready (no poll delay, no repeated calls), and the wait happens in the triggerer rather than on a worker.

## This Provider Design (Work flow)

```mermaid
sequenceDiagram
    autonumber
    participant DAG as DAG task<br/>(WebSocketSensor, deferrable=True)
    participant Worker
    participant Triggerer
    participant Server as Remote WebSocket server

    DAG->>Worker: execute()
    Worker->>Worker: self.defer(trigger=WebSocketTrigger(...))
    Note over Worker: TaskDeferred raised —<br/>state becomes DEFERRED,<br/>worker slot released immediately
    Worker->>Triggerer: hand off serialized WebSocketTrigger
    Triggerer->>Server: connect() + send(message_to_send)
    Note over Triggerer,Server: await recv() — no polling loop,<br/>no worker occupied while waiting
    Server-->>Triggerer: WebSocket message (e.g. job done)
    Triggerer-->>Worker: TriggerEvent(payload)
    Note over Worker: A worker is scheduled again<br/>only once the event fires
    Worker->>DAG: execute_complete(event)
```

The same `WebSocketTrigger` also backs the non-deferrable path (`deferrable=False`, the default): `WebSocketSensor.poke()` opens one connection directly on the worker and blocks on `recv()` up to the sensor's own `timeout` — no repeated reconnects, since a WebSocket message can only be read once and re-sending `message_to_send` could restart the remote job. `mode="reschedule"` is rejected for the same reason: a rescheduled attempt would need a brand-new connection anyway.

Because Airflow does not guarantee a trigger's `run()` executes only once (a triggerer restart or redistribution re-runs it from scratch), a reconnect there re-sends `message_to_send` too. If that message has a side effect on the remote server, such as starting a job, the server must treat a resend as safe — for example by deduplicating on a request id embedded in the message. This is documented on the trigger and sensor, and covered by a test that reconstructs a trigger from its own `serialize()` output and runs it twice.

## Usage

Wait for a message, non-deferrable (holds a worker for the duration):

```python
WebSocketSensor(
    task_id="wait_for_websocket_message",
    url="wss://example.com/socket",
    timeout=3,
)
```

Same thing, but deferrable — releases the worker while waiting:

```python
WebSocketSensor(
    task_id="wait_for_websocket_message_async",
    url="wss://example.com/socket",
    deferrable=True,
    timeout=3,
)
```

Send a request over the connection right after it opens, then wait for the async reply — the common case where the remote server needs to be told what to do before it has anything to report back. `url`, `header`, and `message_to_send` are all templated, so a run id or auth token can come from the Dag context instead of being hard-coded:

```python
WebSocketSensor(
    task_id="request_and_wait_for_websocket_reply",
    url="wss://example.com/socket",
    message_to_send='{"action": "start_job"}',
    header={"Authorization": "Bearer my-token"},
    deferrable=True,
    timeout=3,
)
```

## Test in AirFlow

### Experiment 1 — Does `deferrable=True` really release the pool slot?

Setup: 4x `WebSocketSensor` tasks sharing one pool with **2 slots** (`include_deferred`
left at its default of `False`, so `DEFERRED` tasks are excluded from the pool's
occupied-slot count — see `airflow-core/src/airflow/models/pool.py:294`,
`get_occupied_states()`). The WebSocket server replies once, ~20s after connecting.

### `deferrable=True`

At t+29s, **all 4 tasks are simultaneously `deferred`**, on a pool that only has 2 slots:

```
task_id  | state    | start_date
sensor_2 | deferred | 21:23:33.63
sensor_1 | deferred | 21:23:33.63
sensor_4 | deferred | 21:23:43.16
sensor_3 | deferred | 21:23:43.00
```

None of the 4 are holding a pool slot while waiting — they finish essentially together:

```
sensor_2 | success | end=21:24:06.40
sensor_1 | success | end=21:24:06.47
sensor_4 | success | end=21:24:07.62
sensor_3 | success | end=21:24:07.73
```

**Total wall time (trigger → success): ~45s** (the simulated job itself takes ~20s;
the rest is Airflow's own scheduling/DB overhead in this containerized setup).

### `deferrable=False`, same 2-slot pool

sensor_3 and sensor_4 visibly wait in `scheduled` while sensor_1/2 hold the only 2
slots (`running`):

```
sensor_3 | scheduled |
sensor_4 | scheduled |
sensor_2 | running   | 21:36:33.25
sensor_1 | running   | 21:36:33.24
```

sensor_3/4's `start_date` lands right at sensor_1/2's `end_date` — they were queued
behind the pool limit, not running in parallel:

```
sensor_1 | success | start=21:36:33.24 end=21:37:01.22
sensor_2 | success | start=21:36:33.25 end=21:37:01.16
sensor_3 | success | start=21:37:02.32 end=21:37:22.62   <- starts right as 1/2 end
sensor_4 | success | start=21:37:02.32 end=21:37:22.76
```

**Total wall time: ~99s — roughly 2x**, because only 2 of the 4 tasks could actually
run at once.

---

### Experiment 2 — Does WebSocket actually eliminate repeated round trips?

This directly tests the follow-up question: is a plain HTTP polling sensor — even
run in `deferrable=True` mode, so it's *not* the worker-slot issue from Experiment 1
— any different from `WebSocketSensor` in how many times it has to hit the remote
server? Airflow already ships a polling-based sensor for this
(`airflow.providers.http.sensors.http.HttpSensor`)

Setup: `HttpSensor(deferrable=True, poke_interval=3, timeout=60)` against a demo HTTP
server that answers `{"status": "pending"}` until ~20s have passed since the
**first** request it receives, then `{"status": "done"}` — every request is logged.

```
[http-server] request #1 at t+0.0s  -> pending
[http-server] request #2 at t+3.0s  -> pending
[http-server] request #3 at t+6.1s  -> pending
[http-server] request #4 at t+9.1s  -> pending
[http-server] request #5 at t+12.2s -> pending
[http-server] request #6 at t+15.2s -> pending
[http-server] request #7 at t+18.2s -> pending
[http-server] request #8 at t+21.3s -> done
```

**`HttpSensor(deferrable=True)`: 8 separate round trips over ~21s of waiting.**
**`WebSocketSensor(deferrable=True)`: 1 connection, 0 additional round trips, for the
same kind of wait (Experiment 1).**

This isolates the two benefits of `WebSocketSensor` as genuinely separate:
`deferrable=True` alone (shared by any sensor) fixes the worker-slot problem from
Experiment 1; only the WebSocket push model additionally fixes the round-trip
problem, which `HttpSensor` cannot avoid no matter which mode it runs in — HTTP has
no server-push mechanism, so polling (at whatever interval) is the only option.

## Files needed to reproduce this

<details>
<summary><code>websocket_demo_server.py</code> + <code>websocket_demo.py</code> — Experiment 1</summary>

```python
# websocket_demo_server.py — python websocket_demo_server.py [port] [delay_seconds]
from __future__ import annotations

import asyncio
import sys

from websockets.asyncio.server import serve

PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 8765
DELAY_SECONDS = float(sys.argv[2]) if len(sys.argv) > 2 else 20.0


async def handler(websocket):
    print(f"[server] connection open, sleeping {DELAY_SECONDS}s", flush=True)
    await asyncio.sleep(DELAY_SECONDS)
    await websocket.send("job-done")
    print("[server] sent reply", flush=True)


async def main():
    async with serve(handler, "0.0.0.0", PORT):
        print(f"[server] listening on ws://0.0.0.0:{PORT}, delay={DELAY_SECONDS}s", flush=True)
        await asyncio.Future()


if __name__ == "__main__":
    asyncio.run(main())
```

```python
# websocket_demo.py — 4x WebSocketSensor sharing a 2-slot pool, deferrable vs sync
from __future__ import annotations

import pendulum

from airflow.providers.standard.sensors.websocket import WebSocketSensor
from airflow.sdk import DAG

POOL = "websocket_demo_pool"
URL = "ws://localhost:8765"

with DAG(
    dag_id="websocket_demo_deferrable",
    schedule=None,
    start_date=pendulum.datetime(2024, 1, 1, tz="UTC"),
    catchup=False,
    tags=["demo"],
):
    for i in range(1, 5):
        WebSocketSensor(task_id=f"sensor_{i}", url=URL, deferrable=True, timeout=60, pool=POOL)

with DAG(
    dag_id="websocket_demo_sync",
    schedule=None,
    start_date=pendulum.datetime(2024, 1, 1, tz="UTC"),
    catchup=False,
    tags=["demo"],
):
    for i in range(1, 5):
        WebSocketSensor(task_id=f"sensor_{i}", url=URL, deferrable=False, timeout=60, pool=POOL)
```

Create the pool before triggering: `airflow pools set websocket_demo_pool 2 "demo pool"`.

</details>

<details>
<summary><code>http_demo_server.py</code> + <code>http_polling_demo.py</code> — Experiment 2</summary>

```python
# http_demo_server.py — python http_demo_server.py [port] [delay_seconds]
from __future__ import annotations

import json
import sys
import time
from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer

PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 8766
DELAY_SECONDS = float(sys.argv[2]) if len(sys.argv) > 2 else 20.0
REQUEST_COUNT = 0
FIRST_REQUEST_TIME: float | None = None


class Handler(BaseHTTPRequestHandler):
    def do_GET(self):
        global REQUEST_COUNT, FIRST_REQUEST_TIME
        REQUEST_COUNT += 1
        if FIRST_REQUEST_TIME is None:
            FIRST_REQUEST_TIME = time.monotonic()
        elapsed = time.monotonic() - FIRST_REQUEST_TIME
        status = "done" if elapsed >= DELAY_SECONDS else "pending"
        print(f"[http-server] request #{REQUEST_COUNT} at t+{elapsed:.1f}s -> {status}", flush=True)
        body = json.dumps({"status": status}).encode()
        self.send_response(200)
        self.send_header("Content-Type", "application/json")
        self.send_header("Content-Length", str(len(body)))
        self.end_headers()
        self.wfile.write(body)

    def log_message(self, format, *args):
        pass


if __name__ == "__main__":
    print(f"[http-server] listening on http://0.0.0.0:{PORT}, delay={DELAY_SECONDS}s", flush=True)
    ThreadingHTTPServer(("0.0.0.0", PORT), Handler).serve_forever()
```

```python
# http_polling_demo.py — real HttpSensor, deferrable=True, against the server above
from __future__ import annotations

import pendulum

from airflow.providers.http.sensors.http import HttpSensor
from airflow.sdk import DAG


def response_check(response, **kwargs):
    return response.json().get("status") == "done"


with DAG(
    dag_id="http_polling_demo",
    schedule=None,
    start_date=pendulum.datetime(2024, 1, 1, tz="UTC"),
    catchup=False,
    tags=["demo"],
):
    HttpSensor(
        task_id="poll_http_status",
        http_conn_id="http_demo",
        endpoint="status",
        response_check=response_check,
        poke_interval=3,
        timeout=60,
        deferrable=True,
    )
```

Needs a connection first: `airflow connections add http_demo --conn-type http --conn-host localhost --conn-port 8766`.

</details>

## Sample Usage (In ML Trainning Pipeline)

A data platform team runs a daily Airflow DAG like this:

```
prepare_training_data  ->  submit_training_job  ->  wait_for_training_to_finish  ->  evaluate_model  ->  deploy_if_better
```

`wait_for_training_to_finish` is the step this PR is about. Training duration is genuinely unpredictable: a small nightly fine-tune might finish in 10 minutes; a full retrain on a growing dataset, or a run that has to queue behind other teams' jobs on the same shared GPU pool, can take 4–6 hours. This variability is the normal case, not an edge case — it's exactly the shape of problem `deferrable=True` exists for.

By supporting WebSockets, we can avoid constantly hammering the training platform's API with HTTP polling to check if training is complete. Instead, a WebSocket connection only needs to be established once per task and is maintained entirely by the Triggerer (with zero additional round trips and without holding any worker slots). Once the training finishes, the result is pushed immediately, allowing the downstream pipeline to proceed without delay.

## Changes

- Added `WebSocketTrigger` in `airflow/providers/standard/triggers/websocket.py` — a `BaseTrigger` (not `BaseEventTrigger`, which is the event-driven-scheduling marker and not meant for resuming a deferred task) that opens a `ws://`/`wss://` connection with `websockets.asyncio.client`, optionally sends an initial message, and fires a `TriggerEvent` with the payload once a message is received.
- Added `WebSocketSensor` in `airflow/providers/standard/sensors/websocket.py`, following the `deferrable` / `poke()` / `execute()` / `execute_complete()` pattern used by `FileSensor`. `poke()` shares one deadline between the connection handshake (`open_timeout`) and the message wait (`recv(timeout=...)`), and the sensor is `@poke_mode_only` since a rescheduled attempt can't reuse the connection anyway. `url`, `header`, and `message_to_send` are template fields, with a JSON renderer for `header`.
- Registered both in `provider.yaml` (`triggers` and `sensors` sections); `get_provider_info.py` is regenerated from it via the `update-providers-build-files` prek hook rather than hand-edited, since that file is release-managed.
- Added the `websocket` optional extra (`websockets>=14.0`) to `pyproject.toml`, plus the same dependency in the provider's dev group so tests run without installing the extra separately. `uv.lock` updated to match via `update-providers-dependencies`.
- Added `docs/sensors/websocket.rst` (three usage examples plus the idempotency caveat above) and linked it from `provider.yaml`'s `how-to-guide` list, following `docs/sensors/file.rst`.
- Added the three examples above to `example_dags/example_sensors.py`, referenced by the docs page via `exampleinclude`.
- Added unit tests for the trigger (serialization, message received, no-message-to-send, trigger-reconstruction resend) and the sensor (poke success/timeout, handshake timeout, remaining-time budgeting, reschedule-mode rejection, defer-without-poking-first, single-poke-per-timeout, template rendering) in `tests/unit/standard/triggers/test_websocket.py` and `tests/unit/standard/sensors/test_websocket.py`, using `spec`/`autospec` on all WebSocket mocks per the testing guidelines.

closes: #21139

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)

Generated-by: Claude Code (Sonnet 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
