### PR TITLE
Set the state of a dag run's task instances with one flush, not one per task instance

### DIFF
--- a/airflow-core/src/airflow/api/common/mark_tasks.py
+++ b/airflow-core/src/airflow/api/common/mark_tasks.py
@@ -26,7 +26,7 @@ from sqlalchemy import and_, or_, select
 from sqlalchemy.orm import lazyload
 
 from airflow.models.dagrun import DagRun
-from airflow.models.taskinstance import TaskInstance
+from airflow.models.taskinstance import TaskInstance, set_task_instances_state
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import DagRunState, State, TaskInstanceState
 
@@ -97,9 +97,7 @@ def set_state(
 
     if commit:
         tis_altered = list(session.scalars(qry_dag.with_for_update()).all())
-        for task_instance in tis_altered:
-            task_instance.set_state(state, session=session)
-        session.flush()
+        set_task_instances_state(tis_altered, state, session=session)
     else:
         tis_altered = list(session.scalars(qry_dag).all())
     return tis_altered
@@ -277,7 +275,10 @@ def _set_dag_run_terminal_state(
         task.dag = dag
         return task
 
-    running_tasks = [_set_running_task(task) for task in dag.tasks if task.task_id in task_ids_of_running_tis]
+    # Address each running task instance by (task, map_index): a bare task would select every
+    # map index of a mapped task, and the pending siblings of one running mapped task instance
+    # would end up in ``ti_state`` instead of SKIPPED.
+    running_tasks = [(_set_running_task(dag.task_dict[ti.task_id]), ti.map_index) for ti in killed_tis]
 
     # Mark non-finished tasks as SKIPPED.
     pending_tis: list[TaskInstance] = list(
@@ -300,8 +301,7 @@ def _set_dag_run_terminal_state(
     pending_normal_tis = [ti for ti in pending_tis if not dag.task_dict[ti.task_id].is_teardown]
 
     if commit:
-        for ti in pending_normal_tis:
-            ti.set_state(TaskInstanceState.SKIPPED, session=session)
+        set_task_instances_state(pending_normal_tis, TaskInstanceState.SKIPPED, session=session)
 
         # Set the dag run state only if there is no pending teardown (else this would not be scheduled later).
         if not any(dag.task_dict[ti.task_id].is_teardown for ti in (running_tis + pending_tis)):

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -541,6 +541,25 @@ def clear_task_instances(
     session.flush()
 
 
+def set_task_instances_state(
+    tis: Iterable[TaskInstance], state: TaskInstanceState | None, *, session: Session
+) -> None:
+    """
+    Set the state of task instances loaded in ``session``, flushing once.
+
+    The bulk counterpart of :meth:`TaskInstance.set_state`: the same state and dates on
+    each task instance, then one flush for all of them, so the unit of work emits the
+    UPDATEs in batches instead of a merge and a flush per task instance.
+
+    :meta private:
+    """
+    now = timezone.utcnow()
+    for ti in tis:
+        if ti.state != state:
+            ti._set_state_and_dates(state, now)
+    session.flush()
+
+
 def _creator_note(val):
     """Creator for the ``note`` association proxy."""
     if isinstance(val, str):
@@ -1048,18 +1067,21 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
         if self.state == state:
             return False
 
-        current_time = timezone.utcnow()
         self.log.debug("Setting task state for %s to %s", self, state)
         if self not in session:
             self.refresh_from_db(session=session)
-        self.state = state
-        self.start_date = self.start_date or current_time
-        if self.state in State.finished or self.state == TaskInstanceState.UP_FOR_RETRY:
-            self.end_date = self.end_date or current_time
-            self.duration = (self.end_date - self.start_date).total_seconds()
+        self._set_state_and_dates(state, timezone.utcnow())
         session.merge(self)
         session.flush()
         return True
+
+    def _set_state_and_dates(self, state: str | None, now: datetime) -> None:
+        """Set ``state`` and the dates it implies -- the part of :meth:`set_state` that touches no session."""
+        self.state = state
+        self.start_date = self.start_date or now
+        if self.state in State.finished or self.state == TaskInstanceState.UP_FOR_RETRY:
+            self.end_date = self.end_date or now
+            self.set_duration()
 
     @property
     def is_premature(self) -> bool:

--- a/airflow-core/tests/unit/api/common/test_mark_tasks.py
+++ b/airflow-core/tests/unit/api/common/test_mark_tasks.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 import pytest
 from sqlalchemy import select
 
+from airflow._shared.timezones import timezone
 from airflow.api.common.mark_tasks import (
     find_task_relatives,
     set_dag_run_state_to_failed,
@@ -29,6 +30,8 @@ from airflow.api.common.mark_tasks import (
 from airflow.models.dagrun import DagRun
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.utils.state import DagRunState, State, TaskInstanceState
+
+from tests_common.test_utils.mock_operators import MockOperator
 
 if TYPE_CHECKING:
     from airflow.models.taskinstance import TaskInstance
@@ -59,6 +62,75 @@ def test_set_dag_run_state_to_failed(dag_maker: DagMaker[SerializedDAG]):
     assert task_dict["running"].state == TaskInstanceState.FAILED
     assert task_dict["pending"].state == TaskInstanceState.SKIPPED
     assert "teardown" not in task_dict
+
+
+def test_set_dag_run_state_to_failed_skips_pending_tis_in_bulk(dag_maker: DagMaker[SerializedDAG]):
+    """Pending TIs that never started are skipped by one UPDATE; one that did keeps its start_date."""
+    with dag_maker("TEST_DAG_1") as dag:
+        EmptyOperator(task_id="never_started")
+        EmptyOperator(task_id="never_started_2")
+        EmptyOperator(task_id="up_for_retry")
+    dr = dag_maker.create_dagrun()
+    session = dag_maker.session
+    started_at = timezone.datetime(2024, 1, 1, 12, 0, 0)
+    for ti in dr.get_task_instances(session=session):
+        if ti.task_id == "up_for_retry":
+            ti.state = TaskInstanceState.UP_FOR_RETRY
+            ti.start_date = started_at
+    session.flush()
+
+    updated_tis, killed_tis = set_dag_run_state_to_failed(
+        dag=dag, run_id=dr.run_id, commit=True, session=session
+    )
+    session.flush()
+
+    assert killed_tis == []
+    assert {ti.task_id for ti in updated_tis} == {"never_started", "never_started_2", "up_for_retry"}
+    # The returned objects reflect the new state without a reload...
+    assert all(ti.state == TaskInstanceState.SKIPPED for ti in updated_tis)
+    # ...and so does the database.
+    session.expire_all()
+    task_dict = {ti.task_id: ti for ti in dr.get_task_instances(session=session)}
+    for task_id in ("never_started", "never_started_2"):
+        ti = task_dict[task_id]
+        assert ti.state == TaskInstanceState.SKIPPED
+        assert ti.start_date is not None
+        assert ti.end_date == ti.start_date
+        assert ti.duration == 0
+    ti = task_dict["up_for_retry"]
+    assert ti.state == TaskInstanceState.SKIPPED
+    assert ti.start_date == started_at
+    assert ti.end_date is not None
+    assert ti.duration == pytest.approx((ti.end_date - started_at).total_seconds())
+
+
+def test_set_dag_run_state_to_failed_mapped_task_only_fails_running_map_indexes(
+    dag_maker: DagMaker[SerializedDAG],
+):
+    """Only the running map indexes fail; the pending siblings of the same mapped task are skipped."""
+    with dag_maker("TEST_DAG_1") as dag:
+        MockOperator.partial(task_id="mapped").expand(arg2=[1, 2, 3])
+    dr = dag_maker.create_dagrun()
+    session = dag_maker.session
+    for ti in dr.get_task_instances(session=session):
+        if ti.map_index == 1:
+            ti.set_state(TaskInstanceState.RUNNING, session=session)
+    session.flush()
+
+    updated_tis, killed_tis = set_dag_run_state_to_failed(
+        dag=dag, run_id=dr.run_id, commit=True, session=session
+    )
+    session.flush()
+
+    assert [ti.map_index for ti in killed_tis] == [1]
+    assert len(updated_tis) == 3
+    session.expire_all()
+    states = {ti.map_index: ti.state for ti in dr.get_task_instances(session=session)}
+    assert states == {
+        0: TaskInstanceState.SKIPPED,
+        1: TaskInstanceState.FAILED,
+        2: TaskInstanceState.SKIPPED,
+    }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
related: #71488 (its follow-up)

Marking a dag run failed or success visits every pending task instance with `TaskInstance.set_state`, which merges and flushes each of them: one UPDATE round-trip plus the unit-of-work overhead per task instance — and `set_state()` does the same again for the running ones. #71488 removed the per-task-instance *session*; the per-task-instance *flush* remained.

Measured on a run with 3,000 mapped task instances (Airflow 3.3.1 + #71488, PostgreSQL 17 behind pgbouncer, 2.5 ms RTT): `PATCH state=failed` took **84 s** server-side, well past the proxy timeout the UI request dies at.

This change adds `set_task_instances_state()`, the bulk counterpart of `TaskInstance.set_state` in the shape of `clear_task_instances`: the same state and dates on each loaded task instance — the date logic is shared with `set_state` through `_set_state_and_dates`, which reuses `set_duration` — then one flush, so the unit of work emits the UPDATEs in batches (`executemany`, which the psycopg2 dialect already batches with `values_plus_batch`). Both loops of `mark_tasks` use it. Same run, same machine: **84 s → 2.6 s** (3.7 s when the task instances carry a previous try), the remainder being the response and the run itself (measured with py-spy on the API server).

It also addresses the running task instances by `(task, map_index)`. Passing the bare task to `set_state` selected *every* map index of a mapped task, so the pending siblings of one running mapped task instance ended up FAILED instead of SKIPPED — contrary to the documented behaviour (“non-finished ones to SKIPPED”) — and were updated twice. With 2 of 3,000 mapped task instances running, the 2,998 others are now SKIPPED; the listener hooks still only see the 2 killed ones (`killed_tis` is unchanged).

Tests: the two new tests cover the dates/duration set on never-started and already-started pending task instances, and the mapped case (only the running map index fails).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
