### PR TITLE
Pass the Dag bundle's team to secrets backends during Dag parsing

### DIFF
--- a/airflow-core/docs/core-concepts/multi-team.rst
+++ b/airflow-core/docs/core-concepts/multi-team.rst
@@ -239,6 +239,7 @@ Variables can be associated with teams when created. Tasks belonging to a team c
 2. Global variables (no team association)
 
 When a task requests a variable, the system checks for a team-specific variable first.
+Top-level Dag code in a team's bundle resolves variables the same way while the Dag file is parsed.
 
 Team-scoped variables can be created and managed through the Airflow UI or via environment variables.
 

--- a/airflow-core/newsfragments/72139.feature.rst
+++ b/airflow-core/newsfragments/72139.feature.rst
@@ -1,0 +1,1 @@
+In multi-team mode, secrets backends now receive the Dag bundle's ``team_name`` while the bundle's Dag files are parsed, as they do during task execution, so team-scoped connections and variables resolve in top-level Dag code; variable writes and key listing at parse time are team-scoped in the same way.

--- a/airflow-core/src/airflow/api_fastapi/execution_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/app.py
@@ -24,7 +24,7 @@ import time
 import weakref
 from contextlib import AsyncExitStack
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import attrs
 import svcs
@@ -383,6 +383,14 @@ class InProcessExecutionAPI:
 
     _app: FastAPI | None = None
 
+    bundle_name_header: ClassVar[str] = "airflow-dag-bundle-name"
+    """
+    Request header the in-process caller sets to identify the Dag bundle it acts for.
+
+    Only this in-process app reads it (see ``always_allow`` below); the real API server takes the
+    caller's identity from the signed token and ignores the header.
+    """
+
     @cached_property
     def app(self):
         if not self._app:
@@ -406,13 +414,19 @@ class InProcessExecutionAPI:
             # Set up dag_bag in app state for dependency injection
             self._app.state.dag_bag = create_dag_bag()
 
+            # Bind the header name here rather than closing over ``self``: a reference from the app back to
+            # this instance would keep ``.transport`` reachable from the app and defeat its finalizer.
+            bundle_name_header = self.bundle_name_header
+
             async def always_allow(request: Request):
                 from uuid import UUID
 
                 ti_id = UUID(
                     request.path_params.get("task_instance_id", "00000000-0000-0000-0000-000000000000")
                 )
-                claims = TIClaims(scope="execution")
+                claims = TIClaims(
+                    scope="execution", bundle_name=request.headers.get(bundle_name_header) or None
+                )
                 return TIToken(id=ti_id, claims=claims)
 
             self._app.dependency_overrides[_jwt_bearer] = always_allow

--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/token.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/token.py
@@ -31,13 +31,19 @@ class TIClaims(BaseModel):
     """
     Validated JWT claims for a task identity token.
 
-    Only fields used by the Execution API (sub, scope) are explicitly typed.
+    Only fields used by the Execution API (sub, scope, bundle_name) are explicitly typed.
     JWTValidator already validates exp/iat/nbf/aud/etc. Extra claims are allowed.
     """
 
     model_config = ConfigDict(extra="allow")
 
     scope: TokenScope = "execution"
+    bundle_name: str | None = None
+    """
+    Dag bundle the caller acts for, when the token does not identify a task instance (Dag parsing).
+
+    Task tokens leave this unset; their bundle (and team) is resolved from the task instance.
+    """
 
 
 class TIToken(BaseModel):

--- a/airflow-core/src/airflow/api_fastapi/execution_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/security.py
@@ -248,7 +248,12 @@ class ExecutionAPIRoute(APIRoute):
 
 
 async def get_team_name_dep(token=CurrentTIToken) -> str | None:
-    """Return the team name associated to the task (if any)."""
+    """
+    Return the team name associated to the caller (if any).
+
+    Resolved from the token's ``bundle_name`` claim when set (callers without a task instance, i.e. Dag
+    parsing), otherwise from the task instance the token identifies.
+    """
     from airflow.configuration import conf
 
     if not conf.getboolean("core", "multi_team"):
@@ -256,8 +261,12 @@ async def get_team_name_dep(token=CurrentTIToken) -> str | None:
 
     from airflow.utils.session import create_session_async
 
+    if token.claims.bundle_name is not None:
+        stmt = _team_name_for_bundle_stmt(token.claims.bundle_name)
+    else:
+        stmt = _team_name_for_ti_stmt(token.id)
     async with create_session_async() as session:
-        return await session.scalar(_team_name_for_ti_stmt(token.id))
+        return await session.scalar(stmt)
 
 
 def get_team_name_for_ti(ti_id, session) -> str | None:
@@ -288,6 +297,14 @@ def _team_name_for_ti_stmt(ti_id):
         .join(DagBundleModel.teams)
         .where(TaskInstance.id == ti_id)
     )
+
+
+def _team_name_for_bundle_stmt(bundle_name):
+    """Build the select statement resolving ``DagBundleModel.name -> Team.name``."""
+    from airflow.models.dagbundle import DagBundleModel
+    from airflow.models.team import Team
+
+    return select(Team.name).join(DagBundleModel.teams).where(DagBundleModel.name == bundle_name)
 
 
 def _team_name_for_dag_stmt(dag_id):

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -1419,13 +1419,14 @@ class DagFileProcessorManager(LoggingMixin):
             underlying_logger, processors=processors, logger_name="processor"
         ).bind(), logger_filehandle
 
-    @functools.cached_property
-    def client(self) -> Client:
+    def _make_client(self, bundle_name: str) -> Client:
+        """Return an API client whose requests identify the bundle the process parses."""
         from airflow.sdk.api.client import Client
 
         client = Client(base_url=None, token="", dry_run=True, transport=self._api_server.transport)
         # Mypy is wrong -- the setter accepts a string on the property setter! `URLType = URL | str`
         client.base_url = "http://in-process.invalid./"
+        client.headers[self._api_server.bundle_name_header] = bundle_name
         return client
 
     def _create_process(self, dag_file: DagFileInfo) -> DagFileProcessorProcess:
@@ -1445,7 +1446,7 @@ class DagFileProcessorManager(LoggingMixin):
             logger=logger,
             logger_filehandle=logger_filehandle,
             subprocess_logs_to_stdout=conf.get("logging", "dag_processor_log_target") == "stdout",
-            client=self.client,
+            client=self._make_client(dag_file.bundle_name),
         )
 
     def _start_new_processes(self):

--- a/airflow-core/tests/unit/api_fastapi/execution_api/test_app.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/test_app.py
@@ -20,7 +20,7 @@ import asyncio
 import gc
 import threading
 from unittest import mock
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import httpx
 import pytest
@@ -40,6 +40,14 @@ from airflow.api_fastapi.execution_api.datamodels.taskinstance import TaskInstan
 from airflow.api_fastapi.execution_api.datamodels.token import TIClaims, TIToken
 from airflow.api_fastapi.execution_api.security import require_auth
 from airflow.api_fastapi.execution_api.versions import bundle
+from airflow.models.connection import Connection
+from airflow.models.dagbundle import DagBundleModel
+from airflow.models.team import Team
+from airflow.models.variable import Variable
+from airflow.sdk.api.client import Client
+from airflow.sdk.api.datamodels._generated import ConnectionResponse, VariableResponse
+from airflow.sdk.exceptions import ErrorType
+from airflow.sdk.execution_time.comms import ErrorResponse
 
 from tests_common.test_utils.config import conf_vars
 
@@ -392,3 +400,69 @@ class TestTraceContextPropagation:
                 await gen.asend(None)  # resume past the yield -> else branch -> detach
 
         detach_spy.assert_called_once()
+
+
+class TestInProcessExecutionAPIBundleName:
+    """The in-process caller's bundle header becomes the token's ``bundle_name`` claim, which resolves the team."""
+
+    @staticmethod
+    def _make_client(bundle_name: str | None = None) -> Client:
+        client = Client(base_url=None, token="", dry_run=True, transport=InProcessExecutionAPI().transport)
+        client.base_url = "http://in-process.invalid/"
+        if bundle_name is not None:
+            client.headers[InProcessExecutionAPI.bundle_name_header] = bundle_name
+        return client
+
+    @pytest.fixture
+    def team_bundle(self, session):
+        """Create a bundle owned by a team; yield ``(bundle_name, team_name)``."""
+        bundle = DagBundleModel(name=f"bundle_{uuid4().hex}")
+        team = Team(name=f"team_{uuid4().hex}")
+        bundle.teams.append(team)
+        session.add(bundle)
+        session.commit()
+
+        with conf_vars({("core", "multi_team"): "True"}):
+            yield bundle.name, team.name
+
+        bundle.teams = []
+        session.delete(bundle)
+        session.delete(team)
+        session.commit()
+
+    def test_bundle_header_scopes_variable_lookup(self, session, team_bundle):
+        bundle_name, team_name = team_bundle
+        key = f"var_{uuid4().hex}"
+        Variable.set(key=key, value="team_value", team_name=team_name, session=session)
+        session.commit()
+
+        with_bundle = self._make_client(bundle_name).variables.get(key)
+        without_bundle = self._make_client().variables.get(key)
+        unknown_bundle = self._make_client("does-not-exist").variables.get(key)
+
+        Variable.delete(key=key, team_name=team_name, session=session)
+        session.commit()
+
+        assert with_bundle == VariableResponse(key=key, value="team_value")
+        not_found = ErrorResponse(error=ErrorType.VARIABLE_NOT_FOUND, detail={"key": key})
+        assert without_bundle == not_found
+        assert unknown_bundle == not_found
+
+    def test_bundle_header_scopes_connection_lookup(self, session, team_bundle):
+        bundle_name, team_name = team_bundle
+        conn_id = f"conn_{uuid4().hex}"
+        connection = Connection(conn_id=conn_id, conn_type="http", host="team-host", team_name=team_name)
+        session.add(connection)
+        session.commit()
+
+        with_bundle = self._make_client(bundle_name).connections.get(conn_id)
+        without_bundle = self._make_client().connections.get(conn_id)
+
+        session.delete(connection)
+        session.commit()
+
+        assert isinstance(with_bundle, ConnectionResponse)
+        assert with_bundle.host == "team-host"
+        assert without_bundle == ErrorResponse(
+            error=ErrorType.CONNECTION_NOT_FOUND, detail={"conn_id": conn_id}
+        )

--- a/airflow-core/tests/unit/api_fastapi/execution_api/test_app.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/test_app.py
@@ -29,6 +29,7 @@ from fastapi.params import Security as SecurityParam
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 from opentelemetry import context as otel_context, propagate as otel_propagate
+from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
 
 from airflow.api_fastapi.auth.tokens import JWTValidator
@@ -449,6 +450,49 @@ class TestInProcessExecutionAPIBundleName:
         not_found = ErrorResponse(error=ErrorType.VARIABLE_NOT_FOUND, detail={"key": key})
         assert without_bundle == not_found
         assert unknown_bundle == not_found
+
+    def test_bundle_header_scopes_variable_keys(self, session, team_bundle):
+        bundle_name, team_name = team_bundle
+        prefix = f"keys_{uuid4().hex}_"
+        Variable.set(key=f"{prefix}team", value="team_value", team_name=team_name, session=session)
+        Variable.set(key=f"{prefix}global", value="global_value", session=session)
+        session.commit()
+
+        with_bundle = self._make_client(bundle_name).variables.keys(prefix=prefix)
+        without_bundle = self._make_client().variables.keys(prefix=prefix)
+
+        Variable.delete(key=f"{prefix}team", team_name=team_name, session=session)
+        Variable.delete(key=f"{prefix}global", session=session)
+        session.commit()
+
+        assert with_bundle.keys == [f"{prefix}team"]
+        assert without_bundle.keys == [f"{prefix}global", f"{prefix}team"]
+
+    def test_bundle_header_scopes_variable_write(self, session, team_bundle):
+        bundle_name, team_name = team_bundle
+        key = f"var_{uuid4().hex}"
+
+        self._make_client(bundle_name).variables.set(key, "team_value")
+        written_team = session.scalar(select(Variable.team_name).where(Variable.key == key))
+
+        Variable.delete(key=key, team_name=team_name, session=session)
+        session.commit()
+
+        assert written_team == team_name
+
+    def test_bundle_header_scopes_variable_delete(self, session, team_bundle):
+        bundle_name, team_name = team_bundle
+        key = f"var_{uuid4().hex}"
+        Variable.set(key=key, value="team_value", team_name=team_name, session=session)
+        session.commit()
+
+        self._make_client().variables.delete(key)
+        after_without_bundle = session.scalar(select(Variable.key).where(Variable.key == key))
+        self._make_client(bundle_name).variables.delete(key)
+        after_with_bundle = session.scalar(select(Variable.key).where(Variable.key == key))
+
+        assert after_without_bundle == key
+        assert after_with_bundle is None
 
     def test_bundle_header_scopes_connection_lookup(self, session, team_bundle):
         bundle_name, team_name = team_bundle

--- a/airflow-core/tests/unit/api_fastapi/execution_api/test_app.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/test_app.py
@@ -31,6 +31,7 @@ from fastapi.testclient import TestClient
 from opentelemetry import context as otel_context, propagate as otel_propagate
 from sqlalchemy.exc import SQLAlchemyError
 
+from airflow.api_fastapi.auth.tokens import JWTValidator
 from airflow.api_fastapi.execution_api.app import (
     InProcessExecutionAPI,
     _extract_w3c_trace_context,
@@ -44,6 +45,7 @@ from airflow.models.connection import Connection
 from airflow.models.dagbundle import DagBundleModel
 from airflow.models.team import Team
 from airflow.models.variable import Variable
+from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.sdk.api.client import Client
 from airflow.sdk.api.datamodels._generated import ConnectionResponse, VariableResponse
 from airflow.sdk.exceptions import ErrorType
@@ -466,3 +468,89 @@ class TestInProcessExecutionAPIBundleName:
         assert without_bundle == ErrorResponse(
             error=ErrorType.CONNECTION_NOT_FOUND, detail={"conn_id": conn_id}
         )
+
+
+class TestBundleHeaderIgnoredByExecutionAPI:
+    """
+    The API server resolves the caller's team from the signed token, never from the bundle header.
+
+    Only the in-process app reads ``airflow-dag-bundle-name`` (see
+    ``TestInProcessExecutionAPIBundleName``), so a task token keeps its own team even when the
+    request carries another team's bundle name.
+    """
+
+    @pytest.fixture
+    def team_a_task(self, session, dag_maker, exec_app):
+        """
+        Authenticate the app as a task of team A; yield ``(team_a, team_b, team_b_bundle)``.
+
+        Only the JWT validator is stubbed, so the claims still come from ``JWTBearer`` alone and a
+        header the app folded into them would surface here.
+        """
+        bundle_a_name = f"bundle_{uuid4().hex}"
+        with dag_maker(dag_id=f"dag_{uuid4().hex}", bundle_name=bundle_a_name, session=session):
+            EmptyOperator(task_id="task")
+        ti = dag_maker.create_dagrun().get_task_instance("task")
+
+        bundle_a = session.get(DagBundleModel, bundle_a_name)
+        team_a = Team(name=f"team_{uuid4().hex}")
+        bundle_a.teams.append(team_a)
+        bundle_b = DagBundleModel(name=f"bundle_{uuid4().hex}")
+        team_b = Team(name=f"team_{uuid4().hex}")
+        bundle_b.teams.append(team_b)
+        session.add(bundle_b)
+        session.commit()
+
+        validator = mock.MagicMock(spec=JWTValidator)
+        validator.avalidated_claims.return_value = {"sub": str(ti.id), "scope": "execution"}
+        exec_app.state.svcs_registry.register_value(JWTValidator, validator)
+        exec_app.dependency_overrides.pop(require_auth)
+
+        with conf_vars({("core", "multi_team"): "True"}):
+            yield team_a.name, team_b.name, bundle_b.name
+
+        bundle_a.teams = []
+        bundle_b.teams = []
+        session.delete(bundle_b)
+        session.delete(team_a)
+        session.delete(team_b)
+        session.commit()
+
+    def test_variable_lookup_ignores_bundle_header(self, client, session, team_a_task):
+        team_a, team_b, bundle_b = team_a_task
+        key_a = f"var_{uuid4().hex}"
+        key_b = f"var_{uuid4().hex}"
+        Variable.set(key=key_a, value="a_value", team_name=team_a, session=session)
+        Variable.set(key=key_b, value="b_value", team_name=team_b, session=session)
+        session.commit()
+
+        headers = {InProcessExecutionAPI.bundle_name_header: bundle_b}
+        own_team = client.get(f"/execution/variables/{key_a}", headers=headers)
+        other_team = client.get(f"/execution/variables/{key_b}", headers=headers)
+
+        Variable.delete(key=key_a, team_name=team_a, session=session)
+        Variable.delete(key=key_b, team_name=team_b, session=session)
+        session.commit()
+
+        assert own_team.status_code == 200, own_team.json()
+        assert own_team.json() == {"key": key_a, "value": "a_value"}
+        assert other_team.status_code == 404, other_team.json()
+
+    def test_connection_lookup_ignores_bundle_header(self, client, session, team_a_task):
+        team_a, team_b, bundle_b = team_a_task
+        conn_a = Connection(conn_id=f"conn_{uuid4().hex}", conn_type="http", host="a-host", team_name=team_a)
+        conn_b = Connection(conn_id=f"conn_{uuid4().hex}", conn_type="http", host="b-host", team_name=team_b)
+        session.add_all([conn_a, conn_b])
+        session.commit()
+
+        headers = {InProcessExecutionAPI.bundle_name_header: bundle_b}
+        own_team = client.get(f"/execution/connections/{conn_a.conn_id}", headers=headers)
+        other_team = client.get(f"/execution/connections/{conn_b.conn_id}", headers=headers)
+
+        session.delete(conn_a)
+        session.delete(conn_b)
+        session.commit()
+
+        assert own_team.status_code == 200, own_team.json()
+        assert own_team.json()["host"] == "a-host"
+        assert other_team.status_code == 404, other_team.json()

--- a/airflow-core/tests/unit/api_fastapi/execution_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/test_security.py
@@ -47,6 +47,10 @@ class TestTIClaims:
 
         assert claims.sub == "not-a-uuid"
 
+    def test_bundle_name_claim_defaults_to_none(self):
+        assert TIClaims().bundle_name is None
+        assert TIClaims(bundle_name="my-bundle").bundle_name == "my-bundle"
+
 
 class TestExecutionAPIRoute:
     """Unit tests for ExecutionAPIRoute precomputing allowed_token_types from Security scopes."""
@@ -272,8 +276,8 @@ class TestGetTeamNameDep:
 
     @pytest.mark.asyncio
     async def test_returns_none_without_session_when_multi_team_disabled(self):
-        """When multi_team=False, no async session should be created."""
-        token = MagicMock(spec=TIToken)
+        """When multi_team=False, no async session should be created, even with a bundle_name claim."""
+        token = TIToken(id=UUID(int=0), claims=TIClaims(bundle_name="my-bundle"))
 
         with (
             patch("airflow.configuration.conf.getboolean", return_value=False),

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -3031,6 +3031,25 @@ class TestDagFileProcessorManager:
         assert len(team2.dag_bundles) == 0
 
     @mock.patch.object(DagFileProcessorProcess, "start")
+    def test_create_process_passes_bundle_client_to_process_start(
+        self, mock_process_start, configure_testing_dag_bundle
+    ):
+        """The process gets the client whose requests identify the file's bundle."""
+        with configure_testing_dag_bundle("/tmp"):
+            manager = DagFileProcessorManager(max_runs=1)
+            manager._dag_bundles = list(DagBundlesManager().get_all_dag_bundles())
+
+        file_info = DagFileInfo(
+            bundle_name="testing", rel_path=Path("test_dag.py"), bundle_path=TEST_DAGS_FOLDER
+        )
+        mock_process_start.return_value = self.mock_processor()[0]
+
+        manager._create_process(file_info)
+
+        client = mock_process_start.call_args.kwargs["client"]
+        assert client.headers[manager._api_server.bundle_name_header] == "testing"
+
+    @mock.patch.object(DagFileProcessorProcess, "start")
     def test_create_process_passes_bundle_name_to_process_start(
         self, mock_process_start, configure_testing_dag_bundle
     ):

--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import inspect
+import json
 import logging
 import pathlib
 import sys
@@ -89,6 +90,7 @@ from airflow.utils.session import create_session
 from airflow.utils.state import TaskInstanceState
 
 from tests_common.test_utils.config import conf_vars, env_vars
+from tests_common.test_utils.db import clear_db_connections, clear_db_variables
 
 if TYPE_CHECKING:
     from kgb import SpyAgency
@@ -383,6 +385,131 @@ class TestDagFileProcessor:
         assert result.import_errors != {}
         if result.import_errors:
             assert "The conn_id `my_conn` isn't defined" in next(iter(result.import_errors.values()))
+
+    @pytest.fixture
+    def team_bundle(self, tmp_path: pathlib.Path):
+        """Register ``tmp_path`` as a team-owned bundle in multi-team mode; yield ``(bundle_name, team_name)``."""
+        from airflow.models.dagbundle import DagBundleModel
+        from airflow.models.team import Team
+
+        bundle_name = f"bundle_{uuid.uuid4().hex}"
+        team_name = f"team_{uuid.uuid4().hex}"
+        with create_session() as session:
+            bundle = DagBundleModel(name=bundle_name)
+            bundle.teams.append(Team(name=team_name))
+            session.add(bundle)
+
+        bundle_config = [
+            {
+                "name": bundle_name,
+                "classpath": "airflow.dag_processing.bundles.local.LocalDagBundle",
+                "kwargs": {"path": str(tmp_path), "refresh_interval": 0},
+                "team_name": team_name,
+            }
+        ]
+        with conf_vars(
+            {
+                ("core", "multi_team"): "True",
+                ("dag_processor", "dag_bundle_config_list"): json.dumps(bundle_config),
+            }
+        ):
+            yield bundle_name, team_name
+
+        with create_session() as session:
+            stored_bundle = session.scalars(
+                select(DagBundleModel).where(DagBundleModel.name == bundle_name)
+            ).one()
+            stored_bundle.teams = []
+            session.delete(stored_bundle)
+            session.delete(session.scalars(select(Team).where(Team.name == team_name)).one())
+
+    def test_top_level_team_scoped_variable_access(
+        self, tmp_path: pathlib.Path, inprocess_client, team_bundle
+    ):
+        """Parsing a team bundle's Dag file resolves the team's variables in multi-team mode."""
+        from airflow.models.variable import Variable as VariableORM
+
+        logger = MagicMock(spec=FilteringBoundLogger)
+        logger_filehandle = MagicMock(spec=BinaryIO)
+
+        def dag_in_a_fn():
+            from airflow.sdk import DAG, Variable
+
+            with DAG(f"test_{Variable.get('myvar')}"):
+                ...
+
+        path = write_dag_in_a_fn_to_file(dag_in_a_fn, tmp_path)
+        bundle_name, team_name = team_bundle
+        with create_session() as session:
+            VariableORM.set(key="myvar", value="abc", team_name=team_name, session=session)
+        inprocess_client.headers[InProcessExecutionAPI.bundle_name_header] = bundle_name
+
+        proc = DagFileProcessorProcess.start(
+            id=1,
+            path=path,
+            bundle_path=tmp_path,
+            bundle_name=bundle_name,
+            dag_file_rel_path=str(path.relative_to(tmp_path)),
+            callbacks=[],
+            logger=logger,
+            logger_filehandle=logger_filehandle,
+            client=inprocess_client,
+        )
+
+        while not proc.is_ready:
+            proc._service_subprocess(0.1)
+
+        clear_db_variables()
+
+        result = proc.parsing_result
+        assert result is not None
+        assert result.import_errors == {}
+        assert result.serialized_dags[0].dag_id == "test_abc"
+
+    def test_top_level_team_scoped_connection_access(
+        self, tmp_path: pathlib.Path, inprocess_client, team_bundle
+    ):
+        """Parsing a team bundle's Dag file resolves the team's connections in multi-team mode."""
+        from airflow.models.connection import Connection as ConnectionORM
+
+        logger = MagicMock(spec=FilteringBoundLogger)
+        logger_filehandle = MagicMock(spec=BinaryIO)
+
+        def dag_in_a_fn():
+            from airflow.sdk import DAG, BaseHook
+
+            with DAG(f"test_{BaseHook.get_connection(conn_id='my_conn').host}"):
+                ...
+
+        path = write_dag_in_a_fn_to_file(dag_in_a_fn, tmp_path)
+        bundle_name, team_name = team_bundle
+        with create_session() as session:
+            session.add(
+                ConnectionORM(conn_id="my_conn", conn_type="http", host="team-host", team_name=team_name)
+            )
+        inprocess_client.headers[InProcessExecutionAPI.bundle_name_header] = bundle_name
+
+        proc = DagFileProcessorProcess.start(
+            id=1,
+            path=path,
+            bundle_path=tmp_path,
+            bundle_name=bundle_name,
+            dag_file_rel_path=str(path.relative_to(tmp_path)),
+            callbacks=[],
+            logger=logger,
+            logger_filehandle=logger_filehandle,
+            client=inprocess_client,
+        )
+
+        while not proc.is_ready:
+            proc._service_subprocess(0.1)
+
+        clear_db_connections(add_default_connections_back=False)
+
+        result = proc.parsing_result
+        assert result is not None
+        assert result.import_errors == {}
+        assert result.serialized_dags[0].dag_id == "test_team-host"
 
     def test_import_module_in_bundle_root(self, tmp_path: pathlib.Path, inprocess_client):
         tmp_path.joinpath("util.py").write_text("NAME = 'dag_name'")


### PR DESCRIPTION
Secrets backends receive `team_name` during task execution, but during Dag file parsing it was always `None`, so team-scoped connections and variables did not resolve in top-level Dag code (see #65530).

What changes:

- The Dag processor manager gives each parsing process an in-process API client whose requests carry the bundle name (`airflow-dag-bundle-name` header).
- `InProcessExecutionAPI` reads that header into a new `TIClaims.bundle_name` claim. `get_team_name_dep` resolves the team from `DagBundleModel` when the claim is set, and from the task instance otherwise, so variables and connections routes need no changes.
- Only the in-process app reads the header. The API server takes identity from the signed token and ignores it, so a worker cannot use it to reach another team's secrets.
- Parse-time variable writes and key listing become team-scoped as well, matching task execution.

Design note, feedback welcome: the in-process app is shared by every parsing process in the manager, so the bundle identity has to travel with each request. A header read only by the in-process auth override was the smallest carrier I found. Alternatives considered: a query parameter honored by the real server (spoofable from a task token), resolving secrets directly in the manager (bypasses the execution API), a signed token minted by the Dag processor (needs the JWT key there). If another carrier fits the AIP-92 direction better, I am glad to switch.

Not included: the triggerer has the same gap (`TriggerRunnerSupervisor.team_name` is known but not passed); it can reuse this mechanism through its `make_client` seam in a follow-up.

closes: #70495

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes - Claude Code (Claude Fable 5)

Generated-by: Claude Code (Claude Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
