### PR TITLE
Document scope boundaries the security model leaves implicit

### DIFF
--- a/airflow-core/docs/security/security_model.rst
+++ b/airflow-core/docs/security/security_model.rst
@@ -567,6 +567,19 @@ model — Airflow does not enforce these natively.
      be available to components that need to generate tokens (Scheduler/Executor, API Server) and
      components that need to validate tokens (API Server). Workers should not have access to the signing
      key — they only need the tokens provided to them.
+
+     **Exception — remote edge workers.** The ``edge3`` provider's worker signs its own API requests, so
+     every host running an edge worker must be provisioned with ``[api_auth] jwt_secret``. There is no
+     asymmetric alternative on that path, and no arrangement in which the worker is issued a token by
+     the API server instead: the worker has to authenticate to the Edge API before it can be given
+     any workload, so it must already hold a credential at that point. Provisioning the signing key on
+     the host is what satisfies that bootstrap. In symmetric mode this is the same secret used to sign user
+     JWTs and Execution API task tokens, so a deployment running edge workers cannot satisfy the
+     guidance above, and the assurance in *Token signing key might be a shared secret* below — which is
+     conditioned on the secret being available only to the API server and scheduler — does not hold for
+     it. Deployment Managers should treat edge-worker hosts as part of the control-plane trust boundary,
+     or accept that compromise of any edge-worker host is equivalent to compromise of the deployment's
+     token-signing capability.
    * Connection credentials for external systems (via Secrets Managers) should only be available to the API Server
      (which serves them to workers via the Execution API), not to the Scheduler, Dag File Processor,
      or Triggerer processes directly. This however limits some of the features of Airflow - such as Deadline
@@ -983,9 +996,23 @@ team's connection" are describing a known limitation of the current isolation mo
 Execution API tokens not being revocable
 ........................................
 
-Execution API tokens issued to workers are short-lived (default 10 minutes) with automatic refresh
-and are intentionally not subject to revocation. This is a design choice documented in
-:doc:`/security/jwt_token_authentication`, not a missing security control.
+Execution API tokens issued to workers have a short nominal lifetime (default 10 minutes) with
+automatic refresh, and are intentionally not subject to revocation. This is a design choice documented
+in :doc:`/security/jwt_token_authentication`, not a missing security control.
+
+Deployment Managers should read the two properties together rather than separately. Refresh re-issues
+a token from its own claims, so a holder who keeps presenting a token keeps extending it: the nominal
+lifetime bounds only a holder who *stops* using it. Combined with the absence of revocation, this means a token
+that leaks — through a log, a process listing, or a compromised worker — remains usable for as long as
+its holder continues to present it, and cannot be withdrawn. The ten-minute figure is not a bound on
+exposure after a leak.
+
+Refresh is also not tied to the task's lifecycle: the reissue path validates the token's signature and
+expiry but does not consult the database, so a token naming a task instance that has finished, or whose
+row has been archived, still refreshes. Reports of this specific behaviour are treated as hardening
+opportunities rather than vulnerabilities, and contributions binding reissue to task state are welcome
+through the normal process. Deployments requiring a hard bound on credential lifetime should rely on
+network isolation of workers rather than on token expiry.
 
 Connection configuration capabilities
 ......................................
@@ -997,6 +1024,18 @@ design — connection configuration users are highly privileged and must be trus
 capabilities. The ``test connection`` feature is disabled by default since Airflow 2.7.0, and enabling
 it is an explicit Deployment Manager decision that acknowledges these risks. See
 :ref:`connection-configuration-users` for details.
+
+The boundary of this grant is **worker-context execution and the connection values the role may
+write**. A connection configuration user causing code to run on a worker, or influencing a client
+library's behaviour through connection parameters, is exercising a documented capability and is not a
+vulnerability — even where the mechanism looks like injection.
+
+What this grant does **not** include is obtaining credential material the role is not entitled to
+read, or reaching a component the role has no execution rights over. The role has write-only access to
+stored credentials, so a defect that lets a connection configuration user *recover* a secret, or that
+causes code to execute in the Scheduler or API server rather than on a worker, crosses the boundary and
+**is** a vulnerability. The distinguishing question is not the role, which is privileged either way,
+but whether the defect yields something the role could not already obtain.
 
 Denial of Service by authenticated users
 ........................................
@@ -1048,6 +1087,97 @@ significantly from typical web applications — many scanner findings (such as "
 code" or "database credentials accessible in configuration") are expected behavior. Reports must
 include a proof-of-concept that demonstrates how the finding violates the security model described
 in this document, including identifying the specific user role involved and the attack scenario.
+
+Client libraries and caller-supplied values
+...........................................
+
+The Apache Airflow Python Client, and other client libraries the project publishes, are **libraries**.
+They act on values their calling application supplies and have no basis on which to decide that one
+caller-supplied string is trusted and another is not.
+
+Reports that an embedding application can cause a client library to misbehave by passing it untrusted
+or malformed input — an attacker-influenced path parameter, a configuration value of the wrong type, a
+plaintext scheme chosen for a remote host, or configuration mutated after the client was constructed —
+describe a decision the calling application made. The trust boundary sits in that application, not in
+the library. This mirrors the position taken for Dag authors passing unsanitized input to operators
+and hooks.
+
+A defect in a client library **is** in scope when it misbehaves on input the calling application
+supplied correctly — for example if a value the library itself documents as safe is mishandled, or if
+the library silently ignores a security-relevant setting the caller did set.
+
+Experimental and alpha features
+................................
+
+Features the project documents as experimental, alpha, or preview do not yet carry security
+guarantees, and defects confined to them are not treated as production security vulnerabilities.
+This includes, at the time of writing, multi-team mode and executors marked alpha in their provider
+documentation.
+
+Such defects are still worth fixing and are welcome as public contributions; they are simply not
+handled through the security process, and no advisory is issued. When a feature graduates out of
+experimental status, previously deferred issues affecting it should be reassessed on their merits at
+that point.
+
+Request size limits and other reverse-proxy responsibilities
+.............................................................
+
+Airflow's API server is an ASGI application. Like any such application, it reads a request body into
+memory before dispatching to a handler, and it does not impose a limit on request size. Bounding
+request size, connection rates, and total concurrent connections is the responsibility of the
+terminating reverse proxy or ingress — ``client_max_body_size`` in nginx, ``max_request_bytes`` in
+Envoy, or the equivalent in the deployment's chosen load balancer.
+
+Reports that an unauthenticated client can cause the API server to allocate memory by sending a large
+request body, including to endpoints that must be reachable without credentials such as the login
+route, describe this property. They are not treated as vulnerabilities in Airflow. Note that this
+holds regardless of whether the request is authenticated: it is a distinct point from the
+*Denial of Service by authenticated users* carve-out above, and applies to unauthenticated requests
+as well.
+
+Deployment Managers should ensure a request-size limit is configured at the proxy layer. Airflow is
+not intended to be exposed directly to untrusted networks.
+
+Issues only reachable on end-of-life Airflow versions
+......................................................
+
+Security advisories are issued for release lines that still receive releases. A defect reachable only
+on a line that has reached end of life is not handled through the security process, because there is
+no release in which to ship a fix.
+
+This holds even when a provider package that still installs on that line contains the affected code:
+a provider continuing to support an end-of-life core does not extend security support to that core.
+Users on an end-of-life line should upgrade.
+
+Params and schema validation
+.............................
+
+Airflow's params schema validation is a correctness and usability feature. It is not a security
+control, and it is not relied upon to enforce any trust boundary.
+
+In particular, an operator that declares no params has opted out of validation for that field; it has
+not asserted that the field will be empty. Reports that unchecked data can be supplied where no
+schema was declared describe the absence of a control that was never claimed.
+
+Impersonation and Dag file parsing
+..................................
+
+``run_as_user`` confines task **execution** to a different Unix user. It does not confine Dag file
+**import**.
+
+The effective ``run_as_user`` value is itself Dag-author-controlled — it can be set on the Dag or on
+the task, overriding the deployment default. Airflow therefore cannot know which user to impersonate
+until it has parsed the Dag file, and parsing a Dag file executes its module-level code. That code
+runs as the worker's own Unix user, before any impersonation takes place.
+
+This ordering follows from where the setting lives, not from an oversight, and it cannot be reversed
+without moving the setting somewhere the worker can read before parsing. Reports that module-level
+Dag code executes as the worker user prior to impersonation describe expected behaviour.
+
+Deployment Managers using ``run_as_user`` to confine Dag authors should read it as constraining what
+a task does once it runs, not as a sandbox around the Dag file. A deployment that also needs
+module-level Dag code confined must isolate the worker itself rather than rely on impersonation
+within it. See :ref:`workload-isolation` and the impersonation section of :doc:`/security/workload`.
 
 Supported deployment platforms
 ..............................

--- a/airflow-core/docs/security/workload.rst
+++ b/airflow-core/docs/security/workload.rst
@@ -52,7 +52,7 @@ not set.
     default_impersonation = airflow
 
 What impersonation does not cover
-''''''''''''''''''''''''''''''''
+'''''''''''''''''''''''''''''''''
 
 Impersonation applies to task **execution**. It does not apply to Dag file **parsing**.
 

--- a/airflow-core/docs/security/workload.rst
+++ b/airflow-core/docs/security/workload.rst
@@ -51,6 +51,24 @@ not set.
     [core]
     default_impersonation = airflow
 
+What impersonation does not cover
+''''''''''''''''''''''''''''''''
+
+Impersonation applies to task **execution**. It does not apply to Dag file **parsing**.
+
+``run_as_user`` can be set on the Dag or on the task, so it overrides ``default_impersonation``.
+Airflow cannot know which user to switch to until it has parsed the Dag file, and parsing a Dag file
+executes its module-level code. That code therefore runs as the worker's own unix user, before any
+``sudo -u`` takes place; the file is parsed a second time after the switch, as the impersonated user.
+
+So ``run_as_user`` and ``default_impersonation`` constrain what a task does once it runs. Neither
+isolates the Dag file itself, and neither can be made to without moving the setting somewhere the
+worker can read before parsing. If module-level Dag code also has to be confined, isolate the worker
+— for example by running untrusted Dag authors' workloads on separate workers — rather than relying
+on impersonation within a shared one.
+
+See :doc:`/security/security_model` for how this fits the overall trust boundaries.
+
 .. _workload-isolation:
 
 Workload Isolation and Current Limitations


### PR DESCRIPTION
## Why

The *What is NOT considered a security vulnerability* section of the security model opens by saying it is written for security researchers **and AI agents performing security analysis** to read before reporting. That framing is right, and it is increasingly load-bearing as automated analysis becomes a common source of reports.

Several recurring report shapes are not covered by it. Each currently costs a triage cycle to re-derive from first principles, and — because the reasoning ends up only in closed-issue discussions — it gets re-derived again next time. Writing the boundaries down is cheaper than answering them repeatedly, and lets a reporter self-serve before spending their own time on something out of scope.

## What

**Six new entries**, covering boundaries the project already applies in practice:

| Section | Boundary |
|---|---|
| Client libraries and caller-supplied values | A library acts on what its calling application passes it; that application owns the trust decision — the same position already taken for Dag authors passing unsanitized input to operators. Includes the converse: a library mishandling *correctly*-supplied input is in scope. |
| Experimental and alpha features | Features documented as experimental or alpha carry no guarantees yet. Worth fixing, but not handled through this process — with an explicit clause to reassess when a feature graduates. |
| Request size limits and other reverse-proxy responsibilities | Bounding request size belongs at the terminating proxy. Stated as **distinct** from the authenticated-DoS entry, since it applies to unauthenticated requests too, including endpoints that must be reachable without credentials. |
| Issues only reachable on end-of-life versions | No release in which to ship a fix — including where a provider package still installs on that line. |
| Params and schema validation | A correctness feature, not a control. Declaring no params opts out of validation rather than asserting the field will be empty. |
| Impersonation and Dag file parsing | `run_as_user` confines task **execution**, not Dag file **import**. |

The impersonation entry is worth expanding on, because it looks like a defect until you follow it through. `run_as_user` can be set on the Dag or the task, overriding `default_impersonation`, so Airflow cannot know which user to switch to until it has parsed the Dag file — and parsing executes the file's module-level code. That code therefore runs as the worker's own unix user, before any `sudo -u`. The ordering follows from where the setting lives, and cannot be reversed without moving the setting somewhere the worker can read before parsing.

Nothing currently says so, and a Deployment Manager would reasonably assume `run_as_user` confines all Dag-author code on the worker. The same text is added to `security/workload.rst`, directly under the impersonation instructions where someone configuring the feature will actually encounter it, and the two are cross-linked. It explicitly covers `default_impersonation` as well, which is equally overridable.

**Two existing entries clarified.**

*Connection configuration capabilities* currently reads, in effect, as "this role is privileged, so nothing counts." That is too broad in one direction and unhelpful in the other. The revision draws the line actually applied:

- **Within the grant** — worker-context execution, and the connection values the role may write, even where the mechanism resembles injection.
- **Outside it** — recovering credential material the role cannot read (the role has *write-only* access to stored credentials), or reaching a component it has no execution rights over.

The distinguishing question is what the defect *yields*, not which role holds it.

*Execution API tokens not being revocable* states a short nominal lifetime and non-revocability as two separate facts, which reads as though the ten-minute figure bounds exposure. Read together they do not. Refresh re-issues a token from its own claims, so the lifetime bounds only a holder who **stops** using the token; a token that leaks stays usable for as long as its holder keeps presenting it, and cannot be withdrawn. The revision says so plainly, and also records that the reissue path validates signature and expiry without consulting the database — so a token naming a finished or archived task instance still refreshes. That last behaviour is marked a hardening opportunity, with contributions welcome, rather than being left ambiguous.

**One limitation recorded.** The hardening guidance states workers must never hold the JWT signing key. The `edge3` worker signs its own API requests, so remote edge-worker hosts must be provisioned with `[api_auth] jwt_secret`, and there is no asymmetric alternative on that path.

The text also now states why there is no arrangement in which the edge worker is issued a token by the API server instead: the worker has to authenticate to the Edge API *before* it can be given any workload, so it must already hold a credential at that point. Provisioning the signing key on the host is what satisfies that bootstrap. An earlier draft of this section implied a fix was simply outstanding; it is a genuine constraint, and the text should not read as though it were being withheld.

That still voids the assurance in *Token signing key might be a shared secret*, which is explicitly conditioned on the secret reaching only the API server and scheduler. Deployment Managers should either treat edge-worker hosts as part of the control-plane trust boundary, or accept the equivalence knowingly.

## Notes

- Additions and clarifications only. No existing entry is narrowed, and nothing previously in scope moves out of it.
- The experimental-features entry deliberately defers rather than dismisses, via the graduation clause.
- Two files: `security/security_model.rst` and `security/workload.rst`. Cross-references use the existing `workload-isolation` label and `:doc:` targets; no new `:ref:` labels are introduced.
- RST heading/underline structure verified, and `docutils` parses both files with no new errors — the pre-existing ones are Sphinx-only roles and the `mermaid` directive, which bare docutils does not recognise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
