### PR TITLE
Bind Keycloak cookie tokens to the Airflow session identity

### DIFF
--- a/providers/keycloak/docs/changelog.rst
+++ b/providers/keycloak/docs/changelog.rst
@@ -25,14 +25,6 @@
 Changelog
 ---------
 
-.. note::
-    The Keycloak access and refresh tokens carried in the ``_access_token`` and
-    ``_refresh_token`` cookies are now required to name the same subject as the signed
-    Airflow JWT they accompany. A request whose cookies disagree is rejected rather than
-    served, so a session assembled from tokens belonging to different subjects no longer
-    authenticates. Ordinary sessions are unaffected: the login flow issues all three
-    cookies for one subject.
-
 0.9.0
 .....
 

--- a/providers/keycloak/docs/changelog.rst
+++ b/providers/keycloak/docs/changelog.rst
@@ -25,6 +25,14 @@
 Changelog
 ---------
 
+.. note::
+    The Keycloak access and refresh tokens carried in the ``_access_token`` and
+    ``_refresh_token`` cookies are now required to name the same subject as the signed
+    Airflow JWT they accompany. A request whose cookies disagree is rejected rather than
+    served, so a session assembled from tokens belonging to different subjects no longer
+    authenticates. Ordinary sessions are unaffected: the login flow issues all three
+    cookies for one subject.
+
 0.9.0
 .....
 

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
@@ -29,6 +29,7 @@ from urllib.parse import urljoin
 
 import requests
 from fastapi import FastAPI
+from jwt import InvalidTokenError
 from keycloak import KeycloakOpenID
 from keycloak.exceptions import KeycloakPostError
 from requests.adapters import HTTPAdapter
@@ -174,6 +175,14 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         if not AIRFLOW_V_3_3_PLUS:
             return user
         if access_token:
+            # The Airflow JWT is signed and establishes who the caller is. The Keycloak
+            # tokens arrive in separate cookies that the signature does not cover, so
+            # pairing them unchecked would let a caller combine their own Airflow session
+            # with somebody else's Keycloak token: every authorization decision is then
+            # made for that subject, while the session identity, audit trail and logs
+            # continue to show this one.
+            if self._token_subject(access_token) != user.get_id():
+                raise InvalidTokenError("Keycloak access token does not belong to this Airflow session")
             user.access_token = access_token
             user.refresh_token = refresh_token
             return user
@@ -817,6 +826,29 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
             "Authorization": f"Bearer {access_token}",
             "Content-Type": "application/x-www-form-urlencoded",
         }
+
+    @staticmethod
+    def _token_subject(token: str) -> str | None:
+        """
+        Return the ``sub`` claim of a JWT without verifying its signature.
+
+        :meta private:
+
+        The value is only ever compared against an identity the signed Airflow JWT has
+        already established, so it is never trusted on its own. A forged token is
+        rejected by Keycloak when it is presented; a genuine token belonging to somebody
+        else is exactly what this comparison exists to catch. A token that cannot be
+        parsed yields ``None``, which matches no user id.
+
+        :param token: the token
+        """
+        try:
+            payload_b64 = token.split(".")[1] + "=="
+            payload = json.loads(urlsafe_b64decode(payload_b64))
+        except (IndexError, ValueError, TypeError):
+            return None
+        subject = payload.get("sub")
+        return str(subject) if subject is not None else None
 
     @staticmethod
     def _token_expired(token: str) -> bool:

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
@@ -845,9 +845,9 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         try:
             payload_b64 = token.split(".")[1] + "=="
             payload = json.loads(urlsafe_b64decode(payload_b64))
-        except (IndexError, ValueError, TypeError):
+            subject = payload["sub"]
+        except (IndexError, KeyError, TypeError, ValueError):
             return None
-        subject = payload.get("sub")
         return str(subject) if subject is not None else None
 
     @staticmethod

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
@@ -133,14 +133,19 @@ def _clear_filter_cache():
     cache_module._pending_requests.clear()
 
 
-def keycloak_token(subject: str) -> str:
-    """Build a JWT-shaped Keycloak token carrying ``sub``.
+def token_with_payload(payload: str) -> str:
+    """Build a JWT-shaped token whose payload segment is the given raw text.
 
     Only the payload segment is read when the token is bound to the Airflow session
     identity, so the header and signature are placeholders.
     """
-    payload = base64.urlsafe_b64encode(json.dumps({"sub": subject}).encode()).decode().rstrip("=")
-    return f"header.{payload}.signature"
+    encoded = base64.urlsafe_b64encode(payload.encode()).decode().rstrip("=")
+    return f"header.{encoded}.signature"
+
+
+def keycloak_token(subject: str) -> str:
+    """Build a JWT-shaped Keycloak token carrying ``sub``."""
+    return token_with_payload(json.dumps({"sub": subject}))
 
 
 class TestKeycloakAuthManager:
@@ -307,7 +312,17 @@ class TestKeycloakAuthManager:
 
     @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="Uses KeycloakJWTMiddleware and separate cookies")
     @pytest.mark.asyncio
-    async def test_get_user_from_token_rejects_unparsable_token(self, auth_manager):
+    @pytest.mark.parametrize(
+        "access_token",
+        [
+            pytest.param("not-a-jwt", id="no-payload-segment"),
+            pytest.param(token_with_payload("not json"), id="payload-not-json"),
+            pytest.param(token_with_payload("1"), id="payload-not-an-object"),
+            pytest.param(token_with_payload('{"other": "user_id"}'), id="payload-without-sub"),
+            pytest.param(token_with_payload('{"sub": null}'), id="payload-with-null-sub"),
+        ],
+    )
+    async def test_get_user_from_token_rejects_unparsable_token(self, auth_manager, access_token):
         """A token whose subject cannot be read matches no user and is refused."""
         mock_get_user_from_token = AsyncMock(
             return_value=KeycloakAuthManagerUser(
@@ -318,7 +333,7 @@ class TestKeycloakAuthManager:
             patch.object(BaseAuthManager, "get_user_from_token", mock_get_user_from_token),
             pytest.raises(InvalidTokenError, match="does not belong to this Airflow session"),
         ):
-            await auth_manager.get_user_from_token("token", "not-a-jwt", "refresh_token")
+            await auth_manager.get_user_from_token("token", access_token, "refresh_token")
 
     def test_get_url_login(self, auth_manager):
         result = auth_manager.get_url_login()

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
@@ -23,6 +23,7 @@ from contextlib import ExitStack
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from jwt import InvalidTokenError
 from keycloak import KeycloakPostError
 
 from airflow.api_fastapi.app import AUTH_MANAGER_FASTAPI_APP_PREFIX
@@ -132,6 +133,16 @@ def _clear_filter_cache():
     cache_module._pending_requests.clear()
 
 
+def keycloak_token(subject: str) -> str:
+    """Build a JWT-shaped Keycloak token carrying ``sub``.
+
+    Only the payload segment is read when the token is bound to the Airflow session
+    identity, so the header and signature are placeholders.
+    """
+    payload = base64.urlsafe_b64encode(json.dumps({"sub": subject}).encode()).decode().rstrip("=")
+    return f"header.{payload}.signature"
+
+
 class TestKeycloakAuthManager:
     @pytest.mark.parametrize(
         ("token_data", "exp"),
@@ -207,11 +218,12 @@ class TestKeycloakAuthManager:
                 mock_get_user_from_token,
             ),
         ):
-            user = await auth_manager.get_user_from_token("token", "access_token", "refresh_token")
+            access_token = keycloak_token("user_id")
+            user = await auth_manager.get_user_from_token("token", access_token, "refresh_token")
         mock_get_user_from_token.assert_called_with("token")
         assert user.get_id() == "user_id"
         assert user.get_name() == "name"
-        assert user.access_token == "access_token"
+        assert user.access_token == access_token
         assert user.refresh_token == "refresh_token"
 
     @pytest.mark.skipif(AIRFLOW_V_3_3_PLUS, reason="Testing Old Keycloak JWT flow.")
@@ -270,12 +282,43 @@ class TestKeycloakAuthManager:
                 mock_get_user_from_token,
             ),
         ):
-            user = await auth_manager.get_user_from_token("token", "access_token", "refresh_token")
+            access_token = keycloak_token("user_id")
+            user = await auth_manager.get_user_from_token("token", access_token, "refresh_token")
         mock_get_user_from_token.assert_called_with("token")
         assert user.get_id() == "user_id"
         assert user.get_name() == "name"
-        assert user.access_token == "access_token"
+        assert user.access_token == access_token
         assert user.refresh_token == "refresh_token"
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="Uses KeycloakJWTMiddleware and separate cookies")
+    @pytest.mark.asyncio
+    async def test_get_user_from_token_rejects_another_subjects_token(self, auth_manager):
+        """A Keycloak token naming a different subject must not attach to this session."""
+        mock_get_user_from_token = AsyncMock(
+            return_value=KeycloakAuthManagerUser(
+                user_id="user_id", name="name", access_token="", refresh_token=None
+            )
+        )
+        with (
+            patch.object(BaseAuthManager, "get_user_from_token", mock_get_user_from_token),
+            pytest.raises(InvalidTokenError, match="does not belong to this Airflow session"),
+        ):
+            await auth_manager.get_user_from_token("token", keycloak_token("someone_else"), "refresh_token")
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="Uses KeycloakJWTMiddleware and separate cookies")
+    @pytest.mark.asyncio
+    async def test_get_user_from_token_rejects_unparsable_token(self, auth_manager):
+        """A token whose subject cannot be read matches no user and is refused."""
+        mock_get_user_from_token = AsyncMock(
+            return_value=KeycloakAuthManagerUser(
+                user_id="user_id", name="name", access_token="", refresh_token=None
+            )
+        )
+        with (
+            patch.object(BaseAuthManager, "get_user_from_token", mock_get_user_from_token),
+            pytest.raises(InvalidTokenError, match="does not belong to this Airflow session"),
+        ):
+            await auth_manager.get_user_from_token("token", "not-a-jwt", "refresh_token")
 
     def test_get_url_login(self, auth_manager):
         result = auth_manager.get_url_login()


### PR DESCRIPTION
For Airflow 3.3+ the Keycloak access and refresh tokens are no longer carried in the signed Airflow JWT — `serialize_user` deliberately omits them, because Keycloak tokens can exceed the 4k cookie limit — and they travel in separate `_access_token` / `_refresh_token` cookies instead.

`get_user_from_token` validated the Airflow JWT and then attached whatever those cookies contained:

```python
user = cast("KeycloakAuthManagerUser", await super().get_user_from_token(token))
...
if access_token:
    user.access_token = access_token
    user.refresh_token = refresh_token
    return user
```

Nothing checked that the cookies described the same subject as the JWT. A caller could pair their own Airflow session with another subject's Keycloak token: every authorization decision is sent to Keycloak carrying `user.access_token`, so the effective privileges are that token's, while `get_id()` and `get_name()` — used for the session identity, audit records and logging — remain those of the Airflow JWT.

## The fix

The access token's `sub` is compared against the user id the signed JWT established, before the token is attached.

Both are the Keycloak subject. Every place a `KeycloakAuthManagerUser` is constructed sets `user_id` from `userinfo["sub"]` — the interactive login (`routes/login.py`), the password grant and the client-credentials grant (`services/token.py`) — so the comparison is direct rather than a mapping.

A token whose payload cannot be read yields no subject and therefore matches nothing.

## On reading the subject unverified

`_token_subject` decodes the payload without verifying the signature, mirroring the existing `_token_expired` helper alongside it. That is sufficient for this purpose, and deliberately so:

- the value is only ever compared against an identity the **signed** Airflow JWT has already established, so it is never trusted on its own;
- a forged token is rejected by Keycloak when it is presented for an authorization decision;
- a *genuine* token belonging to somebody else is precisely what this comparison exists to catch, and its `sub` is authentic.

Verifying the Keycloak signature here would add a round trip or key handling on every request without changing which tokens are accepted.

## Tests

The two existing tests passed the literal string `"access_token"` as a cookie value, which carries no subject at all; they now build a JWT-shaped token naming the same subject as the session. Added coverage for a token naming a different subject and for one that cannot be parsed. Reverting the source change fails both new tests.

Local: 290 passed, 1 skipped across the Keycloak provider; ruff and mypy clean.

The provider changelog gains a note at the top, since a session whose cookies disagree will now be refused rather than served.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
