### PR TITLE
Resolve the caller from the explicit credential, not the session cookie

### DIFF
--- a/airflow-core/newsfragments/72225.significant.rst
+++ b/airflow-core/newsfragments/72225.significant.rst
@@ -1,0 +1,24 @@
+An explicit credential now takes precedence over the session cookie
+
+``get_user()`` codes the precedence bearer, then OAuth2, then the session cookie, but
+that block was unreachable whenever a cookie was present. ``JWTRefreshMiddleware`` runs
+first, resolves a user from the ``_token`` cookie alone and stamps it on
+``request.state``, and ``get_user()`` returned that cached user before looking at either
+explicit credential. The effective order on every core-API route was cookie over bearer.
+
+A request carrying both a session cookie and an explicit credential therefore executed,
+and was recorded in the audit log, as the cookie's principal rather than the identity the
+client presented. The cached user is now honoured only when the request carries no
+explicit credential.
+
+**Behaviour changes:**
+
+- A request carrying **both** a ``_token`` cookie and an ``Authorization: Bearer`` header
+  is now resolved as the bearer token's principal, where it was previously resolved as the
+  cookie's. The same applies to a cookie combined with an OAuth2 token.
+- Requests carrying a single credential are unaffected. Cookie-only browser sessions keep
+  the token-refresh behaviour of ``JWTRefreshMiddleware`` unchanged.
+- Clients that relied on the cookie winning -- for example a browser-based tool that sent a
+  service account's bearer token while a user session cookie was present, and expected the
+  user's identity to apply -- will now act as the bearer token's principal. Remove the
+  header, or the cookie, to select the intended identity explicitly.

--- a/airflow-core/newsfragments/72225.significant.rst
+++ b/airflow-core/newsfragments/72225.significant.rst
@@ -16,6 +16,9 @@ explicit credential.
 - A request carrying **both** a ``_token`` cookie and an ``Authorization: Bearer`` header
   is now resolved as the bearer token's principal, where it was previously resolved as the
   cookie's. The same applies to a cookie combined with an OAuth2 token.
+- An **invalid or expired** explicit credential is now rejected with ``401``/``403`` even
+  when a valid ``_token`` cookie accompanies it. Previously the cookie silently took over
+  and the request succeeded as the cookie's principal; the failure is now loud.
 - Requests carrying a single credential are unaffected. Cookie-only browser sessions keep
   the token-refresh behaviour of ``JWTRefreshMiddleware`` unchanged.
 - Clients that relied on the cookie winning -- for example a browser-based tool that sent a

--- a/airflow-core/src/airflow/api_fastapi/core_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/security.py
@@ -147,22 +147,26 @@ async def get_user(
     oauth_token: str | None = Depends(oauth2_scheme),
     bearer_credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
 ) -> BaseUser:
-    # A user might have been already built by a trusted in-tree middleware (currently
-    # only `JWTRefreshMiddleware`); if so, it is stored in `request.state.user` AND
-    # `request.state.user_authenticated_via` is set to the trust sentinel above.
-    # Honour the cached user only when both are present, so a stray `state.user`
-    # assignment from unrelated middleware can't bypass JWT validation.
-    user: BaseUser | None = getattr(request.state, "user", None)
-    trust_marker = getattr(request.state, "user_authenticated_via", None)
-    if user and trust_marker is USER_INJECTED_BY_TRUSTED_MIDDLEWARE:
-        return user
-
+    # An explicitly supplied credential always wins over the ambient session cookie.
     token_str: str | None
     if bearer_credentials and bearer_credentials.scheme.lower() == "bearer":
         token_str = bearer_credentials.credentials
     elif oauth_token:
         token_str = oauth_token
     else:
+        token_str = None
+
+    if token_str is None:
+        # No explicit credential on this request, so the cookie is the caller's identity.
+        # A user might have been already built by a trusted in-tree middleware (currently
+        # only `JWTRefreshMiddleware`); if so, it is stored in `request.state.user` AND
+        # `request.state.user_authenticated_via` is set to the trust sentinel above.
+        # Honour the cached user only when both are present, so a stray `state.user`
+        # assignment from unrelated middleware can't bypass JWT validation.
+        user: BaseUser | None = getattr(request.state, "user", None)
+        trust_marker = getattr(request.state, "user_authenticated_via", None)
+        if user and trust_marker is USER_INJECTED_BY_TRUSTED_MIDDLEWARE:
+            return user
         token_str = request.cookies.get(COOKIE_NAME_JWT_TOKEN)
 
     return await resolve_user_from_token(token_str)

--- a/airflow-core/src/airflow/api_fastapi/core_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/security.py
@@ -148,28 +148,22 @@ async def get_user(
     bearer_credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
 ) -> BaseUser:
     # An explicitly supplied credential always wins over the ambient session cookie.
-    token_str: str | None
     if bearer_credentials and bearer_credentials.scheme.lower() == "bearer":
-        token_str = bearer_credentials.credentials
-    elif oauth_token:
-        token_str = oauth_token
-    else:
-        token_str = None
+        return await resolve_user_from_token(bearer_credentials.credentials)
+    if oauth_token:
+        return await resolve_user_from_token(oauth_token)
 
-    if token_str is None:
-        # No explicit credential on this request, so the cookie is the caller's identity.
-        # A user might have been already built by a trusted in-tree middleware (currently
-        # only `JWTRefreshMiddleware`); if so, it is stored in `request.state.user` AND
-        # `request.state.user_authenticated_via` is set to the trust sentinel above.
-        # Honour the cached user only when both are present, so a stray `state.user`
-        # assignment from unrelated middleware can't bypass JWT validation.
-        user: BaseUser | None = getattr(request.state, "user", None)
-        trust_marker = getattr(request.state, "user_authenticated_via", None)
-        if user and trust_marker is USER_INJECTED_BY_TRUSTED_MIDDLEWARE:
-            return user
-        token_str = request.cookies.get(COOKIE_NAME_JWT_TOKEN)
-
-    return await resolve_user_from_token(token_str)
+    # No explicit credential on this request, so the cookie is the caller's identity.
+    # A user might have been already built by a trusted in-tree middleware (currently
+    # only `JWTRefreshMiddleware`); if so, it is stored in `request.state.user` AND
+    # `request.state.user_authenticated_via` is set to the trust sentinel above.
+    # Honour the cached user only when both are present, so a stray `state.user`
+    # assignment from unrelated middleware can't bypass JWT validation.
+    user: BaseUser | None = getattr(request.state, "user", None)
+    trust_marker = getattr(request.state, "user_authenticated_via", None)
+    if user and trust_marker is USER_INJECTED_BY_TRUSTED_MIDDLEWARE:
+        return user
+    return await resolve_user_from_token(request.cookies.get(COOKIE_NAME_JWT_TOKEN))
 
 
 GetUserDep = Annotated[BaseUser, Depends(get_user)]

--- a/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
@@ -200,6 +200,48 @@ class TestFastApiSecurity:
         mock_resolve_user_from_token.assert_called_once_with("cookie_token")
 
     @pytest.mark.parametrize(
+        ("oauth_token", "bearer_credentials_creds", "expected"),
+        [
+            pytest.param(None, "bearer_token", "bearer_token", id="bearer"),
+            pytest.param("oauth_token", None, "oauth_token", id="oauth"),
+        ],
+    )
+    @patch("airflow.api_fastapi.core_api.security.resolve_user_from_token")
+    async def test_get_user_explicit_credential_beats_cookie_user(
+        self, mock_resolve_user_from_token, oauth_token, bearer_credentials_creds, expected
+    ):
+        """An explicitly supplied credential wins over the cookie-derived session user.
+
+        `JWTRefreshMiddleware` resolves a user from the `_token` cookie alone and stamps
+        it on `request.state`. When the client *also* presents an explicit credential,
+        that credential is the identity the caller asked to act as, so it must be the one
+        that is resolved — otherwise the request executes, and is audit-logged, as the
+        cookie's principal instead.
+        """
+        from airflow.api_fastapi.core_api.security import USER_INJECTED_BY_TRUSTED_MIDDLEWARE
+
+        cookie_user = Mock(name="cookie_user")
+        token_user = Mock(name="token_user")
+        mock_resolve_user_from_token.return_value = token_user
+
+        request = Mock()
+        request.state.user = cookie_user
+        request.state.user_authenticated_via = USER_INJECTED_BY_TRUSTED_MIDDLEWARE
+        request.cookies = {COOKIE_NAME_JWT_TOKEN: "cookie_token"}
+
+        bearer_credentials = None
+        if bearer_credentials_creds:
+            bearer_credentials = Mock()
+            bearer_credentials.scheme = "bearer"
+            bearer_credentials.credentials = bearer_credentials_creds
+
+        result = await get_user(request, oauth_token, bearer_credentials)
+
+        assert result == token_user
+        assert result != cookie_user
+        mock_resolve_user_from_token.assert_called_once_with(expected)
+
+    @pytest.mark.parametrize(
         ("oauth_token", "bearer_credentials_creds", "cookies", "expected"),
         [
             ("oauth_token", None, {}, "oauth_token"),


### PR DESCRIPTION
`get_user()` codes an explicit precedence — bearer, then OAuth2, then the
session cookie:

```python
if bearer_credentials and bearer_credentials.scheme.lower() == "bearer":
    token_str = bearer_credentials.credentials
elif oauth_token:
    token_str = oauth_token
else:
    token_str = request.cookies.get(COOKIE_NAME_JWT_TOKEN)
```

That block was never reached when a session cookie was present. `JWTRefreshMiddleware`
runs first, resolves a user from the `_token` cookie alone, and stamps it on
`request.state` together with the trust sentinel; `get_user()` returned that cached
user up front, before looking at either explicit credential. The effective order on
every core-API route was therefore **cookie over bearer** — the inverse of what the
function reads as doing.

So a request carrying both a cookie and an explicit `Authorization: Bearer` token ran
as the cookie's principal. The token the client deliberately presented was ignored,
and the request was recorded in the audit log under the wrong identity.

## The change

The cached user is honoured only when the request carries no explicit credential —
which is the case it exists for: a browser session whose token the middleware has just
refreshed. When a bearer or OAuth2 token is present, that token is resolved instead.

The trust-sentinel check is unchanged and still guards the cached-user path; it has
simply moved inside the no-explicit-credential branch.

## Behaviour

| Request carries | Resolved as |
|---|---|
| cookie only | cookie principal (refreshed by the middleware, as before) |
| bearer only | bearer principal (as before) |
| OAuth2 only | OAuth2 principal (as before) |
| cookie **and** bearer | bearer principal (**changed** — was the cookie) |
| cookie **and** OAuth2 | OAuth2 principal (**changed** — was the cookie) |

Only the two mixed-credential rows change. A client that sends one credential is
unaffected, and cookie-only browser sessions keep the refresh behaviour intact.

## Tests

`test_get_user_explicit_credential_beats_cookie_user`, parametrised over bearer and
OAuth2: a trusted cookie-derived user is stamped on `request.state` *and* an explicit
credential is supplied; the explicit one must win. Both fail if the source change is
reverted.

The existing `test_get_user_with_trusted_request_state` still passes unmodified — it
supplies no explicit credential, so it exercises the path that was deliberately kept.

140 passed across `core_api/test_security.py` and `auth/middlewares/`; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
