### PR TITLE
Fix id_to_job_info memory leak in the AWS Batch executor

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/executors/batch/utils.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/executors/batch/utils.py
@@ -126,6 +126,7 @@ class BatchJobCollection:
         del self.key_to_id[workload_key]
         del self.id_to_key[job_id]
         del self.id_to_failure_counts[job_id]
+        del self.id_to_job_info[job_id]
         return workload_key
 
     def remove_job(self, job_id: str) -> BatchJobWorkloadKey | None:

--- a/providers/amazon/tests/unit/amazon/aws/executors/batch/test_utils.py
+++ b/providers/amazon/tests/unit/amazon/aws/executors/batch/test_utils.py
@@ -206,9 +206,7 @@ class TestBatchJobCollection:
         assert len(self.collection) == 0
         assert self.job_id1 not in self.collection.id_to_key
         assert self.key1 not in self.collection.key_to_id
-        # id_to_job_info is NOT removed by pop_by_id in the current implementation.
-        assert self.job_id1 in self.collection.id_to_job_info
-        assert self.collection.id_to_job_info[self.job_id1].cmd == self.cmd1
+        assert self.job_id1 not in self.collection.id_to_job_info
         # id_to_failure_counts is a defaultdict, so accessing a removed key returns 0.
         assert self.collection.id_to_failure_counts[self.job_id1] == 0
 


### PR DESCRIPTION
## Why

- `BatchJobCollection.pop_by_id()` clears three of the collection's four mappings, but leaves `id_to_job_info`.
- `pop_by_id()` runs for every job that succeeds and every job that fails. `__len__` only counts `key_to_id`, so the collection reports itself empty while still holding objects in `id_to_job_info`.
- `remove_job()` (#71380) already clears all four mappings, and the ECS executor's `pop_by_key()` has always deleted its equivalent `key_to_task_info`. Batch is the only AWS executor missing it.

## How

- Add the missing `del self.id_to_job_info[job_id]` to `pop_by_id()`.

## Verification

- `uv run --project providers/amazon pytest providers/amazon/tests/unit/amazon/aws/executors/ -q`

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
