### PR TITLE
Add json line support for DocumentLoaderOperator

### DIFF
--- a/providers/common/ai/docs/operators/document_loader.rst
+++ b/providers/common/ai/docs/operators/document_loader.rst
@@ -32,8 +32,8 @@ LangChain, or any other AI framework.
 Basic usage
 -----------
 
-``.txt``, ``.md``, ``.csv``, and ``.json`` are handled with zero extra
-dependencies:
+``.txt``, ``.md``, ``.csv``, ``.json``, and ``.jsonl`` are handled with zero
+extra dependencies:
 
 .. exampleinclude:: /../../ai/src/airflow/providers/common/ai/example_dags/example_document_loader.py
     :language: python
@@ -45,6 +45,9 @@ with a top-level array produce one document per element; a single JSON object
 produces one document. By default each dict is flattened into ``"key: value,
 key: value"`` text so the embedding sees content tokens rather than JSON
 syntax (see the ``json_text_field`` section below for the structured variant).
+JSON Lines files produce one document per non-empty line. A JSON array on a
+single line remains one document rather than being expanded, and
+``json_text_field`` applies to each line just as it does to JSON records.
 
 PDF parsing
 -----------
@@ -153,8 +156,8 @@ Format coverage roadmap
 -----------------------
 
 The current built-in dispatch covers ``.txt``, ``.md``, ``.csv``, ``.json``,
-``.pdf``, ``.docx``. Additional formats are deferred to follow-ups, each
-gated behind its own extra so users only install what they need:
+``.jsonl``, ``.pdf``, ``.docx``. Additional formats are deferred to follow-ups,
+each gated behind its own extra so users only install what they need:
 
 - ``.pptx`` via ``python-pptx``
 - ``.epub`` via ``ebooklib``
@@ -233,13 +236,13 @@ download-then-parse pattern still works:
 Non-UTF-8 inputs
 ----------------
 
-The text parsers (``.txt`` / ``.md`` / ``.csv`` / ``.json``) and the bytes
-path default to UTF-8. To handle Windows-1252 CSVs, files with a leading
-``utf-8-sig`` byte-order mark, or any other encoding, set the ``encoding``
-parameter on the operator (and optionally ``encoding_errors="replace"`` to
-tolerate mixed-encoding sources at the cost of some character loss). A
-failed decode includes the offending file path in the error so
-directory-mode runs are easy to diagnose.
+The text parsers (``.txt`` / ``.md`` / ``.csv`` / ``.json`` / ``.jsonl``) and
+the bytes path default to UTF-8. To handle Windows-1252 CSVs, files with a
+leading ``utf-8-sig`` byte-order mark, or any other encoding, set the
+``encoding`` parameter on the operator (and optionally
+``encoding_errors="replace"`` to tolerate mixed-encoding sources at the cost
+of some character loss). A failed decode includes the offending file path in
+the error so directory-mode runs are easy to diagnose.
 
 Metadata precedence
 -------------------
@@ -287,12 +290,12 @@ Parameters
        not override auto-extracted keys.
    * - ``encoding``
      - Text encoding for the bytes path and ``.txt`` / ``.md`` / ``.csv`` /
-       ``.json`` files. Defaults to ``"utf-8"``.
+       ``.json`` / ``.jsonl`` files. Defaults to ``"utf-8"``.
    * - ``encoding_errors``
      - How decode errors are handled (``"strict"`` / ``"replace"`` /
        ``"ignore"``). Defaults to ``"strict"``.
    * - ``json_text_field``
-     - When parsing JSON, treat this key as the embedding text; every other
-       key on the same item lands in ``metadata``. When unset, dicts are
-       flattened to ``"k: v, k: v"`` so the embedding sees content tokens
-       rather than JSON syntax.
+     - When parsing JSON or JSON Lines, treat this key as the embedding text;
+       every other key on the same item lands in ``metadata``. When unset,
+       dicts are flattened to ``"k: v, k: v"`` so the embedding sees content
+       tokens rather than JSON syntax.

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/document_loader.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/document_loader.py
@@ -366,7 +366,7 @@ class DocumentLoaderOperator(BaseOperator):
         return self._parse_json_lines_text(self._read_text(file_path))
 
     def _parse_json_lines_text(self, text: str) -> list[dict[str, Any]]:
-        documents = []
+        documents: list[dict[str, Any]] = []
         for line in text.splitlines():
             if not line.strip():
                 continue

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/document_loader.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/document_loader.py
@@ -367,10 +367,13 @@ class DocumentLoaderOperator(BaseOperator):
 
     def _parse_json_lines_text(self, text: str) -> list[dict[str, Any]]:
         documents: list[dict[str, Any]] = []
-        for line in text.splitlines():
+        for line_number, line in enumerate(text.splitlines(), start=1):
             if not line.strip():
                 continue
-            item = json.loads(line)
+            try:
+                item = json.loads(line)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"Invalid JSON on line {line_number}, column {e.colno}: {e.msg}") from e
             documents.append(self._json_item_to_doc(item, item_index=len(documents)))
         return documents
 

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/document_loader.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/document_loader.py
@@ -50,9 +50,9 @@ class DocumentLoaderOperator(BaseOperator):
     with metadata). Framework-agnostic: no LlamaIndex, LangChain, or other
     AI framework dependency.
 
-    Built-in parsers handle ``.txt``, ``.md``, ``.csv``, and ``.json`` with
-    zero extra dependencies. PDF and DOCX support require optional packages
-    installable via extras::
+    Built-in parsers handle ``.txt``, ``.md``, ``.csv``, ``.json``, and
+    ``.jsonl`` with zero extra dependencies. PDF and DOCX support require
+    optional packages installable via extras::
 
         pip install apache-airflow-providers-common-ai[pdf]    # pypdf
         pip install apache-airflow-providers-common-ai[docx]   # python-docx
@@ -89,17 +89,18 @@ class DocumentLoaderOperator(BaseOperator):
         document's ``metadata`` dict. Auto-extracted fields such as
         ``file_name``, ``file_path``, ``row_index``, ``item_index``, and
         ``page_number`` take precedence over keys with the same name.
-    :param encoding: Text encoding used for ``.txt``/``.md``/``.csv``/``.json``
-        and for the bytes path. Defaults to ``"utf-8"``.
+    :param encoding: Text encoding used for
+        ``.txt``/``.md``/``.csv``/``.json``/``.jsonl`` and for the bytes path.
+        Defaults to ``"utf-8"``.
     :param encoding_errors: How decode errors are handled. Defaults to
         ``"strict"``; set to ``"replace"`` or ``"ignore"`` to tolerate
         mixed-encoding inputs at the cost of some character loss.
-    :param json_text_field: When parsing JSON, treat this key as the
-        embedding text and put every other key into ``metadata``. Applies
-        to each item when the top-level JSON is a list, or to the object
-        when it is a single dict. When ``None`` (default), the operator
-        flattens dicts into ``"k: v, k: v"`` text (same shape as the CSV
-        parser).
+    :param json_text_field: When parsing JSON or JSON Lines, treat this key
+        as the embedding text and put every other key into ``metadata``.
+        Applies to each item when the top-level JSON is a list, to the object
+        when it is a single dict, or to each JSON Lines record. When ``None``
+        (default), the operator flattens dicts into ``"k: v, k: v"`` text
+        (same shape as the CSV parser).
     """
 
     template_fields: Sequence[str] = (
@@ -116,6 +117,7 @@ class DocumentLoaderOperator(BaseOperator):
         ".md": "text",
         ".csv": "csv",
         ".json": "json",
+        ".jsonl": "jsonl",
         ".pdf": "pypdf",
         ".docx": "python-docx",
     }
@@ -284,6 +286,8 @@ class DocumentLoaderOperator(BaseOperator):
             return self._parse_csv_text(text)
         if backend == "json":
             return self._parse_json_text(text)
+        if backend == "jsonl":
+            return self._parse_json_lines_text(text)
         return [{"text": text, "metadata": {}}]
 
     def _parse_file(self, file_path: Path, ext: str) -> list[dict[str, Any]]:
@@ -295,6 +299,8 @@ class DocumentLoaderOperator(BaseOperator):
             return self._parse_csv(file_path)
         if backend == "json":
             return self._parse_json(file_path)
+        if backend == "jsonl":
+            return self._parse_json_lines(file_path)
         if backend == "pypdf":
             with file_path.open("rb") as fh:
                 return self._parse_pdf_stream(fh)
@@ -355,6 +361,18 @@ class DocumentLoaderOperator(BaseOperator):
         if isinstance(data, list):
             return [self._json_item_to_doc(item, item_index=idx) for idx, item in enumerate(data)]
         return [self._json_item_to_doc(data, item_index=None)]
+
+    def _parse_json_lines(self, file_path: Path) -> list[dict[str, Any]]:
+        return self._parse_json_lines_text(self._read_text(file_path))
+
+    def _parse_json_lines_text(self, text: str) -> list[dict[str, Any]]:
+        documents = []
+        for line in text.splitlines():
+            if not line.strip():
+                continue
+            item = json.loads(line)
+            documents.append(self._json_item_to_doc(item, item_index=len(documents)))
+        return documents
 
     def _json_item_to_doc(self, item: Any, *, item_index: int | None) -> dict[str, Any]:
         metadata: dict[str, Any] = {}

--- a/providers/common/ai/tests/unit/common/ai/operators/test_document_loader.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_document_loader.py
@@ -192,6 +192,42 @@ class TestJsonParser:
         assert len(result) == 2
 
 
+class TestJsonLinesParser:
+    def test_one_document_per_non_empty_line(self, tmp_path):
+        f = tmp_path / "items.jsonl"
+        f.write_text('{"title": "First"}\n\n[1, 2]\n', encoding="utf-8")
+
+        op = DocumentLoaderOperator(task_id="test", source_path=str(f))
+        result = op.execute(context=MagicMock())
+
+        assert len(result) == 2
+        assert result[0]["text"] == "title: First"
+        assert result[1]["text"] == "[1, 2]"
+        assert [doc["metadata"]["item_index"] for doc in result] == [0, 1]
+
+    def test_source_bytes_uses_json_text_field(self):
+        raw = b'{"body": "First", "source": "a"}\n{"body": "Second", "source": "b"}\n'
+        op = DocumentLoaderOperator(
+            task_id="test",
+            source_bytes=raw,
+            file_type=".jsonl",
+            json_text_field="body",
+        )
+        result = op.execute(context=MagicMock())
+
+        assert [doc["text"] for doc in result] == ["First", "Second"]
+        assert [doc["metadata"]["source"] for doc in result] == ["a", "b"]
+
+    def test_directory_recognizes_jsonl_extension(self, tmp_path):
+        (tmp_path / "items.jsonl").write_text('{"name": "kept"}\n', encoding="utf-8")
+
+        op = DocumentLoaderOperator(task_id="test", source_path=str(tmp_path))
+        result = op.execute(context=MagicMock())
+
+        assert len(result) == 1
+        assert result[0]["text"] == "name: kept"
+
+
 def _make_mock_pypdf_module(mock_reader):
     """Create a fake pypdf module with a PdfReader that returns mock_reader."""
     mock_module = MagicMock()

--- a/providers/common/ai/tests/unit/common/ai/operators/test_document_loader.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_document_loader.py
@@ -218,6 +218,13 @@ class TestJsonLinesParser:
         assert [doc["text"] for doc in result] == ["First", "Second"]
         assert [doc["metadata"]["source"] for doc in result] == ["a", "b"]
 
+    def test_invalid_json_line(self):
+        raw = b'{"valid": true}\n\n{"invalid": }\n'
+        op = DocumentLoaderOperator(task_id="test", source_bytes=raw, file_type=".jsonl")
+
+        with pytest.raises(ValueError, match=r"Invalid JSON on line 3, column 13"):
+            op.execute(context=MagicMock())
+
     def test_directory_recognizes_jsonl_extension(self, tmp_path):
         (tmp_path / "items.jsonl").write_text('{"name": "kept"}\n', encoding="utf-8")
 


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
## Why

`DocumentLoaderOperator` supports regular JSON, but it does not recognize JSON Lines (`.jsonl`) files.


## What

- Add built-in `.jsonl` parsing without additional dependencies.
- Produce **one document per non-empty line** and assign consecutive `item_index` metadata.
- Support JSON Lines from file paths, directory discovery, and `source_bytes` with `file_type=".jsonl"`.

### Different with JSON file

For example, this regular JSON file produces two documents because its top-level array is expanded:

```json
[
  {"body": "First"},
  {"body": "Second"}
]
```

In a JSON Lines file, each non-empty line produces exactly one document. The array on the first line remains one document instead of being expanded, so this file also produces two documents:

```jsonl
[{"body": "First"}, {"body": "Second"}]
{"body": "Third"}
```

## Testing

### Before

```
::group::Log message source details
/root/airflow/logs/dag_id=example_document_loader_jsonl/run_id=manual__2026-08-29T06:23:56.559631+00:00/task_id=load_events/attempt=1.log
::endgroup::
[2026-08-29T06:23:57.671540Z] INFO - ::group::Pre Execute
Task Identity ti_id=01a04c30-6aa2-7411-a073-f1ad1073cd42 dag_id=example_document_loader_jsonl task_id=load_events run_id=manual__2026-08-29T06:23:56.559631+00:00 try_number=1 map_index=-1
[2026-08-29T06:24:03.707696Z] INFO - DAG bundles loaded: dags-folder
[2026-08-29T06:24:03.708918Z] INFO - Filling up the DagBag from /files/dags/example_document_loader_jsonl.py
[2026-08-29T06:24:03.781146Z] INFO - Worker startup parse complete bundle_name=dags-folder  bundle_version=null  dag_file=example_document_loader_jsonl.py  bundle_prepare_ms=4  dag_file_parse_ms=72 
[2026-08-29T06:24:03.824981Z] INFO - ::endgroup::
[2026-08-29T06:24:03.825318Z] ERROR - Task failed with exceptionValueError: No parser registered for extension '.jsonl'. Supported extensions: .csv, .docx, .json, .md, .pdf, .txt. Set 'parser' explicitly to override auto-detection.
```


### After
```
::group::Log message source details
/root/airflow/logs/dag_id=example_document_loader_jsonl/run_id=manual__2026-08-29T06:10:10.890844+00:00/task_id=load_events/attempt=1.log
::endgroup::
[2026-08-29T06:10:11.897592Z] INFO - ::group::Pre Execute
Task Identity ti_id=01a04c23-d167-7cbb-b0a1-888ca1cbeed1 dag_id=example_document_loader_jsonl task_id=load_events run_id=manual__2026-08-29T06:10:10.890844+00:00 try_number=1 map_index=-1
[2026-08-29T06:10:17.924766Z] INFO - DAG bundles loaded: dags-folder
[2026-08-29T06:10:17.926232Z] INFO - Filling up the DagBag from /files/dags/example_document_loader_jsonl.py
[2026-08-29T06:10:18.003334Z] INFO - Worker startup parse complete bundle_name=dags-folder  bundle_version=null  dag_file=example_document_loader_jsonl.py  bundle_prepare_ms=3  dag_file_parse_ms=77 
[2026-08-29T06:10:18.046544Z] INFO - ::endgroup::
[2026-08-29T06:10:18.047021Z] INFO - Parsed 3 documents from 1 file(s)
[2026-08-29T06:10:18.047139Z] INFO - ::group::Post Execute
[2026-08-29T06:10:18.047330Z] INFO - Pushing xcom ti=RuntimeTaskInstance(id=UUID('01a04c23-d167-7cbb-b0a1-888ca1cbeed1'), task_id='load_events', dag_id='example_document_loader_jsonl', run_id='manual__2026-08-29T06:10:10.890844+00:00', try_number=1, dag_version_id=UUID('01a04c22-161b-7e24-bb58-fbac6568e066'), map_index=-1, hostname='d5873b0b3ad5', context_carrier={'traceparent': '00-a8201c08aed315888a0215944bfaf514-c055bbb704c1e9ff-00'}, queue='default', task=<Task(DocumentLoaderOperator): load_events>, bundle_instance=LocalDagBundle(name=dags-folder), max_tries=0, start_date=datetime.datetime(2026, 8, 29, 6, 10, 17, 912797, tzinfo=datetime.timezone.utc), end_date=None, state=<TaskInstanceState.RUNNING: 'running'>, is_mapped=False, rendered_map_index=None, sentry_integration='') 
[2026-08-29T06:10:18.095744Z] INFO - ::endgroup::
```


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes — Codex (GPT-5.6-sol)

Generated-by: Codex (GPT-5.6-sol) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
