### PR TITLE
Change edge worker heartbeat message from info to debug

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/cli/worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/cli/worker.py
@@ -220,7 +220,7 @@ class EdgeWorker:
             self.background_tasks.add(task)
             task.add_done_callback(self.background_tasks.discard)
         else:
-            logger.info("Request to get status of Edge Worker received.")
+            logger.debug("Request to get status of Edge Worker received.")
         status_path = Path(status_file_path(None))
         status_path.write_text(
             WorkerStatus(


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

Change log level from info to debug for Edge worker status requests

The "Request to get status of Edge Worker received." message in
signal_status() drops from info to debug.

Why: this line fires whenever someone runs `airflow edge status`. That
command just asks the worker what it's doing and prints the answer — it
doesn't change anything about the worker. It's also the sort of command
people put in a loop: health checks, monitoring scripts, or an operator
keeping an eye on a worker that's draining. Every one of those calls
leaves an info line in the log saying someone asked a question.

The other half of the same if-statement makes the point. When a
maintenance marker is present the worker really does change state, and
that branch logs at info — which is right. Answering a status query
isn't a change, so it shouldn't sit at the same level.

The command sending the signal already logs at debug on its side
("Sending SIGUSR2 to worker pid ..."), so this just gets both ends to
agree.

No behaviour change. The status file is written exactly as before and
`airflow edge status` prints the same thing. If you want these messages
back, set the edge worker log level to DEBUG.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] No
<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
