### PR TITLE
Add AthenaSparkSensor

### DIFF
--- a/providers/amazon/docs/operators/athena/athena_spark.rst
+++ b/providers/amazon/docs/operators/athena/athena_spark.rst
@@ -15,8 +15,8 @@
    specific language governing permissions and limitations
    under the License.
 
-Athena Spark Operators
-======================
+Athena Spark Operators and Sensors
+==================================
 
 Amazon Athena supports Apache Spark calculations through session-based APIs.
 This page documents the provider support for submitting and monitoring those
@@ -49,3 +49,23 @@ to submit Spark code to an existing Athena Spark session.
     :language: python
     :start-after: [START howto_operator_athena_spark]
     :end-before: [END howto_operator_athena_spark]
+
+Sensors
+-------
+
+Wait for an Athena Spark calculation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use :class:`~airflow.providers.amazon.aws.sensors.athena_spark.AthenaSparkSensor`
+to wait for an existing Athena Spark calculation execution to reach a terminal
+state.
+
+The sensor expects a calculation execution ID that was already created, for
+example by calling
+:class:`~airflow.providers.amazon.aws.operators.athena_spark.AthenaSparkOperator`
+or by starting the calculation outside Airflow.
+
+.. exampleinclude:: /../../amazon/tests/system/amazon/aws/example_athena_spark.py
+    :language: python
+    :start-after: [START howto_sensor_athena_spark]
+    :end-before: [END howto_sensor_athena_spark]

--- a/providers/amazon/docs/operators/athena/athena_spark.rst
+++ b/providers/amazon/docs/operators/athena/athena_spark.rst
@@ -1,0 +1,51 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+..   http://www.apache.org/licenses/LICENSE-2.0
+
+.. Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+
+Athena Spark Operators
+======================
+
+Amazon Athena supports Apache Spark calculations through session-based APIs.
+This page documents the provider support for submitting and monitoring those
+calculations from Airflow.
+
+Prerequisite Tasks
+------------------
+
+Before using the Athena Spark operator or sensor, make sure that:
+
+* an Athena Spark session already exists;
+* an AWS connection is configured in Airflow;
+* the connection has permission to start and read Athena calculation
+  executions for the target session.
+
+The :class:`~airflow.providers.amazon.aws.operators.athena_spark.AthenaSparkOperator`
+submits Spark code to an existing Athena session and waits for the calculation
+to reach a terminal state. It does not create the Athena Spark session.
+
+Operators
+---------
+
+Submit Spark code to an Athena session
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use :class:`~airflow.providers.amazon.aws.operators.athena_spark.AthenaSparkOperator`
+to submit Spark code to an existing Athena Spark session.
+
+.. exampleinclude:: /../../amazon/tests/system/amazon/aws/example_athena_spark.py
+    :language: python
+    :start-after: [START howto_operator_athena_spark]
+    :end-before: [END howto_operator_athena_spark]

--- a/providers/amazon/provider.yaml
+++ b/providers/amazon/provider.yaml
@@ -139,6 +139,7 @@ integrations:
     how-to-guide:
       - /docs/apache-airflow-providers-amazon/operators/athena/athena_boto.rst
       - /docs/apache-airflow-providers-amazon/operators/athena/athena_sql.rst
+      - /docs/apache-airflow-providers-amazon/operators/athena/athena_spark.rst
     tags: [aws]
   - integration-name: Amazon Bedrock
     external-doc-url: https://aws.amazon.com/bedrock/
@@ -429,6 +430,7 @@ operators:
   - integration-name: Amazon Athena
     python-modules:
       - airflow.providers.amazon.aws.operators.athena
+      - airflow.providers.amazon.aws.operators.athena_spark
   - integration-name: Amazon Web Services
     python-modules:
       - airflow.providers.amazon.aws.operators.base_aws

--- a/providers/amazon/provider.yaml
+++ b/providers/amazon/provider.yaml
@@ -552,6 +552,7 @@ sensors:
   - integration-name: Amazon Athena
     python-modules:
       - airflow.providers.amazon.aws.sensors.athena
+      - airflow.providers.amazon.aws.sensors.athena_spark
   - integration-name: Amazon Web Services
     python-modules:
       - airflow.providers.amazon.aws.sensors.base_aws

--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/athena.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/athena.py
@@ -86,6 +86,20 @@ class AthenaHook(AwsBaseHook):
         "CANCELLED",
     )
 
+    SPARK_INTERMEDIATE_STATES = (
+        "CREATING",
+        "CREATED",
+        "QUEUED",
+        "RUNNING",
+        "CANCELING",
+    )
+    SPARK_FAILURE_STATES = (
+        "FAILED",
+        "CANCELED",
+    )
+    SPARK_SUCCESS_STATES = ("COMPLETED",)
+    SPARK_TERMINAL_STATES = SPARK_SUCCESS_STATES + SPARK_FAILURE_STATES
+
     def __init__(self, *args: Any, log_query: bool = True, **kwargs: Any) -> None:
         super().__init__(client_type="athena", *args, **kwargs)  # type: ignore
         self.log_query = log_query
@@ -344,3 +358,141 @@ class AthenaHook(AwsBaseHook):
         """
         self.log.info("Stopping Query with executionId - %s", query_execution_id)
         return self.get_conn().stop_query_execution(QueryExecutionId=query_execution_id)
+
+    def _get_spark_calculation_status(self, response: dict[str, Any] | None) -> dict[str, Any]:
+        calculation_execution = (response or {}).get("CalculationExecution") or {}
+        return calculation_execution.get("Status") or (response or {}).get("Status") or {}
+
+    def start_spark_calculation(
+        self,
+        *,
+        session_id: str,
+        code_block: str,
+        description: str | None = None,
+        calculation_configuration: dict[str, Any] | None = None,
+        client_request_token: str | None = None,
+    ) -> str:
+        """
+        Start an Athena Spark calculation execution.
+
+        .. seealso::
+            - :external+boto3:py:meth:`Athena.Client.start_calculation_execution`
+
+        :param session_id: The Athena session ID.
+        :param code_block: Spark code to execute, typically notebook-like code.
+        :param description: Optional description of the calculation. Defaults to None.
+        :param calculation_configuration: Contains configuration information for the calculation. Defaults to None.
+        :param client_request_token: Optional idempotency token. Defaults to None.
+        :return: CalculationExecutionId
+        """
+        params: dict[str, Any] = {
+            "SessionId": session_id,
+            "CodeBlock": code_block,
+        }
+        if description:
+            params["Description"] = description
+
+        if calculation_configuration:
+            params["CalculationConfiguration"] = calculation_configuration
+
+        if client_request_token:
+            params["ClientRequestToken"] = client_request_token
+
+        if self.log_query:
+            self.log.info("Starting CalculationExecution with params:\n%s", query_params_to_string(params))
+
+        response = self.get_conn().start_calculation_execution(**params)
+        calculation_execution_id = response["CalculationExecutionId"]
+        self.log.info("Calculation execution id: %s", calculation_execution_id)
+        return calculation_execution_id
+
+    def get_spark_calculation_info(
+        self,
+        calculation_execution_id: str,
+        use_cache: bool = False,
+    ) -> dict[str, Any]:
+        """
+        Get information about a single Athena Spark calculation execution.
+
+        .. seealso::
+            - :external+boto3:py:meth:`Athena.Client.get_calculation_execution`
+
+        :param calculation_execution_id: CalculationExecutionId returned by start_spark_calculation.
+        :param use_cache: If True, use execution information cache. Defaults to False.
+        :return: Calculation execution response.
+        """
+        cache_key = f"calculation:{calculation_execution_id}"
+        if use_cache and cache_key in self.__query_results:
+            return self.__query_results[cache_key]
+
+        response = self.get_conn().get_calculation_execution(
+            CalculationExecutionId=calculation_execution_id,
+        )
+
+        if use_cache:
+            self.__query_results[cache_key] = response
+        return response
+
+    def check_spark_calculation_status(
+        self,
+        calculation_execution_id: str,
+        use_cache: bool = False,
+    ) -> str | None:
+        """
+        Fetch the state of a submitted Athena Spark calculation execution.
+
+        .. seealso::
+            - :external+boto3:py:meth:`Athena.Client.get_calculation_execution`
+
+        :param calculation_execution_id: CalculationExecutionId returned by start_spark_calculation.
+        :param use_cache: If True, use execution information cache. Defaults to False.
+        :return: One of valid calculation states, or *None* if the response is malformed.
+        """
+        response = self.get_spark_calculation_info(
+            calculation_execution_id=calculation_execution_id,
+            use_cache=use_cache,
+        )
+
+        status = self._get_spark_calculation_status(response)
+        state = status.get("State")
+
+        if state is None:
+            self.log.error("Could not parse status for calculation %s", calculation_execution_id)
+
+        return state
+
+    def get_spark_calculation_state_change_reason(
+        self,
+        calculation_execution_id: str,
+        use_cache: bool = False,
+    ) -> str | None:
+        """
+        Fetch the reason for an Athena Spark calculation state change, such as an error message.
+
+        .. seealso::
+            - :external+boto3:py:meth:`Athena.Client.get_calculation_execution`
+
+        :param calculation_execution_id: CalculationExecutionId returned by start_spark_calculation.
+        :param use_cache: If True, use execution information cache. Defaults to False.
+        :return: State change reason string, or None.
+        """
+        response = self.get_spark_calculation_info(
+            calculation_execution_id=calculation_execution_id,
+            use_cache=use_cache,
+        )
+        return self._get_spark_calculation_status(response).get("StateChangeReason")
+
+    def stop_spark_calculation(self, calculation_execution_id: str) -> dict[str, Any]:
+        """
+        Cancel the submitted Athena Spark calculation execution.
+
+        .. seealso::
+            - :external+boto3:py:meth:`Athena.Client.stop_calculation_execution`
+
+        :param calculation_execution_id: CalculationExecutionId returned by start_spark_calculation.
+        :return: Response from stop_calculation_execution.
+        """
+        self.log.info("Stopping CalculationExecution with id - %s", calculation_execution_id)
+        return self.get_conn().stop_calculation_execution(
+            CalculationExecutionId=calculation_execution_id,
+        )

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/athena_spark.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/athena_spark.py
@@ -1,0 +1,208 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import time
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+from airflow.providers.amazon.aws.hooks.athena import AthenaHook
+from airflow.providers.amazon.aws.operators.base_aws import AwsBaseOperator
+from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
+
+if TYPE_CHECKING:
+    from airflow.sdk import Context
+
+
+class AthenaSparkOperator(AwsBaseOperator[AthenaHook]):
+    """
+    Run an Apache Spark calculation in an Amazon Athena session.
+
+    Submits a calculation, such as PySpark code, via the Athena API, polls until
+    the calculation reaches a terminal state, and returns execution metadata.
+
+    .. seealso::
+        - :class:`airflow.providers.amazon.aws.hooks.athena.AthenaHook`
+        - `Athena for Apache Spark
+          <https://docs.aws.amazon.com/athena/latest/ug/notebooks-spark-api-list.html>`__
+
+    :param session_id: The Athena session ID in which to run the calculation. (templated)
+    :param code_block: The calculation code, such as PySpark, to execute. (templated)
+    :param description: Optional description of the calculation. Defaults to None.
+    :param client_request_token: Optional idempotency token for the submission. Defaults to None.
+    :param poll_interval: Seconds to wait between status checks. Defaults to 30.
+    :param max_attempts: Maximum number of polling attempts before timing out. Defaults to 120.
+        To limit total task time, use execution_timeout on the task as well.
+    :param log_query: Whether to log submission details. Defaults to True.
+    :param aws_conn_id: The Airflow connection used for AWS credentials. Defaults to ``aws_default``.
+    :param region_name: AWS region. If not set, default boto3 behavior is used. Defaults to None.
+    :param verify: Whether to verify SSL certificates. Defaults to None.
+    :param botocore_config: Optional botocore configuration dict. Defaults to None.
+    """
+
+    aws_hook_class = AthenaHook
+    ui_color = "#44b5e2"
+    template_fields: Sequence[str] = aws_template_fields("session_id", "code_block", "description")
+    template_ext: Sequence[str] = (".py",)
+    template_fields_renderers = {"code_block": "python"}
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        code_block: str,
+        description: str | None = None,
+        client_request_token: str | None = None,
+        poll_interval: int = 30,
+        max_attempts: int = 120,
+        log_query: bool = True,
+        aws_conn_id: str | None = "aws_default",
+        region_name: str | None = None,
+        verify: bool | str | None = None,
+        botocore_config: dict | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            aws_conn_id=aws_conn_id,
+            region_name=region_name,
+            verify=verify,
+            botocore_config=botocore_config,
+            **kwargs,
+        )
+        self.session_id = session_id
+        self.code_block = code_block
+        self.description = description
+        self.client_request_token = client_request_token
+        self.poll_interval = poll_interval
+        self.max_attempts = max_attempts
+        self.log_query = log_query
+        self._calculation_execution_id: str | None = None
+
+    @property
+    def _hook_parameters(self) -> dict[str, Any]:
+        return {**super()._hook_parameters, "log_query": self.log_query}
+
+    def execute(self, context: Context) -> dict[str, Any]:
+        """Submit the Spark calculation, poll until terminal state, then return metadata."""
+        self.log.info("Starting Athena Spark calculation in session %s", self.session_id)
+
+        calculation_execution_id = self.hook.start_spark_calculation(
+            session_id=self.session_id,
+            code_block=self.code_block,
+            description=self.description,
+            client_request_token=self.client_request_token,
+        )
+        self._calculation_execution_id = calculation_execution_id
+
+        self.log.info("Calculation submitted. CalculationExecutionId: %s", calculation_execution_id)
+
+        final_state = self._poll_until_terminal(calculation_execution_id)
+        return self._handle_terminal_state(calculation_execution_id, final_state)
+
+    def _poll_until_terminal(self, calculation_execution_id: str) -> str:
+        """Poll calculation status until a terminal state or timeout."""
+        for attempt in range(1, self.max_attempts + 1):
+            state = self.hook.check_spark_calculation_status(calculation_execution_id)
+
+            if state is None:
+                raise RuntimeError(
+                    f"Malformed or missing status for calculation {calculation_execution_id}. "
+                    "Cannot continue polling."
+                )
+
+            self.log.info(
+                "CalculationExecutionId: %s, current state: %s (attempt %d/%d)",
+                calculation_execution_id,
+                state,
+                attempt,
+                self.max_attempts,
+            )
+
+            if state in AthenaHook.SPARK_TERMINAL_STATES:
+                return state
+
+            if attempt != self.max_attempts:
+                time.sleep(self.poll_interval)
+
+        raise RuntimeError(
+            f"Polling timed out after {self.max_attempts} attempts for calculation "
+            f"{calculation_execution_id}. Use execution_timeout or increase max_attempts."
+        )
+
+    def _handle_terminal_state(self, calculation_execution_id: str, state: str) -> dict[str, Any]:
+        """Resolve terminal state: raise on failure/cancel, build and return metadata."""
+        reason = self.hook.get_spark_calculation_state_change_reason(calculation_execution_id)
+        execution_info = self.hook.get_spark_calculation_info(calculation_execution_id)
+        status = execution_info.get("Status", {})
+        result_info = execution_info.get("Result", {})
+
+        submission_time = status.get("SubmissionDateTime")
+        completion_time = status.get("CompletionDateTime")
+
+        result = {
+            "calculation_execution_id": calculation_execution_id,
+            "state": state,
+            "state_change_reason": reason,
+            "submission_time": str(submission_time) if submission_time else None,
+            "completion_time": str(completion_time) if completion_time else None,
+            "session_id": execution_info.get("SessionId") or self.session_id,
+            "working_directory": execution_info.get("WorkingDirectory"),
+            "stdout_s3_uri": result_info.get("StdOutS3Uri"),
+            "stderr_s3_uri": result_info.get("StdErrorS3Uri"),
+            "result_s3_uri": result_info.get("ResultS3Uri"),
+            "result_type": result_info.get("ResultType"),
+        }
+
+        if state in AthenaHook.SPARK_FAILURE_STATES:
+            self.log.error(
+                "Calculation failed. CalculationExecutionId: %s, state: %s, reason: %s",
+                calculation_execution_id,
+                state,
+                reason,
+            )
+            raise RuntimeError(
+                f"Athena Spark calculation ended in {state}. "
+                f"CalculationExecutionId: {calculation_execution_id}. "
+                f"Reason: {reason or 'No reason provided.'}"
+            )
+
+        if state not in AthenaHook.SPARK_SUCCESS_STATES:
+            raise RuntimeError(
+                f"Unexpected terminal state: {state} for calculation {calculation_execution_id}. "
+                f"Expected one of: {', '.join(AthenaHook.SPARK_TERMINAL_STATES)}."
+            )
+
+        self.log.info(
+            "Calculation completed successfully. CalculationExecutionId: %s",
+            calculation_execution_id,
+        )
+        return result
+
+    def on_kill(self) -> None:
+        """Request cancellation of the calculation when the task is killed."""
+        if self._calculation_execution_id:
+            self.log.info("Received kill signal; stopping calculation %s", self._calculation_execution_id)
+            try:
+                self.hook.stop_spark_calculation(self._calculation_execution_id)
+            except Exception:
+                self.log.warning(
+                    "Failed to stop calculation %s",
+                    self._calculation_execution_id,
+                    exc_info=True,
+                )

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/athena_spark.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/athena_spark.py
@@ -1,0 +1,88 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from airflow.providers.amazon.aws.hooks.athena import AthenaHook
+from airflow.providers.amazon.aws.sensors.base_aws import AwsBaseSensor
+
+if TYPE_CHECKING:
+    from airflow.sdk import Context
+
+
+class AthenaSparkSensor(AwsBaseSensor[AthenaHook]):
+    """
+    Waits for an Amazon Athena Spark calculation to reach a terminal state.
+
+    :param calculation_execution_id: Athena Spark calculation execution ID. (templated)
+    :param aws_conn_id: The Airflow connection used for AWS credentials. Defaults to ``aws_default``.
+    :param region_name: AWS region name. Defaults to ``None``. (templated)
+    """
+
+    aws_hook_class = AthenaHook
+
+    template_fields: Sequence[str] = (
+        "calculation_execution_id",
+        "aws_conn_id",
+        "region_name",
+    )
+
+    def __init__(
+        self,
+        *,
+        calculation_execution_id: str,
+        aws_conn_id: str = "aws_default",
+        region_name: str | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(aws_conn_id=aws_conn_id, region_name=region_name, **kwargs)
+        self.calculation_execution_id = calculation_execution_id
+
+    def poke(self, context: Context) -> bool:
+        state = self.hook.check_spark_calculation_status(
+            calculation_execution_id=self.calculation_execution_id,
+        )
+
+        self.log.info("Calculation %s state is: %s", self.calculation_execution_id, state)
+
+        if state in AthenaHook.SPARK_SUCCESS_STATES:
+            self.log.info("Athena Spark calculation %s completed.", self.calculation_execution_id)
+            return True
+
+        if state in AthenaHook.SPARK_FAILURE_STATES:
+            reason = self.hook.get_spark_calculation_state_change_reason(
+                calculation_execution_id=self.calculation_execution_id,
+            )
+            raise RuntimeError(
+                f"Athena Spark calculation {self.calculation_execution_id} failed with state {state}. "
+                f"Reason: {reason or 'Unknown'}"
+            )
+
+        if state in AthenaHook.SPARK_INTERMEDIATE_STATES:
+            self.log.info(
+                "Athena Spark calculation %s is in state %s.",
+                self.calculation_execution_id,
+                state,
+            )
+            return False
+
+        raise RuntimeError(
+            f"Unexpected Athena Spark calculation state for {self.calculation_execution_id}: {state!r}"
+        )

--- a/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
+++ b/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
@@ -34,6 +34,7 @@ def get_provider_info():
                 "how-to-guide": [
                     "/docs/apache-airflow-providers-amazon/operators/athena/athena_boto.rst",
                     "/docs/apache-airflow-providers-amazon/operators/athena/athena_sql.rst",
+                    "/docs/apache-airflow-providers-amazon/operators/athena/athena_spark.rst",
                 ],
                 "tags": ["aws"],
             },
@@ -391,7 +392,10 @@ def get_provider_info():
         "operators": [
             {
                 "integration-name": "Amazon Athena",
-                "python-modules": ["airflow.providers.amazon.aws.operators.athena"],
+                "python-modules": [
+                    "airflow.providers.amazon.aws.operators.athena",
+                    "airflow.providers.amazon.aws.operators.athena_spark",
+                ],
             },
             {
                 "integration-name": "Amazon Web Services",

--- a/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
+++ b/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
@@ -562,7 +562,10 @@ def get_provider_info():
         "sensors": [
             {
                 "integration-name": "Amazon Athena",
-                "python-modules": ["airflow.providers.amazon.aws.sensors.athena"],
+                "python-modules": [
+                    "airflow.providers.amazon.aws.sensors.athena",
+                    "airflow.providers.amazon.aws.sensors.athena_spark",
+                ],
             },
             {
                 "integration-name": "Amazon Web Services",

--- a/providers/amazon/tests/system/amazon/aws/example_athena_spark.py
+++ b/providers/amazon/tests/system/amazon/aws/example_athena_spark.py
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from datetime import datetime
+
+from airflow.providers.amazon.aws.operators.athena_spark import AthenaSparkOperator
+
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.sdk import DAG
+else:
+    # Airflow 2 path
+    from airflow.models.dag import DAG  # type: ignore[attr-defined,no-redef,assignment]
+
+DAG_ID = "example_athena_spark"
+
+
+with DAG(
+    dag_id=DAG_ID,
+    schedule="@once",
+    start_date=datetime(2021, 1, 1),
+    catchup=False,
+) as dag:
+    # [START howto_operator_athena_spark]
+    run_spark_calculation = AthenaSparkOperator(
+        task_id="run_spark_calculation",
+        session_id="my-athena-spark-session-id",
+        code_block="print('hello from athena spark')",
+        poll_interval=30,
+        max_attempts=120,
+    )
+    # [END howto_operator_athena_spark]
+
+from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
+
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
+test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_athena_spark.py
+++ b/providers/amazon/tests/system/amazon/aws/example_athena_spark.py
@@ -19,14 +19,15 @@ from __future__ import annotations
 from datetime import datetime
 
 from airflow.providers.amazon.aws.operators.athena_spark import AthenaSparkOperator
+from airflow.providers.amazon.aws.sensors.athena_spark import AthenaSparkSensor
 
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import DAG
+    from airflow.sdk import DAG, chain
 else:
     # Airflow 2 path
-    from airflow.models.dag import DAG  # type: ignore[attr-defined,no-redef,assignment]
+    from airflow.models.dag import DAG, chain  # type: ignore[attr-defined,no-redef,assignment]
 
 DAG_ID = "example_athena_spark"
 
@@ -46,6 +47,17 @@ with DAG(
         max_attempts=120,
     )
     # [END howto_operator_athena_spark]
+
+    # [START howto_sensor_athena_spark]
+    await_spark_calculation = AthenaSparkSensor(
+        task_id="await_spark_calculation",
+        calculation_execution_id=run_spark_calculation.output,
+        poke_interval=30,
+        timeout=3600,
+    )
+    # [END howto_sensor_athena_spark]
+
+    chain(run_spark_calculation, await_spark_calculation)
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_athena.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_athena.py
@@ -40,6 +40,10 @@ MOCK_DATA = {
     "query_execution_id": "eac427d0-1c6d-4dfb-96aa-2835d3ac6595",
     "next_token_id": "eac427d0-1c6d-4dfb-96aa-2835d3ac6595",
     "max_items": 1000,
+    "code_block": "print('hello spark')",
+    "calculation_execution_id": "calc-123456",
+    "session_id": "session-123456",
+    "description": "spark-calc",
 }
 
 mock_query_context = {"Database": MOCK_DATA["database"]}
@@ -57,6 +61,11 @@ MOCK_QUERY_EXECUTION_OUTPUT = {
         "Status": {"StateChangeReason": "Terminated by user."},
     }
 }
+
+MOCK_CALCULATION_EXECUTION = {"CalculationExecutionId": MOCK_DATA["calculation_execution_id"]}
+
+MOCK_RUNNING_CALC_EXECUTION = {"Status": {"State": "RUNNING"}}
+MOCK_SUCCEEDED_CALC_EXECUTION = {"Status": {"State": "COMPLETED"}}
 
 
 @mock_aws
@@ -314,3 +323,128 @@ class TestAthenaHook:
         assert result.count("\n") == len(params.keys()) + num_query_lines
         # All lines except the first line of the multiline query log message get the double prefix/indent.
         assert result.count(MULTI_LINE_QUERY_LOG_PREFIX) == (num_query_lines * 2) - 1
+
+    @mock.patch.object(AthenaHook, "get_conn")
+    @pytest.mark.parametrize(
+        ("optional_kwargs", "expected_optional_params"),
+        [
+            ({}, {}),
+            (
+                {
+                    "description": MOCK_DATA["description"],
+                    "calculation_configuration": {"CodeBlock": MOCK_DATA["code_block"]},
+                    "client_request_token": MOCK_DATA["client_request_token"],
+                },
+                {
+                    "Description": MOCK_DATA["description"],
+                    "CalculationConfiguration": {"CodeBlock": MOCK_DATA["code_block"]},
+                    "ClientRequestToken": MOCK_DATA["client_request_token"],
+                },
+            ),
+        ],
+    )
+    def test_hook_start_spark_calculation(self, mock_conn, optional_kwargs, expected_optional_params):
+        mock_conn.return_value.start_calculation_execution.return_value = MOCK_CALCULATION_EXECUTION
+
+        result = self.athena.start_spark_calculation(
+            session_id=MOCK_DATA["session_id"],
+            code_block=MOCK_DATA["code_block"],
+            **optional_kwargs,
+        )
+
+        mock_conn.return_value.start_calculation_execution.assert_called_once_with(
+            SessionId=MOCK_DATA["session_id"],
+            CodeBlock=MOCK_DATA["code_block"],
+            **expected_optional_params,
+        )
+        assert result == MOCK_DATA["calculation_execution_id"]
+
+    @mock.patch.object(AthenaHook, "get_conn")
+    def test_hook_get_spark_calculation_info(self, mock_conn):
+        mock_conn.return_value.get_calculation_execution.return_value = MOCK_SUCCEEDED_CALC_EXECUTION
+
+        result = self.athena.get_spark_calculation_info(
+            calculation_execution_id=MOCK_DATA["calculation_execution_id"]
+        )
+
+        mock_conn.return_value.get_calculation_execution.assert_called_once_with(
+            CalculationExecutionId=MOCK_DATA["calculation_execution_id"]
+        )
+        assert result == MOCK_SUCCEEDED_CALC_EXECUTION
+
+    @mock.patch.object(AthenaHook, "get_conn")
+    def test_hook_get_spark_calculation_info_uses_cache(self, mock_conn):
+        mock_conn.return_value.get_calculation_execution.return_value = MOCK_SUCCEEDED_CALC_EXECUTION
+
+        self.athena.get_spark_calculation_info(
+            calculation_execution_id=MOCK_DATA["calculation_execution_id"],
+            use_cache=True,
+        )
+        result = self.athena.get_spark_calculation_info(
+            calculation_execution_id=MOCK_DATA["calculation_execution_id"],
+            use_cache=True,
+        )
+
+        mock_conn.return_value.get_calculation_execution.assert_called_once_with(
+            CalculationExecutionId=MOCK_DATA["calculation_execution_id"]
+        )
+        assert result == MOCK_SUCCEEDED_CALC_EXECUTION
+
+    @mock.patch.object(AthenaHook, "get_conn")
+    @pytest.mark.parametrize(
+        ("response", "expected_state"),
+        [
+            ({"Status": {"State": "RUNNING"}}, "RUNNING"),
+            ({"Status": {"State": "COMPLETED"}}, "COMPLETED"),
+            (None, None),
+            ({}, None),
+            ({"Status": None}, None),
+            ({"Status": {}}, None),
+        ],
+    )
+    def test_hook_check_spark_calculation_status(self, mock_conn, response, expected_state):
+        mock_conn.return_value.get_calculation_execution.return_value = response
+
+        state = self.athena.check_spark_calculation_status(
+            calculation_execution_id=MOCK_DATA["calculation_execution_id"]
+        )
+
+        assert state == expected_state
+
+    @mock.patch.object(AthenaHook, "get_conn")
+    @pytest.mark.parametrize(
+        ("response", "expected_reason"),
+        [
+            (
+                {
+                    "Status": {
+                        "State": "FAILED",
+                        "StateChangeReason": "Calculation failed",
+                    }
+                },
+                "Calculation failed",
+            ),
+            ({"Status": {"State": "FAILED"}}, None),
+            ({"Status": {"State": "COMPLETED"}}, None),
+            (None, None),
+            ({}, None),
+            ({"Status": None}, None),
+            ({"Status": {}}, None),
+        ],
+    )
+    def test_hook_get_spark_calculation_state_change_reason(self, mock_conn, response, expected_reason):
+        mock_conn.return_value.get_calculation_execution.return_value = response
+
+        reason = self.athena.get_spark_calculation_state_change_reason(
+            calculation_execution_id=MOCK_DATA["calculation_execution_id"]
+        )
+
+        assert reason == expected_reason
+
+    @mock.patch.object(AthenaHook, "get_conn")
+    def test_hook_stop_spark_calculation(self, mock_conn):
+        self.athena.stop_spark_calculation(calculation_execution_id=MOCK_DATA["calculation_execution_id"])
+
+        mock_conn.return_value.stop_calculation_execution.assert_called_once_with(
+            CalculationExecutionId=MOCK_DATA["calculation_execution_id"]
+        )

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_athena_spark.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_athena_spark.py
@@ -1,0 +1,290 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+from moto import mock_aws
+
+from airflow.models import DAG
+from airflow.providers.amazon.aws.hooks.athena import AthenaHook
+from airflow.providers.amazon.aws.operators.athena_spark import AthenaSparkOperator
+
+from tests_common.test_utils.compat import timezone
+from unit.amazon.aws.utils.test_template_fields import validate_template_fields
+
+TEST_DAG_ID = "unit_tests"
+DEFAULT_DATE = timezone.datetime(2018, 1, 1)
+ATHENA_CALCULATION_ID = "calc-exec-123"
+
+MOCK_DATA = {
+    "task_id": "test_athena_spark_operator",
+    "session_id": "session-456",
+    "code_block": "1 + 1",
+    "description": "Test Spark calculation",
+    "client_request_token": "eac427d0-1c6d-4dfb-96aa-2835d3ac6595",
+}
+
+
+def _calculation_info(state: str, submission_time=None, completion_time=None):
+    return {
+        "CalculationExecutionId": ATHENA_CALCULATION_ID,
+        "SessionId": MOCK_DATA["session_id"],
+        "WorkingDirectory": "s3://test-bucket/spark/",
+        "Status": {
+            "State": state,
+            "SubmissionDateTime": submission_time,
+            "CompletionDateTime": completion_time,
+        },
+        "Result": {
+            "StdOutS3Uri": "s3://test-bucket/spark/stdout",
+            "StdErrorS3Uri": "s3://test-bucket/spark/stderr",
+            "ResultS3Uri": "s3://test-bucket/spark/results",
+            "ResultType": "application/vnd.aws.athena.v1+json",
+        },
+    }
+
+
+@mock_aws
+class TestAthenaSparkOperator:
+    @pytest.fixture(autouse=True)
+    def _setup_test_cases(self):
+        args = {
+            "owner": "airflow",
+            "start_date": DEFAULT_DATE,
+        }
+
+        self.dag = DAG(TEST_DAG_ID, default_args=args, schedule="@once")
+        self.default_op_kwargs = dict(
+            task_id=MOCK_DATA["task_id"],
+            session_id=MOCK_DATA["session_id"],
+            code_block=MOCK_DATA["code_block"],
+            client_request_token=MOCK_DATA["client_request_token"],
+            poll_interval=0,
+            max_attempts=3,
+        )
+        self.athena = AthenaSparkOperator(**self.default_op_kwargs, aws_conn_id=None, dag=self.dag)
+
+    def test_base_aws_op_attributes(self):
+        op = AthenaSparkOperator(**self.default_op_kwargs)
+        assert op.hook.aws_conn_id == "aws_default"
+        assert op.hook._region_name is None
+        assert op.hook._verify is None
+        assert op.hook._config is None
+        assert op.hook.log_query is True
+
+        op = AthenaSparkOperator(
+            **self.default_op_kwargs,
+            aws_conn_id="aws-test-custom-conn",
+            region_name="eu-west-1",
+            verify=False,
+            botocore_config={"read_timeout": 42},
+            log_query=False,
+        )
+        assert op.hook.aws_conn_id == "aws-test-custom-conn"
+        assert op.hook._region_name == "eu-west-1"
+        assert op.hook._verify is False
+        assert op.hook._config is not None
+        assert op.hook._config.read_timeout == 42
+        assert op.hook.log_query is False
+
+    def test_init(self):
+        assert self.athena.task_id == MOCK_DATA["task_id"]
+        assert self.athena.session_id == MOCK_DATA["session_id"]
+        assert self.athena.code_block == MOCK_DATA["code_block"]
+        assert self.athena.client_request_token == MOCK_DATA["client_request_token"]
+        assert self.athena.poll_interval == 0
+        assert self.athena.max_attempts == 3
+        assert self.athena._calculation_execution_id is None
+
+    @mock.patch.object(AthenaHook, "get_spark_calculation_info")
+    @mock.patch.object(AthenaHook, "get_spark_calculation_state_change_reason", return_value=None)
+    @mock.patch.object(AthenaHook, "check_spark_calculation_status", side_effect=("COMPLETED",))
+    @mock.patch.object(AthenaHook, "start_spark_calculation", return_value=ATHENA_CALCULATION_ID)
+    @mock.patch.object(AthenaHook, "get_conn")
+    def test_execute_success(
+        self,
+        mock_conn,
+        mock_start_spark_calculation,
+        mock_check_spark_calculation_status,
+        mock_get_spark_calculation_state_change_reason,
+        mock_get_spark_calculation_info,
+    ):
+        mock_get_spark_calculation_info.return_value = _calculation_info("COMPLETED")
+
+        result = self.athena.execute({})
+
+        mock_start_spark_calculation.assert_called_once_with(
+            session_id=MOCK_DATA["session_id"],
+            code_block=MOCK_DATA["code_block"],
+            description=None,
+            client_request_token=MOCK_DATA["client_request_token"],
+        )
+
+        assert mock_check_spark_calculation_status.call_count == 1
+        mock_get_spark_calculation_state_change_reason.assert_called_once_with(ATHENA_CALCULATION_ID)
+        mock_get_spark_calculation_info.assert_called_once_with(ATHENA_CALCULATION_ID)
+
+        assert result["calculation_execution_id"] == ATHENA_CALCULATION_ID
+        assert result["state"] == "COMPLETED"
+        assert result["session_id"] == MOCK_DATA["session_id"]
+        assert result["working_directory"] == "s3://test-bucket/spark/"
+        assert result["stdout_s3_uri"] == "s3://test-bucket/spark/stdout"
+        assert result["stderr_s3_uri"] == "s3://test-bucket/spark/stderr"
+        assert result["result_s3_uri"] == "s3://test-bucket/spark/results"
+        assert result["result_type"] == "application/vnd.aws.athena.v1+json"
+
+    @mock.patch.object(AthenaHook, "get_spark_calculation_info")
+    @mock.patch.object(AthenaHook, "get_spark_calculation_state_change_reason", return_value=None)
+    @mock.patch.object(
+        AthenaHook,
+        "check_spark_calculation_status",
+        side_effect=("RUNNING", "COMPLETED"),
+    )
+    @mock.patch.object(AthenaHook, "start_spark_calculation", return_value=ATHENA_CALCULATION_ID)
+    @mock.patch.object(AthenaHook, "get_conn")
+    def test_execute_poll_then_success(
+        self,
+        mock_conn,
+        mock_start_spark_calculation,
+        mock_check_spark_calculation_status,
+        mock_get_spark_calculation_state_change_reason,
+        mock_get_spark_calculation_info,
+    ):
+        mock_get_spark_calculation_info.return_value = _calculation_info("COMPLETED")
+
+        result = self.athena.execute({})
+
+        mock_start_spark_calculation.assert_called_once_with(
+            session_id=MOCK_DATA["session_id"],
+            code_block=MOCK_DATA["code_block"],
+            description=None,
+            client_request_token=MOCK_DATA["client_request_token"],
+        )
+        assert mock_check_spark_calculation_status.call_count == 2
+        assert result["state"] == "COMPLETED"
+
+    @mock.patch.object(AthenaHook, "get_spark_calculation_info")
+    @mock.patch.object(AthenaHook, "get_spark_calculation_state_change_reason", return_value="Job failed")
+    @mock.patch.object(AthenaHook, "check_spark_calculation_status", return_value="FAILED")
+    @mock.patch.object(AthenaHook, "start_spark_calculation", return_value=ATHENA_CALCULATION_ID)
+    @mock.patch.object(AthenaHook, "get_conn")
+    def test_execute_failure(
+        self,
+        mock_conn,
+        mock_start_spark_calculation,
+        mock_check_spark_calculation_status,
+        mock_get_spark_calculation_state_change_reason,
+        mock_get_spark_calculation_info,
+    ):
+        mock_get_spark_calculation_info.return_value = _calculation_info("FAILED")
+
+        with pytest.raises(RuntimeError):
+            self.athena.execute({})
+
+        mock_start_spark_calculation.assert_called_once_with(
+            session_id=MOCK_DATA["session_id"],
+            code_block=MOCK_DATA["code_block"],
+            description=None,
+            client_request_token=MOCK_DATA["client_request_token"],
+        )
+        assert mock_get_spark_calculation_state_change_reason.call_count == 1
+
+    @mock.patch.object(AthenaHook, "get_spark_calculation_info")
+    @mock.patch.object(AthenaHook, "get_spark_calculation_state_change_reason", return_value="Canceled")
+    @mock.patch.object(AthenaHook, "check_spark_calculation_status", return_value="CANCELED")
+    @mock.patch.object(AthenaHook, "start_spark_calculation", return_value=ATHENA_CALCULATION_ID)
+    @mock.patch.object(AthenaHook, "get_conn")
+    def test_execute_cancelled(
+        self,
+        mock_conn,
+        mock_start_spark_calculation,
+        mock_check_spark_calculation_status,
+        mock_get_spark_calculation_state_change_reason,
+        mock_get_spark_calculation_info,
+    ):
+        mock_get_spark_calculation_info.return_value = _calculation_info("CANCELED")
+
+        with pytest.raises(RuntimeError):
+            self.athena.execute({})
+
+        mock_start_spark_calculation.assert_called_once_with(
+            session_id=MOCK_DATA["session_id"],
+            code_block=MOCK_DATA["code_block"],
+            description=None,
+            client_request_token=MOCK_DATA["client_request_token"],
+        )
+
+    @mock.patch.object(AthenaHook, "check_spark_calculation_status", return_value="RUNNING")
+    @mock.patch.object(AthenaHook, "start_spark_calculation", return_value=ATHENA_CALCULATION_ID)
+    @mock.patch.object(AthenaHook, "get_conn")
+    def test_execute_timeout(
+        self,
+        mock_conn,
+        mock_start_spark_calculation,
+        mock_check_spark_calculation_status,
+    ):
+        with pytest.raises(RuntimeError):
+            self.athena.execute({})
+
+        mock_start_spark_calculation.assert_called_once_with(
+            session_id=MOCK_DATA["session_id"],
+            code_block=MOCK_DATA["code_block"],
+            description=None,
+            client_request_token=MOCK_DATA["client_request_token"],
+        )
+        assert mock_check_spark_calculation_status.call_count == self.athena.max_attempts
+
+    @mock.patch.object(AthenaHook, "check_spark_calculation_status", return_value=None)
+    @mock.patch.object(AthenaHook, "start_spark_calculation", return_value=ATHENA_CALCULATION_ID)
+    @mock.patch.object(AthenaHook, "get_conn")
+    def test_execute_malformed_status(
+        self,
+        mock_conn,
+        mock_start_spark_calculation,
+        mock_check_spark_calculation_status,
+    ):
+        with pytest.raises(RuntimeError, match="Malformed or missing status"):
+            self.athena.execute({})
+
+        mock_start_spark_calculation.assert_called_once_with(
+            session_id=MOCK_DATA["session_id"],
+            code_block=MOCK_DATA["code_block"],
+            description=None,
+            client_request_token=MOCK_DATA["client_request_token"],
+        )
+
+    @mock.patch.object(AthenaHook, "stop_spark_calculation")
+    @mock.patch.object(AthenaHook, "get_conn")
+    def test_on_kill_calls_stop_spark_calculation(self, mock_conn, mock_stop_spark_calculation):
+        self.athena._calculation_execution_id = ATHENA_CALCULATION_ID
+
+        self.athena.on_kill()
+
+        mock_stop_spark_calculation.assert_called_once_with(ATHENA_CALCULATION_ID)
+
+    @mock.patch.object(AthenaHook, "stop_spark_calculation")
+    @mock.patch.object(AthenaHook, "get_conn")
+    def test_on_kill_no_op_when_no_calculation_execution_id(self, mock_conn, mock_stop_spark_calculation):
+        self.athena.on_kill()
+
+        mock_stop_spark_calculation.assert_not_called()
+
+    def test_template_fields(self):
+        validate_template_fields(self.athena)

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_athena_spark.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_athena_spark.py
@@ -1,0 +1,106 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+from moto import mock_aws
+
+from airflow.providers.amazon.aws.hooks.athena import AthenaHook
+from airflow.providers.amazon.aws.sensors.athena_spark import AthenaSparkSensor
+
+
+@pytest.fixture
+def mock_check_spark_calculation_status():
+    with mock.patch.object(AthenaHook, "check_spark_calculation_status") as m:
+        yield m
+
+
+@pytest.fixture
+def mock_get_spark_calculation_state_change_reason():
+    with mock.patch.object(AthenaHook, "get_spark_calculation_state_change_reason") as m:
+        yield m
+
+
+@mock_aws
+class TestAthenaSparkSensor:
+    def setup_method(self, _):
+        self.default_op_kwargs = dict(
+            task_id="test_athena_spark_sensor",
+            calculation_execution_id="abc",
+        )
+        self.sensor = AthenaSparkSensor(**self.default_op_kwargs, aws_conn_id=None)
+
+    def test_base_aws_op_attributes(self):
+        op = AthenaSparkSensor(**self.default_op_kwargs)
+        assert op.hook.aws_conn_id == "aws_default"
+        assert op.hook._region_name is None
+        assert op.hook._verify is None
+        assert op.hook._config is None
+        assert op.hook.log_query is True
+
+        op = AthenaSparkSensor(
+            **self.default_op_kwargs,
+            aws_conn_id="aws-test-custom-conn",
+            region_name="eu-west-1",
+            verify=False,
+            botocore_config={"read_timeout": 42},
+        )
+        assert op.hook.aws_conn_id == "aws-test-custom-conn"
+        assert op.hook._region_name == "eu-west-1"
+        assert op.hook._verify is False
+        assert op.hook._config is not None
+        assert op.hook._config.read_timeout == 42
+
+    def test_template_fields(self):
+        assert AthenaSparkSensor.template_fields == (
+            "calculation_execution_id",
+            "aws_conn_id",
+            "region_name",
+        )
+
+    @pytest.mark.parametrize("state", ["COMPLETED"])
+    def test_poke_success_states(self, state, mock_check_spark_calculation_status):
+        mock_check_spark_calculation_status.side_effect = [state]
+
+        assert self.sensor.poke({}) is True
+        mock_check_spark_calculation_status.assert_called_once_with(calculation_execution_id="abc")
+
+    @pytest.mark.parametrize("state", ["CREATING", "CREATED", "QUEUED", "RUNNING"])
+    def test_poke_intermediate_states(self, state, mock_check_spark_calculation_status):
+        mock_check_spark_calculation_status.side_effect = [state]
+
+        assert self.sensor.poke({}) is False
+        mock_check_spark_calculation_status.assert_called_once_with(calculation_execution_id="abc")
+
+    @pytest.mark.parametrize("state", ["FAILED", "CANCELED"])
+    def test_poke_failure_states(
+        self,
+        state,
+        mock_check_spark_calculation_status,
+        mock_get_spark_calculation_state_change_reason,
+    ):
+        mock_check_spark_calculation_status.side_effect = [state]
+        mock_get_spark_calculation_state_change_reason.return_value = "Calculation failed"
+
+        with pytest.raises(RuntimeError, match=f"failed with state {state}"):
+            self.sensor.poke({})
+
+        mock_check_spark_calculation_status.assert_called_once_with(calculation_execution_id="abc")
+        mock_get_spark_calculation_state_change_reason.assert_called_once_with(calculation_execution_id="abc")


### PR DESCRIPTION
**Description**

This change introduces a new sensor, `AthenaSparkSensor`, to wait for an existing Amazon Athena Spark calculation execution to reach a terminal state.

The sensor delegates to `AthenaHook` Spark calculation helpers to poll the calculation status. It succeeds when the calculation reaches `COMPLETED`, continues poking while the calculation is in an in-progress state, and raises when the calculation reaches a failed, canceled, or unexpected state.

**Rationale**

Amazon Athena Spark calculations are identified by a `calculation_execution_id` after they are submitted. While `AthenaSparkOperator` can submit Spark code and wait for completion, users may also need to monitor calculations started outside the operator, for example by another task or by an external system.

Adding `AthenaSparkSensor` gives DAG authors a provider-native way to wait on an existing Athena Spark calculation without writing custom polling logic around boto3.

**Tests**

Added unit tests verifying that:

* the sensor inherits the expected AWS hook configuration behavior.
* successful calculation states are handled correctly.
* in-progress states such as `CREATING`, `CREATED`, `QUEUED`, and `RUNNING` continue waiting.
* failed and canceled calculation states raise an error.
* the state change reason is included when Athena provides one.

**Example DAG**

Updated the Athena Spark example DAG to demonstrate waiting for an existing Athena Spark calculation execution using `AthenaSparkSensor`.

**Documentation**

Added documentation for `AthenaSparkSensor`, including its expected `calculation_execution_id` input and an example usage snippet.

**Backwards Compatibility**

This is a new sensor and does not modify existing Athena sensor behavior. No breaking changes are introduced.

**Acknowledgements**

This change builds on the Athena Spark provider support previously explored in PR #66576 by @Andisha2004 which proposed adding an Athena Spark hook, sensor, and operator to the Amazon provider. This PR carries that direction forward with a narrower initial scope focused on `AthenaSparkSensor` methods, along with updated tests, documentation, and an example DAG aligned with current provider conventions.

###### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: [GPT 5.5] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)