### PR TITLE
Clarify to agents that inter provider versions must not be bumped

### DIFF
--- a/providers/AGENTS.md
+++ b/providers/AGENTS.md
@@ -15,7 +15,13 @@ Each provider is an independent package with its own `pyproject.toml`, tests, an
 
 - Keep `provider.yaml` metadata, docs, and tests in sync.
 - Don't upper-bound dependencies by default; add limits only with justification.
-- Changing a symbol another provider imports from yours? Bump the consuming provider's dependency with a `# use next version` marker so independently-released packages stay compatible — see [`contributing-docs/13_airflow_dependencies_and_extras.rst`](../contributing-docs/13_airflow_dependencies_and_extras.rst).
+- **Never edit an `apache-airflow-providers-*` `>=` floor in a `pyproject.toml`.** Only Release Managers do that; a contributor PR that raises one fails the `check_provider_dependency_bumps` selective check. When a provider needs something added to another provider in the same PR (most often `common.compat`), leave the existing version untouched and append the exact comment `# use next version` to that dependency line — release tooling rewrites it to the real version at release time:
+
+  ```toml
+  "apache-airflow-providers-common-compat>=1.8.0",  # use next version
+  ```
+
+  Modifying `common.compat` alongside any other provider makes the marker **mandatory** on that provider's common-compat line — a second selective check (`common_compat_changed_without_next_version`) enforces it. See [`contributing-docs/13_airflow_dependencies_and_extras.rst`](../contributing-docs/13_airflow_dependencies_and_extras.rst).
 - Tests live alongside the provider — mirror source paths in test directories.
 - Full guide: [`contributing-docs/12_provider_distributions.rst`](../contributing-docs/12_provider_distributions.rst)
 


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

`providers/AGENTS.md` told contributors(and agents) to "bump the consuming provider's dependency with a `# use next version` marker" when one provider needs a change landing in another in the same PR. That phrasing invites the opposite of the actual rule: it reads as "raise the version number and add a comment", when [`contributing-docs/13_airflow_dependencies_and_extras.rst`](contributing-docs/13_airflow_dependencies_and_extras.rst) is explicit that contributors **must not** change the version at all - only append the marker, which release tooling resolves at release time.

The guidance also only described the producing provider's side ("changing a symbol another provider imports from yours"), not the far more common consuming side: needing a feature you are adding to `common.compat` in the same PR.

### Current behaviour

Following the line as written produces a `>=` floor bump, which fails CI on two separate selective checks, with no hint in the agent instructions that either exists.

### Proposed change

Rewrites the checklist entry to lead with the prohibition, name both enforcing checks, and show the literal dependency line - the marker text must match exactly or the release automation skips it.


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
