### PR TITLE
Use subquery instead of CTE in asset orphanage queries

### DIFF
--- a/airflow-core/newsfragments/72188.bugfix.rst
+++ b/airflow-core/newsfragments/72188.bugfix.rst
@@ -1,0 +1,1 @@
+Fix scheduler crash-loop on MySQL-compatible backends without CTE-in-DML support (e.g. Vitess) by using a subquery instead of a CTE in asset orphanage queries

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -35,7 +35,6 @@ from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID
 
 from sqlalchemy import (
-    CTE,
     Text,
     and_,
     case,
@@ -3885,15 +3884,15 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             .group_by(AssetModel.id)
         )
 
-        orphan_query = asset_reference_query.having(orphaned).cte()
-        activate_query = asset_reference_query.having(~orphaned).cte()
+        orphan_query = asset_reference_query.having(orphaned).subquery()
+        activate_query = asset_reference_query.having(~orphaned).subquery()
 
         self._orphan_unreferenced_assets(orphan_query, session=session)
         self._activate_referenced_assets(activate_query, session=session)
         self._cleanup_orphaned_asset_state_store(session=session)
 
     @staticmethod
-    def _orphan_unreferenced_assets(assets_query: CTE, *, session: Session) -> None:
+    def _orphan_unreferenced_assets(assets_query: Subquery, *, session: Session) -> None:
         deleted_orphaned_assets = session.execute(
             delete(AssetActive).where(
                 exists().where(
@@ -3905,7 +3904,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         stats.gauge("asset.orphaned", max(getattr(deleted_orphaned_assets, "rowcount", 0), 0))
 
     @staticmethod
-    def _activate_referenced_assets(assets_query: CTE, *, session: Session) -> None:
+    def _activate_referenced_assets(assets_query: Subquery, *, session: Session) -> None:
         active_assets_query = select(AssetActive.name, AssetActive.uri).join(
             assets_query,
             and_(AssetActive.name == assets_query.c.name, AssetActive.uri == assets_query.c.uri),


### PR DESCRIPTION
closes: #72187

The asset orphanage cleanup in the scheduler loop (`_update_asset_orphanage`) built its reference-count query as a CTE and passed it to a DELETE, producing `WITH ... DELETE FROM asset_active ...`. MySQL-compatible backends whose planner does not support CTEs in DML (e.g. Vitess / PlanetScale — `VT12001: unsupported: WITH expression in DELETE statement`) reject the statement at plan time, and since this runs on the `parsing_cleanup_interval` timer (default 60s) the scheduler crash-loops.

The CTE is not semantically required: `orphan_query` and `activate_query` are each consumed by a single statement, so a plain derived-table subquery is equivalent.

- `.cte()` → `.subquery()` for both queries; behavior is unchanged (`Subquery` exposes the same `.c` interface used by both consumers).
- The DELETE now compiles (MySQL dialect) to `DELETE FROM asset_active WHERE EXISTS (SELECT * FROM (...) AS anon_1 WHERE ...)` — no `WITH`. The DELETE target `asset_active` is not referenced inside the subquery, so MySQL's self-reference restriction does not apply.
- Type hints updated (`CTE` → `Subquery`); the now-unused `CTE` import removed.

Dialect-compat precedent for this same method: #40349. Airflow 2.x is unaffected.

Existing asset-orphanage tests cover the behavior (including the #58303 regression tests); this change only alters the SQL construct, not semantics.
