### PR TITLE
Use RELEASE_DATE for the provider testing issue title

### DIFF
--- a/dev/README_RELEASE_PROVIDERS.md
+++ b/dev/README_RELEASE_PROVIDERS.md
@@ -924,8 +924,11 @@ unchecked). If the issue was already created, apply the same local edit and then
 Once you are satisfied with `files/provider_issue.md` (and any checkmarks have been carried over), create the issue from the file:
 
 ```shell script
+# Fill prepared-on date by hand when RELEASE_DATE is unset, since an empty date formats as *today* on GNU date.
+date_cmd=(date -d); [[ "${OSTYPE}" == *darwin* ]] && date_cmd=(date -j -f "%Y-%m-%d")
+PREPARED_ON="<MONTH DD, YYYY>"; [[ -n "${RELEASE_DATE:-}" ]] && PREPARED_ON=$("${date_cmd[@]}" "${RELEASE_DATE%%_*}" +'%B %d, %Y')
 gh issue create --repo apache/airflow \
-    --title "Status of testing Providers that were prepared on <MONTH DD, YYYY>" \
+    --title "Status of testing Providers that were prepared on ${PREPARED_ON}" \
     --body-file files/provider_issue.md --label "testing status,kind:meta"
 ```
 


### PR DESCRIPTION
The testing-status issue title is `Status of testing Providers that were prepared on <date>`, where the date identifies the wave. The documented `gh issue create` command left it as a `<MONTH DD, YYYY>` placeholder to fill in by hand, so in practice it gets typed from today's date — which is not necessarily the wave's date. The two diverge whenever issue creation slips past midnight, or a wave is re-cut and the issue is regenerated a day later, leaving the issue naming a different wave than the one being tested and voted on.

`RELEASE_DATE` is already exported by the release manager at the start of the process and is the canonical wave identifier, so this derives the title from it, stripping the optional `_NN` wave suffix. The `OSTYPE` split follows the same pattern the vote-email step in this document already uses for `date`.

**Tested:** ran both branches' formatting locally — `2026-08-25` and `2026-08-25_01` both yield `Status of testing Providers that were prepared on August 25, 2026`, byte-identical to the title of the issue created for the current wave (#72117) and to what `breeze release-management generate-issue-content-providers` prints. `prek run --from-ref upstream/main --stage pre-commit` is clean.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Kiro CLI (claude-fable-5)

Generated-by: Kiro CLI (claude-fable-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)