### PR TITLE
Fix impersonation_chain and poll_sleep ignored by deferrable Beam Dataflow pipelines

### DIFF
--- a/providers/apache/beam/src/airflow/providers/apache/beam/operators/beam.py
+++ b/providers/apache/beam/src/airflow/providers/apache/beam/operators/beam.py
@@ -473,6 +473,8 @@ class BeamRunPythonPipelineOperator(BeamBasePipelineOperator):
                 "project_id": self.dataflow_config.project_id,
                 "location": location,
                 "gcp_conn_id": self.gcp_conn_id,
+                "poll_sleep": self.dataflow_config.poll_sleep,
+                "impersonation_chain": self.dataflow_config.impersonation_chain,
             }
             trigger: DataflowJobStatusTrigger | DataflowJobStateCompleteTrigger
 
@@ -667,6 +669,8 @@ class BeamRunJavaPipelineOperator(BeamBasePipelineOperator):
                         "project_id": self.dataflow_config.project_id,
                         "location": self.dataflow_config.location,
                         "gcp_conn_id": self.gcp_conn_id,
+                        "poll_sleep": self.dataflow_config.poll_sleep,
+                        "impersonation_chain": self.dataflow_config.impersonation_chain,
                     }
                     trigger: DataflowJobStatusTrigger | DataflowJobStateCompleteTrigger
 

--- a/providers/apache/beam/tests/unit/apache/beam/operators/test_beam.py
+++ b/providers/apache/beam/tests/unit/apache/beam/operators/test_beam.py
@@ -53,6 +53,7 @@ STAGING_LOCATION = "gs://test/staging"
 OUTPUT_LOCATION = "gs://test/output"
 TEST_VERSION = f"v{version.replace('.', '-').replace('+', '-')}"
 TEST_IMPERSONATION_ACCOUNT = "test@impersonation.com"
+TEST_POLL_SLEEP = 30
 BEAM_OPERATOR_PATH = "airflow.providers.apache.beam.operators.beam.{}"
 
 
@@ -992,12 +993,10 @@ class TestBeamRunPythonPipelineOperatorAsync:
     @mock.patch(BEAM_OPERATOR_PATH.format("DataflowHook"))
     @mock.patch(BEAM_OPERATOR_PATH.format("GCSHook"))
     def test_exec_dataflow_runner(self, gcs_hook_mock, dataflow_hook_mock, beam_hook_mock):
-        """
-        Test DataflowHook is created and the right args are passed to
-        start_python_dataflow when executing Dataflow runner.
-        """
-
-        dataflow_config = DataflowConfiguration(impersonation_chain=TEST_IMPERSONATION_ACCOUNT)
+        """Test the Dataflow hook and the deferral trigger both receive the dataflow_config args."""
+        dataflow_config = DataflowConfiguration(
+            impersonation_chain=TEST_IMPERSONATION_ACCOUNT, poll_sleep=TEST_POLL_SLEEP
+        )
         op = BeamRunPythonPipelineOperator(
             runner="DataflowRunner",
             dataflow_config=dataflow_config,
@@ -1005,7 +1004,7 @@ class TestBeamRunPythonPipelineOperatorAsync:
         )
         magic_mock = mock.MagicMock()
         if AIRFLOW_V_3_0_PLUS:
-            with pytest.raises(TaskDeferred):
+            with pytest.raises(TaskDeferred) as exc:
                 op.execute(context=magic_mock)
         else:
             exception_msg = (
@@ -1014,11 +1013,13 @@ class TestBeamRunPythonPipelineOperatorAsync:
                 " completed!"
             )
             with (
-                pytest.raises(TaskDeferred),
+                pytest.raises(TaskDeferred) as exc,
                 pytest.warns(AirflowProviderDeprecationWarning, match=exception_msg),
             ):
                 op.execute(context=magic_mock)
 
+        assert exc.value.trigger.impersonation_chain == TEST_IMPERSONATION_ACCOUNT
+        assert exc.value.trigger.poll_sleep == TEST_POLL_SLEEP
         dataflow_hook_mock.assert_called_once_with(
             gcp_conn_id=dataflow_config.gcp_conn_id,
             poll_sleep=dataflow_config.poll_sleep,
@@ -1122,18 +1123,17 @@ class TestBeamRunJavaPipelineOperatorAsync:
     @mock.patch(BEAM_OPERATOR_PATH.format("DataflowHook"))
     @mock.patch(BEAM_OPERATOR_PATH.format("GCSHook"))
     def test_exec_dataflow_runner(self, gcs_hook_mock, dataflow_hook_mock, beam_hook_mock):
-        """
-        Test DataflowHook is created and the right args are passed to
-        start_java_pipeline when executing Dataflow runner.
-        """
-        dataflow_config = DataflowConfiguration(impersonation_chain=TEST_IMPERSONATION_ACCOUNT)
+        """Test the Dataflow hook and the deferral trigger both receive the dataflow_config args."""
+        dataflow_config = DataflowConfiguration(
+            impersonation_chain=TEST_IMPERSONATION_ACCOUNT, poll_sleep=TEST_POLL_SLEEP
+        )
         op = BeamRunJavaPipelineOperator(
             runner="DataflowRunner", dataflow_config=dataflow_config, **self.default_op_kwargs
         )
         dataflow_hook_mock.return_value.is_job_dataflow_running.return_value = False
         magic_mock = mock.MagicMock()
         if AIRFLOW_V_3_0_PLUS:
-            with pytest.raises(TaskDeferred):
+            with pytest.raises(TaskDeferred) as exc:
                 op.execute(context=magic_mock)
         else:
             exception_msg = (
@@ -1142,11 +1142,13 @@ class TestBeamRunJavaPipelineOperatorAsync:
                 " completed!"
             )
             with (
-                pytest.raises(TaskDeferred),
+                pytest.raises(TaskDeferred) as exc,
                 pytest.warns(AirflowProviderDeprecationWarning, match=exception_msg),
             ):
                 op.execute(context=magic_mock)
 
+        assert exc.value.trigger.impersonation_chain == TEST_IMPERSONATION_ACCOUNT
+        assert exc.value.trigger.poll_sleep == TEST_POLL_SLEEP
         dataflow_hook_mock.assert_called_once_with(
             gcp_conn_id=dataflow_config.gcp_conn_id,
             poll_sleep=dataflow_config.poll_sleep,


### PR DESCRIPTION
## Summary

A Beam pipeline on the Dataflow runner honours the service account chain from `dataflow_config` only until it defers: the trigger polls through a hook of its own, and neither `impersonation_chain` nor `poll_sleep` ever reached it. Impersonating deployments watch the job launch and then fail with a permission error the moment the task defers, which reads as a Dataflow problem rather than an Airflow one.

The report names the Java operator; the Python one builds its trigger the same way. Both trigger classes have accepted these arguments since before the `DataflowJobStateCompleteTrigger` compatibility branch existed, so the older-provider fallback is safe.

closes: #72135

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)