### PR TITLE
Compare session and user identifiers consistently when resetting a password

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -619,7 +619,12 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
             else:
                 for s in session.scalars(select(user_session_model)).all():
                     session_details = interface.serializer.decode(want_bytes(s.data))
-                    if session_details.get("_user_id") == user.id:
+                    session_user_id = session_details.get("_user_id")
+                    # Flask-Login stores whatever ``User.get_id()`` returns, which is a
+                    # string, while ``user.id`` is the integer column. Compare both sides
+                    # as strings so the two representations match; older sessions written
+                    # before ``get_id()`` returned a string are still handled.
+                    if session_user_id is not None and str(session_user_id) == str(user.id):
                         session.delete(s)
                 session.commit()
         else:

--- a/providers/fab/tests/unit/fab/www/views/test_views_custom_user_views.py
+++ b/providers/fab/tests/unit/fab/www/views/test_views_custom_user_views.py
@@ -259,7 +259,7 @@ class TestResetUserSessions:
             delete_user(app, "user_to_delete_1")
             delete_user(app, "user_to_delete_2")
 
-    def create_user_db_session(self, session_id: str, time_delta: timedelta, user_id: int):
+    def create_user_db_session(self, session_id: str, time_delta: timedelta, user_id: str | int):
         self.session.add(
             self.model(
                 session_id=session_id,
@@ -277,8 +277,8 @@ class TestResetUserSessions:
         ],
     )
     def test_reset_user_sessions_delete(self, time_delta: timedelta, user_sessions_deleted: bool):
-        self.create_user_db_session("session_id_1", time_delta, self.user_1.id)
-        self.create_user_db_session("session_id_2", time_delta, self.user_2.id)
+        self.create_user_db_session("session_id_1", time_delta, self.user_1.get_id())
+        self.create_user_db_session("session_id_2", time_delta, self.user_2.get_id())
         self.session.commit()
         self.session.flush()
         assert self.session.scalar(select(func.count()).select_from(self.model)) == 2
@@ -296,6 +296,40 @@ class TestResetUserSessions:
             assert self.session.scalar(select(func.count()).select_from(self.model)) == 2
             assert self.get_session_by_id("session_id_1") is not None
 
+    def test_reset_user_sessions_delete_legacy_integer_user_id(self):
+        """Sessions written before ``get_id()`` returned a string stored an int."""
+        self.create_user_db_session("session_id_1", timedelta(days=1), self.user_1.id)
+        self.create_user_db_session("session_id_2", timedelta(days=1), self.user_2.id)
+        self.session.commit()
+        self.session.flush()
+
+        with self.app.app_context():
+            self.security_manager.reset_password(self.user_1.id, "new_password")
+        self.session.commit()
+        self.session.flush()
+
+        assert self.get_session_by_id("session_id_1") is None
+        assert self.get_session_by_id("session_id_2") is not None
+
+    def test_reset_user_sessions_ignores_sessions_without_user_id(self):
+        """A session row with no ``_user_id`` must not raise and must not be deleted."""
+        self.session.add(
+            self.model(
+                session_id="session_id_anon",
+                data=self.serializer.encode({}),
+                expiry=datetime.now() + timedelta(days=1),
+            )
+        )
+        self.session.commit()
+        self.session.flush()
+
+        with self.app.app_context():
+            self.security_manager.reset_password(self.user_1.id, "new_password")
+        self.session.commit()
+        self.session.flush()
+
+        assert self.get_session_by_id("session_id_anon") is not None
+
     def get_session_by_id(self, session_id: str):
         return self.session.scalar(select(self.model).where(self.model.session_id == session_id))
 
@@ -307,8 +341,8 @@ class TestResetUserSessions:
         "airflow.providers.fab.auth_manager.security_manager.override.MAX_NUM_DATABASE_USER_SESSIONS", 1
     )
     def test_refuse_delete(self, _mock_has_context, flash_mock):
-        self.create_user_db_session("session_id_1", timedelta(days=1), self.user_1.id)
-        self.create_user_db_session("session_id_2", timedelta(days=1), self.user_2.id)
+        self.create_user_db_session("session_id_1", timedelta(days=1), self.user_1.get_id())
+        self.create_user_db_session("session_id_2", timedelta(days=1), self.user_2.get_id())
         self.session.commit()
         self.session.flush()
         assert self.session.scalar(select(func.count()).select_from(self.model)) == 2
@@ -344,8 +378,8 @@ class TestResetUserSessions:
         "airflow.providers.fab.auth_manager.security_manager.override.MAX_NUM_DATABASE_USER_SESSIONS", 1
     )
     def test_refuse_delete_cli(self, log_mock):
-        self.create_user_db_session("session_id_1", timedelta(days=1), self.user_1.id)
-        self.create_user_db_session("session_id_2", timedelta(days=1), self.user_2.id)
+        self.create_user_db_session("session_id_1", timedelta(days=1), self.user_1.get_id())
+        self.create_user_db_session("session_id_2", timedelta(days=1), self.user_2.get_id())
         self.session.commit()
         self.session.flush()
         assert self.session.scalar(select(func.count()).select_from(self.model)) == 2


### PR DESCRIPTION
`reset_user_sessions()` decodes each stored session and compares its `_user_id` against `user.id`:

```python
if session_details.get("_user_id") == user.id:
```

Flask-Login stores whatever `User.get_id()` returns — a **string** (`models/__init__.py:357`) — while `user.id` is the integer column. The comparison is therefore `"1" == 1`, which is never true, so no session is ever deleted and the password update proceeds independently. With `[fab] session_backend=database`, `provider.yaml` documents that a password reset deletes all sessions for that user; it deletes none.

Both sides are now compared as strings, and a row carrying no `_user_id` is skipped rather than matched.

**On the test.** `test_reset_user_sessions_delete` passed throughout, because its fixture wrote an *integer* `_user_id` into the session row by hand — exercising a comparison that cannot occur in practice. It now stores what `get_id()` returns. Reverting the source change makes all three parametrisations fail (`assert 2 == 1`), which they did not before. Added coverage for sessions written before `get_id()` returned a string, and for a row with no `_user_id`.

Local: 28 passed in the touched file, 460 across the provider; ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
