### PR TITLE
Google: Fix CloudComposer external-task empty-window success

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py
+++ b/providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py
@@ -570,6 +570,7 @@ class CloudComposerExternalTaskSensor(BaseSensorOperator):
             for task_instance in task_instances
             if start_ts < parser.parse(task_instance[date_key]).timestamp() < end_ts
         ]
+        # all([]) is True; an empty window must keep waiting.
         if not in_window:
             return False
         return all(task_instance["state"] in states for task_instance in in_window)

--- a/providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py
+++ b/providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py
@@ -562,16 +562,17 @@ class CloudComposerExternalTaskSensor(BaseSensorOperator):
         end_date: datetime,
         states: Iterable[str],
     ) -> bool:
-        for task_instance in task_instances:
-            if (
-                start_date.timestamp()
-                < parser.parse(
-                    task_instance["execution_date" if self._composer_airflow_version < 3 else "logical_date"]
-                ).timestamp()
-                < end_date.timestamp()
-            ) and task_instance["state"] not in states:
-                return False
-        return True
+        date_key = "execution_date" if self._composer_airflow_version < 3 else "logical_date"
+        start_ts = start_date.timestamp()
+        end_ts = end_date.timestamp()
+        in_window = [
+            task_instance
+            for task_instance in task_instances
+            if start_ts < parser.parse(task_instance[date_key]).timestamp() < end_ts
+        ]
+        if not in_window:
+            return False
+        return all(task_instance["state"] in states for task_instance in in_window)
 
     def _get_composer_airflow_version(self) -> int:
         """Return Composer Airflow version."""

--- a/providers/google/src/airflow/providers/google/cloud/triggers/cloud_composer.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/cloud_composer.py
@@ -455,6 +455,7 @@ class CloudComposerExternalTaskTrigger(BaseTrigger):
             for task_instance in task_instances
             if start_ts < parser.parse(task_instance[date_key]).timestamp() < end_ts
         ]
+        # all([]) is True; an empty window must keep waiting.
         if not in_window:
             return False
         return all(task_instance["state"] in states for task_instance in in_window)

--- a/providers/google/src/airflow/providers/google/cloud/triggers/cloud_composer.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/cloud_composer.py
@@ -447,16 +447,17 @@ class CloudComposerExternalTaskTrigger(BaseTrigger):
         end_date: datetime,
         states: Iterable[str],
     ) -> bool:
-        for task_instance in task_instances:
-            if (
-                start_date.timestamp()
-                < parser.parse(
-                    task_instance["execution_date" if self.composer_airflow_version < 3 else "logical_date"]
-                ).timestamp()
-                < end_date.timestamp()
-            ) and task_instance["state"] not in states:
-                return False
-        return True
+        date_key = "execution_date" if self.composer_airflow_version < 3 else "logical_date"
+        start_ts = start_date.timestamp()
+        end_ts = end_date.timestamp()
+        in_window = [
+            task_instance
+            for task_instance in task_instances
+            if start_ts < parser.parse(task_instance[date_key]).timestamp() < end_ts
+        ]
+        if not in_window:
+            return False
+        return all(task_instance["state"] in states for task_instance in in_window)
 
     def _get_async_hook(self) -> CloudComposerAsyncHook:
         return CloudComposerAsyncHook(

--- a/providers/google/tests/system/google/cloud/composer/example_cloud_composer.py
+++ b/providers/google/tests/system/google/cloud/composer/example_cloud_composer.py
@@ -301,6 +301,9 @@ with DAG(
     )
     # [END howto_operator_trigger_dag_run]
 
+    # Exclusive window. A parse-time `datetime.now()` end excludes TIs created
+    # after parse (env create + trigger_dag_run). Keep the end in the future;
+    # timeout stops an empty window from hanging the system test.
     # [START howto_sensor_external_task]
     external_task_sensor = CloudComposerExternalTaskSensor(
         task_id="external_task_sensor",
@@ -310,7 +313,11 @@ with DAG(
         composer_external_dag_id="airflow_monitoring",
         composer_external_task_id="echo",
         allowed_states=["success"],
-        execution_range=[datetime.now() - timedelta(1), datetime.now()],
+        execution_range=[
+            datetime.now() - timedelta(days=1),
+            datetime.now() + timedelta(days=1),
+        ],
+        timeout=60 * 60,
     )
     # [END howto_sensor_external_task]
 
@@ -323,8 +330,12 @@ with DAG(
         composer_external_dag_id="airflow_monitoring",
         composer_external_task_id="echo",
         allowed_states=["success"],
-        execution_range=[datetime.now() - timedelta(1), datetime.now()],
+        execution_range=[
+            datetime.now() - timedelta(days=1),
+            datetime.now() + timedelta(days=1),
+        ],
         deferrable=True,
+        timeout=60 * 60,
     )
     # [END howto_sensor_external_task_deferrable_mode]
 

--- a/providers/google/tests/unit/google/cloud/sensors/test_cloud_composer.py
+++ b/providers/google/tests/unit/google/cloud/sensors/test_cloud_composer.py
@@ -28,6 +28,7 @@ from airflow.providers.google.cloud.sensors.cloud_composer import (
     CloudComposerDAGRunSensor,
     CloudComposerExternalTaskSensor,
 )
+from airflow.providers.standard.exceptions import ExternalTaskFailedError
 
 TEST_PROJECT_ID = "test_project_id"
 TEST_OPERATION_NAME = "test_operation_name"
@@ -75,6 +76,7 @@ TEST_GET_TASK_INSTANCES_RESULT = lambda state, date_key, task_id: {
 TEST_WINDOW_START = datetime(2024, 5, 22, 0, 0, 0, tzinfo=timezone.utc)
 TEST_WINDOW_END = datetime(2024, 5, 23, 0, 0, 0, tzinfo=timezone.utc)
 TEST_IN_WINDOW_DATE = "2024-05-22T11:10:00+00:00"
+TEST_IN_WINDOW_DATE_2 = "2024-05-22T15:10:00+00:00"
 TEST_OUT_OF_WINDOW_DATE = "2024-05-20T11:10:00+00:00"
 TEST_WINDOW_START_DATE = "2024-05-22T00:00:00+00:00"
 TEST_WINDOW_END_DATE = "2024-05-23T00:00:00+00:00"
@@ -407,12 +409,55 @@ class TestCloudComposerExternalTaskSensor:
         date_key = "execution_date" if composer_airflow_version < 3 else "logical_date"
         mock_hook.return_value.get_task_instances.return_value = _task_instances_result(
             _task_instance("success", date_key, when=TEST_IN_WINDOW_DATE),
-            _task_instance("running", date_key, task_id="other_task", when=TEST_OUT_OF_WINDOW_DATE),
+            _task_instance("running", date_key, when=TEST_OUT_OF_WINDOW_DATE),
         )
-        task = _external_task_sensor()
+        task = _external_task_sensor(composer_external_task_id=TEST_COMPOSER_EXTERNAL_TASK_ID)
         task._composer_airflow_version = composer_airflow_version
 
         assert task.poke(context={"logical_date": TEST_WINDOW_END})
+
+    @pytest.mark.parametrize("composer_airflow_version", [2, 3])
+    @mock.patch("airflow.providers.google.cloud.sensors.cloud_composer.CloudComposerHook")
+    def test_in_window_running_keeps_waiting(self, mock_hook, composer_airflow_version):
+        date_key = "execution_date" if composer_airflow_version < 3 else "logical_date"
+        mock_hook.return_value.get_task_instances.return_value = _task_instances_result(
+            _task_instance("running", date_key, when=TEST_IN_WINDOW_DATE),
+            _task_instance("success", date_key, when=TEST_OUT_OF_WINDOW_DATE),
+        )
+        task = _external_task_sensor(composer_external_task_id=TEST_COMPOSER_EXTERNAL_TASK_ID)
+        task._composer_airflow_version = composer_airflow_version
+
+        assert not task.poke(context={"logical_date": TEST_WINDOW_END})
+
+    @pytest.mark.parametrize("composer_airflow_version", [2, 3])
+    @mock.patch("airflow.providers.google.cloud.sensors.cloud_composer.CloudComposerHook")
+    def test_two_in_window_mixed_states_keep_waiting(self, mock_hook, composer_airflow_version):
+        date_key = "execution_date" if composer_airflow_version < 3 else "logical_date"
+        mock_hook.return_value.get_task_instances.return_value = _task_instances_result(
+            _task_instance("success", date_key, when=TEST_IN_WINDOW_DATE),
+            _task_instance("running", date_key, when=TEST_IN_WINDOW_DATE_2),
+        )
+        task = _external_task_sensor(composer_external_task_id=TEST_COMPOSER_EXTERNAL_TASK_ID)
+        task._composer_airflow_version = composer_airflow_version
+
+        assert not task.poke(context={"logical_date": TEST_WINDOW_END})
+
+    @pytest.mark.parametrize("composer_airflow_version", [2, 3])
+    @mock.patch("airflow.providers.google.cloud.sensors.cloud_composer.CloudComposerHook")
+    def test_failed_states_fire_when_all_in_window_failed(self, mock_hook, composer_airflow_version):
+        date_key = "execution_date" if composer_airflow_version < 3 else "logical_date"
+        mock_hook.return_value.get_task_instances.return_value = _task_instances_result(
+            _task_instance("failed", date_key, when=TEST_IN_WINDOW_DATE),
+            _task_instance("failed", date_key, when=TEST_IN_WINDOW_DATE_2),
+        )
+        task = _external_task_sensor(
+            composer_external_task_id=TEST_COMPOSER_EXTERNAL_TASK_ID,
+            failed_states=["failed"],
+        )
+        task._composer_airflow_version = composer_airflow_version
+
+        with pytest.raises(ExternalTaskFailedError):
+            task.poke(context={"logical_date": TEST_WINDOW_END})
 
     @pytest.mark.parametrize("composer_airflow_version", [2, 3])
     @mock.patch("airflow.providers.google.cloud.sensors.cloud_composer.CloudComposerHook")

--- a/providers/google/tests/unit/google/cloud/sensors/test_cloud_composer.py
+++ b/providers/google/tests/unit/google/cloud/sensors/test_cloud_composer.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import mock
 
 import pytest
@@ -69,6 +69,44 @@ TEST_GET_TASK_INSTANCES_RESULT = lambda state, date_key, task_id: {
     "task_instances": TEST_TASK_INSTANCES_RESULT(state, date_key, task_id),
     "total_entries": 1,
 }
+
+# Exclusive window used by the empty-window regression tests. UTC so the
+# comparisons do not depend on the worker's local timezone.
+TEST_WINDOW_START = datetime(2024, 5, 22, 0, 0, 0, tzinfo=timezone.utc)
+TEST_WINDOW_END = datetime(2024, 5, 23, 0, 0, 0, tzinfo=timezone.utc)
+TEST_IN_WINDOW_DATE = "2024-05-22T11:10:00+00:00"
+TEST_OUT_OF_WINDOW_DATE = "2024-05-20T11:10:00+00:00"
+TEST_WINDOW_START_DATE = "2024-05-22T00:00:00+00:00"
+TEST_WINDOW_END_DATE = "2024-05-23T00:00:00+00:00"
+
+
+def _task_instance(state, date_key, task_id=TEST_COMPOSER_EXTERNAL_TASK_ID, when=TEST_IN_WINDOW_DATE):
+    return {
+        "task_id": task_id,
+        "dag_id": "test_dag_id",
+        "state": state,
+        date_key: when,
+        "start_date": "2024-05-22T11:20:01.531988+00:00",
+        "end_date": "2024-05-22T11:20:11.997479+00:00",
+    }
+
+
+def _task_instances_result(*task_instances):
+    return {"task_instances": list(task_instances), "total_entries": len(task_instances)}
+
+
+def _external_task_sensor(**kwargs):
+    defaults = {
+        "task_id": "task-id",
+        "project_id": TEST_PROJECT_ID,
+        "region": TEST_REGION,
+        "environment_id": TEST_ENVIRONMENT_ID,
+        "composer_external_dag_id": "test_dag_id",
+        "allowed_states": ["success"],
+        "execution_range": [TEST_WINDOW_START, TEST_WINDOW_END],
+    }
+    defaults.update(kwargs)
+    return CloudComposerExternalTaskSensor(**defaults)
 
 
 class TestCloudComposerDAGRunSensor:
@@ -350,3 +388,71 @@ class TestCloudComposerExternalTaskSensor:
         task._composer_airflow_version = composer_airflow_version
 
         assert not task.poke(context={"logical_date": datetime(2024, 5, 23, 0, 0, 0)})
+
+    @pytest.mark.parametrize("composer_airflow_version", [2, 3])
+    @mock.patch("airflow.providers.google.cloud.sensors.cloud_composer.CloudComposerHook")
+    def test_all_task_instances_outside_window_keeps_waiting(self, mock_hook, composer_airflow_version):
+        date_key = "execution_date" if composer_airflow_version < 3 else "logical_date"
+        mock_hook.return_value.get_task_instances.return_value = _task_instances_result(
+            _task_instance("success", date_key, when=TEST_OUT_OF_WINDOW_DATE),
+        )
+        task = _external_task_sensor()
+        task._composer_airflow_version = composer_airflow_version
+
+        assert not task.poke(context={"logical_date": TEST_WINDOW_END})
+
+    @pytest.mark.parametrize("composer_airflow_version", [2, 3])
+    @mock.patch("airflow.providers.google.cloud.sensors.cloud_composer.CloudComposerHook")
+    def test_mixed_window_uses_only_in_window_states(self, mock_hook, composer_airflow_version):
+        date_key = "execution_date" if composer_airflow_version < 3 else "logical_date"
+        mock_hook.return_value.get_task_instances.return_value = _task_instances_result(
+            _task_instance("success", date_key, when=TEST_IN_WINDOW_DATE),
+            _task_instance("running", date_key, task_id="other_task", when=TEST_OUT_OF_WINDOW_DATE),
+        )
+        task = _external_task_sensor()
+        task._composer_airflow_version = composer_airflow_version
+
+        assert task.poke(context={"logical_date": TEST_WINDOW_END})
+
+    @pytest.mark.parametrize("composer_airflow_version", [2, 3])
+    @mock.patch("airflow.providers.google.cloud.sensors.cloud_composer.CloudComposerHook")
+    def test_failed_states_do_not_fire_when_window_empty(self, mock_hook, composer_airflow_version):
+        date_key = "execution_date" if composer_airflow_version < 3 else "logical_date"
+        mock_hook.return_value.get_task_instances.return_value = _task_instances_result(
+            _task_instance("failed", date_key, when=TEST_OUT_OF_WINDOW_DATE),
+        )
+        task = _external_task_sensor(
+            composer_external_task_id=TEST_COMPOSER_EXTERNAL_TASK_ID,
+            failed_states=["failed"],
+        )
+        task._composer_airflow_version = composer_airflow_version
+
+        assert not task.poke(context={"logical_date": TEST_WINDOW_END})
+
+    @pytest.mark.parametrize("composer_airflow_version", [2, 3])
+    @mock.patch("airflow.providers.google.cloud.sensors.cloud_composer.CloudComposerHook")
+    def test_skipped_states_do_not_fire_when_window_empty(self, mock_hook, composer_airflow_version):
+        date_key = "execution_date" if composer_airflow_version < 3 else "logical_date"
+        mock_hook.return_value.get_task_instances.return_value = _task_instances_result(
+            _task_instance("skipped", date_key, when=TEST_OUT_OF_WINDOW_DATE),
+        )
+        task = _external_task_sensor(
+            composer_external_task_id=TEST_COMPOSER_EXTERNAL_TASK_ID,
+            skipped_states=["skipped"],
+        )
+        task._composer_airflow_version = composer_airflow_version
+
+        assert not task.poke(context={"logical_date": TEST_WINDOW_END})
+
+    @pytest.mark.parametrize("composer_airflow_version", [2, 3])
+    @pytest.mark.parametrize("when", [TEST_WINDOW_START_DATE, TEST_WINDOW_END_DATE])
+    @mock.patch("airflow.providers.google.cloud.sensors.cloud_composer.CloudComposerHook")
+    def test_boundary_timestamp_excluded(self, mock_hook, composer_airflow_version, when):
+        date_key = "execution_date" if composer_airflow_version < 3 else "logical_date"
+        mock_hook.return_value.get_task_instances.return_value = _task_instances_result(
+            _task_instance("success", date_key, when=when),
+        )
+        task = _external_task_sensor()
+        task._composer_airflow_version = composer_airflow_version
+
+        assert not task.poke(context={"logical_date": TEST_WINDOW_END})

--- a/providers/google/tests/unit/google/cloud/triggers/test_cloud_composer.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_cloud_composer.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest import mock
 
@@ -26,6 +26,7 @@ import pytest
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import Connection
 from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.google.cloud.hooks.cloud_composer import CloudComposerAsyncHook
 from airflow.providers.google.cloud.triggers.cloud_composer import (
     CloudComposerAirflowCLICommandTrigger,
     CloudComposerDAGRunTrigger,
@@ -268,3 +269,77 @@ class TestCloudComposerExternalTaskTrigger:
             },
         )
         assert actual_data == expected_data
+
+    @pytest.mark.parametrize("composer_airflow_version", [2, 3])
+    @pytest.mark.parametrize(
+        ("extra_kwargs", "out_of_window_state"),
+        [
+            ({}, "success"),
+            ({"failed_states": ["failed"]}, "failed"),
+            ({"skipped_states": ["skipped"]}, "skipped"),
+        ],
+        ids=["allowed", "failed", "skipped"],
+    )
+    @pytest.mark.asyncio
+    @mock.patch(
+        "airflow.providers.google.cloud.triggers.cloud_composer.asyncio.sleep", new_callable=mock.AsyncMock
+    )
+    async def test_run_keeps_waiting_when_all_task_instances_outside_window(
+        self, mock_sleep, extra_kwargs, out_of_window_state, composer_airflow_version
+    ):
+        date_key = "execution_date" if composer_airflow_version < 3 else "logical_date"
+        start_date = datetime(2024, 3, 22, 11, 0, 0, tzinfo=timezone.utc)
+        end_date = datetime(2024, 3, 22, 12, 0, 0, tzinfo=timezone.utc)
+        hook = mock.AsyncMock(spec=CloudComposerAsyncHook)
+        hook.get_environment.return_value = SimpleNamespace(
+            config=SimpleNamespace(airflow_uri="https://composer.example")
+        )
+        hook.get_task_instances.side_effect = [
+            {
+                "task_instances": [
+                    {
+                        "task_id": TEST_COMPOSER_EXTERNAL_TASK_IDS[0],
+                        "dag_id": TEST_COMPOSER_DAG_ID,
+                        "state": out_of_window_state,
+                        date_key: "2024-03-21T11:10:00+00:00",
+                    }
+                ],
+                "total_entries": 1,
+            },
+            {
+                "task_instances": [
+                    {
+                        "task_id": TEST_COMPOSER_EXTERNAL_TASK_IDS[0],
+                        "dag_id": TEST_COMPOSER_DAG_ID,
+                        "state": "success",
+                        date_key: "2024-03-22T11:10:00+00:00",
+                    }
+                ],
+                "total_entries": 1,
+            },
+        ]
+        trigger_kwargs = {
+            "project_id": TEST_PROJECT_ID,
+            "region": TEST_LOCATION,
+            "environment_id": TEST_ENVIRONMENT_ID,
+            "start_date": start_date,
+            "end_date": end_date,
+            "allowed_states": TEST_ALLOWED_STATES,
+            "skipped_states": [],
+            "failed_states": [],
+            "composer_external_dag_id": TEST_COMPOSER_DAG_ID,
+            "composer_external_task_ids": TEST_COMPOSER_EXTERNAL_TASK_IDS,
+            "gcp_conn_id": TEST_GCP_CONN_ID,
+            "impersonation_chain": TEST_IMPERSONATION_CHAIN,
+            "poll_interval": TEST_POLL_INTERVAL,
+            "composer_airflow_version": composer_airflow_version,
+        }
+        trigger_kwargs.update(extra_kwargs)
+        trigger = CloudComposerExternalTaskTrigger(**trigger_kwargs)
+
+        with mock.patch.object(trigger, "_get_async_hook", return_value=hook):
+            actual_event = await trigger.run().asend(None)
+
+        assert actual_event == TriggerEvent({"status": "success"})
+        assert hook.get_task_instances.await_count == 2
+        assert mock_sleep.await_count == 1

--- a/providers/google/tests/unit/google/cloud/triggers/test_cloud_composer.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_cloud_composer.py
@@ -290,34 +290,39 @@ class TestCloudComposerExternalTaskTrigger:
         date_key = "execution_date" if composer_airflow_version < 3 else "logical_date"
         start_date = datetime(2024, 3, 22, 11, 0, 0, tzinfo=timezone.utc)
         end_date = datetime(2024, 3, 22, 12, 0, 0, tzinfo=timezone.utc)
-        hook = mock.AsyncMock(spec=CloudComposerAsyncHook)
-        hook.get_environment.return_value = SimpleNamespace(
-            config=SimpleNamespace(airflow_uri="https://composer.example")
+        # get_environment is wrapped by fallback_to_default_project_id, so
+        # inspect.iscoroutinefunction is False and AsyncMock(spec=...) is a
+        # MagicMock on Python 3.10. Awaited methods must be AsyncMock.
+        hook = mock.Mock(spec=CloudComposerAsyncHook)
+        hook.get_environment = mock.AsyncMock(
+            return_value=SimpleNamespace(config=SimpleNamespace(airflow_uri="https://composer.example"))
         )
-        hook.get_task_instances.side_effect = [
-            {
-                "task_instances": [
-                    {
-                        "task_id": TEST_COMPOSER_EXTERNAL_TASK_IDS[0],
-                        "dag_id": TEST_COMPOSER_DAG_ID,
-                        "state": out_of_window_state,
-                        date_key: "2024-03-21T11:10:00+00:00",
-                    }
-                ],
-                "total_entries": 1,
-            },
-            {
-                "task_instances": [
-                    {
-                        "task_id": TEST_COMPOSER_EXTERNAL_TASK_IDS[0],
-                        "dag_id": TEST_COMPOSER_DAG_ID,
-                        "state": "success",
-                        date_key: "2024-03-22T11:10:00+00:00",
-                    }
-                ],
-                "total_entries": 1,
-            },
-        ]
+        hook.get_task_instances = mock.AsyncMock(
+            side_effect=[
+                {
+                    "task_instances": [
+                        {
+                            "task_id": TEST_COMPOSER_EXTERNAL_TASK_IDS[0],
+                            "dag_id": TEST_COMPOSER_DAG_ID,
+                            "state": out_of_window_state,
+                            date_key: "2024-03-21T11:10:00+00:00",
+                        }
+                    ],
+                    "total_entries": 1,
+                },
+                {
+                    "task_instances": [
+                        {
+                            "task_id": TEST_COMPOSER_EXTERNAL_TASK_IDS[0],
+                            "dag_id": TEST_COMPOSER_DAG_ID,
+                            "state": "success",
+                            date_key: "2024-03-22T11:10:00+00:00",
+                        }
+                    ],
+                    "total_entries": 1,
+                },
+            ]
+        )
         trigger_kwargs = {
             "project_id": TEST_PROJECT_ID,
             "region": TEST_LOCATION,


### PR DESCRIPTION
## What is the change?

`CloudComposerExternalTaskSensor` and `CloudComposerExternalTaskTrigger` now succeed only when at least one task instance falls inside `execution_range` and every in-window instance is in the requested states. An empty window means keep waiting, not success, failed, or skipped.

## Why did I do it?

closes: #67051
related: #67052

The old window check returned True whenever it saw no in-window TI in a disallowed state. A non-empty API response whose TIs all sit outside the window is vacuously True, so the sensor went green and downstream MERGE/load ran against data that never showed up. The same hole fires `failed_states` and `skipped_states` for a window that contained nothing.

#67052 is the Dag-run sibling and stays Dag-run only. This PR is the task-instance class.

## How did I do it?

Both copies of `_check_task_instances_states` now partition TIs with the existing exclusive timestamp test (`start < ts < end`), return False when the in-window set is empty, and otherwise require every in-window TI to be in `states`. Airflow 2 `execution_date` and Airflow 3 `logical_date` keys are unchanged. I did not extract a shared helper with #67052, did not touch `_check_dag_runs_states`, and did not switch the bounds to inclusive.

## What's the impact?

No more false success, fail, or skip from out-of-window-only TI lists. Users who relied on the old empty-window success should set a finite `timeout`, because an empty window now waits. Existing in-window behaviour is unchanged.

## What's the test plan?

New unit tests in `test_cloud_composer.py` (sensor and trigger):

- all TIs outside the window keep waiting (AF2 and AF3)
- mixed window uses only in-window states
- `failed_states` / `skipped_states` do not fire when the window is empty
- timestamps equal to `start_date` or `end_date` stay excluded
- deferrable trigger sleeps and does not yield success/failed/skipped on the first poll, then succeeds when an in-window TI appears

I reverted the production change and re-ran the new tests: 16 failed for the right reason (vacuous True / failed / skipped). The mixed-window tests still passed, as they should: old code already ignored out-of-window TIs when any TI was inside the window.

```
uv run --project providers/google pytest \
  providers/google/tests/unit/google/cloud/sensors/test_cloud_composer.py \
  providers/google/tests/unit/google/cloud/triggers/test_cloud_composer.py \
  -xvs
```

58 passed. Ruff format/check on the four files: clean. Live Composer was not run; it needs real GCP infrastructure.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Grok 4.6

Generated-by: Grok 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

Drafted-by: Grok 4.6 (no human review before posting)