### PR TITLE
Fix hierarchical_alphabetical sort order breaking the graph and grid

### DIFF
--- a/airflow-core/src/airflow/serialization/definitions/taskgroup.py
+++ b/airflow-core/src/airflow/serialization/definitions/taskgroup.py
@@ -216,6 +216,20 @@ class SerializedTaskGroup(TaskGroupMixin, DAGNode):
                 yield group
             group = group.parent_group
 
+    def hierarchical_alphabetical_sort(self) -> list[DAGNode]:
+        """
+        Sort children in hierarchical alphabetical order: groups first, then tasks, each alphabetical.
+
+        Mirrors ``TaskGroup.hierarchical_alphabetical_sort`` in task-sdk. This orders one group's
+        direct children; the server-side graph/grid builder in
+        ``api_fastapi.core_api.services.ui.task_group`` walks the tree and re-applies it at every
+        level, so the API response is fully ordered at all nesting levels and the UI renders it as-is.
+        """
+        return sorted(
+            self.children.values(),
+            key=lambda node: (not isinstance(node, SerializedTaskGroup), node.node_id),
+        )
+
     def topological_sort(
         self, *, group_dict: dict[str | None, SerializedTaskGroup] | None = None
     ) -> list[DAGNode]:

--- a/airflow-core/tests/unit/utils/test_task_group.py
+++ b/airflow-core/tests/unit/utils/test_task_group.py
@@ -20,7 +20,11 @@ from __future__ import annotations
 import pendulum
 import pytest
 
-from airflow.api_fastapi.core_api.services.ui.task_group import task_group_to_dict, task_group_to_dict_grid
+from airflow.api_fastapi.core_api.services.ui.task_group import (
+    get_task_group_children_getter,
+    task_group_to_dict,
+    task_group_to_dict_grid,
+)
 from airflow.providers.standard.operators.bash import BashOperator
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.operators.python import PythonOperator
@@ -36,6 +40,7 @@ from airflow.sdk import (
 from airflow.serialization.definitions.taskgroup import SerializedTaskGroup
 from airflow.utils.dag_edges import dag_edges
 
+from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.dag import create_scheduler_dag
 from unit.models import DEFAULT_DATE
 
@@ -251,6 +256,31 @@ def test_task_group_to_dict_alternative_syntax():
     serialized_dag = create_scheduler_dag(dag)
 
     assert task_group_to_dict(serialized_dag.task_group) == EXPECTED_JSON
+
+
+@conf_vars({("api", "grid_view_sorting_order"): "hierarchical_alphabetical"})
+def test_task_group_to_dict_hierarchical_alphabetical_sort():
+    """``hierarchical_alphabetical`` orders serialized children: groups first, then tasks, each alphabetical."""
+    # The getter caches the resolved sort order, so force a re-read under the patched config.
+    get_task_group_children_getter.cache_clear()
+    try:
+        logical_date = pendulum.parse("20200101")
+        dag = DAG("test_tg_hier_alpha", schedule=None, start_date=logical_date)
+        # Added in a non-alphabetical order, mixing tasks and groups.
+        EmptyOperator(task_id="zeta", dag=dag)
+        group_b = TaskGroup("group_b", dag=dag)
+        EmptyOperator(task_id="b1", dag=dag, task_group=group_b)
+        group_a = TaskGroup("group_a", dag=dag)
+        EmptyOperator(task_id="a1", dag=dag, task_group=group_a)
+        EmptyOperator(task_id="alpha", dag=dag)
+
+        serialized_dag = create_scheduler_dag(dag)
+        node = task_group_to_dict(serialized_dag.task_group)
+
+        assert [child["id"] for child in node["children"]] == ["group_a", "group_b", "alpha", "zeta"]
+    finally:
+        # Don't leak the patched sort order to other tests.
+        get_task_group_children_getter.cache_clear()
 
 
 def test_task_group_to_dict_builds_group_dict_once(monkeypatch):


### PR DESCRIPTION
Only `topological_sort` was ported to `SerializedTaskGroup` — `hierarchical_alphabetical_sort` exists solely on the task-SDK `TaskGroup`. So selecting `hierarchical_alphabetical` calls a method that doesn't exist on the class the UI renders:

```
AttributeError: 'SerializedTaskGroup' object has no attribute 'hierarchical_alphabetical_sort'
```

`500`s the whole graph/grid.

### Fix
Implement `hierarchical_alphabetical_sort` on `SerializedTaskGroup`, mirroring the task-SDK version (groups first, then tasks, each alphabetical by `node_id`).

With this, `[api] grid_view_sorting_order = hierarchical_alphabetical` orders tasks and nested TaskGroups alphabetically in both the graph and grid.

### Reproduced
On `main`, `hasattr(SerializedTaskGroup, "hierarchical_alphabetical_sort")` is `False`; calling the UI getter under that config raises the `AttributeError` above. The added test fails without the fix (same `AttributeError`) and asserts the alphabetical order with it.

closes: #72114

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)