### PR TITLE
Escape values interpolated into Google Drive q= queries

### DIFF
--- a/providers/google/src/airflow/providers/google/suite/hooks/drive.py
+++ b/providers/google/src/airflow/providers/google/suite/hooks/drive.py
@@ -29,6 +29,19 @@ from googleapiclient.http import HttpRequest, MediaFileUpload
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 
 
+def _escape_drive_query_value(value: str) -> str:
+    r"""
+    Escape a value for interpolation into a Drive ``q=`` string literal.
+
+    The Drive query language delimits string literals with single quotes and escapes
+    ``'`` and ``\\`` with a backslash. Values reaching these queries are frequently
+    object names taken from a source bucket listing rather than written by hand, so a
+    quote in the value is ordinary input; left unescaped it ends the literal early and
+    the expression no longer means what the caller intended.
+    """
+    return str(value).replace("\\", "\\\\").replace("'", "\\'")
+
+
 class GoogleDriveHook(GoogleBaseHook):
     """
     Hook for the Google Drive APIs.
@@ -87,8 +100,8 @@ class GoogleDriveHook(GoogleBaseHook):
             conditions = [
                 "trashed=false",
                 "mimeType='application/vnd.google-apps.folder'",
-                f"name='{current_folder}'",
-                f"'{current_parent}' in parents",
+                f"name='{_escape_drive_query_value(current_folder)}'",
+                f"'{_escape_drive_query_value(current_parent)}' in parents",
             ]
             result = (
                 service.files()
@@ -223,9 +236,9 @@ class GoogleDriveHook(GoogleBaseHook):
 
         :return: Google Drive file id if the file exists, otherwise None
         """
-        query = f"name = '{file_name}'"
+        query = f"name = '{_escape_drive_query_value(file_name)}'"
         if folder_id:
-            query += f" and '{folder_id}' in parents"
+            query += f" and '{_escape_drive_query_value(folder_id)}' in parents"
 
         if not include_trashed:
             query += " and trashed=false"

--- a/providers/google/tests/unit/google/suite/hooks/test_drive.py
+++ b/providers/google/tests/unit/google/suite/hooks/test_drive.py
@@ -21,7 +21,7 @@ from unittest import mock
 
 import pytest
 
-from airflow.providers.google.suite.hooks.drive import GoogleDriveHook
+from airflow.providers.google.suite.hooks.drive import GoogleDriveHook, _escape_drive_query_value
 
 from unit.google.cloud.utils.base_gcp_mock import GCP_CONNECTION_WITH_PROJECT_ID
 
@@ -523,3 +523,71 @@ class TestGoogleDriveHook:
         )
         mock_execute.assert_called_once()
         assert result == {"id": "NEW_FILE_ID", "webViewLink": "https://example.com/view"}
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("plain.csv", "plain.csv"),
+        ("o'brien.csv", "o\\'brien.csv"),
+        ("back\\slash", "back\\\\slash"),
+        ("x' or name!='", "x\\' or name!=\\'"),
+    ],
+)
+def test_escape_drive_query_value(raw, expected):
+    """Quotes and backslashes are escaped; backslashes first so the quote-escape is not doubled."""
+    assert _escape_drive_query_value(raw) == expected
+
+
+@pytest.mark.db_test
+class TestDriveQueryQuoting:
+    """Names containing quotes are carried through the ``q=`` expression intact.
+
+    Names routinely come from a bucket listing rather than being written by hand, so a
+    quote in one is ordinary input and must not change how the expression parses.
+    """
+
+    def setup_method(self):
+        self.patcher_get_connection = mock.patch(
+            f"{BASEHOOK_PATCH_PATH}.get_connection", return_value=GCP_CONNECTION_WITH_PROJECT_ID
+        )
+        self.patcher_get_connection.start()
+        self.gdrive_hook = GoogleDriveHook(gcp_conn_id="test")
+
+    def teardown_method(self) -> None:
+        self.patcher_get_connection.stop()
+
+    @mock.patch("airflow.providers.google.suite.hooks.drive.GoogleDriveHook.get_conn")
+    def test_get_file_id_escapes_quote_in_file_name(self, mock_get_conn):
+        mock_list = mock_get_conn.return_value.files.return_value.list
+        mock_list.return_value.execute.side_effect = [{"files": []}]
+
+        self.gdrive_hook.get_file_id("folder1", "evil' or name!='")
+
+        query = mock_list.call_args.kwargs["q"]
+        assert query == r"name = 'evil\' or name!=\'' and 'folder1' in parents"
+
+    @mock.patch("airflow.providers.google.suite.hooks.drive.GoogleDriveHook.get_conn")
+    def test_get_file_id_escapes_quote_in_folder_id(self, mock_get_conn):
+        mock_list = mock_get_conn.return_value.files.return_value.list
+        mock_list.return_value.execute.side_effect = [{"files": []}]
+
+        self.gdrive_hook.get_file_id("evil' or name!='", "file1")
+
+        query = mock_list.call_args.kwargs["q"]
+        assert query == r"name = 'file1' and 'evil\' or name!=\'' in parents"
+
+    @mock.patch("airflow.providers.google.suite.hooks.drive.GoogleDriveHook.get_conn")
+    def test_ensure_folders_exists_escapes_quote_in_folder_name(self, mock_get_conn):
+        mock_list = mock_get_conn.return_value.files.return_value.list
+        mock_list.return_value.execute.side_effect = [
+            {"files": [{"id": "ID_1", "name": "x"}]},
+        ]
+
+        self.gdrive_hook._ensure_folders_exists("evil' or name!='", "root")
+
+        query = mock_list.call_args.kwargs["q"]
+        assert query == (
+            "trashed=false and mimeType='application/vnd.google-apps.folder' "
+            r"and name='evil\' or name!=\'' and 'root' in parents"
+        )


### PR DESCRIPTION
## Why

`GoogleDriveHook` builds Drive search expressions by interpolating names directly into single-quoted string literals:

```python
# _ensure_folders_exists
f"name='{current_folder}'"
f"'{current_parent}' in parents"

# get_file_id
query = f"name = '{file_name}'"
query += f" and parents in '{folder_id}'"
```

The Drive query language delimits string literals with single quotes and escapes `'` and `\` with a backslash. Neither call site escapes either character, so a name containing a quote ends the literal early and the expression stops meaning what the caller asked for.

Names routinely arrive from a bucket listing rather than being typed by hand — a wildcard `gcs_to_gdrive` transfer passes through whatever object names the bucket happens to contain — so quotes in them are ordinary input, not an exotic case.

## What

- Add `_escape_drive_query_value()` and route all four interpolations through it.
- Backslashes are escaped **before** quotes, so the backslash introduced by the quote escape is not itself doubled.
- Tests: a parametrised check of the escaping itself, plus two asserting the built `q=` expression for `get_file_id` and `_ensure_folders_exists`.

A single shared helper rather than escaping at each site, since there are four interpolations across two methods and the next one added would otherwise be easy to miss.

## Compatibility

No change for names without `'` or `\` — the overwhelming majority. Names that previously produced a malformed expression now produce a correct one.

## Testing

Escaping verified locally across `plain.csv`, `o'brien.csv`, a backslash-containing name, and a name with an embedded quote-and-clause, including the backslash-ordering case.

`ruff check` and `ruff format` are clean and `py_compile` passes, but **the provider test suite could not be executed in my environment** (an unrelated local editable-install problem prevented importing `airflow`), so **CI needs to run `providers/google`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)