### PR TITLE
Stop Breeze container SSH setup from modifying the host ~/.ssh

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1303,15 +1303,35 @@ function environment_initialization() {
     ln -s -f /usr/bin/gcloud /usr/lib/google-cloud-sdk/bin/gcloud
 
     if [[ ${SKIP_SSH_SETUP="false"} == "false" ]]; then
-        # Set up ssh keys
-        echo 'yes' | ssh-keygen -t rsa -C your_email@youremail.com -m PEM -P '' -f ~/.ssh/id_rsa \
-            >"${AIRFLOW_HOME}/logs/ssh-keygen.log" 2>&1
+        # Set up the ssh-to-localhost plumbing used by the SSH/SFTP provider tests under a
+        # dedicated directory instead of ~/.ssh: `breeze --forward-credentials` bind-mounts
+        # the host's ~/.ssh at /root/.ssh and container startup must never modify it.
+        breeze_ssh_dir="/root/.breeze-ssh"
+        mkdir -p "${breeze_ssh_dir}"
+        chmod 700 "${breeze_ssh_dir}"
+        if [[ ! -f "${breeze_ssh_dir}/id_rsa" ]]; then
+            ssh-keygen -t rsa -C airflow-breeze-internal-key -m PEM -P '' -f "${breeze_ssh_dir}/id_rsa" \
+                >"${AIRFLOW_HOME}/logs/ssh-keygen.log" 2>&1
+        fi
+        cp "${breeze_ssh_dir}/id_rsa.pub" "${breeze_ssh_dir}/authorized_keys"
+        chmod 600 "${breeze_ssh_dir}/id_rsa" "${breeze_ssh_dir}/authorized_keys"
+        echo "AuthorizedKeysFile ${breeze_ssh_dir}/authorized_keys .ssh/authorized_keys" \
+            > /etc/ssh/sshd_config.d/airflow-breeze.conf
+        # The heredoc delimiter must not be "EOF": Dockerfile.ci inlines this script inside
+        # a COPY <<"EOF" heredoc and a bare EOF line would terminate it early.
+        cat > /etc/ssh/ssh_config.d/airflow-breeze.conf <<SSH_CONFIG
+Host localhost 127.0.0.1 ::1
+    IdentityFile ${breeze_ssh_dir}/id_rsa
+    UserKnownHostsFile ${breeze_ssh_dir}/known_hosts
+    StrictHostKeyChecking accept-new
+SSH_CONFIG
+        # Paramiko-based hooks do not read /etc/ssh/ssh_config.d but try ssh-agent keys by
+        # default, so expose the key through an agent. The fixed socket path lets shells
+        # entered via entrypoint_exec.sh (breeze exec) pick up the same agent.
+        rm -f "${breeze_ssh_dir}/agent.sock"
+        eval "$(ssh-agent -s -a "${breeze_ssh_dir}/agent.sock")" >/dev/null
+        ssh-add "${breeze_ssh_dir}/id_rsa" >>"${AIRFLOW_HOME}/logs/ssh-keygen.log" 2>&1
 
-        cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
-        ln -s -f ~/.ssh/authorized_keys ~/.ssh/authorized_keys2
-        chmod 600 ~/.ssh/*
-
-        # SSH Service
         sudo service ssh restart >/dev/null 2>&1
 
         # Sometimes the server is not quick enough to load the keys!
@@ -1320,7 +1340,7 @@ function environment_initialization() {
             sleep 0.05
         done
 
-        ssh-keyscan -H localhost >> ~/.ssh/known_hosts 2>/dev/null
+        ssh-keyscan -H localhost > "${breeze_ssh_dir}/known_hosts" 2>/dev/null
     fi
 
     if [[ ${INTEGRATION_LOCALSTACK:-"false"} == "true" ]]; then
@@ -1699,6 +1719,10 @@ COPY <<"EOF" /entrypoint_exec.sh
 . /opt/airflow/scripts/in_container/configure_environment.sh
 
 . /opt/airflow/scripts/in_container/run_init_script.sh
+
+if [[ -S /root/.breeze-ssh/agent.sock ]]; then
+    export SSH_AUTH_SOCK="/root/.breeze-ssh/agent.sock"
+fi
 
 exec /bin/bash "${@}"
 EOF

--- a/scripts/ci/docker-compose/forward-credentials.yml
+++ b/scripts/ci/docker-compose/forward-credentials.yml
@@ -21,6 +21,8 @@ services:
     # Useful for gcloud/aws/kubernetes etc. authorisation to be passed
     # To inside docker. Use with care - your credentials will be available to
     # everything you install in Docker.
+    # Container startup must never write into these directories - they are the
+    # user's real dotfiles (see the ssh setup in entrypoint_ci.sh).
     environment:
       - GITHUB_TOKEN
     volumes:

--- a/scripts/docker/entrypoint_ci.sh
+++ b/scripts/docker/entrypoint_ci.sh
@@ -169,15 +169,35 @@ function environment_initialization() {
     ln -s -f /usr/bin/gcloud /usr/lib/google-cloud-sdk/bin/gcloud
 
     if [[ ${SKIP_SSH_SETUP="false"} == "false" ]]; then
-        # Set up ssh keys
-        echo 'yes' | ssh-keygen -t rsa -C your_email@youremail.com -m PEM -P '' -f ~/.ssh/id_rsa \
-            >"${AIRFLOW_HOME}/logs/ssh-keygen.log" 2>&1
+        # Set up the ssh-to-localhost plumbing used by the SSH/SFTP provider tests under a
+        # dedicated directory instead of ~/.ssh: `breeze --forward-credentials` bind-mounts
+        # the host's ~/.ssh at /root/.ssh and container startup must never modify it.
+        breeze_ssh_dir="/root/.breeze-ssh"
+        mkdir -p "${breeze_ssh_dir}"
+        chmod 700 "${breeze_ssh_dir}"
+        if [[ ! -f "${breeze_ssh_dir}/id_rsa" ]]; then
+            ssh-keygen -t rsa -C airflow-breeze-internal-key -m PEM -P '' -f "${breeze_ssh_dir}/id_rsa" \
+                >"${AIRFLOW_HOME}/logs/ssh-keygen.log" 2>&1
+        fi
+        cp "${breeze_ssh_dir}/id_rsa.pub" "${breeze_ssh_dir}/authorized_keys"
+        chmod 600 "${breeze_ssh_dir}/id_rsa" "${breeze_ssh_dir}/authorized_keys"
+        echo "AuthorizedKeysFile ${breeze_ssh_dir}/authorized_keys .ssh/authorized_keys" \
+            > /etc/ssh/sshd_config.d/airflow-breeze.conf
+        # The heredoc delimiter must not be "EOF": Dockerfile.ci inlines this script inside
+        # a COPY <<"EOF" heredoc and a bare EOF line would terminate it early.
+        cat > /etc/ssh/ssh_config.d/airflow-breeze.conf <<SSH_CONFIG
+Host localhost 127.0.0.1 ::1
+    IdentityFile ${breeze_ssh_dir}/id_rsa
+    UserKnownHostsFile ${breeze_ssh_dir}/known_hosts
+    StrictHostKeyChecking accept-new
+SSH_CONFIG
+        # Paramiko-based hooks do not read /etc/ssh/ssh_config.d but try ssh-agent keys by
+        # default, so expose the key through an agent. The fixed socket path lets shells
+        # entered via entrypoint_exec.sh (breeze exec) pick up the same agent.
+        rm -f "${breeze_ssh_dir}/agent.sock"
+        eval "$(ssh-agent -s -a "${breeze_ssh_dir}/agent.sock")" >/dev/null
+        ssh-add "${breeze_ssh_dir}/id_rsa" >>"${AIRFLOW_HOME}/logs/ssh-keygen.log" 2>&1
 
-        cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
-        ln -s -f ~/.ssh/authorized_keys ~/.ssh/authorized_keys2
-        chmod 600 ~/.ssh/*
-
-        # SSH Service
         sudo service ssh restart >/dev/null 2>&1
 
         # Sometimes the server is not quick enough to load the keys!
@@ -186,7 +206,7 @@ function environment_initialization() {
             sleep 0.05
         done
 
-        ssh-keyscan -H localhost >> ~/.ssh/known_hosts 2>/dev/null
+        ssh-keyscan -H localhost > "${breeze_ssh_dir}/known_hosts" 2>/dev/null
     fi
 
     if [[ ${INTEGRATION_LOCALSTACK:-"false"} == "true" ]]; then

--- a/scripts/docker/entrypoint_exec.sh
+++ b/scripts/docker/entrypoint_exec.sh
@@ -24,4 +24,10 @@
 # shellcheck source=scripts/in_container/run_init_script.sh
 . /opt/airflow/scripts/in_container/run_init_script.sh
 
+# Reuse the ssh-agent started by entrypoint_ci.sh so that ssh-ing to localhost also
+# works in shells entered with `breeze exec`.
+if [[ -S /root/.breeze-ssh/agent.sock ]]; then
+    export SSH_AUTH_SOCK="/root/.breeze-ssh/agent.sock"
+fi
+
 exec /bin/bash "${@}"


### PR DESCRIPTION
When Breeze runs with `--forward-credentials`, the host's `~/.ssh` is bind-mounted read-write at `/root/.ssh` and the container start used to operate on it directly. Every start overwrote the user's id_rsa with a throwaway key, appended that key to authorized_keys and three localhost entries to known_hosts (observed to accumulate hundreds of entries), left a dangling `authorized_keys2` symlink, and ran `chmod 600 ~/.ssh/*`. That chmod also strips the execute bit from the `~/.ssh/agent` directory that OpenSSH 10.x uses for agent sockets. On macOS this kills the launchd-managed ssh-agent and, after the next reboot, makes every ssh on the host hang waiting on the dead agent socket.

The ssh-to-localhost setup, which the real-connection SSH and SFTP provider tests rely on, now lives entirely in `/root/.breeze-ssh`, a path that is never mounted from the host. sshd accepts the generated key via an `sshd_config.d` drop-in, the OpenSSH client finds it via an `ssh_config.d` drop-in, and paramiko-based hooks, which read neither, discover it through an ssh-agent started by the entrypoint. `entrypoint_exec.sh` exports the agent socket so `breeze exec` shells get it too. The `authorized_keys2` symlink had no consumers anywhere in the repo and is dropped.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (Claude Code Fable 5)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
