### PR TITLE
Add drift tripwires for common.ai Vertex model prefix

### DIFF
--- a/providers/common/ai/tests/unit/common/ai/hooks/test_pydantic_ai.py
+++ b/providers/common/ai/tests/unit/common/ai/hooks/test_pydantic_ai.py
@@ -16,7 +16,9 @@
 # under the License.
 from __future__ import annotations
 
+import contextlib
 import json
+import re
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -27,12 +29,31 @@ from pydantic_ai.models.test import TestModel
 from pydantic_ai.providers import infer_provider_class
 
 from airflow.models.connection import Connection
+from airflow.providers.common.ai.get_provider_info import get_provider_info
 from airflow.providers.common.ai.hooks.pydantic_ai import (
     PydanticAIAzureHook,
     PydanticAIBedrockHook,
     PydanticAIHook,
     PydanticAIVertexHook,
 )
+
+# Matches the `google...` provider key pydantic-ai expects before the `:model-name`
+# separator, e.g. "google-cloud" out of "google-cloud:gemini-2.0-flash".
+_GOOGLE_MODEL_PREFIX_RE = re.compile(r"google[\w-]*(?=:)")
+
+
+def _assert_prefix_is_known_provider(prefix: str) -> None:
+    """
+    Assert pydantic-ai's provider registry recognizes ``prefix``.
+
+    ``infer_provider_class`` raises ``ValueError: Unknown provider: ...`` for a
+    name it doesn't recognize, but ``ImportError`` for a recognized name whose
+    optional dependency (``google-genai``) isn't installed in this test env.
+    Only the former indicates the advertised prefix has drifted out of sync
+    with what's actually installed.
+    """
+    with contextlib.suppress(ImportError):
+        infer_provider_class(prefix)
 
 
 class TestPydanticAIHookInit:
@@ -930,3 +951,35 @@ class TestPydanticAIVertexHook:
             # environment; failing past provider-name resolution is enough to
             # prove "google-cloud" is recognized.
             pass
+
+    def test_conn_fields_model_description_prefix_is_valid_provider(self):
+        """
+        Drift tripwire for the ``provider.yaml`` conn-field, the actual UI source.
+
+        Once a hook's ``provider.yaml`` declares ``conn-fields``, the connection
+        form renders those and ``get_ui_field_behaviour`` placeholders are never
+        shown (``providers_manager.py``'s ``ui_metadata_loaded``, deprecated
+        since 3.2.0) — so this description, not the placeholder below, is what
+        a user actually copies the model prefix from.
+        """
+        connection_types = get_provider_info()["connection-types"]
+        vertex_conn_fields = next(
+            c["conn-fields"] for c in connection_types if c["connection-type"] == "pydanticai-vertex"
+        )
+        description = vertex_conn_fields["model"]["description"]
+        match = _GOOGLE_MODEL_PREFIX_RE.search(description)
+        assert match, f"no google model prefix found in description: {description!r}"
+        _assert_prefix_is_known_provider(match.group())
+
+    def test_ui_field_behaviour_placeholder_prefix_is_valid_provider(self):
+        """
+        Drift tripwire for the ``get_ui_field_behaviour`` placeholder.
+
+        Superseded at runtime by the ``provider.yaml`` conn-field above, but
+        still source code a developer can read and copy from directly, so it
+        needs to stay accurate too.
+        """
+        placeholder = PydanticAIVertexHook.get_ui_field_behaviour()["placeholders"]["extra"]
+        match = _GOOGLE_MODEL_PREFIX_RE.search(placeholder)
+        assert match, f"no google model prefix found in placeholder: {placeholder!r}"
+        _assert_prefix_is_known_provider(match.group())

--- a/providers/common/ai/tests/unit/common/ai/hooks/test_pydantic_ai.py
+++ b/providers/common/ai/tests/unit/common/ai/hooks/test_pydantic_ai.py
@@ -52,8 +52,28 @@ def _assert_prefix_is_known_provider(prefix: str) -> None:
     Only the former indicates the advertised prefix has drifted out of sync
     with what's actually installed.
     """
-    with contextlib.suppress(ImportError):
-        infer_provider_class(prefix)
+    try:
+        with contextlib.suppress(ImportError):
+            infer_provider_class(prefix)
+    except ValueError as exc:
+        pytest.fail(f"{prefix!r} is not a recognized pydantic-ai provider: {exc}")
+
+
+def _extract_google_cloud_prefix(text: str) -> str:
+    """
+    Extract the ``google...`` model prefix out of ``text`` and assert it is exactly
+    ``"google-cloud"``.
+
+    ``_GOOGLE_MODEL_PREFIX_RE`` alone would also match the bare ``"google"``
+    provider (the Generative Language API, which pydantic-ai also recognizes),
+    so a documented prefix that silently regressed from ``google-cloud:`` to
+    ``google:`` would still pass a plain "is it a known provider" check. The
+    exact-match assertion here is what actually catches that drift.
+    """
+    match = _GOOGLE_MODEL_PREFIX_RE.search(text)
+    assert match, f"no google model prefix found in: {text!r}"
+    assert match.group() == "google-cloud", f"expected 'google-cloud' prefix, got {match.group()!r}"
+    return match.group()
 
 
 class TestPydanticAIHookInit:
@@ -942,15 +962,7 @@ class TestPydanticAIVertexHook:
         pydantic/pydantic-ai#5336, which renamed the old Vertex provider id shortly
         before Airflow's docstrings/placeholders were written).
         """
-        try:
-            infer_provider_class("google-cloud")
-        except ValueError as exc:
-            pytest.fail(f"Documented prefix 'google-cloud' is not a recognized provider: {exc}")
-        except ImportError:
-            # The optional `google-genai` dependency isn't installed in the test
-            # environment; failing past provider-name resolution is enough to
-            # prove "google-cloud" is recognized.
-            pass
+        _assert_prefix_is_known_provider("google-cloud")
 
     def test_conn_fields_model_description_prefix_is_valid_provider(self):
         """
@@ -967,9 +979,26 @@ class TestPydanticAIVertexHook:
             c["conn-fields"] for c in connection_types if c["connection-type"] == "pydanticai-vertex"
         )
         description = vertex_conn_fields["model"]["description"]
-        match = _GOOGLE_MODEL_PREFIX_RE.search(description)
-        assert match, f"no google model prefix found in description: {description!r}"
-        _assert_prefix_is_known_provider(match.group())
+        prefix = _extract_google_cloud_prefix(description)
+        _assert_prefix_is_known_provider(prefix)
+
+    def test_conn_types_ui_field_behaviour_placeholder_prefix_is_valid_provider(self):
+        """
+        Drift tripwire for the ``provider.yaml`` ``ui-field-behaviour.placeholders.extra``,
+        a sibling of ``conn-fields`` under the same connection-type block.
+
+        This placeholder is superseded at runtime by the ``conn-fields`` description
+        above (once ``conn-fields`` is declared, the connection form no longer shows
+        ``ui-field-behaviour`` placeholders), but ``provider.yaml`` still carries its
+        own independent copy of the model prefix here, and nothing was covering it.
+        """
+        connection_types = get_provider_info()["connection-types"]
+        vertex_connection_type = next(
+            c for c in connection_types if c["connection-type"] == "pydanticai-vertex"
+        )
+        placeholder = vertex_connection_type["ui-field-behaviour"]["placeholders"]["extra"]
+        prefix = _extract_google_cloud_prefix(placeholder)
+        _assert_prefix_is_known_provider(prefix)
 
     def test_ui_field_behaviour_placeholder_prefix_is_valid_provider(self):
         """
@@ -980,6 +1009,5 @@ class TestPydanticAIVertexHook:
         needs to stay accurate too.
         """
         placeholder = PydanticAIVertexHook.get_ui_field_behaviour()["placeholders"]["extra"]
-        match = _GOOGLE_MODEL_PREFIX_RE.search(placeholder)
-        assert match, f"no google model prefix found in placeholder: {placeholder!r}"
-        _assert_prefix_is_known_provider(match.group())
+        prefix = _extract_google_cloud_prefix(placeholder)
+        _assert_prefix_is_known_provider(prefix)


### PR DESCRIPTION
The `google-cloud:` prefix advertised by `provider.yaml`'s `pydanticai-vertex` conn-field description, by that connection type's own `ui-field-behaviour` placeholder, and by `get_ui_field_behaviour`'s placeholder is now asserted to be exactly `google-cloud` and a provider pydantic-ai's `infer_provider_class` recognizes — so a provider-registry rename, or a silent regression to the bare `google` provider (a different, valid API), cannot leave any of the three surfaces out of sync.


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: [Claude] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
