### PR TITLE
Contain remote log upload paths within base_log_folder

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/log/s3_task_handler.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/log/s3_task_handler.py
@@ -84,6 +84,18 @@ class S3RemoteLogIO(LoggingMixin):  # noqa: D101
             local_loc = self.base_log_folder.joinpath(path)
             remote_loc = os.path.join(self.remote_base, path)
 
+        # The log path is supplied by the caller and is not guaranteed to stay within
+        # ``base_log_folder``: ``joinpath`` and ``PurePath.relative_to`` are purely lexical and
+        # do not normalise ``..``. Without this check a traversing path would have its contents
+        # uploaded to the remote log store and, with ``delete_local_copy``, its parent directory
+        # removed. Mirrors the containment check in ``CloudWatchRemoteLogIO.upload``.
+        base = self.base_log_folder.resolve()
+        try:
+            local_loc.resolve().relative_to(base)
+        except ValueError:
+            self.log.warning("Skipping upload: path %s is outside base_log_folder %s", local_loc, base)
+            return
+
         if local_loc.is_file():
             # read log and remove old logs to get just the latest additions
             log = local_loc.read_text()

--- a/providers/amazon/tests/unit/amazon/aws/log/test_s3_task_handler.py
+++ b/providers/amazon/tests/unit/amazon/aws/log/test_s3_task_handler.py
@@ -538,3 +538,26 @@ class TestS3TaskHandler:
     def test_filename_template_for_backward_compatibility(self):
         # filename_template arg support for running the latest provider on airflow 2
         S3TaskHandler(self.local_log_location, self.remote_log_base, filename_template=None)
+
+
+def test_upload_skips_path_outside_base_log_folder(tmp_path, caplog):
+    """A traversing log path is refused before the file is read or its parent removed.
+
+    ``base_log_folder.joinpath(path)`` is purely lexical, so a ``..``-bearing relative path
+    escapes the log folder. Without the containment check the file would be uploaded to the
+    remote log store and, with ``delete_local_copy``, its parent directory deleted.
+    """
+    base = tmp_path / "logs"
+    base.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "secret.log"
+    secret.write_text("sensitive")
+
+    subject = S3RemoteLogIO(remote_base="s3://bucket/remote", base_log_folder=base, delete_local_copy=True)
+    with caplog.at_level(logging.WARNING):
+        subject.upload(os.path.join("..", "outside", "secret.log"))
+
+    assert secret.exists()
+    assert outside.exists()
+    assert "outside base_log_folder" in caplog.text

--- a/providers/google/src/airflow/providers/google/cloud/log/gcs_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/gcs_task_handler.py
@@ -107,6 +107,18 @@ class GCSRemoteLogIO(LoggingMixin):  # noqa: D101
             local_loc = self.base_log_folder.joinpath(path)
             remote_loc = os.path.join(self.remote_base, path)
 
+        # The log path is supplied by the caller and is not guaranteed to stay within
+        # ``base_log_folder``: ``joinpath`` and ``PurePath.relative_to`` are purely lexical and
+        # do not normalise ``..``. Without this check a traversing path would have its contents
+        # uploaded to the remote log store and, with ``delete_local_copy``, its parent directory
+        # removed. Mirrors the containment check in ``CloudWatchRemoteLogIO.upload``.
+        base = self.base_log_folder.resolve()
+        try:
+            local_loc.resolve().relative_to(base)
+        except ValueError:
+            self.log.warning("Skipping upload: path %s is outside base_log_folder %s", local_loc, base)
+            return
+
         if local_loc.is_file():
             # read log and remove old logs to get just the latest additions
             log = local_loc.read_text()

--- a/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
@@ -727,3 +727,26 @@ class TestGCSRemoteLogIOMisconfiguredConn:
             "remote_log_conn_id" in r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
         )
         mock_hook.assert_not_called()
+
+
+def test_upload_skips_path_outside_base_log_folder(tmp_path, caplog):
+    """A traversing log path is refused before the file is read or its parent removed.
+
+    ``base_log_folder.joinpath(path)`` is purely lexical, so a ``..``-bearing relative path
+    escapes the log folder. Without the containment check the file would be uploaded to the
+    remote log store and, with ``delete_local_copy``, its parent directory deleted.
+    """
+    base = tmp_path / "logs"
+    base.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "secret.log"
+    secret.write_text("sensitive")
+
+    subject = GCSRemoteLogIO(remote_base="gs://bucket/remote", base_log_folder=base, delete_local_copy=True)
+    with caplog.at_level(logging.WARNING):
+        subject.upload(os.path.join("..", "outside", "secret.log"))
+
+    assert secret.exists()
+    assert outside.exists()
+    assert "outside base_log_folder" in caplog.text

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/log/wasb_task_handler.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/log/wasb_task_handler.py
@@ -89,6 +89,18 @@ class WasbRemoteLogIO(LoggingMixin):  # noqa: D101
             local_loc = self.base_log_folder.joinpath(path)
             remote_loc = os.path.join(self.remote_base, path)
 
+        # The log path is supplied by the caller and is not guaranteed to stay within
+        # ``base_log_folder``: ``joinpath`` and ``PurePath.relative_to`` are purely lexical and
+        # do not normalise ``..``. Without this check a traversing path would have its contents
+        # uploaded to the remote log store and, with ``delete_local_copy``, its parent directory
+        # removed. Mirrors the containment check in ``CloudWatchRemoteLogIO.upload``.
+        base = self.base_log_folder.resolve()
+        try:
+            local_loc.resolve().relative_to(base)
+        except ValueError:
+            self.log.warning("Skipping upload: path %s is outside base_log_folder %s", local_loc, base)
+            return
+
         if local_loc.is_file():
             # read log and remove old logs to get just the latest additions
             log = local_loc.read_text()

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/log/test_wasb_task_handler.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/log/test_wasb_task_handler.py
@@ -465,3 +465,31 @@ class TestWasbTaskHandler:
             delete_local_copy=True,
             filename_template=None,
         )
+
+
+def test_upload_skips_path_outside_base_log_folder(tmp_path, caplog):
+    """A traversing log path is refused before the file is read or its parent removed.
+
+    ``base_log_folder.joinpath(path)`` is purely lexical, so a ``..``-bearing relative path
+    escapes the log folder. Without the containment check the file would be uploaded to the
+    remote log store and, with ``delete_local_copy``, its parent directory deleted.
+    """
+    base = tmp_path / "logs"
+    base.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "secret.log"
+    secret.write_text("sensitive")
+
+    subject = WasbRemoteLogIO(
+        remote_base="remote/log/location",
+        base_log_folder=base,
+        delete_local_copy=True,
+        wasb_container="container",
+    )
+    with caplog.at_level(logging.WARNING):
+        subject.upload(os.path.join("..", "outside", "secret.log"))
+
+    assert secret.exists()
+    assert outside.exists()
+    assert "outside base_log_folder" in caplog.text


### PR DESCRIPTION
## Why

`S3RemoteLogIO.upload`, `GCSRemoteLogIO.upload` and `WasbRemoteLogIO.upload` build the local log path as `base_log_folder.joinpath(path)`, then read that file and — when `delete_local_copy` is set — `shutil.rmtree(os.path.dirname(local_loc))`.

`joinpath` and `PurePath.relative_to` are purely **lexical**: neither normalises `..`. A relative log path containing `..` therefore resolves outside `base_log_folder`, so its contents get uploaded to the remote log store and its parent directory gets removed.

`CloudWatchRemoteLogIO.upload`, in the same package, already guards exactly this operation:

```python
base = self.base_log_folder.resolve()
local_path = (raw if raw.is_absolute() else base / raw).resolve()
try:
    local_path.relative_to(base)
except ValueError:
    self.log.warning("Skipping deletion: path %s is outside base_log_folder %s", local_path, base)
    return
```

So the correct behaviour is already established here — three of the four remote log handlers just don't have it. This makes them consistent.

## What

- Add a `resolve()` + `relative_to(base_log_folder)` containment check to `upload()` in the S3, GCS and WASB remote log handlers, skipping with a warning when the path escapes — mirroring the CloudWatch handler.
- The check runs **before** the file is read, so it covers both the read/upload and the `delete_local_copy` deletion.
- Add a test to each of the three provider test suites covering the traversing path and asserting the file and its parent survive.

## Compatibility

No behaviour change for paths that resolve inside `base_log_folder`. That explicitly includes relative paths with internal `..` segments that stay within the folder (e.g. `dag_id=a/../1.log`), and absolute paths inside the folder — both verified.

## Testing

`moto` and the other provider test dependencies aren't available in my local environment, so I could not execute the three provider suites — **CI needs to run them.** What I did verify locally:

- `py_compile` and `ruff check` clean on all six changed files.
- The containment arithmetic itself, exercised against real temporary directories across six cases: normal relative path (allowed), `..` traversal (blocked), deep traversal (blocked), absolute inside base (allowed), absolute outside base (blocked), and internal `..` staying inside (allowed — confirming no false positives on legitimate paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)