### PR TITLE
Fix scheduler crash when the Kafka event producer plugin is enabled

### DIFF
--- a/providers/apache/kafka/src/airflow/providers/apache/kafka/plugins/event_producer.py
+++ b/providers/apache/kafka/src/airflow/providers/apache/kafka/plugins/event_producer.py
@@ -21,6 +21,7 @@ import json
 import logging
 import os
 import time
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from fnmatch import fnmatch
 from functools import lru_cache
@@ -178,21 +179,34 @@ def _reset_state_after_fork() -> None:
 os.register_at_fork(after_in_child=_reset_state_after_fork)
 
 
+def _build_producer() -> Producer:
+    """Resolve the Kafka connection and build a producer from it."""
+    # Deferred import: KafkaProducerHook pulls in confluent_kafka.Producer, which is heavy
+    # and shouldn't be loaded by every Airflow process at plugin import time.
+    from airflow.providers.apache.kafka.hooks.produce import KafkaProducerHook
+
+    hook_kwargs: dict[str, Any] = {}
+    if _get_kafka_config_id():
+        hook_kwargs["kafka_config_id"] = _get_kafka_config_id()
+    return KafkaProducerHook(**hook_kwargs).get_producer()
+
+
 def _get_producer() -> Producer | None:
     """Build (once) and return the plugin's Kafka producer, or ``None`` on init failure."""
     global _producer
     if _producer is not None:
         return _producer
 
-    # Deferred import: KafkaProducerHook pulls in confluent_kafka.Producer, which is heavy
-    # and shouldn't be loaded by every Airflow process at plugin import time.
-    from airflow.providers.apache.kafka.hooks.produce import KafkaProducerHook
-
     try:
-        hook_kwargs: dict[str, Any] = {}
-        if _get_kafka_config_id():
-            hook_kwargs["kafka_config_id"] = _get_kafka_config_id()
-        producer = KafkaProducerHook(**hook_kwargs).get_producer()
+        # The connection lookup opens a DB session, so it runs on a thread of its own.
+        #
+        # settings.Session gives out one session per thread. MetastoreBackend.get_connection
+        # carries @provide_session, so on the caller's thread it reuses the session that
+        # thread already has, and closes it on the way out. The scheduler calls the listeners
+        # in this module while it is moving queued DagRuns to RUNNING. Closing its session
+        # detaches those DagRuns, and the scheduler crashes the next time it reads one.
+        with ThreadPoolExecutor(max_workers=1, thread_name_prefix="kafka-event-producer") as pool:
+            producer = pool.submit(_build_producer).result()
     except Exception as exc:
         log.warning("Kafka event producer: failed to initialize producer (%s).", exc)
         return None

--- a/providers/apache/kafka/tests/integration/apache/kafka/plugins/test_event_producer.py
+++ b/providers/apache/kafka/tests/integration/apache/kafka/plugins/test_event_producer.py
@@ -64,6 +64,8 @@ class TestEventProducer:
     dag_folder = os.path.join(test_dir, "dags")
 
     KAFKA_CONFIG_ID = "kafka_default"
+    # This config id lives in the metadata DB only.
+    DB_KAFKA_CONFIG_ID = "kafka_event_producer_db"
     # Use a unique topic per run to avoid errors on a re-run, in case
     # the previous teardown hasn't finished with the topic deletion.
     TOPIC = f"airflow.events.itest.{uuid.uuid4().hex[:8]}"
@@ -127,6 +129,75 @@ class TestEventProducer:
         finally:
             terminate_process(scheduler_process)
             terminate_process(apiserver_process)
+
+    @pytest.fixture
+    def kafka_connection_in_metadata_db(self):
+        """Give the plugin a Kafka connection that only the metadata DB has.
+
+        setup_class exports AIRFLOW_CONN_KAFKA_DEFAULT, and the environment secrets backend
+        answers from that variable without opening a DB session. This test needs the lookup
+        to reach the metastore backend instead, and that only happens for a connection the
+        environment does not have.
+
+        The topic is separate too. The other test counts the messages on the class topic,
+        and the runs here would add to that count.
+        """
+        topic = f"airflow.events.itest.{uuid.uuid4().hex[:8]}"
+        self._admin.create_topic([(topic, 1, 1)])
+
+        connection = Connection(
+            conn_id=self.DB_KAFKA_CONFIG_ID,
+            conn_type="kafka",
+            extra=json.dumps(client_config),
+        )
+        subprocess.run(
+            ["airflow", "connections", "add", self.DB_KAFKA_CONFIG_ID, "--conn-json", connection.as_json()],
+            check=True,
+            env=os.environ.copy(),
+        )
+        os.environ["AIRFLOW__KAFKA_EVENT_PRODUCER__KAFKA_CONFIG_ID"] = self.DB_KAFKA_CONFIG_ID
+        os.environ["AIRFLOW__KAFKA_EVENT_PRODUCER__TOPIC"] = topic
+        try:
+            yield
+        finally:
+            os.environ["AIRFLOW__KAFKA_EVENT_PRODUCER__TOPIC"] = self.TOPIC
+            os.environ.pop("AIRFLOW__KAFKA_EVENT_PRODUCER__KAFKA_CONFIG_ID", None)
+            subprocess.run(
+                ["airflow", "connections", "delete", self.DB_KAFKA_CONFIG_ID],
+                check=False,
+                env=os.environ.copy(),
+            )
+            try:
+                self._admin.delete_topic([topic])
+            except Exception as exc:
+                log.warning("teardown: failed to delete topic %r: %s", topic, exc)
+
+    @pytest.mark.execution_timeout(300)
+    def test_scheduler_starts_every_queued_dag_run(self, kafka_connection_in_metadata_db):
+        """The scheduler starts every queued Dag run, not only the first one.
+
+        Both runs are triggered before the scheduler starts, so a single pass of
+        _start_queued_dagruns has more than one row to get through. That pass is holding a
+        DB session. If building the Kafka producer closes it, the rows the pass has not
+        reached yet are detached, and the scheduler exits.
+        """
+        dag_id = "demo_dag"
+        run_ids = [unpause_trigger_dag_and_get_run_id(dag_id=dag_id) for _ in range(2)]
+
+        scheduler_process, apiserver_process = start_scheduler()
+        try:
+            states = [wait_for_dag_run(dag_id=dag_id, run_id=run_id, max_wait_time=60) for run_id in run_ids]
+            scheduler_exit_code = scheduler_process.poll()
+        finally:
+            terminate_process(scheduler_process)
+            terminate_process(apiserver_process)
+
+        assert scheduler_exit_code is None, (
+            f"the scheduler exited while starting queued Dag runs, exit code {scheduler_exit_code}"
+        )
+        assert states == [State.SUCCESS, State.SUCCESS], (
+            f"the scheduler did not finish both queued Dag runs, final states: {states}"
+        )
 
     @pytest.mark.execution_timeout(90)
     def test_dag_run_produces_event_messages(self, start_components):

--- a/providers/apache/kafka/tests/unit/apache/kafka/plugins/test_event_producer.py
+++ b/providers/apache/kafka/tests/unit/apache/kafka/plugins/test_event_producer.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import json
+import threading
 from collections.abc import Callable
 from unittest.mock import MagicMock, patch
 
@@ -321,6 +322,32 @@ class TestGetProducer:
         # Unset options must not be passed to the hook at all (e.g. as ""), so the
         # hook's own defaults (the "kafka_default" connection) apply.
         hook_cls_mock.assert_called_once_with()
+
+    def test_producer_is_not_built_on_the_calling_thread(self):
+        """Building the producer must not run on the thread that called the listener.
+
+        Building it resolves the Kafka connection, and settings.Session gives out one
+        session per thread. The scheduler is what calls these listeners. On its thread
+        the lookup would reuse the scheduler's own session and close it, detaching the
+        rows the scheduler is working on.
+        """
+        calling_thread = threading.get_ident()
+        lookup_thread = {}
+
+        def record_thread():
+            lookup_thread["ident"] = threading.get_ident()
+            return MagicMock()
+
+        # get_producer is where the real hook resolves the connection.
+        hook_mock = MagicMock()
+        hook_mock.get_producer.side_effect = record_thread
+
+        with patch(_PRODUCER_HOOK_CLS, return_value=hook_mock):
+            assert event_producer._get_producer() is not None
+
+        assert lookup_thread["ident"] != calling_thread, (
+            "the Kafka connection was resolved on the caller's thread"
+        )
 
 
 class TestCheckTopicExists:


### PR DESCRIPTION
## Why

- With `[kafka_event_producer] dag_run_events_enabled = True`, the scheduler crashes with `sqlalchemy.orm.exc.DetachedInstanceError` when more than one Dag run is queued.
- The DagRun listeners run inside the scheduler's own transaction. It moves queued Dag runs to RUNNING.
- Building the Kafka producer resolves the Kafka connection. On the scheduler that means `MetastoreBackend.get_connection`, which is decorated with `@provide_session`. `create_session()` is thread-scoped, so on the scheduler's thread it reuses the scheduler's own session and closes it on exit.
- The first Dag run in `_start_queued_dagruns` passes. the second crashes on `dag_run.dag_id`.

## How

- Producer construction moves into `_build_producer`, which runs on a single-use `ThreadPoolExecutor`. `settings.Session` gives out one session per thread, so the connection lookup gets a session of its own and leaves the caller's transaction alone.

## Verification

- `uv run --project providers/apache/kafka pytest providers/apache/kafka/tests/unit`
- `breeze shell --integration kafka --backend postgres --db-reset`, then `pytest providers/apache/kafka/tests/integration/apache/kafka/plugins/test_event_producer.py --integration kafka`.
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
