### PR TITLE
Document six recurring non-issue shapes in the security model

### DIFF
--- a/airflow-core/docs/security/security_model.rst
+++ b/airflow-core/docs/security/security_model.rst
@@ -1067,3 +1067,104 @@ judged on the Linux behavior; the non-Linux aspect is informational.
 
 Reporters who identify a non-Linux-only bug should still report it through the regular contribution
 process — fixes are welcome as defense-in-depth hardening, with no CVE or advisory.
+
+Hardening opportunities with no demonstrated exploitation path
+...............................................................
+
+Many reports describe code that could be written more defensively — a shell command assembled by
+string formatting, a path that is not confined, a check that fails open on a branch the reporter
+has not shown to be reachable. Where no path exists by which an actor reaches an outcome they were
+not already entitled to, the finding is hardening rather than a vulnerability.
+
+Hardening is handled in public: open a normal pull request or issue and it is reviewed like any
+other change. No CVE is allocated and no advisory is issued. This is the disposition the security
+team applies most often, and it is not a dismissal — such findings are frequently fixed soon after
+they reach the public process, which is the faster route precisely because it does not wait on a
+coordinated release.
+
+A report that states a weakness and then observes that it is not reachable has answered its own
+question. If you believe the weakness *is* reachable, show the path; that is the part that decides
+which process handles it.
+
+Findings whose premise is a misconfiguration
+.............................................
+
+Airflow gives Deployment Managers settings that widen what the software will do: deserialization
+allow-lists, module and plugin paths loaded by name, and the ``test connection`` feature among
+others. Reports of the form "if this allow-list were misconfigured, arbitrary classes could be
+instantiated", or "a misconfigured module path could load unintended code", describe the
+consequence of choosing an unsafe value. They do not describe a defect in the code that reads it.
+
+Choosing that value is a Deployment Manager decision of the same kind as granting a user the Admin
+role, and Deployment Managers are trusted. For a report in this shape to be actionable it has to
+establish one of two things: that the **default** configuration is exploitable, or that some actor
+who is not a Deployment Manager can cause the setting to take the unsafe value.
+
+The same applies to a call site presented without a route to it. Pointing at ``import_string()``, a
+deserialization helper, or a subprocess invocation does not establish that attacker-controlled
+input reaches it. Name the entry point, the role of the actor who controls the input, and each hop
+in between — that trace is the finding, not the call site.
+
+Restating a documented design property
+.......................................
+
+Sections of this document record decisions the project has made and the consequences that follow:
+that a symmetric JWT signing secret is held by every component that must verify tokens, that Dag
+authors execute arbitrary code, that the Execution API does not isolate workloads from one another.
+A report whose evidence is a link to one of those sections restates the project's position rather
+than contradicting it, and submitting the same restatement more than once does not change the
+assessment.
+
+Such a report becomes useful at the point where it shows behaviour that differs from what this
+document describes, or a consequence of a documented decision that the document does not
+acknowledge and that a Deployment Manager could not reasonably have anticipated. Disagreement with
+a documented decision is welcome and often productive, but it is a design discussion for the
+developer mailing list rather than a security report.
+
+Components the project does not release
+........................................
+
+The security process covers what the Apache Airflow project releases: ``apache-airflow``, the
+provider distributions, the Task SDK, the Helm chart, and the reference Docker image. Third-party
+plugins, operators distributed outside the project, forks, vendor builds, and images built by
+others are not ASF releases and fall outside it — including when they are widely deployed
+alongside Airflow, and when their name contains "airflow".
+
+Report those to whoever publishes them. Where a third-party component is only exploitable because
+of something Airflow itself does, that part is in scope and worth reporting here; say which part is
+which.
+
+Findings whose precondition already grants the capability
+..........................................................
+
+A report has to gain an attacker something they could not already do. Where the stated precondition
+is write access to the metadata database, the ability to place a file in a Dag bundle, or a
+permission whose documented purpose is the action being demonstrated, the conclusion follows from
+the premise and no boundary has been crossed.
+
+Two shapes recur. The first assumes a principal that is already inside a trust boundary — a
+metadata-database writer can approve a gated task, but that principal can already set task and Dag
+run states directly. The second reads an administrative permission as an escalation: a role holding
+the FAB user-administration permission can grant roles, Admin included, because granting roles is
+what that permission is for.
+
+State what the attacker holds at the start and what they hold at the end. Where those are the same,
+there is no escalation to report.
+
+Values outside the secret-masking contract
+...........................................
+
+Secret masking covers values Airflow has been told are secret: a connection's password and its
+``extra``, and values whose field name matches the sensitive-field list that
+``[core] sensitive_var_conn_names`` extends. It reduces accidental disclosure in logs and the UI.
+It is not a boundary that contains a Dag author, who can always read and print the values their
+tasks are given.
+
+Two consequences of that scope are by design. Identity fields are not secrets — a connection's
+``login`` is deliberately absent from the sensitive-field list, as are ``user`` and ``username`` —
+so a report that ``login`` appears in logs describes intended behaviour. And values placed
+somewhere Airflow has not been told is sensitive, most often a Dag run configuration, are not
+masked; the project has never documented them as being.
+
+A value that *is* within the contract and appears in clear text is a real bug and worth raising, in most
+cases through the public issue tracker rather than the security process.


### PR DESCRIPTION
## Why

*What is NOT considered a security vulnerability* opens by asking security researchers and AI agents to read it before reporting. It works: the shapes it names largely stop arriving. The shapes it does not name keep arriving, and each one costs a triage cycle to re-derive — the reasoning ends up in a private thread, so the next instance is reasoned out from scratch.

Six dispositions recur often enough to be worth writing down. Each is drawn from how the security team has actually been closing reports, not from speculation about what might arrive.

## What

Six new entries, appended to the existing section:

| Entry | Boundary |
|---|---|
| Hardening opportunities with no demonstrated exploitation path | A weakness nobody can show a path to is hardening. It is handled in public, on the normal PR/issue track, with no CVE — which is also the faster route, since it does not wait on a coordinated release. |
| Findings whose premise is a misconfiguration | "If this allow-list were misconfigured…" describes the consequence of choosing an unsafe value, not a defect in the code that reads it. Actionable only if the **default** is exploitable, or if a non-Deployment-Manager can cause the setting to take that value. Covers the related "here is an `import_string()` call site" report with no route to it. |
| Restating a documented design property | A report whose evidence is a link to a section of this document restates the position rather than contradicting it. Resubmitting it does not change the assessment. Disagreement is welcome — on the devlist, as a design discussion. |
| Components the project does not release | Third-party plugins, forks, vendor builds and images built by others are outside the process, including when the name contains "airflow". |
| Findings whose precondition already grants the capability | Metadata-DB write access, or a permission whose documented purpose *is* the demonstrated action (the FAB user-administration permission grants roles because that is what it is for). State what the attacker holds at the start and at the end; if those match, there is no escalation. |
| Values outside the secret-masking contract | Masking covers a connection's password and `extra` plus names matching `[core] sensitive_var_conn_names`. Identity fields are deliberately excluded — `login`, `user`, `username` are absent from `DEFAULT_SENSITIVE_FIELDS` — and values placed in a Dag run configuration were never claimed to be masked. A value that *is* within the contract and leaks is still a real bug. |

Both factual claims in the last entry were checked against the code rather than asserted: `shared/secrets_masker/.../secrets_masker.py` (`DEFAULT_SENSITIVE_FIELDS` contains no identity field) and `task-sdk/.../execution_time/context.py` (`_mask_connection_secrets` masks `password` and `extra`).

## Scope

Additions only — no existing entry is narrowed and nothing previously in scope moves out of it. The entries are written as generalised categories; no report, reporter, tool or vendor is identifiable from the text.

The first entry is deliberately framed as a redirection rather than a rejection, because that is what it is: findings sent to the public track are frequently fixed within days.

## Note for the reviewer

This touches the same section as #72172, which is still open. The two were written to append at different points, so they should merge without conflict, but whichever lands second is worth a glance.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
