### PR TITLE
Pass impersonation_chain to the Dataflow trigger for Beam Java/Python operators

### DIFF
--- a/providers/apache/beam/src/airflow/providers/apache/beam/operators/beam.py
+++ b/providers/apache/beam/src/airflow/providers/apache/beam/operators/beam.py
@@ -473,6 +473,7 @@ class BeamRunPythonPipelineOperator(BeamBasePipelineOperator):
                 "project_id": self.dataflow_config.project_id,
                 "location": location,
                 "gcp_conn_id": self.gcp_conn_id,
+                "impersonation_chain": self.dataflow_config.impersonation_chain,
             }
             trigger: DataflowJobStatusTrigger | DataflowJobStateCompleteTrigger
 
@@ -667,6 +668,7 @@ class BeamRunJavaPipelineOperator(BeamBasePipelineOperator):
                         "project_id": self.dataflow_config.project_id,
                         "location": self.dataflow_config.location,
                         "gcp_conn_id": self.gcp_conn_id,
+                        "impersonation_chain": self.dataflow_config.impersonation_chain,
                     }
                     trigger: DataflowJobStatusTrigger | DataflowJobStateCompleteTrigger
 

--- a/providers/apache/beam/tests/unit/apache/beam/operators/test_beam.py
+++ b/providers/apache/beam/tests/unit/apache/beam/operators/test_beam.py
@@ -1029,6 +1029,33 @@ class TestBeamRunPythonPipelineOperatorAsync:
         )
         beam_hook_mock.return_value.start_python_pipeline.assert_called_once()
 
+    @mock.patch(BEAM_OPERATOR_PATH.format("BeamHook"))
+    @mock.patch(BEAM_OPERATOR_PATH.format("DataflowHook"))
+    @mock.patch(BEAM_OPERATOR_PATH.format("GCSHook"))
+    def test_exec_dataflow_runner_passes_impersonation_chain_to_trigger(
+        self, gcs_hook_mock, dataflow_hook_mock, beam_hook_mock
+    ):
+        """The DataflowHook picks up impersonation_chain fine, but the trigger the
+        operator hands off to for the deferred wait was building its own kwargs
+        from scratch and dropping it, so a deferred run would poll Dataflow with
+        whatever credentials the worker itself has instead of the one configured
+        here."""
+        dataflow_config = DataflowConfiguration(impersonation_chain=TEST_IMPERSONATION_ACCOUNT)
+        op = BeamRunPythonPipelineOperator(
+            runner="DataflowRunner",
+            dataflow_config=dataflow_config,
+            **self.default_op_kwargs,
+        )
+        magic_mock = mock.MagicMock()
+        if AIRFLOW_V_3_0_PLUS:
+            with pytest.raises(TaskDeferred) as exc:
+                op.execute(context=magic_mock)
+        else:
+            with pytest.raises(TaskDeferred) as exc, pytest.warns(AirflowProviderDeprecationWarning):
+                op.execute(context=magic_mock)
+
+        assert exc.value.trigger.impersonation_chain == TEST_IMPERSONATION_ACCOUNT
+
     @mock.patch(BEAM_OPERATOR_PATH.format("DataflowJobLink.persist"))
     @mock.patch(BEAM_OPERATOR_PATH.format("BeamHook"))
     @mock.patch(BEAM_OPERATOR_PATH.format("GCSHook"))
@@ -1156,6 +1183,31 @@ class TestBeamRunJavaPipelineOperatorAsync:
             wait_until_finished=dataflow_config.wait_until_finished,
         )
         beam_hook_mock.return_value.start_python_pipeline.assert_not_called()
+
+    @mock.patch(BEAM_OPERATOR_PATH.format("BeamHook"))
+    @mock.patch(BEAM_OPERATOR_PATH.format("DataflowHook"))
+    @mock.patch(BEAM_OPERATOR_PATH.format("GCSHook"))
+    def test_exec_dataflow_runner_passes_impersonation_chain_to_trigger(
+        self, gcs_hook_mock, dataflow_hook_mock, beam_hook_mock
+    ):
+        """Same gap as on the Python operator: the DataflowHook gets
+        impersonation_chain but the trigger built for the deferred wait
+        doesn't, so it ends up polling the job status under whatever
+        credentials the worker happens to have."""
+        dataflow_config = DataflowConfiguration(impersonation_chain=TEST_IMPERSONATION_ACCOUNT)
+        op = BeamRunJavaPipelineOperator(
+            runner="DataflowRunner", dataflow_config=dataflow_config, **self.default_op_kwargs
+        )
+        dataflow_hook_mock.return_value.is_job_dataflow_running.return_value = False
+        magic_mock = mock.MagicMock()
+        if AIRFLOW_V_3_0_PLUS:
+            with pytest.raises(TaskDeferred) as exc:
+                op.execute(context=magic_mock)
+        else:
+            with pytest.raises(TaskDeferred) as exc, pytest.warns(AirflowProviderDeprecationWarning):
+                op.execute(context=magic_mock)
+
+        assert exc.value.trigger.impersonation_chain == TEST_IMPERSONATION_ACCOUNT
 
     @mock.patch(BEAM_OPERATOR_PATH.format("DataflowJobLink.persist"))
     @mock.patch(BEAM_OPERATOR_PATH.format("BeamHook"))


### PR DESCRIPTION
Fixes #72135

BeamRunJavaPipelineOperator and BeamRunPythonPipelineOperator both use `self.dataflow_config.impersonation_chain` when running the pipeline directly, but when deferrable mode is on and they build `trigger_args` for `DataflowJobStatusTrigger` / `DataflowJobStateCompleteTrigger`, that value never gets passed through. So a deferred task ends up polling Dataflow for completion with whatever credentials the worker has, not the impersonated account the operator was configured with.

Both trigger classes already accept `impersonation_chain` in their constructor (see `airflow/providers/google/cloud/triggers/dataflow.py`), so this is just a matter of including it in the dict the operators build.

While looking at this I noticed the exact same pattern shows up in both operators, the Java one that the issue reports and the Python one that wasn't reported but has the identical bug, so I fixed both.

I added a test for each operator asserting the trigger it raises actually carries the configured impersonation_chain. I couldn't run the full provider test suite locally since it needs the breeze dev environment, but I verified the fix against the real installed package by patching in the modified module and driving it through the exact same code path the tests exercise, confirming it fails without the change (impersonation_chain comes through as None) and passes with it.

Ran ruff on both changed files with no issues.
