### PR TITLE
Fix static checks randomly failing with "PYTHONWARNINGS not set"

### DIFF
--- a/dev/breeze/src/airflow_breeze/params/shell_params.py
+++ b/dev/breeze/src/airflow_breeze/params/shell_params.py
@@ -588,7 +588,9 @@ services:
         separately with different test types.
 
         This is the only place where you need to add environment variables if you want to pass them to
-        docker or docker-compose.
+        docker or docker-compose. Variables that only some of the invocations set are the exception -
+        they are listed in the ``environment`` section of ``scripts/ci/docker-compose/base.yml``
+        instead, see _generate_env_for_docker_compose_file_if_needed for why.
 
         :return: dictionary of env variables to use for docker-compose and docker command
         """
@@ -705,7 +707,6 @@ services:
         _set_var(_env, "PROVIDERS_CONSTRAINTS_REFERENCE", self.providers_constraints_reference)
         _set_var(_env, "PROVIDERS_SKIP_CONSTRAINTS", self.providers_skip_constraints)
         _set_var(_env, "PYTHONDONTWRITEBYTECODE", "true")
-        _set_var(_env, "PYTHONWARNINGS", None, None)
         _set_var(_env, "PYTHON_MAJOR_MINOR_VERSION", self.python)
         _set_var(_env, "QUIET", self.quiet)
         _set_var(_env, "REDIS_HOST_PORT", None, REDIS_HOST_PORT)
@@ -793,6 +794,10 @@ services:
         The list of variables might change over time, and we want to keep the list updated only in
         one place (above env_variables_for_docker_commands method). So we need to regenerate the env
         files automatically when new variable is added to the list or removed.
+
+        The keys must not depend on the ambient environment though. All concurrent breeze invocations
+        share these files, so a key that only some of them contribute is taken away again from the
+        containers of the others as soon as another invocation regenerates the files.
 
         Docker-Compose based tests can start in parallel, so we want to make sure we generate it once
         per invocation of breeze command otherwise there could be nasty race condition that

--- a/dev/breeze/tests/test_shell_params.py
+++ b/dev/breeze/tests/test_shell_params.py
@@ -20,10 +20,12 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
+import yaml
 from rich.console import Console
 
 from airflow_breeze.branch_defaults import AIRFLOW_BRANCH
 from airflow_breeze.params.shell_params import ShellParams
+from airflow_breeze.utils.path_utils import SCRIPTS_CI_DOCKER_COMPOSE_BASE_PATH
 
 console = Console(width=400, color_system="standard")
 
@@ -229,3 +231,26 @@ def test_shell_params_to_env_var_conversion(
                 console.print(env_vars)
                 error = True
         assert not error, "Some values are not as expected."
+
+
+def test_generated_env_files_do_not_change_when_pythonwarnings_is_set(tmp_path, monkeypatch):
+    docker_env_path = tmp_path / "_generated_docker.env"
+    compose_env_path = tmp_path / "_generated_docker_compose.env"
+    with (
+        patch("airflow_breeze.params.shell_params.GENERATED_DOCKER_ENV_PATH", docker_env_path),
+        patch("airflow_breeze.params.shell_params.GENERATED_DOCKER_COMPOSE_ENV_PATH", compose_env_path),
+        patch("airflow_breeze.params.shell_params.GENERATED_DOCKER_LOCK_PATH", tmp_path / "_generated.lock"),
+    ):
+        monkeypatch.delenv("PYTHONWARNINGS", raising=False)
+        _ = ShellParams().env_variables_for_docker_commands
+        docker_env = docker_env_path.read_text()
+        compose_env = compose_env_path.read_text()
+        monkeypatch.setenv("PYTHONWARNINGS", "default")
+        _ = ShellParams().env_variables_for_docker_commands
+        assert docker_env_path.read_text() == docker_env
+        assert compose_env_path.read_text() == compose_env
+
+
+def test_pythonwarnings_is_forwarded_by_the_compose_base_file():
+    base_compose_file = yaml.safe_load(SCRIPTS_CI_DOCKER_COMPOSE_BASE_PATH.read_text())
+    assert "PYTHONWARNINGS" in base_compose_file["services"]["airflow"]["environment"]

--- a/scripts/ci/docker-compose/base.yml
+++ b/scripts/ci/docker-compose/base.yml
@@ -23,6 +23,9 @@ services:
       - USER=root
       - ADDITIONAL_PATH=~/.local/bin
       - KUBECONFIG=/files/.kube/config
+      # Only some breeze invocations set it, so it cannot go through the shared
+      # _generated_docker_compose.env - see ShellParams.env_variables_for_docker_commands.
+      - PYTHONWARNINGS
     env_file:
       - _generated_docker_compose.env
     volumes:


### PR DESCRIPTION
## Summary

The `check-provider-yaml-valid` hook has been aborting with `Error: PYTHONWARNINGS not set` on unrelated pull requests — six times over 27–28 August, each cleared by a rerun.

`_generated_docker_compose.env` names the variables Compose forwards into the container, and every breeze invocation rewrites it from its own environment. prek runs the breeze-backed hooks concurrently and only the provider.yaml and template-fields checks ask for `PYTHONWARNINGS`, so any other hook regenerating the file between that write and `docker compose run` took the variable away again.

Passing it through `base.yml` instead keeps it out of that shared file, so it no longer depends on what a concurrent invocation writes, and a `PYTHONWARNINGS` exported on the host is still forwarded.

## Tests

The generated env file used to gain or lose its `PYTHONWARNINGS` line depending on whether the invoking process exported the variable; it is now identical either way.

Against Docker, on a compose project shaped like `base.yml` with a second invocation regenerating the shared file during startup, the container came up without the variable in 18 of 45 runs before this change and none of 45 after. That window is forced open, so the rate is not CI's.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
