### PR TITLE
Drop connection-supplied HTTP headers on cross-host redirects

### DIFF
--- a/providers/http/src/airflow/providers/http/hooks/http.py
+++ b/providers/http/src/airflow/providers/http/hooks/http.py
@@ -120,6 +120,34 @@ def _retryable_error_async(exception: BaseException) -> bool:
     return exception.status >= 500
 
 
+class _ConnectionHeaderSession(Session):
+    """
+    A :class:`~requests.Session` that drops connection-supplied headers across hosts.
+
+    ``requests`` removes only the ``Authorization`` header when a redirect crosses to a
+    different host (see :meth:`requests.Session.rebuild_auth`). Credentials placed in a
+    connection's ``extra`` field — the documented way to supply them — commonly use other
+    header names such as ``X-API-Key``, and those would otherwise be replayed verbatim to
+    whatever host a redirect points at.
+
+    Only headers that came from the connection are dropped; headers passed explicitly by
+    the caller are left alone, since the caller controls the request either way.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.connection_header_keys: set[str] = set()
+
+    def rebuild_auth(self, prepared_request, response):
+        """Strip connection-supplied headers when the redirect changes host."""
+        super().rebuild_auth(prepared_request, response)
+        if not self.connection_header_keys:
+            return
+        if self.should_strip_auth(response.request.url, prepared_request.url):
+            for header in self.connection_header_keys:
+                prepared_request.headers.pop(header, None)
+
+
 class HttpHook(BaseHook):
     """
     Interact with HTTP servers.
@@ -196,7 +224,7 @@ class HttpHook(BaseHook):
         :param extra_options: additional options to be used when executing the request
         :return: A configured requests.Session object.
         """
-        session = Session()
+        session: Session = _ConnectionHeaderSession()
         connection = self.get_connection(self.http_conn_id)
         self._set_base_url(connection)
         session = self._configure_session_from_auth(session, connection)  # type: ignore[arg-type]
@@ -268,6 +296,11 @@ class HttpHook(BaseHook):
             session.headers.update(conn_extra_options)
         except TypeError:
             self.log.warning("Connection to %s has invalid extra field.", connection.host)
+        else:
+            if isinstance(session, _ConnectionHeaderSession):
+                # Remember which headers came from the connection so they can be dropped
+                # if a redirect crosses to a different host.
+                session.connection_header_keys.update(conn_extra_options)
 
         return session
 

--- a/providers/http/tests/unit/http/hooks/test_http.py
+++ b/providers/http/tests/unit/http/hooks/test_http.py
@@ -35,7 +35,12 @@ from requests.models import DEFAULT_REDIRECT_LIMIT
 
 from airflow.models import Connection
 from airflow.providers.common.compat.sdk import AirflowException
-from airflow.providers.http.hooks.http import HttpAsyncHook, HttpHook, _process_extra_options_from_connection
+from airflow.providers.http.hooks.http import (
+    HttpAsyncHook,
+    HttpHook,
+    _ConnectionHeaderSession,
+    _process_extra_options_from_connection,
+)
 
 from tests_common.test_utils.aiohttp import MockAiohttpClientResponse
 
@@ -898,3 +903,61 @@ class TestHttpAsyncHook:
             async with aiohttp.ClientSession() as session:
                 await hook.run(session=session, endpoint="test.com:8080/v1/test")
                 assert mocked_function.call_args.args[0] == "http://test.com:8080/v1/test"
+
+
+class TestConnectionHeadersAcrossRedirects:
+    """Connection-supplied headers must not follow a redirect to a different host.
+
+    ``requests`` strips only ``Authorization`` (``Session.rebuild_auth``), so a credential
+    carried in a differently-named header — the documented ``extra``-field pattern — would
+    otherwise be replayed to whatever host the redirect points at.
+    """
+
+    @staticmethod
+    def _redirect(session, old_url, new_url):
+        original = requests.Request("GET", old_url).prepare()
+        response = Response()
+        response.request = original
+        prepared = requests.Request("GET", new_url).prepare()
+        prepared.headers.update(session.headers)
+        session.rebuild_auth(prepared, response)
+        return prepared.headers
+
+    def test_connection_headers_dropped_on_cross_host_redirect(self):
+        session = _ConnectionHeaderSession()
+        session.headers.update({"X-API-Key": "secret", "Accept": "application/json"})
+        session.connection_header_keys.update({"X-API-Key", "Accept"})
+
+        headers = self._redirect(session, "https://original.example.com/a", "https://evil.example.com/b")
+
+        assert "X-API-Key" not in headers
+        assert "Accept" not in headers
+
+    def test_connection_headers_kept_on_same_host_redirect(self):
+        session = _ConnectionHeaderSession()
+        session.headers.update({"X-API-Key": "secret"})
+        session.connection_header_keys.update({"X-API-Key"})
+
+        headers = self._redirect(session, "https://example.com/a", "https://example.com/b")
+
+        assert headers["X-API-Key"] == "secret"
+
+    def test_caller_supplied_headers_are_not_dropped(self):
+        """Only headers that came from the connection are stripped."""
+        session = _ConnectionHeaderSession()
+        session.headers.update({"X-Caller": "kept"})
+
+        headers = self._redirect(session, "https://original.example.com/a", "https://evil.example.com/b")
+
+        assert headers["X-Caller"] == "kept"
+
+    @mock.patch(
+        "airflow.providers.http.hooks.http.HttpHook.get_connection",
+        side_effect=get_airflow_connection_with_extra({"X-API-Key": "secret"}),
+    )
+    def test_get_conn_records_connection_header_keys(self, mock_get_connection):
+        hook = HttpHook()
+        session = hook.get_conn()
+
+        assert isinstance(session, _ConnectionHeaderSession)
+        assert "X-API-Key" in session.connection_header_keys

--- a/providers/http/tests/unit/http/sensors/test_http.py
+++ b/providers/http/tests/unit/http/sensors/test_http.py
@@ -285,7 +285,7 @@ class FakeSession:
 
 
 class TestHttpOpSensor:
-    @mock.patch("airflow.providers.http.hooks.http.Session", FakeSession)
+    @mock.patch("airflow.providers.http.hooks.http._ConnectionHeaderSession", FakeSession)
     def test_get(self):
         op = HttpOperator(
             task_id="get_op",
@@ -296,7 +296,7 @@ class TestHttpOpSensor:
         )
         op.execute({})
 
-    @mock.patch("airflow.providers.http.hooks.http.Session", FakeSession)
+    @mock.patch("airflow.providers.http.hooks.http._ConnectionHeaderSession", FakeSession)
     def test_get_response_check(self):
         op = HttpOperator(
             task_id="get_op",
@@ -309,7 +309,7 @@ class TestHttpOpSensor:
         op.execute({})
 
     @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Test only for Airflow 3.0+")
-    @mock.patch("airflow.providers.http.hooks.http.Session", FakeSession)
+    @mock.patch("airflow.providers.http.hooks.http._ConnectionHeaderSession", FakeSession)
     def test_sensor(self, run_task):
         sensor = HttpSensor(
             task_id="http_sensor_check",
@@ -327,7 +327,7 @@ class TestHttpOpSensor:
         assert run_task.error is None
 
     @pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="Test only for Airflow < 3.0")
-    @mock.patch("airflow.providers.http.hooks.http.Session", FakeSession)
+    @mock.patch("airflow.providers.http.hooks.http._ConnectionHeaderSession", FakeSession)
     def test_sensor_af2(self):
         dag = DAG(TEST_DAG_ID, schedule=None)
         sensor = HttpSensor(


### PR DESCRIPTION
## Why

`HttpHook.get_conn` applies every unrecognised key from a connection's `extra` field as a persistent session header:

```python
session.headers.update(conn_extra_options)   # _configure_session_from_extra
```

and the hook's own docstring documents that field as the place to put them — *"headers can also be specified in the Extra field in json format"*.

`requests` removes only the `Authorization` header when a redirect crosses to a different host (`Session.rebuild_auth` → `should_strip_auth`). A credential carried under any **other** header name — `X-API-Key`, `X-Auth-Token` and similar, which is exactly what the documented `extra`-field pattern produces — stays on the session and is replayed verbatim to whatever host the redirect points at. Redirects are followed by default (`session.max_redirects = DEFAULT_REDIRECT_LIMIT`).

## What

- Add `_ConnectionHeaderSession`, a `requests.Session` subclass that records which header names came from the connection and drops **only those** when `should_strip_auth()` reports the redirect is cross-origin.
- Use it in `get_conn`, and populate `connection_header_keys` where the extra-field headers are applied.
- Tests covering cross-host stripping, same-host preservation, caller-supplied headers being left alone, and the keys being recorded through `get_conn`.

Delegating the decision to `requests`' own `should_strip_auth()` means an `https` → `http` downgrade on the same host is covered too, without duplicating that logic.

## Compatibility

- Headers passed explicitly by the caller (`get_conn(headers=...)`, `default_headers`) are **not** affected — the caller controls the request either way.
- Same-host redirects are unchanged.
- Only connection-`extra`-derived headers are dropped, and only on a cross-origin hop.

## Testing

Verified locally against real `requests`, all five cases passing: cross-host connection header dropped, same-host preserved, caller-supplied header preserved, `Authorization` still stripped by `requests` itself, and same-host `https`→`http` downgrade stripped.

**The provider test suite could not be executed in my environment** — a local editable-install issue unrelated to this change prevented `airflow` from importing. `ruff check` and `ruff format --check` are clean, and `py_compile` passes on both files, but **CI needs to run `providers/http` tests.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)