### PR TITLE
Fix unscheduled tasks left on a stale Dag version

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -3094,7 +3094,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             .where(
                 TI.dag_id == dag_run.dag_id,
                 TI.run_id == dag_run.run_id,
-                TI.state.in_(State.unfinished),
+                or_(TI.state.is_(None), TI.state.in_(State.unfinished)),
             )
             .values(dag_version_id=latest_dag_version.id),
             execution_options={"synchronize_session": False},

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -5204,6 +5204,55 @@ class TestSchedulerJob:
         session.rollback()
         session.close()
 
+    def test_verify_integrity_if_dag_changed_moves_unscheduled_tis(self, dag_maker, session):
+        """Task instances that have not been scheduled yet must also be moved to the new Dag version."""
+        with dag_maker(dag_id="test_verify_integrity_unscheduled_tis", serialized=False) as dag:
+            BashOperator(task_id="upstream", bash_command="echo hi") >> BashOperator(
+                task_id="downstream", bash_command="echo hi"
+            )
+
+        orm_dag = dag_maker.dag_model
+        SerializedDagModel.write_dag(
+            LazyDeserializedDAG.from_dag(dag), bundle_name="testing", session=session
+        )
+        session.commit()
+        assert orm_dag.bundle_version is None
+
+        self.job_runner = SchedulerJobRunner(job=Job())
+        self.job_runner._create_dag_runs([orm_dag], session)
+        dr = DagRun.find(dag_id=dag.dag_id, session=session)[0]
+
+        self.job_runner._schedule_dag_run(dag_run=dr, session=session)
+        session.commit()
+        dag_version_1 = DagVersion.get_latest_version(dr.dag_id, session=session)
+
+        states = {ti.task_id: ti.state for ti in dr.task_instances}
+        assert states == {"upstream": State.SCHEDULED, "downstream": None}
+
+        BashOperator(task_id="extra", dag=dag, bash_command="echo hi")
+        SerializedDagModel.write_dag(
+            LazyDeserializedDAG.from_dag(dag), bundle_name="testing", session=session
+        )
+        session.commit()
+        dag_version_2 = DagVersion.get_latest_version(dr.dag_id, session=session)
+        assert dag_version_2.id != dag_version_1.id
+
+        self.job_runner._schedule_dag_run(dr, session)
+        session.commit()
+
+        versions = dict(
+            session.execute(
+                select(TaskInstance.task_id, TaskInstance.dag_version_id).where(
+                    TaskInstance.dag_id == dr.dag_id, TaskInstance.run_id == dr.run_id
+                )
+            ).all()
+        )
+        assert versions == {
+            "upstream": dag_version_2.id,
+            "downstream": dag_version_2.id,
+            "extra": dag_version_2.id,
+        }
+
     def test_verify_integrity_not_called_for_versioned_bundles(self, dag_maker, session):
         with dag_maker("test_verify_integrity_if_dag_not_changed") as dag:
             BashOperator(task_id="dummy", bash_command="echo hi")


### PR DESCRIPTION
## Why

- Before #60956, a task instance with `state = None` can be updated to the latest Dag version when the Dag changed. The code was a Python loop over the run's task instances and `None in State.unfinished` is `True`.
- #60956 rewrote that loop as a bulk `UPDATE ... WHERE state IN (...)` so the scheduler no longer loads every task instance into memory. `State.unfinished` still contains `None`, but SQL `IN` doesn't match `NULL`. The scheduler cannot update the task instances to the latest Dag version that have not been scheduled yet.

## How

- Use the same guard in other call sites like taskmap, taskinstance: `or_(TI.state.is_(None), TI.state.in_(State.unfinished))`.

## Verification

- `uv run --project airflow-core pytest airflow-core/tests/unit/jobs/test_scheduler_job.py -q`

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
