### PR TITLE
Support full downstream skip on LLM branch reject

### DIFF
--- a/providers/common/ai/docs/operators/llm_branch.rst
+++ b/providers/common/ai/docs/operators/llm_branch.rst
@@ -98,16 +98,19 @@ matching
 teardown carve-out applies only to rejection: approving branches as usual,
 so a teardown that is not among the chosen branch(es) is skipped like any
 other unselected downstream task. Set ``fail_on_reject=True`` to fail the
-task on rejection instead (generally discouraged). Letting
-``approval_timeout`` expire fails the task (``HITLTimeoutError``).
+task on rejection instead (generally discouraged), or
+``ignore_downstream_trigger_rules=True`` to skip every downstream task rather
+than only the direct ones, so a task whose trigger rule would still run it is
+skipped too. Letting ``approval_timeout`` expire fails the task
+(``HITLTimeoutError``).
 
 ``require_approval=True`` requires a string prompt: a decorated callable
 returning a ``Sequence[UserContent]`` raises ``TypeError`` before the LLM
 call.
 
-Apart from ``fail_on_reject``, which is specific to this operator,
-``approval_timeout`` and the rest of the approval behaviour are inherited
-from :ref:`LLMOperator <howto/operator:llm>`.
+Apart from ``fail_on_reject`` and ``ignore_downstream_trigger_rules``, which
+are specific to this operator, ``approval_timeout`` and the rest of the
+approval behaviour are inherited from :ref:`LLMOperator <howto/operator:llm>`.
 
 How It Works
 ------------
@@ -141,6 +144,8 @@ Parameters
   branch(es) before approving.  Default ``False``.
 - ``fail_on_reject``: If ``True``, a rejected review fails the task instead of
   skipping the downstream tasks.  Generally discouraged.  Default ``False``.
+- ``ignore_downstream_trigger_rules``: If ``True``, a rejected review skips every
+  downstream task rather than only the direct ones.  Default ``False``.
 
 Logging
 -------

--- a/providers/common/ai/docs/operators/llm_branch.rst
+++ b/providers/common/ai/docs/operators/llm_branch.rst
@@ -143,9 +143,11 @@ Parameters
 - ``allow_modifications``: If ``True``, the reviewer can change the chosen
   branch(es) before approving.  Default ``False``.
 - ``fail_on_reject``: If ``True``, a rejected review fails the task instead of
-  skipping the downstream tasks.  Generally discouraged.  Default ``False``.
+  skipping the downstream tasks.  Generally discouraged.  Only takes effect
+  with ``require_approval=True``.  Default ``False``.
 - ``ignore_downstream_trigger_rules``: If ``True``, a rejected review skips every
-  downstream task rather than only the direct ones.  Default ``False``.
+  downstream task rather than only the direct ones.  Only takes effect with
+  ``require_approval=True``.  Default ``False``.
 
 Logging
 -------

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/llm_branch.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/llm_branch.py
@@ -51,6 +51,9 @@ class LLMBranchOperator(LLMOperator, BranchMixIn):
         instead of skipping the downstream tasks. Generally discouraged,
         as for :class:`~airflow.providers.standard.operators.hitl.ApprovalOperator`.
         Default ``False``.
+    :param ignore_downstream_trigger_rules: If ``True``, a rejected review skips
+        every downstream task rather than only the direct ones, so a task whose
+        trigger rule would still run it is skipped too. Default ``False``.
     :param agent_params: Additional keyword arguments passed to the pydantic-ai
         ``Agent`` constructor (e.g. ``retries``, ``model_settings``, ``tools``).
 
@@ -61,7 +64,9 @@ class LLMBranchOperator(LLMOperator, BranchMixIn):
     unselected downstream tasks once a reviewer approves. Rejecting the
     review skips the direct downstream tasks except teardowns, matching
     :class:`~airflow.providers.standard.operators.hitl.ApprovalOperator`;
-    set ``fail_on_reject=True`` to fail the task instead. The review form
+    set ``fail_on_reject=True`` to fail the task instead, or
+    ``ignore_downstream_trigger_rules=True`` to skip every downstream task
+    rather than only the direct ones. The review form
     lists the valid downstream task IDs; with ``allow_modifications=True``
     the editable choice is rendered as a dropdown of those IDs (single-branch
     mode) or a multi-select of them (``allow_multiple_branches=True``), and
@@ -78,12 +83,14 @@ class LLMBranchOperator(LLMOperator, BranchMixIn):
         *,
         allow_multiple_branches: bool = False,
         fail_on_reject: bool = False,
+        ignore_downstream_trigger_rules: bool = False,
         **kwargs: Any,
     ) -> None:
         kwargs.pop("output_type", None)
         super().__init__(**kwargs)
         self.allow_multiple_branches = allow_multiple_branches
         self.fail_on_reject = fail_on_reject
+        self.ignore_downstream_trigger_rules = ignore_downstream_trigger_rules
 
     def execute(self, context: Context) -> str | Iterable[str] | None:
         if self.require_approval:
@@ -149,7 +156,12 @@ class LLMBranchOperator(LLMOperator, BranchMixIn):
             if self.fail_on_reject:
                 raise
             self.log.info("Rejected by %s. Skipping downstream tasks...", event.get("responded_by_user"))
-            tasks = context["task"].get_direct_relatives(upstream=False)
+            task = context["task"]
+            tasks = (
+                task.get_flat_relatives(upstream=False)
+                if self.ignore_downstream_trigger_rules
+                else task.get_direct_relatives(upstream=False)
+            )
             self.skip(ti=context["ti"], tasks=(t for t in tasks if not t.is_teardown))
             return None
         branches = self._parse_reviewed_branches(output)

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/llm_branch.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/llm_branch.py
@@ -50,10 +50,11 @@ class LLMBranchOperator(LLMOperator, BranchMixIn):
     :param fail_on_reject: If ``True``, a rejected review fails the task
         instead of skipping the downstream tasks. Generally discouraged,
         as for :class:`~airflow.providers.standard.operators.hitl.ApprovalOperator`.
-        Default ``False``.
+        Only takes effect with ``require_approval=True``. Default ``False``.
     :param ignore_downstream_trigger_rules: If ``True``, a rejected review skips
         every downstream task rather than only the direct ones, so a task whose
-        trigger rule would still run it is skipped too. Default ``False``.
+        trigger rule would still run it is skipped too. Only takes effect with
+        ``require_approval=True``. Default ``False``.
     :param agent_params: Additional keyword arguments passed to the pydantic-ai
         ``Agent`` constructor (e.g. ``retries``, ``model_settings``, ``tools``).
 

--- a/providers/common/ai/tests/unit/common/ai/operators/test_llm_branch.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_llm_branch.py
@@ -420,6 +420,29 @@ class TestLLMBranchOperatorApproval:
         assert list(mock_skip.call_args.kwargs["tasks"]) == [task_a]
         mock_do_branch.assert_not_called()
 
+    @patch.object(LLMBranchOperator, "skip")
+    @patch.object(LLMBranchOperator, "do_branch")
+    def test_execute_complete_reject_skips_indirect_downstream_when_ignoring_trigger_rules(
+        self, mock_do_branch, mock_skip
+    ):
+        op = LLMBranchOperator(task_id="t", prompt="p", llm_conn_id="c", ignore_downstream_trigger_rules=True)
+        op.downstream_task_ids = {"task_a"}
+        event = {"chosen_options": ["Reject"], "responded_by_user": "admin"}
+        task_a = MagicMock(is_teardown=False)
+        indirect = MagicMock(is_teardown=False)
+        cleanup = MagicMock(is_teardown=True)
+        task = MagicMock()
+        task.get_flat_relatives.return_value = [task_a, indirect, cleanup]
+        ti = MagicMock()
+        ctx = MagicMock(**{"__getitem__": lambda self, key: {"task": task, "ti": ti}[key]})
+
+        op.execute_complete(ctx, generated_output="task_a", event=event)
+
+        task.get_flat_relatives.assert_called_once_with(upstream=False)
+        task.get_direct_relatives.assert_not_called()
+        assert list(mock_skip.call_args.kwargs["tasks"]) == [task_a, indirect]
+        mock_do_branch.assert_not_called()
+
     @patch.object(LLMBranchOperator, "do_branch")
     def test_execute_complete_reject_fails_with_fail_on_reject(self, mock_do_branch):
         op = LLMBranchOperator(task_id="t", prompt="p", llm_conn_id="c", fail_on_reject=True)

--- a/providers/common/ai/tests/unit/common/ai/operators/test_llm_branch.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_llm_branch.py
@@ -27,6 +27,7 @@ from airflow.providers.common.ai.operators.llm import LLMOperator
 from airflow.providers.common.ai.operators.llm_branch import LLMBranchOperator
 from airflow.providers.common.compat.sdk import Param, ParamValidationError, TaskDeferred
 from airflow.providers.standard.exceptions import HITLRejectException
+from airflow.providers.standard.operators.empty import EmptyOperator
 
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_1_PLUS, AIRFLOW_V_3_3_PLUS
 
@@ -398,49 +399,45 @@ class TestLLMBranchOperatorApproval:
         assert result == ["task_a", "task_c"]
         mock_do_branch.assert_called_once_with(ctx, ["task_a", "task_c"])
 
+    @pytest.mark.db_test
+    @pytest.mark.parametrize(
+        ("ignore_downstream_trigger_rules", "with_teardown", "expected"),
+        [
+            (False, True, {"op2"}),
+            (False, False, {"op2"}),
+            (True, True, {"op2", "op3"}),
+            (True, False, {"op2", "op3", "op4"}),
+        ],
+    )
     @patch.object(LLMBranchOperator, "skip")
     @patch.object(LLMBranchOperator, "do_branch")
-    def test_execute_complete_reject_skips_downstream_except_teardowns(self, mock_do_branch, mock_skip):
-        op = LLMBranchOperator(task_id="t", prompt="p", llm_conn_id="c")
-        op.downstream_task_ids = {"task_a", "cleanup"}
+    def test_execute_complete_reject_skips_downstream_except_teardowns(
+        self, mock_do_branch, mock_skip, dag_maker, ignore_downstream_trigger_rules, with_teardown, expected
+    ):
+        with dag_maker(serialized=True):
+            op1 = LLMBranchOperator(
+                task_id="op1",
+                prompt="p",
+                llm_conn_id="c",
+                require_approval=True,
+                ignore_downstream_trigger_rules=ignore_downstream_trigger_rules,
+            )
+            op2 = EmptyOperator(task_id="op2")
+            op3 = EmptyOperator(task_id="op3")
+            op4 = EmptyOperator(task_id="op4")
+            if with_teardown:
+                op4.as_teardown()
+            op1 >> op2 >> op3 >> op4
         event = {"chosen_options": ["Reject"], "responded_by_user": "admin"}
-        task_a = MagicMock(is_teardown=False)
-        cleanup = MagicMock(is_teardown=True)
-        task = MagicMock()
-        task.get_direct_relatives.return_value = [task_a, cleanup]
         ti = MagicMock()
-        ctx = MagicMock(**{"__getitem__": lambda self, key: {"task": task, "ti": ti}[key]})
+        ctx = MagicMock(**{"__getitem__": lambda self, key: {"task": op1, "ti": ti}[key]})
 
-        result = op.execute_complete(ctx, generated_output="task_a", event=event)
+        result = op1.execute_complete(ctx, generated_output="op2", event=event)
 
         assert result is None
-        task.get_direct_relatives.assert_called_once_with(upstream=False)
         mock_skip.assert_called_once()
         assert mock_skip.call_args.kwargs["ti"] is ti
-        assert list(mock_skip.call_args.kwargs["tasks"]) == [task_a]
-        mock_do_branch.assert_not_called()
-
-    @patch.object(LLMBranchOperator, "skip")
-    @patch.object(LLMBranchOperator, "do_branch")
-    def test_execute_complete_reject_skips_indirect_downstream_when_ignoring_trigger_rules(
-        self, mock_do_branch, mock_skip
-    ):
-        op = LLMBranchOperator(task_id="t", prompt="p", llm_conn_id="c", ignore_downstream_trigger_rules=True)
-        op.downstream_task_ids = {"task_a"}
-        event = {"chosen_options": ["Reject"], "responded_by_user": "admin"}
-        task_a = MagicMock(is_teardown=False)
-        indirect = MagicMock(is_teardown=False)
-        cleanup = MagicMock(is_teardown=True)
-        task = MagicMock()
-        task.get_flat_relatives.return_value = [task_a, indirect, cleanup]
-        ti = MagicMock()
-        ctx = MagicMock(**{"__getitem__": lambda self, key: {"task": task, "ti": ti}[key]})
-
-        op.execute_complete(ctx, generated_output="task_a", event=event)
-
-        task.get_flat_relatives.assert_called_once_with(upstream=False)
-        task.get_direct_relatives.assert_not_called()
-        assert list(mock_skip.call_args.kwargs["tasks"]) == [task_a, indirect]
+        assert {t.task_id for t in mock_skip.call_args.kwargs["tasks"]} == expected
         mock_do_branch.assert_not_called()
 
     @patch.object(LLMBranchOperator, "do_branch")


### PR DESCRIPTION
## Why

- Rejecting a branch review only skipped the direct downstream tasks.
- A task further down the chain with a permissive trigger rule still ran.

## How

- Add `ignore_downstream_trigger_rules` to skip every downstream task on reject.
- Keep the teardown carve-out and the direct-only default unchanged.

This completes the alignment with `ApprovalOperator` started in #71073.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)