### PR TITLE
Accept only the configured client on the Keycloak client_credentials grant

### DIFF
--- a/providers/keycloak/docs/changelog.rst
+++ b/providers/keycloak/docs/changelog.rst
@@ -25,6 +25,14 @@
 Changelog
 ---------
 
+.. note::
+    The unauthenticated ``POST /auth/token`` endpoint now accepts the ``client_credentials``
+    grant only for the client configured in ``[keycloak_auth_manager] client_id``. Previously
+    the credentials of any confidential client in the realm were accepted and exchanged for an
+    Airflow token. If a deployment authenticates with a service account belonging to a different
+    client, either point ``[keycloak_auth_manager] client_id`` at that client or issue the
+    credentials against the configured one -- other clients now receive ``403``.
+
 0.9.0
 .....
 

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/services/token.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/services/token.py
@@ -24,6 +24,10 @@ from keycloak import KeycloakAuthenticationError
 
 from airflow.api_fastapi.app import get_auth_manager
 from airflow.providers.common.compat.sdk import conf
+from airflow.providers.keycloak.auth_manager.constants import (
+    CONF_CLIENT_ID_KEY,
+    CONF_SECTION_NAME,
+)
 from airflow.providers.keycloak.auth_manager.keycloak_auth_manager import KeycloakAuthManager
 from airflow.providers.keycloak.auth_manager.user import KeycloakAuthManagerUser
 
@@ -71,7 +75,20 @@ def create_client_credentials_token(
     - Client Authentication: ON (confidential client)
 
     The service account must be configured with the appropriate roles/permissions.
+
+    Only the client Airflow is configured to use is accepted. The route this is reached
+    from is unauthenticated, so without that restriction the credentials of any
+    confidential client in the realm would be usable to obtain an Airflow token.
     """
+    if client_id != conf.get(CONF_SECTION_NAME, CONF_CLIENT_ID_KEY):
+        # Deliberately the same response as a failed credential exchange below: telling
+        # the caller which of the two checks rejected them would make the endpoint a
+        # discovery oracle for client ids in the realm.
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Client credentials authentication failed",
+        )
+
     # Get Keycloak client with service account credentials
     client = KeycloakAuthManager.get_keycloak_client(
         client_id=client_id,

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/services/test_token.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/services/test_token.py
@@ -83,6 +83,7 @@ class TestTokenService:
     @conf_vars(
         {
             ("api_auth", "jwt_expiration_time"): "10",
+            ("keycloak_auth_manager", "client_id"): "test_client",
         }
     )
     @patch("airflow.providers.keycloak.auth_manager.services.token.get_auth_manager")
@@ -117,6 +118,7 @@ class TestTokenService:
     @conf_vars(
         {
             ("api_auth", "jwt_expiration_time"): "10",
+            ("keycloak_auth_manager", "client_id"): "invalid_client",
         }
     )
     @patch("airflow.providers.keycloak.auth_manager.services.token.KeycloakAuthManager.get_keycloak_client")
@@ -133,3 +135,43 @@ class TestTokenService:
 
         assert exc_info.value.status_code == 403
         assert "Client credentials authentication failed" in exc_info.value.detail
+
+    @conf_vars(
+        {
+            ("api_auth", "jwt_expiration_time"): "10",
+            ("keycloak_auth_manager", "client_id"): "airflow",
+        }
+    )
+    @patch("airflow.providers.keycloak.auth_manager.services.token.KeycloakAuthManager.get_keycloak_client")
+    def test_create_token_client_credentials_rejects_other_client(self, mock_get_keycloak_client):
+        """Only the client Airflow is configured with may exchange credentials for a token."""
+        with pytest.raises(fastapi.exceptions.HTTPException) as exc_info:
+            create_client_credentials_token(
+                client_id="some_other_realm_client", client_secret="its_own_valid_secret"
+            )
+
+        assert exc_info.value.status_code == 403
+        # No exchange is attempted: the credentials are never sent to Keycloak, so the
+        # endpoint cannot be used to test whether another client's secret is valid.
+        mock_get_keycloak_client.assert_not_called()
+
+    @conf_vars(
+        {
+            ("api_auth", "jwt_expiration_time"): "10",
+            ("keycloak_auth_manager", "client_id"): "airflow",
+        }
+    )
+    @patch("airflow.providers.keycloak.auth_manager.services.token.KeycloakAuthManager.get_keycloak_client")
+    def test_create_token_client_credentials_rejection_is_indistinguishable(self, mock_get_keycloak_client):
+        """A wrong client id and a wrong secret must not be tellable apart."""
+        mock_keycloak_client = Mock()
+        mock_keycloak_client.token.side_effect = KeycloakAuthenticationError()
+        mock_get_keycloak_client.return_value = mock_keycloak_client
+
+        with pytest.raises(fastapi.exceptions.HTTPException) as wrong_secret:
+            create_client_credentials_token(client_id="airflow", client_secret="wrong")
+        with pytest.raises(fastapi.exceptions.HTTPException) as wrong_client:
+            create_client_credentials_token(client_id="other", client_secret="wrong")
+
+        assert wrong_secret.value.status_code == wrong_client.value.status_code
+        assert wrong_secret.value.detail == wrong_client.value.detail


### PR DESCRIPTION
`create_client_credentials_token` built a Keycloak client from the caller-supplied `client_id` and `client_secret`, performed the `client_credentials` grant, and minted an Airflow session JWT for whichever service account came back:

```python
client = KeycloakAuthManager.get_keycloak_client(
    client_id=client_id,
    client_secret=client_secret,
)
```

The route reaching it (`POST /auth/token`) is unauthenticated and there was no restriction on which `client_id` was acceptable. In a realm shared with other applications, the credentials of **any** confidential client became valid Airflow login credentials — not only those of the client Airflow is configured with.

The `client_id` is now compared against `[keycloak_auth_manager] client_id` before anything is sent to Keycloak.

Two properties of the rejection are deliberate, and both are covered by tests:

- **It reuses the response of a failed credential exchange.** A caller cannot tell "that client id is not the configured one" from "that secret is wrong", so the endpoint does not become a way to discover which client ids exist in the realm.
- **It returns before the exchange.** Nothing is sent to Keycloak, so the endpoint cannot be used to test whether some other client's secret is valid.

**On the tests.** The two existing `client_credentials` tests passed an arbitrary `client_id` with no configured value present; they now declare one, which is closer to a real deployment either way. Added a test that another realm client is refused with no exchange attempted (`assert_not_called` on the client factory), and one asserting a wrong id and a wrong secret remain indistinguishable.

Local: 290 passed, 1 skipped across the Keycloak provider; ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
