### PR TITLE
Log capability tool calls in AgentOperator

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1,5 +1,6 @@
 aarch
 abc
+AbstractCapability
 AbstractFileSystem
 AbstractToolset
 accessor
@@ -671,6 +672,7 @@ Filesystem
 filesystem
 filesystems
 filetype
+FilteredToolset
 finalStatus
 fips
 firebase
@@ -1313,6 +1315,7 @@ preflight
 prek
 Preload
 preload
+PreparedToolset
 prepend
 prepended
 prepends
@@ -1940,6 +1943,7 @@ winrm
 WIT
 workgroup
 workspaces
+WrapperToolset
 writeable
 wsman
 WTF

--- a/providers/common/ai/docs/operators/agent.rst
+++ b/providers/common/ai/docs/operators/agent.rst
@@ -374,6 +374,13 @@ but anything passed through ``agent_params`` is forwarded to the underlying
 
 Capabilities compose with toolsets -- pydantic-ai merges tools from both.
 
+When ``enable_tool_logging=True`` (the default), ``AgentOperator`` applies
+real-time tool-call logging to a concrete toolset supplied through a ``Toolset``
+capability, just as it does for entries in ``toolsets=``. Other capability
+types and ``Toolset`` capabilities backed by a callable factory are left
+unchanged because they do not expose a concrete toolset when the operator is
+built.
+
 .. exampleinclude:: /../../ai/src/airflow/providers/common/ai/example_dags/example_agent_capabilities.py
     :language: python
     :start-after: [START howto_operator_agent_capabilities_composed]
@@ -476,7 +483,8 @@ Parameters
   ``BaseModel`` for structured output.
 - ``toolsets``: List of pydantic-ai toolsets (``SQLToolset``, ``HookToolset``,
   ``AgentSkillsToolset`` for :ref:`agent-skills`, etc.).
-- ``enable_tool_logging``: Wrap each toolset in
+- ``enable_tool_logging``: Wrap each toolset supplied through ``toolsets=`` or
+  a concrete pydantic-ai ``Toolset`` capability in
   :class:`~airflow.providers.common.ai.toolsets.logging.LoggingToolset` so that
   every tool call is logged in real time. Default ``True``.
 - ``agent_params``: Additional keyword arguments passed to the pydantic-ai
@@ -530,8 +538,9 @@ Logging
 -------
 
 All AI operators automatically log a post-run summary after ``run_sync()``
-completes. ``AgentOperator`` additionally wraps toolsets for real-time
-per-tool-call logging (controlled by ``enable_tool_logging``).
+completes. ``AgentOperator`` additionally wraps toolsets, including concrete
+toolsets provided by ``Toolset`` capabilities, for real-time per-tool-call
+logging (controlled by ``enable_tool_logging``).
 
 **Real-time tool call logging** (AgentOperator only) — each tool call is
 logged as it happens:

--- a/providers/common/ai/docs/operators/agent.rst
+++ b/providers/common/ai/docs/operators/agent.rst
@@ -376,7 +376,8 @@ Capabilities compose with toolsets -- pydantic-ai merges tools from both.
 
 When ``enable_tool_logging=True`` (the default), ``AgentOperator`` applies
 real-time tool-call logging to the complete toolset assembled from capabilities,
-including factory-backed toolsets, nested capabilities, and MCP tools.
+including factory-backed toolsets, nested capabilities, and MCP tools. Provider-native
+tools that execute server-side are not covered by Airflow's real-time tool-call logging.
 
 .. exampleinclude:: /../../ai/src/airflow/providers/common/ai/example_dags/example_agent_capabilities.py
     :language: python

--- a/providers/common/ai/docs/operators/agent.rst
+++ b/providers/common/ai/docs/operators/agent.rst
@@ -375,11 +375,8 @@ but anything passed through ``agent_params`` is forwarded to the underlying
 Capabilities compose with toolsets -- pydantic-ai merges tools from both.
 
 When ``enable_tool_logging=True`` (the default), ``AgentOperator`` applies
-real-time tool-call logging to a concrete toolset supplied through a ``Toolset``
-capability, just as it does for entries in ``toolsets=``. Other capability
-types and ``Toolset`` capabilities backed by a callable factory are left
-unchanged because they do not expose a concrete toolset when the operator is
-built.
+real-time tool-call logging to the complete toolset assembled from capabilities,
+including factory-backed toolsets, nested capabilities, and MCP tools.
 
 .. exampleinclude:: /../../ai/src/airflow/providers/common/ai/example_dags/example_agent_capabilities.py
     :language: python
@@ -483,8 +480,8 @@ Parameters
   ``BaseModel`` for structured output.
 - ``toolsets``: List of pydantic-ai toolsets (``SQLToolset``, ``HookToolset``,
   ``AgentSkillsToolset`` for :ref:`agent-skills`, etc.).
-- ``enable_tool_logging``: Wrap each toolset supplied through ``toolsets=`` or
-  a concrete pydantic-ai ``Toolset`` capability in
+- ``enable_tool_logging``: Wrap the toolsets supplied through ``toolsets=`` and
+  capabilities in
   :class:`~airflow.providers.common.ai.toolsets.logging.LoggingToolset` so that
   every tool call is logged in real time. Default ``True``.
 - ``agent_params``: Additional keyword arguments passed to the pydantic-ai
@@ -538,9 +535,8 @@ Logging
 -------
 
 All AI operators automatically log a post-run summary after ``run_sync()``
-completes. ``AgentOperator`` additionally wraps toolsets, including concrete
-toolsets provided by ``Toolset`` capabilities, for real-time per-tool-call
-logging (controlled by ``enable_tool_logging``).
+completes. ``AgentOperator`` additionally wraps the assembled toolset for
+real-time per-tool-call logging (controlled by ``enable_tool_logging``).
 
 **Real-time tool call logging** (AgentOperator only) — each tool call is
 logged as it happens:

--- a/providers/common/ai/docs/toolsets.rst
+++ b/providers/common/ai/docs/toolsets.rst
@@ -355,7 +355,8 @@ in real time. ``AgentOperator`` applies it automatically (see
 :class:`~airflow.providers.common.ai.toolsets.logging.ToolLoggingCapability`.
 Applying the wrapper as a capability means logging covers the complete toolset
 that pydantic-ai assembles, including factory-backed toolsets, nested
-capabilities, and MCP tools.
+capabilities, and MCP tools. Provider-native tools that execute server-side are
+not covered by Airflow's real-time tool-call logging.
 
 You can also use ``LoggingToolset`` directly with any pydantic-ai ``Agent``:
 

--- a/providers/common/ai/docs/toolsets.rst
+++ b/providers/common/ai/docs/toolsets.rst
@@ -351,8 +351,13 @@ Parameters
 :class:`~airflow.providers.common.ai.toolsets.logging.LoggingToolset` is a
 ``WrapperToolset`` that intercepts ``call_tool()`` to log each tool invocation
 in real time. ``AgentOperator`` applies it automatically (see
-``enable_tool_logging``), but you can also use it directly with any pydantic-ai
-``Agent``:
+``enable_tool_logging``) through
+:class:`~airflow.providers.common.ai.toolsets.logging.ToolLoggingCapability`.
+Applying the wrapper as a capability means logging covers the complete toolset
+that pydantic-ai assembles, including factory-backed toolsets, nested
+capabilities, and MCP tools.
+
+You can also use ``LoggingToolset`` directly with any pydantic-ai ``Agent``:
 
 .. code-block:: python
 

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py
@@ -137,9 +137,10 @@ class AgentOperator(BaseOperator, HITLReviewMixin):
         cannot be deserialized from XCom.
     :param toolsets: List of pydantic-ai toolsets the agent can use
         (e.g. ``SQLToolset``, ``HookToolset``).
-    :param enable_tool_logging: When ``True`` (default), wraps each toolset in a
-        ``LoggingToolset`` that logs tool calls with timing at INFO level and
-        arguments at DEBUG level. Set to ``False`` to disable.
+    :param enable_tool_logging: When ``True`` (default), wraps each toolset and
+        each concrete pydantic-ai ``Toolset`` capability in a ``LoggingToolset``
+        that logs tool calls with timing at INFO level and arguments at DEBUG
+        level. Set to ``False`` to disable.
     :param agent_params: Additional keyword arguments passed to the pydantic-ai
         ``Agent`` constructor (e.g. ``retries``, ``model_settings``).
     :param usage_limits: Optional pydantic-ai
@@ -333,6 +334,8 @@ class AgentOperator(BaseOperator, HITLReviewMixin):
             # ``toolsets=`` wrapping above, so their results would re-execute on
             # every retry instead of replaying; wrap their inner toolset too.
             capabilities = self._build_durable_capabilities(capabilities, storage, counter)
+        if capabilities and self.enable_tool_logging:
+            capabilities = self._build_logging_capabilities(capabilities)
         if self.code_mode:
             capabilities.append(_build_code_mode())
         if capabilities:
@@ -391,6 +394,22 @@ class AgentOperator(BaseOperator, HITLReviewMixin):
                     "factory are not cached for replay; pass the toolset via `toolsets=` "
                     "for durability."
                 )
+            rewrapped.append(capability)
+        return rewrapped
+
+    def _build_logging_capabilities(self, capabilities: list[Any]) -> list[Any]:
+        """Wrap concrete toolsets provided via a pydantic-ai ``Toolset`` capability for logging."""
+        # Keep capability imports out of Dag-parse-time code paths; they are only
+        # needed while constructing the runtime agent.
+        from pydantic_ai.capabilities import Toolset
+        from pydantic_ai.toolsets.abstract import AbstractToolset
+
+        rewrapped: list[Any] = []
+        for capability in capabilities:
+            if isinstance(capability, Toolset) and isinstance(capability.toolset, AbstractToolset):
+                logged = wrap_toolsets_for_logging([capability.toolset], self.log)[0]
+                rewrapped.append(replace(capability, toolset=logged))
+                continue
             rewrapped.append(capability)
         return rewrapped
 

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py
@@ -29,6 +29,7 @@ from pydantic import BaseModel
 
 from airflow.providers.common.ai.hooks.pydantic_ai import PydanticAIHook
 from airflow.providers.common.ai.mixins.hitl_review import HITLReviewMixin
+from airflow.providers.common.ai.toolsets.logging import ToolLoggingCapability
 from airflow.providers.common.ai.utils.logging import log_run_summary
 from airflow.providers.common.ai.utils.output_type import rehydrate_pydantic_output
 from airflow.providers.common.compat.sdk import (
@@ -334,9 +335,7 @@ class AgentOperator(BaseOperator, HITLReviewMixin):
             capabilities = self._build_durable_capabilities(capabilities, storage, counter)
         if self.code_mode:
             capabilities.append(_build_code_mode())
-        if self.enable_tool_logging and (self.toolsets or capabilities):
-            from airflow.providers.common.ai.toolsets.logging import ToolLoggingCapability
-
+        if self.enable_tool_logging:
             capabilities.append(ToolLoggingCapability(logger=self.log))
         if capabilities:
             extra_kwargs["capabilities"] = capabilities

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py
@@ -29,7 +29,7 @@ from pydantic import BaseModel
 
 from airflow.providers.common.ai.hooks.pydantic_ai import PydanticAIHook
 from airflow.providers.common.ai.mixins.hitl_review import HITLReviewMixin
-from airflow.providers.common.ai.utils.logging import log_run_summary, wrap_toolsets_for_logging
+from airflow.providers.common.ai.utils.logging import log_run_summary
 from airflow.providers.common.ai.utils.output_type import rehydrate_pydantic_output
 from airflow.providers.common.compat.sdk import (
     AirflowOptionalProviderFeatureException,
@@ -137,10 +137,10 @@ class AgentOperator(BaseOperator, HITLReviewMixin):
         cannot be deserialized from XCom.
     :param toolsets: List of pydantic-ai toolsets the agent can use
         (e.g. ``SQLToolset``, ``HookToolset``).
-    :param enable_tool_logging: When ``True`` (default), wraps each toolset and
-        each concrete pydantic-ai ``Toolset`` capability in a ``LoggingToolset``
-        that logs tool calls with timing at INFO level and arguments at DEBUG
-        level. Set to ``False`` to disable.
+    :param enable_tool_logging: When ``True`` (default), wraps the agent's
+        assembled toolset in a ``LoggingToolset`` that logs tool calls with
+        timing at INFO level and arguments at DEBUG level. Set to ``False`` to
+        disable.
     :param agent_params: Additional keyword arguments passed to the pydantic-ai
         ``Agent`` constructor (e.g. ``retries``, ``model_settings``).
     :param usage_limits: Optional pydantic-ai
@@ -325,8 +325,6 @@ class AgentOperator(BaseOperator, HITLReviewMixin):
             toolsets = self.toolsets
             if self.durable and storage is not None and counter is not None:
                 toolsets = self._build_durable_toolsets(toolsets, storage, counter)
-            if self.enable_tool_logging:
-                toolsets = wrap_toolsets_for_logging(toolsets, self.log)
             extra_kwargs["toolsets"] = toolsets
         capabilities = list(extra_kwargs.get("capabilities") or [])
         if self.durable and storage is not None and counter is not None:
@@ -334,10 +332,12 @@ class AgentOperator(BaseOperator, HITLReviewMixin):
             # ``toolsets=`` wrapping above, so their results would re-execute on
             # every retry instead of replaying; wrap their inner toolset too.
             capabilities = self._build_durable_capabilities(capabilities, storage, counter)
-        if capabilities and self.enable_tool_logging:
-            capabilities = self._build_logging_capabilities(capabilities)
         if self.code_mode:
             capabilities.append(_build_code_mode())
+        if self.enable_tool_logging and (self.toolsets or capabilities):
+            from airflow.providers.common.ai.toolsets.logging import ToolLoggingCapability
+
+            capabilities.append(ToolLoggingCapability(logger=self.log))
         if capabilities:
             extra_kwargs["capabilities"] = capabilities
         return self.llm_hook.create_agent(
@@ -394,22 +394,6 @@ class AgentOperator(BaseOperator, HITLReviewMixin):
                     "factory are not cached for replay; pass the toolset via `toolsets=` "
                     "for durability."
                 )
-            rewrapped.append(capability)
-        return rewrapped
-
-    def _build_logging_capabilities(self, capabilities: list[Any]) -> list[Any]:
-        """Wrap concrete toolsets provided via a pydantic-ai ``Toolset`` capability for logging."""
-        # Keep capability imports out of Dag-parse-time code paths; they are only
-        # needed while constructing the runtime agent.
-        from pydantic_ai.capabilities import Toolset
-        from pydantic_ai.toolsets.abstract import AbstractToolset
-
-        rewrapped: list[Any] = []
-        for capability in capabilities:
-            if isinstance(capability, Toolset) and isinstance(capability.toolset, AbstractToolset):
-                logged = wrap_toolsets_for_logging([capability.toolset], self.log)[0]
-                rewrapped.append(replace(capability, toolset=logged))
-                continue
             rewrapped.append(capability)
         return rewrapped
 

--- a/providers/common/ai/src/airflow/providers/common/ai/toolsets/logging.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/toolsets/logging.py
@@ -24,10 +24,11 @@ import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.toolsets.wrapper import WrapperToolset
 
 if TYPE_CHECKING:
-    from pydantic_ai.toolsets.abstract import ToolsetTool
+    from pydantic_ai.toolsets.abstract import AbstractToolset, ToolsetTool
 
     from airflow.sdk.types import Logger
 
@@ -60,3 +61,17 @@ class LoggingToolset(WrapperToolset[Any]):
             self.logger.exception("Tool %s failed after %.2fs", name, elapsed)
             self.logger.info("::endgroup::")
             raise
+
+
+@dataclass
+class ToolLoggingCapability(AbstractCapability[Any]):
+    """Apply tool-call logging to the complete toolset assembled for an agent run."""
+
+    logger: Logger | logging.Logger = field(default_factory=lambda: logging.getLogger(__name__))
+
+    @classmethod
+    def get_serialization_name(cls) -> str | None:
+        return None
+
+    def get_wrapper_toolset(self, toolset: AbstractToolset[Any]) -> AbstractToolset[Any]:
+        return LoggingToolset(wrapped=toolset, logger=self.logger)

--- a/providers/common/ai/src/airflow/providers/common/ai/utils/logging.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/utils/logging.py
@@ -23,11 +23,8 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic_ai.messages import ToolCallPart
 
-from airflow.providers.common.ai.toolsets.logging import LoggingToolset
-
 if TYPE_CHECKING:
     from pydantic_ai.result import AgentRunResult
-    from pydantic_ai.toolsets.abstract import AbstractToolset
 
     from airflow.sdk.types import Logger
 
@@ -80,11 +77,3 @@ def _extract_tool_sequence(result: AgentRunResult[Any]) -> list[str]:
             if isinstance(part, ToolCallPart):
                 tool_names.append(part.tool_name)
     return tool_names
-
-
-def wrap_toolsets_for_logging(
-    toolsets: list[AbstractToolset[Any]],
-    logger: Logger | logging.Logger,
-) -> list[AbstractToolset[Any]]:
-    """Wrap each toolset in a LoggingToolset."""
-    return [LoggingToolset(wrapped=ts, logger=logger) for ts in toolsets]

--- a/providers/common/ai/tests/unit/common/ai/decorators/test_agent.py
+++ b/providers/common/ai/tests/unit/common/ai/decorators/test_agent.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel
 from pydantic_ai.messages import ImageUrl
 
 from airflow.providers.common.ai.decorators.agent import _AgentDecoratedOperator
-from airflow.providers.common.ai.toolsets.logging import LoggingToolset
+from airflow.providers.common.ai.toolsets.logging import ToolLoggingCapability
 
 try:
     from airflow.sdk.serde import SUPPORTS_OPERATOR_DESERIALIZATION_WALKER as _CORE_WALKER
@@ -166,10 +166,8 @@ class TestAgentDecoratedOperator:
         op.execute(context={})
 
         create_call = mock_hook_cls.get_hook.return_value.create_agent.call_args
-        passed_toolsets = create_call[1]["toolsets"]
-        assert len(passed_toolsets) == 1
-        assert isinstance(passed_toolsets[0], LoggingToolset)
-        assert passed_toolsets[0].wrapped is mock_toolset
+        assert create_call[1]["toolsets"] == [mock_toolset]
+        assert isinstance(create_call[1]["capabilities"][0], ToolLoggingCapability)
 
     @requires_typed_xcom
     @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)

--- a/providers/common/ai/tests/unit/common/ai/operators/test_agent.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_agent.py
@@ -243,6 +243,47 @@ class TestAgentOperatorExecute:
         assert create_call[1]["toolsets"] == [mock_toolset]
 
     @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
+    def test_tool_logging_wraps_only_concrete_toolset_capabilities(self, mock_hook_cls):
+        """Capability logging follows the setting and preserves non-concrete capabilities."""
+        mock_hook_cls.get_hook.return_value.create_agent.return_value = _make_mock_agent("done")
+
+        inner = FunctionToolset()
+
+        def factory(ctx):
+            return FunctionToolset()
+
+        factory_capability = Toolset(factory)
+        passthrough = object()
+        capabilities = [Toolset(inner), factory_capability, passthrough]
+
+        enabled = AgentOperator(
+            task_id="enabled",
+            prompt="Do something",
+            llm_conn_id="my_llm",
+            agent_params={"capabilities": capabilities},
+        )
+        enabled.execute(context={})
+
+        passed = mock_hook_cls.get_hook.return_value.create_agent.call_args.kwargs["capabilities"]
+        assert isinstance(passed[0].toolset, LoggingToolset)
+        assert passed[0].toolset.wrapped is inner
+        assert passed[0].toolset.logger is enabled.log
+        assert passed[1] is factory_capability
+        assert passed[2] is passthrough
+
+        disabled = AgentOperator(
+            task_id="disabled",
+            prompt="Do something",
+            llm_conn_id="my_llm",
+            enable_tool_logging=False,
+            agent_params={"capabilities": capabilities},
+        )
+        disabled.execute(context={})
+
+        passed = mock_hook_cls.get_hook.return_value.create_agent.call_args.kwargs["capabilities"]
+        assert passed[0] is capabilities[0]
+
+    @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
     def test_execute_passes_agent_params(self, mock_hook_cls):
         """agent_params are unpacked into create_agent."""
         mock_hook_cls.get_hook.return_value.create_agent.return_value = _make_mock_agent("ok")
@@ -699,6 +740,28 @@ class TestAgentOperatorDurable:
         )
 
         assert result[0] is cap
+
+    def test_toolset_capability_logging_wraps_durable_cache(self):
+        """Logging stays outside durable caching for a concrete ``Toolset`` capability."""
+        inner = FunctionToolset()
+        op = AgentOperator(
+            task_id="t",
+            prompt="p",
+            llm_conn_id="c",
+            durable=True,
+            agent_params={"capabilities": [Toolset(inner)]},
+        )
+        op._durable_storage = MagicMock(spec=DurableStorageProtocol)
+        op._durable_counter = DurableStepCounter()
+        hook = MagicMock(spec=["create_agent"])
+        op.llm_hook = hook
+
+        op._build_agent()
+
+        capability = hook.create_agent.call_args.kwargs["capabilities"][0]
+        assert isinstance(capability.toolset, LoggingToolset)
+        assert isinstance(capability.toolset.wrapped, CachingToolset)
+        assert capability.toolset.wrapped.wrapped is inner
 
     def test_toolset_capability_tool_replayed_on_retry(self):
         """A tool supplied via a ``Toolset`` capability is cached and replayed on a

--- a/providers/common/ai/tests/unit/common/ai/operators/test_agent.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_agent.py
@@ -23,7 +23,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pydantic import BaseModel
 from pydantic_ai import Agent
-from pydantic_ai.capabilities import Toolset
+from pydantic_ai.capabilities import MCP, PrefixTools, Toolset
 from pydantic_ai.messages import (
     ModelMessagesTypeAdapter,
     ModelRequest,
@@ -42,7 +42,7 @@ from airflow.providers.common.ai.durable.caching_toolset import CachingToolset
 from airflow.providers.common.ai.durable.step_counter import DurableStepCounter
 from airflow.providers.common.ai.durable.storage import DurableStorage
 from airflow.providers.common.ai.operators.agent import AgentOperator, HITLReviewLink, _build_code_mode
-from airflow.providers.common.ai.toolsets.logging import LoggingToolset
+from airflow.providers.common.ai.toolsets.logging import LoggingToolset, ToolLoggingCapability
 from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException
 
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_1_PLUS, AIRFLOW_V_3_3_PLUS
@@ -219,10 +219,8 @@ class TestAgentOperatorExecute:
         op.execute(context=MagicMock())
 
         create_call = mock_hook_cls.get_hook.return_value.create_agent.call_args
-        passed_toolsets = create_call[1]["toolsets"]
-        assert len(passed_toolsets) == 1
-        assert isinstance(passed_toolsets[0], LoggingToolset)
-        assert passed_toolsets[0].wrapped is mock_toolset
+        assert create_call[1]["toolsets"] == [mock_toolset]
+        assert isinstance(create_call[1]["capabilities"][0], ToolLoggingCapability)
 
     @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
     def test_enable_tool_logging_false_skips_wrapping(self, mock_hook_cls):
@@ -243,8 +241,8 @@ class TestAgentOperatorExecute:
         assert create_call[1]["toolsets"] == [mock_toolset]
 
     @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
-    def test_tool_logging_wraps_only_concrete_toolset_capabilities(self, mock_hook_cls):
-        """Capability logging follows the setting and preserves non-concrete capabilities."""
+    def test_tool_logging_wraps_assembled_capability_toolsets(self, mock_hook_cls):
+        """Capability logging applies after pydantic-ai assembles all toolset shapes."""
         mock_hook_cls.get_hook.return_value.create_agent.return_value = _make_mock_agent("done")
 
         inner = FunctionToolset()
@@ -252,9 +250,12 @@ class TestAgentOperatorExecute:
         def factory(ctx):
             return FunctionToolset()
 
-        factory_capability = Toolset(factory)
-        passthrough = object()
-        capabilities = [Toolset(inner), factory_capability, passthrough]
+        capabilities = [
+            Toolset(inner),
+            Toolset(factory),
+            PrefixTools(wrapped=Toolset(inner), prefix="nested"),
+            MCP(url="https://example.com/mcp"),
+        ]
 
         enabled = AgentOperator(
             task_id="enabled",
@@ -265,11 +266,14 @@ class TestAgentOperatorExecute:
         enabled.execute(context={})
 
         passed = mock_hook_cls.get_hook.return_value.create_agent.call_args.kwargs["capabilities"]
-        assert isinstance(passed[0].toolset, LoggingToolset)
-        assert passed[0].toolset.wrapped is inner
-        assert passed[0].toolset.logger is enabled.log
-        assert passed[1] is factory_capability
-        assert passed[2] is passthrough
+        assert passed[:-1] == capabilities
+        logging_capability = passed[-1]
+        assert isinstance(logging_capability, ToolLoggingCapability)
+        assembled = FunctionToolset()
+        wrapped = logging_capability.get_wrapper_toolset(assembled)
+        assert isinstance(wrapped, LoggingToolset)
+        assert wrapped.wrapped is assembled
+        assert wrapped.logger is enabled.log
 
         disabled = AgentOperator(
             task_id="disabled",
@@ -281,7 +285,7 @@ class TestAgentOperatorExecute:
         disabled.execute(context={})
 
         passed = mock_hook_cls.get_hook.return_value.create_agent.call_args.kwargs["capabilities"]
-        assert passed[0] is capabilities[0]
+        assert passed == capabilities
 
     @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
     def test_execute_passes_agent_params(self, mock_hook_cls):
@@ -305,7 +309,13 @@ class TestAgentOperatorExecute:
         """code_mode defaults to False, so no capabilities are injected."""
         mock_hook_cls.get_hook.return_value.create_agent.return_value = _make_mock_agent("ok")
 
-        op = AgentOperator(task_id="t", prompt="hi", llm_conn_id="my_llm", toolsets=[MagicMock()])
+        op = AgentOperator(
+            task_id="t",
+            prompt="hi",
+            llm_conn_id="my_llm",
+            toolsets=[MagicMock()],
+            enable_tool_logging=False,
+        )
         op.execute(context=MagicMock())
 
         create_call = mock_hook_cls.get_hook.return_value.create_agent.call_args
@@ -318,7 +328,12 @@ class TestAgentOperatorExecute:
         mock_hook_cls.get_hook.return_value.create_agent.return_value = _make_mock_agent("ok")
 
         op = AgentOperator(
-            task_id="t", prompt="hi", llm_conn_id="my_llm", toolsets=[MagicMock()], code_mode=True
+            task_id="t",
+            prompt="hi",
+            llm_conn_id="my_llm",
+            toolsets=[MagicMock()],
+            code_mode=True,
+            enable_tool_logging=False,
         )
         op.execute(context=MagicMock())
 
@@ -337,6 +352,7 @@ class TestAgentOperatorExecute:
             prompt="hi",
             llm_conn_id="my_llm",
             code_mode=True,
+            enable_tool_logging=False,
             agent_params={"capabilities": ["existing"]},
         )
         op.execute(context=MagicMock())
@@ -758,10 +774,12 @@ class TestAgentOperatorDurable:
 
         op._build_agent()
 
-        capability = hook.create_agent.call_args.kwargs["capabilities"][0]
-        assert isinstance(capability.toolset, LoggingToolset)
-        assert isinstance(capability.toolset.wrapped, CachingToolset)
-        assert capability.toolset.wrapped.wrapped is inner
+        capabilities = hook.create_agent.call_args.kwargs["capabilities"]
+        assert isinstance(capabilities[0].toolset, CachingToolset)
+        assert capabilities[0].toolset.wrapped is inner
+        wrapped = capabilities[1].get_wrapper_toolset(capabilities[0].toolset)
+        assert isinstance(wrapped, LoggingToolset)
+        assert wrapped.wrapped is capabilities[0].toolset
 
     def test_toolset_capability_tool_replayed_on_retry(self):
         """A tool supplied via a ``Toolset`` capability is cached and replayed on a

--- a/providers/common/ai/tests/unit/common/ai/operators/test_agent.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_agent.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import logging
 import sys
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
@@ -23,7 +24,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pydantic import BaseModel
 from pydantic_ai import Agent
-from pydantic_ai.capabilities import MCP, PrefixTools, Toolset
+from pydantic_ai.capabilities import Toolset
 from pydantic_ai.messages import (
     ModelMessagesTypeAdapter,
     ModelRequest,
@@ -199,9 +200,10 @@ class TestAgentOperatorExecute:
 
         assert result == "The answer is 42."
         mock_hook_cls.get_hook.assert_called_once_with("my_llm", hook_params={"model_id": None})
-        mock_hook_cls.get_hook.return_value.create_agent.assert_called_once_with(
-            output_type=str, instructions="You are helpful."
-        )
+        create_kwargs = mock_hook_cls.get_hook.return_value.create_agent.call_args.kwargs
+        assert create_kwargs["output_type"] is str
+        assert create_kwargs["instructions"] == "You are helpful."
+        assert isinstance(create_kwargs["capabilities"][0], ToolLoggingCapability)
         mock_agent.run_sync.assert_called_once_with("What is the answer?", usage_limits=None)
 
     @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
@@ -241,51 +243,33 @@ class TestAgentOperatorExecute:
         assert create_call[1]["toolsets"] == [mock_toolset]
 
     @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
-    def test_tool_logging_wraps_assembled_capability_toolsets(self, mock_hook_cls):
-        """Capability logging applies after pydantic-ai assembles all toolset shapes."""
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = _make_mock_agent("done")
+    def test_tool_logging_wraps_agent_param_tools(self, mock_hook_cls, caplog):
+        """Tool logging wraps the complete toolset assembled by pydantic-ai."""
 
-        inner = FunctionToolset()
+        def my_tool() -> str:
+            return "tool-result"
 
-        def factory(ctx):
-            return FunctionToolset()
+        def model_fn(messages, info):
+            saw_return = any(isinstance(p, ToolReturnPart) for m in messages for p in getattr(m, "parts", []))
+            if saw_return:
+                return ModelResponse(parts=[TextPart(content="done")])
+            return ModelResponse(parts=[ToolCallPart(tool_name="my_tool", args={}, tool_call_id="c1")])
 
-        capabilities = [
-            Toolset(inner),
-            Toolset(factory),
-            PrefixTools(wrapped=Toolset(inner), prefix="nested"),
-            MCP(url="https://example.com/mcp"),
-        ]
-
-        enabled = AgentOperator(
-            task_id="enabled",
+        mock_hook_cls.get_hook.return_value.create_agent.side_effect = lambda **kw: Agent(
+            FunctionModel(model_fn), **kw
+        )
+        op = AgentOperator(
+            task_id="test",
             prompt="Do something",
             llm_conn_id="my_llm",
-            agent_params={"capabilities": capabilities},
+            agent_params={"tools": [my_tool]},
         )
-        enabled.execute(context={})
 
-        passed = mock_hook_cls.get_hook.return_value.create_agent.call_args.kwargs["capabilities"]
-        assert passed[:-1] == capabilities
-        logging_capability = passed[-1]
-        assert isinstance(logging_capability, ToolLoggingCapability)
-        assembled = FunctionToolset()
-        wrapped = logging_capability.get_wrapper_toolset(assembled)
-        assert isinstance(wrapped, LoggingToolset)
-        assert wrapped.wrapped is assembled
-        assert wrapped.logger is enabled.log
+        with caplog.at_level(logging.INFO):
+            result = op.execute(context={})
 
-        disabled = AgentOperator(
-            task_id="disabled",
-            prompt="Do something",
-            llm_conn_id="my_llm",
-            enable_tool_logging=False,
-            agent_params={"capabilities": capabilities},
-        )
-        disabled.execute(context={})
-
-        passed = mock_hook_cls.get_hook.return_value.create_agent.call_args.kwargs["capabilities"]
-        assert passed == capabilities
+        assert result == "done"
+        assert any(record.message == "::group::Tool call: my_tool" for record in caplog.records)
 
     @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
     def test_execute_passes_agent_params(self, mock_hook_cls):

--- a/providers/common/ai/tests/unit/common/ai/toolsets/test_logging.py
+++ b/providers/common/ai/tests/unit/common/ai/toolsets/test_logging.py
@@ -20,8 +20,9 @@ import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pydantic_ai.toolsets import FunctionToolset
 
-from airflow.providers.common.ai.toolsets.logging import LoggingToolset
+from airflow.providers.common.ai.toolsets.logging import LoggingToolset, ToolLoggingCapability
 
 
 @pytest.fixture
@@ -109,3 +110,17 @@ class TestLoggingToolset:
             await logging_toolset.call_tool("list_tables", {}, ctx, tool)
 
         assert not any("Tool args:" in r.message for r in caplog.records)
+
+
+class TestToolLoggingCapability:
+    def test_wraps_assembled_toolset(self, logger):
+        toolset = FunctionToolset()
+
+        wrapped = ToolLoggingCapability(logger=logger).get_wrapper_toolset(toolset)
+
+        assert isinstance(wrapped, LoggingToolset)
+        assert wrapped.wrapped is toolset
+        assert wrapped.logger is logger
+
+    def test_is_not_serializable(self):
+        assert ToolLoggingCapability.get_serialization_name() is None

--- a/providers/common/ai/tests/unit/common/ai/utils/test_logging.py
+++ b/providers/common/ai/tests/unit/common/ai/utils/test_logging.py
@@ -26,11 +26,9 @@ from pydantic_ai.messages import (
     ToolCallPart,
 )
 
-from airflow.providers.common.ai.toolsets.logging import LoggingToolset
 from airflow.providers.common.ai.utils.logging import (
     _log_output_debug,
     log_run_summary,
-    wrap_toolsets_for_logging,
 )
 
 
@@ -134,18 +132,3 @@ class TestLogOutputDebug:
 
         debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
         assert len(debug_records) == 0
-
-
-class TestWrapToolsetsForLogging:
-    def test_wraps_each_toolset(self):
-        ts_a = MagicMock()
-        ts_b = MagicMock()
-        logger = logging.getLogger("test.wrap")
-
-        wrapped = wrap_toolsets_for_logging([ts_a, ts_b], logger)
-
-        assert len(wrapped) == 2
-        assert all(isinstance(w, LoggingToolset) for w in wrapped)
-        assert wrapped[0].wrapped is ts_a
-        assert wrapped[1].wrapped is ts_b
-        assert wrapped[0].logger is logger


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->


## Why

`AgentOperator` applies real-time tool-call logging to entries passed through `toolsets=`, but concrete toolsets supplied through a pydantic-ai `Toolset` capability bypass that logging even when `enable_tool_logging=True`.

## What

- Apply `LoggingToolset` to concrete toolsets supplied through a `Toolset` capability.
- Keep logging outside durable caching as `LoggingToolset(CachingToolset(...))`.

## Testing

- Unit tests cover concrete, factory-backed, non-`Toolset`, disabled-logging, and durable-cache cases.


### Before

<img width="928" height="151" alt="image" src="https://github.com/user-attachments/assets/fd780eed-ae82-4cce-be2b-dda857c5bc6e" />


### After


<img width="935" height="173" alt="image" src="https://github.com/user-attachments/assets/7fe9115b-4e17-478b-b3e8-a8a6e4bbbd80" />


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes — Codex (GPT-5.6-sol)

Generated-by: Codex (GPT-5.6-sol) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
