### PR TITLE
Let Dag viewers read the audit log of the Dags they can see

### DIFF
--- a/providers/fab/docs/auth-manager/access-control.rst
+++ b/providers/fab/docs/auth-manager/access-control.rst
@@ -172,10 +172,10 @@ Endpoint                                                                        
 /assets                                                                            GET    Assets.can_read                                                   Viewer
 /assets/{uri}                                                                      GET    Assets.can_read                                                   Viewer
 /assets/events                                                                     GET    Assets.can_read                                                   Viewer
-/eventLogs                                                                         GET    Audit Logs.can_read                                               Admin
-                                                                                          All Audit Logs.can_read (for rows not tied to a Dag)
-/eventLogs/{event_log_id}                                                          GET    Audit Logs.can_read                                               Admin
-                                                                                          All Audit Logs.can_read (for rows not tied to a Dag)
+/eventLogs                                                                         GET    Dags.can_read, Audit Logs.can_read (rows tied to a Dag)           Viewer
+/eventLogs                                                                         GET    All Audit Logs.can_read (rows not tied to a Dag)                  Admin
+/eventLogs/{event_log_id}                                                          GET    Dags.can_read, Audit Logs.can_read (rows tied to a Dag)           Viewer
+/eventLogs/{event_log_id}                                                          GET    All Audit Logs.can_read (rows not tied to a Dag)                  Admin
 /importErrors                                                                      GET    ImportError.can_read                                              Viewer
 /importErrors/{import_error_id}                                                    GET    ImportError.can_read                                              Viewer
 /health                                                                            GET    None                                                              Public

--- a/providers/fab/docs/changelog.rst
+++ b/providers/fab/docs/changelog.rst
@@ -20,6 +20,16 @@
 Changelog
 ---------
 
+.. warning::
+  On Airflow 3.4.0 and newer the ``Audit Logs.can_read`` and ``Audit Logs.menu_access``
+  permissions move from the ``Admin`` role to the ``Viewer`` role, so ``Viewer``, ``User`` and
+  ``Op`` now reach the audit log of the Dags they may read. The audit rows that are not tied to
+  a Dag -- Connection, Variable and Pool operations -- stay behind ``All Audit Logs.can_read``,
+  which only ``Admin`` holds. On an older Airflow those rows are not gated separately, so both
+  permissions stay with ``Admin`` there. Upgrading syncs the new permissions onto the built-in
+  roles; a deployment that wants the previous behaviour has to revoke them from the ``Viewer``
+  role explicitly.
+
 3.8.1
 .....
 

--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -73,6 +73,7 @@ from sqlalchemy.orm import joinedload
 from werkzeug.security import check_password_hash, generate_password_hash
 
 from airflow.providers.common.compat.sdk import conf
+from airflow.providers.common.compat.security.access_view import AUDIT_LOGS_ALL_ACCESS_VIEW
 from airflow.providers.fab.auth_manager.models import (
     Action,
     Group,
@@ -157,6 +158,16 @@ log = logging.getLogger(__name__)
 # continuously creates new sessions. Such setup should be fixed by reusing sessions or by periodically
 # purging the old sessions by using `airflow db clean` command.
 MAX_NUM_DATABASE_USER_SESSIONS = 50000
+
+# Airflow 3.4.0 moved the audit rows that carry no Dag -- Connection, Variable and Pool
+# operations -- behind ``AccessView.AUDIT_LOGS_ALL``, which leaves ``Audit Logs.can_read``
+# covering only the rows the event log endpoints already narrow to the caller's readable Dags.
+# An older core returns those Dag-less rows to anyone holding ``Audit Logs.can_read``, so there
+# the permission has to stay admin-only.
+_DAG_AUDIT_LOG_PERMISSIONS = [
+    (permissions.ACTION_CAN_READ, permissions.RESOURCE_AUDIT_LOG),
+    (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_AUDIT_LOG),
+]
 
 
 class FabException(Exception):
@@ -269,6 +280,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_WARNING),
         (permissions.ACTION_CAN_READ, RESOURCE_ASSET),
         (permissions.ACTION_CAN_READ, RESOURCE_ASSET_ALIAS),
+        (permissions.ACTION_CAN_READ, permissions.RESOURCE_AUDIT_LOG),
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_BACKFILL),
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_CLUSTER_ACTIVITY),
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_POOL),
@@ -289,6 +301,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_DAG_DEPENDENCIES),
         (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_DAG_RUN),
         (permissions.ACTION_CAN_ACCESS_MENU, RESOURCE_ASSET),
+        (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_AUDIT_LOG),
         (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_CLUSTER_ACTIVITY),
         (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_DOCS),
         (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_DOCS_MENU),
@@ -352,8 +365,6 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
 
     # [START security_admin_perms]
     ADMIN_PERMISSIONS = [
-        (permissions.ACTION_CAN_READ, permissions.RESOURCE_AUDIT_LOG),
-        (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_AUDIT_LOG),
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_AUDIT_LOG_ALL),
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_IMPORT_ERROR_ALL),
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_RESCHEDULE),
@@ -366,6 +377,12 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_ROLE),
     ]
     # [END security_admin_perms]
+
+    if AUDIT_LOGS_ALL_ACCESS_VIEW is None:
+        VIEWER_PERMISSIONS = [
+            permission for permission in VIEWER_PERMISSIONS if permission not in _DAG_AUDIT_LOG_PERMISSIONS
+        ]
+        ADMIN_PERMISSIONS = ADMIN_PERMISSIONS + _DAG_AUDIT_LOG_PERMISSIONS
 
     ###########################################################################
     #                     DEFAULT ROLE CONFIGURATIONS

--- a/providers/fab/tests/unit/fab/auth_manager/test_security.py
+++ b/providers/fab/tests/unit/fab/auth_manager/test_security.py
@@ -47,9 +47,11 @@ except ImportError:
     Mapped = Any  # type: ignore[assignment,misc]
 
 from airflow.api_fastapi.app import get_auth_manager
+from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity, DagDetails
 from airflow.models import DagModel
 from airflow.models.dag import DAG
 from airflow.models.dagbundle import DagBundleModel
+from airflow.providers.common.compat.security.access_view import AUDIT_LOGS_ALL_ACCESS_VIEW
 from airflow.providers.common.compat.sqlalchemy.orm import mapped_column
 from airflow.providers.fab.auth_manager.fab_auth_manager import FabAuthManager
 from airflow.providers.fab.auth_manager.models.anonymous_user import AnonymousUser
@@ -512,6 +514,11 @@ def test_get_user_roles_for_anonymous_user(app, security_manager):
         (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_DOCS_MENU),
         (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_DOCS),
     }
+    if AUDIT_LOGS_ALL_ACCESS_VIEW is not None:
+        viewer_role_perms |= {
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_AUDIT_LOG),
+            (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_AUDIT_LOG),
+        }
     app.config["AUTH_ROLE_PUBLIC"] = "Viewer"
 
     with app.app_context():
@@ -521,6 +528,30 @@ def test_get_user_roles_for_anonymous_user(app, security_manager):
         for role in security_manager.get_user_roles(user):
             perms_views.update({(perm.action.name, perm.resource.name) for perm in role.permissions})
         assert perms_views == viewer_role_perms
+
+
+@pytest.mark.skipif(
+    AUDIT_LOGS_ALL_ACCESS_VIEW is None,
+    reason="Viewers are granted audit log access only on a core that gates the Dag-less rows separately",
+)
+@pytest.mark.parametrize(
+    ("role_name", "expected_all_audit_logs"),
+    [("Viewer", False), ("User", False), ("Op", False), ("Admin", True)],
+)
+def test_default_roles_read_dag_audit_logs(app, role_name, expected_all_audit_logs):
+    """Every default role reads the audit rows of a Dag it can see; only Admin reads the rows with no Dag."""
+    with app.app_context():
+        with create_user_scope(app, username="audit_log_user", role_name=role_name) as user:
+            assert get_auth_manager().is_authorized_dag(
+                method="GET",
+                access_entity=DagAccessEntity.AUDIT_LOG,
+                details=DagDetails(id="example_dag"),
+                user=user,
+            )
+            assert (
+                get_auth_manager().is_authorized_view(access_view=AUDIT_LOGS_ALL_ACCESS_VIEW, user=user)
+                is expected_all_audit_logs
+            )
 
 
 def test_get_current_user_permissions(app):


### PR DESCRIPTION
## Summary

Under the FAB auth manager only `Admin` can read the audit log, so the events a Dag's own users need in order to debug it — a task killed by the executor, a heartbeat that timed out — are out of their reach.

Audit access was narrowed to `Admin` in #37501 because the audit log mixed Dag-scoped rows together with Connection, Variable and Pool operations, which carry no per-Dag key to authorize on. #70759 separated the two in Airflow 3.4.0: those rows now sit behind `All Audit Logs`, leaving `Audit Logs.can_read` covering only the Dag-scoped rows, which both event log endpoints already narrow to the Dags the caller may read.

## Compatibility

The grant follows that split rather than the provider version: a core without `AccessView.AUDIT_LOGS_ALL` still returns the Dag-less rows to anyone holding `Audit Logs.can_read`, so both permissions stay with `Admin` there.

## Known limitation

The split is `dag_id IS NULL`, and `action_logging` stamps `dag_id` from query parameters as well as the path: `POST /api/v2/connections?dag_id=some_dag` lands a connection write among the Dag-scoped rows. That was inert while those rows were admin-only; here it makes them readable by every viewer, since a default `Viewer` holds global `Dags.can_read`. It takes an actor who already holds write access to the resource, and the maskers still redact the secrets, so what surfaces is metadata — a connection id, host, login. Narrowing the stamp to path parameters belongs in core, not here.

closes: #72238

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 5 (1M context)

Generated-by: Claude Opus 5 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
