### PR TITLE
Add performance_target to Databricks RunNow and CreateJobs operators

### DIFF
--- a/providers/databricks/docs/operators/jobs_create.rst
+++ b/providers/databricks/docs/operators/jobs_create.rst
@@ -56,6 +56,7 @@ Currently the named parameters that ``DatabricksCreateJobsOperator`` supports ar
   - ``max_concurrent_runs``
   - ``git_source``
   - ``access_control_list``
+  - ``performance_target``
 
 
 Forwarding Airflow Dag params as Databricks job parameters

--- a/providers/databricks/docs/operators/run_now.rst
+++ b/providers/databricks/docs/operators/run_now.rst
@@ -46,6 +46,7 @@ All other parameters are optional and described in documentation for ``Databrick
 * ``jar_params``
 * ``spark_submit_params``
 * ``idempotency_token``
+* ``performance_target``
 * ``repair_run``
 * ``cancel_previous_runs``
 

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
@@ -452,6 +452,15 @@ class DatabricksCreateJobsOperator(BaseOperator):
         .. seealso::
             This will only be used on create. In order to reset ACL consider using the Databricks
             UI.
+    :param performance_target: Optional performance mode for runs of this job on serverless compute.
+        Either ``PERFORMANCE_OPTIMIZED`` (prioritizes fast startup and execution) or
+        ``STANDARD`` (enables cost-efficient execution of serverless workloads). The API drops any
+        other value instead of rejecting it, so a mistyped ``STANDARD`` raises no error and the run
+        falls back to the more expensive default, ``PERFORMANCE_OPTIMIZED``. This field will be
+        templated.
+
+        .. seealso::
+            https://docs.databricks.com/api/workspace/jobs/create
     :param databricks_conn_id: Reference to the
         :ref:`Databricks connection <howto/connection:databricks>`. (templated)
     :param polling_period_seconds: Controls the rate which we poll for the result of
@@ -488,6 +497,7 @@ class DatabricksCreateJobsOperator(BaseOperator):
         "max_concurrent_runs",
         "git_source",
         "access_control_list",
+        "performance_target",
         "databricks_conn_id",
     )
     # Databricks brand color (blue) under white text
@@ -511,6 +521,7 @@ class DatabricksCreateJobsOperator(BaseOperator):
         max_concurrent_runs: int | None = None,
         git_source: dict | None = None,
         access_control_list: list[dict] | None = None,
+        performance_target: str | None = None,
         databricks_conn_id: str = "databricks_default",
         polling_period_seconds: int = 30,
         databricks_retry_limit: int = 3,
@@ -534,6 +545,7 @@ class DatabricksCreateJobsOperator(BaseOperator):
         self.max_concurrent_runs = max_concurrent_runs
         self.git_source = git_source
         self.access_control_list = access_control_list
+        self.performance_target = performance_target
         self.databricks_conn_id = databricks_conn_id
         self.polling_period_seconds = polling_period_seconds
         self.databricks_retry_limit = databricks_retry_limit
@@ -555,6 +567,7 @@ class DatabricksCreateJobsOperator(BaseOperator):
             "max_concurrent_runs": self.max_concurrent_runs,
             "git_source": self.git_source,
             "access_control_list": self.access_control_list,
+            "performance_target": self.performance_target,
         }
 
     def _get_merged_json(self) -> dict[str, Any]:
@@ -706,8 +719,10 @@ class DatabricksSubmitRunOperator(ResumableJobMixin, BaseOperator):
         supported task types are retrieved.
     :param performance_target: Optional performance mode for the run on serverless compute.
         Either ``PERFORMANCE_OPTIMIZED`` (prioritizes fast startup and execution) or
-        ``STANDARD`` (enables cost-efficient execution of serverless workloads). This field
-        will be templated.
+        ``STANDARD`` (enables cost-efficient execution of serverless workloads). The API drops any
+        other value instead of rejecting it, so a mistyped ``STANDARD`` raises no error and the run
+        falls back to the more expensive default, ``PERFORMANCE_OPTIMIZED``. This field will be
+        templated.
 
         .. seealso::
             https://docs.databricks.com/api/workspace/jobs/submit
@@ -1087,6 +1102,7 @@ class DatabricksRunNowOperator(ResumableJobMixin, BaseOperator):
         - ``jar_params``
         - ``spark_submit_params``
         - ``idempotency_token``
+        - ``performance_target``
         - ``repair_run``
         - ``databricks_repair_reason_new_settings``
         - ``cancel_previous_runs``
@@ -1186,6 +1202,15 @@ class DatabricksRunNowOperator(ResumableJobMixin, BaseOperator):
     :param idempotency_token: an optional token that can be used to guarantee the idempotency of job run
         requests. If a run with the provided token already exists, the request does not create a new run but
         returns the ID of the existing run instead.  This token must have at most 64 characters.
+    :param performance_target: Optional performance mode for this run on serverless compute, overriding
+        the performance target defined at the job level. Either ``PERFORMANCE_OPTIMIZED`` (prioritizes
+        fast startup and execution) or ``STANDARD`` (enables cost-efficient execution of serverless
+        workloads). The API drops any other value instead of rejecting it, so a mistyped ``STANDARD``
+        raises no error and the run falls back to the more expensive default, ``PERFORMANCE_OPTIMIZED``.
+        This field will be templated.
+
+        .. seealso::
+            https://docs.databricks.com/api/workspace/jobs/runnow
     :param databricks_conn_id: Reference to the :ref:`Databricks connection <howto/connection:databricks>`.
         By default and in the common case this will be ``databricks_default``. To use
         token based authentication, provide the key ``token`` in the extra field for the
@@ -1243,6 +1268,7 @@ class DatabricksRunNowOperator(ResumableJobMixin, BaseOperator):
         "jar_params",
         "spark_submit_params",
         "idempotency_token",
+        "performance_target",
         "databricks_conn_id",
     )
     template_ext: Sequence[str] = (".json-tpl",)
@@ -1265,6 +1291,7 @@ class DatabricksRunNowOperator(ResumableJobMixin, BaseOperator):
         spark_submit_params: list[str] | None = None,
         python_named_params: dict[str, str] | None = None,
         idempotency_token: str | None = None,
+        performance_target: str | None = None,
         databricks_conn_id: str = "databricks_default",
         polling_period_seconds: int = 30,
         databricks_retry_limit: int = 3,
@@ -1297,6 +1324,7 @@ class DatabricksRunNowOperator(ResumableJobMixin, BaseOperator):
         self.jar_params = jar_params
         self.spark_submit_params = spark_submit_params
         self.idempotency_token = idempotency_token
+        self.performance_target = performance_target
         self.databricks_conn_id = databricks_conn_id
         self.polling_period_seconds = polling_period_seconds
         self.databricks_retry_limit = databricks_retry_limit
@@ -1325,6 +1353,7 @@ class DatabricksRunNowOperator(ResumableJobMixin, BaseOperator):
             "jar_params": self.jar_params,
             "spark_submit_params": self.spark_submit_params,
             "idempotency_token": self.idempotency_token,
+            "performance_target": self.performance_target,
         }
 
     def _get_merged_json(self) -> dict[str, Any]:

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks.py
@@ -355,6 +355,26 @@ class TestDatabricksCreateJobsOperator:
 
         assert expected == utils.normalise_json_content(op._get_merged_json())
 
+    def test_init_with_performance_target_named_parameter(self):
+        """
+        Test the initializer merges ``performance_target`` into the create payload.
+        """
+        op = DatabricksCreateJobsOperator(
+            task_id=TASK_ID,
+            name=JOB_NAME,
+            tasks=TASKS,
+            performance_target="PERFORMANCE_OPTIMIZED",
+        )
+        expected = utils.normalise_json_content(
+            {
+                "name": JOB_NAME,
+                "tasks": TASKS,
+                "performance_target": "PERFORMANCE_OPTIMIZED",
+            }
+        )
+
+        assert expected == utils.normalise_json_content(op._get_merged_json())
+
     def test_init_with_json(self):
         """
         Test the initializer with json data.
@@ -1927,6 +1947,15 @@ class TestDatabricksRunNowOperator:
         """
         op = DatabricksRunNowOperator(job_id=JOB_ID, task_id=TASK_ID)
         expected = utils.normalise_json_content({"job_id": 42})
+
+        assert expected == utils.normalise_json_content(op._get_merged_json())
+
+    def test_init_with_performance_target_named_parameter(self):
+        """
+        Test the initializer merges ``performance_target`` into the run-now payload.
+        """
+        op = DatabricksRunNowOperator(job_id=JOB_ID, task_id=TASK_ID, performance_target="STANDARD")
+        expected = utils.normalise_json_content({"job_id": 42, "performance_target": "STANDARD"})
 
         assert expected == utils.normalise_json_content(op._get_merged_json())
 


### PR DESCRIPTION
#71374 added `performance_target` to `DatabricksSubmitRunOperator`. The `jobs/create` and `jobs/run-now` endpoints accept the same field, but the two operators that call them still lack it, so these three operators now behave differently for one API field. This exposes it as a templated named parameter that merges into the request like the other task fields.


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
