### PR TITLE
Replace CTE with subquery in asset orphanage to support MySQL backends without CTE-in-DML

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -35,7 +35,7 @@ from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID
 
 from sqlalchemy import (
-    CTE,
+    Subquery,
     Text,
     and_,
     case,
@@ -3798,15 +3798,15 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             .group_by(AssetModel.id)
         )
 
-        orphan_query = asset_reference_query.having(orphaned).cte()
-        activate_query = asset_reference_query.having(~orphaned).cte()
+        orphan_query = asset_reference_query.having(orphaned).subquery()
+        activate_query = asset_reference_query.having(~orphaned).subquery()
 
         self._orphan_unreferenced_assets(orphan_query, session=session)
         self._activate_referenced_assets(activate_query, session=session)
         self._cleanup_orphaned_asset_state_store(session=session)
 
     @staticmethod
-    def _orphan_unreferenced_assets(assets_query: CTE, *, session: Session) -> None:
+    def _orphan_unreferenced_assets(assets_query: Subquery, *, session: Session) -> None:
         deleted_orphaned_assets = session.execute(
             delete(AssetActive).where(
                 exists().where(
@@ -3818,7 +3818,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         stats.gauge("asset.orphaned", max(getattr(deleted_orphaned_assets, "rowcount", 0), 0))
 
     @staticmethod
-    def _activate_referenced_assets(assets_query: CTE, *, session: Session) -> None:
+    def _activate_referenced_assets(assets_query: Subquery, *, session: Session) -> None:
         active_assets_query = select(AssetActive.name, AssetActive.uri).join(
             assets_query,
             and_(AssetActive.name == assets_query.c.name, AssetActive.uri == assets_query.c.uri),


### PR DESCRIPTION
Closes #72187.

### Motivation

MySQL-compatible backends like Vitess/PlanetScale do not support CTEs in DML statements. When `SchedulerJobRunner._update_asset_orphanage` runs its asset reference-count query as a CTE and executes a `DELETE`, the query planner rejects it. Because this runs on the parsing cleanup interval, it causes the scheduler to crash-loop.

### Changes

- Replaced `.cte()` with `.subquery()` for both `orphan_query` and `activate_query` in `_update_asset_orphanage`.
- Updated the type hints for `assets_query` in `_orphan_unreferenced_assets` and `_activate_referenced_assets` from `CTE` to `Subquery`.

Since each query is consumed by a single statement, the CTE is not semantically required and a standard derived-table subquery achieves the same outcome. This unblocks deployments on Vitess without changing query semantics for Postgres or standard MySQL.