### PR TITLE
Fix docs spellcheck failure in the IBM Db2 provider

### DIFF
--- a/providers/ibm/db2/src/airflow/providers/ibm/db2/hooks/db2.py
+++ b/providers/ibm/db2/src/airflow/providers/ibm/db2/hooks/db2.py
@@ -74,7 +74,7 @@ class Db2Hook(DbApiHook):
 
     def get_conn(self) -> Any:
         """
-        Return ibm_db_dbi connection object.
+        Return ``ibm_db_dbi`` connection object.
 
         :return: Db2 connection object
         """


### PR DESCRIPTION
The nightly `Build documentation (--spellcheck-only)` job has been failing on the new IBM Db2 provider: sphinxcontrib-spelling flags `dbi` in the `Db2Hook.get_conn` docstring, because the module name is written as unquoted prose. Quoting it as an RST literal excludes it from the spellcheck, as the build's own error message recommends.

Failing job: https://github.com/apache/airflow/actions/runs/33166271901/job/98838898069

Verified locally with `breeze build-docs ibm.db2 --spellcheck-only` — `Finished spell-checking successfully`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)