### PR TITLE
Fix scheduler stalling when a Dag switches to a coarser schedule

### DIFF
--- a/airflow-core/newsfragments/72250.bugfix.rst
+++ b/airflow-core/newsfragments/72250.bugfix.rst
@@ -1,0 +1,1 @@
+Changing a Dag's schedule to a coarser cron no longer stops it being scheduled. The scheduler previously proposed a ``logical_date`` the last run already occupied and looped on ``run already exists; skipping dagrun creation`` without advancing.

--- a/airflow-core/src/airflow/timetables/interval.py
+++ b/airflow-core/src/airflow/timetables/interval.py
@@ -111,18 +111,17 @@ class _DataIntervalTimetable(Timetable):
                 # Data interval starts from the end of the previous interval.
                 start = align_last_data_interval_end
 
-            # CronTriggerTimetable stores its runs as point-in-time intervals
-            # (start == end == logical_date). After a switch to a
-            # CronDataIntervalTimetable the aligned `start` lands back on that
-            # same logical_date, so without this guard we'd propose a run
-            # identical to the existing one — which collides with the
-            # (dag_id, logical_date) unique constraint and leaves the scheduler
-            # looping on "run already exists; skipping dagrun creation" until
-            # the next period elapses. Advance one period to skip past it.
-            if (
-                last_automated_data_interval.start == last_automated_data_interval.end
-                and start == last_automated_data_interval.start
-            ):
+            # `start` is the next run's logical_date and
+            # `last_automated_data_interval.start` is the previous run's, so the
+            # former has to be strictly later. Aligning the previous end to this
+            # schedule can land on or before it whenever the previous run came
+            # from a different one: a zero-length interval left by
+            # CronTriggerTimetable, or an interval whose end aligns back onto the
+            # boundary the run already occupies after a switch to a coarser cron.
+            # Proposing it again collides with the (dag_id, logical_date) unique
+            # constraint and leaves the scheduler looping on "run already exists;
+            # skipping dagrun creation" until the next period elapses.
+            if start <= last_automated_data_interval.start:
                 start = self._get_next(start)
         if restriction.latest is not None and start > restriction.latest:
             return None

--- a/airflow-core/tests/unit/timetables/test_interval_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_interval_timetable.py
@@ -93,6 +93,32 @@ def test_zero_length_last_interval_does_not_re_emit_logical_date(catchup: bool) 
 
 
 @pytest.mark.parametrize(
+    "catchup",
+    [pytest.param(True, id="catchup_true"), pytest.param(False, id="catchup_false")],
+)
+@time_machine.travel(pendulum.DateTime(2021, 9, 7, 15, tzinfo=utc))
+def test_coarser_schedule_does_not_re_emit_logical_date(catchup: bool) -> None:
+    """Switching to a coarser cron must not re-emit the previous run's logical_date.
+
+    An hourly run leaves the interval [00:00, 01:00). Aligning that end to a daily
+    schedule lands back on 00:00, the logical_date the run already occupies, which
+    stalls the scheduler on "run already exists; skipping dagrun creation".
+    """
+    timetable = CronDataIntervalTimetable("0 0 * * *", utc)
+    last = DataInterval(
+        start=pendulum.DateTime(2021, 9, 6, 0, tzinfo=utc),
+        end=pendulum.DateTime(2021, 9, 6, 1, tzinfo=utc),
+    )
+    next_info = timetable.next_dagrun_info(
+        last_automated_data_interval=last,
+        restriction=TimeRestriction(earliest=None, latest=None, catchup=catchup),
+    )
+    expected_start = pendulum.DateTime(2021, 9, 7, 0, tzinfo=utc)
+    expected_end = pendulum.DateTime(2021, 9, 8, 0, tzinfo=utc)
+    assert next_info == DagRunInfo.interval(start=expected_start, end=expected_end)
+
+
+@pytest.mark.parametrize(
     "earliest",
     [pytest.param(None, id="none"), pytest.param(START_DATE, id="start_date")],
 )


### PR DESCRIPTION
Changing a Dag from an hourly to a daily cron stops it being scheduled again. The scheduler keeps logging `run already exists; skipping dagrun creation` for a `logical_date` that is already taken and never advances past it, so the Dag silently stops producing runs until rows are deleted by hand.

`_align_to_prev` maps the previous run's interval end back onto the new schedule. When the new cron is coarser than the one that produced that run, the result is the boundary the run already occupies, so `next_dagrun_info` proposes a `logical_date` identical to the existing run's.

Reproduced on `main` (3.4.0) with the reporter's scenario — an hourly run at `2026-05-04 00:00` with interval `[00:00, 01:00)`, then a switch to `0 0 * * *`:

```
  previous run logical_date : 2026-05-04 00:00:00+00:00
  proposed next logical_date: 2026-05-04 00:00:00+00:00   <- collides, scheduler stalls
```

and after the change:

```
  proposed next logical_date: 2026-05-05 00:00:00+00:00   <- advances
```

Verified through the API the scheduler actually calls. `SchedulerJobRunner` reaches the timetable via `next_dagrun_info_v2()`, and the base `Timetable.next_dagrun_info_v2` delegates to `next_dagrun_info` with `last_dagrun_info.data_interval`, so this is the live path rather than a helper reached only from tests:

```python
last = DagRunInfo(
    run_after=pendulum.datetime(2026, 5, 4, 1, tz=UTC),
    data_interval=DataInterval(start=pendulum.datetime(2026, 5, 4, 0, tz=UTC),
                               end=pendulum.datetime(2026, 5, 4, 1, tz=UTC)),   # the hourly run
)
CronDataIntervalTimetable("0 0 * * *", UTC).next_dagrun_info_v2(          # now daily
    last_dagrun_info=last,
    restriction=TimeRestriction(earliest=..., latest=None, catchup=True),
)
```

At the merge base `82215cf97c`:

```
  previous run logical_date : 2026-05-04 00:00:00+00:00
  proposed next logical_date: 2026-05-04 00:00:00+00:00   <- the run that already exists
```

With this change:

```
  proposed next logical_date: 2026-05-05 00:00:00+00:00
```

`CronDataIntervalTimetable` is reached when `[scheduler] create_cron_data_intervals` is true, which is the configuration the report names.

Scope of that check, stated plainly: this drives the scheduler's own timetable API, not a running scheduler against a metadata database. I could not stand a full scheduler up in this checkout — the Dag failed to deserialize in my local dev environment — so the last link, watching a `dag_run` row appear after the schedule change, is not something I have evidence for.

A guard for this already existed, added in #66132, but it only covered the zero-length intervals `CronTriggerTimetable` leaves behind (`start == end`). The collision is not specific to those: it happens whenever the previous run came from any finer schedule. Comparing the proposed `logical_date` against the previous run's expresses the invariant the scheduler actually depends on — a proposed run must be strictly later than the last one — and subsumes the zero-length case, so the existing test for it still passes unchanged.

Tests: `test_coarser_schedule_does_not_re_emit_logical_date` covers the hourly-to-daily switch for both catchup settings. It fails on `main` (2 failed) and passes with this change, while `test_zero_length_last_interval_does_not_re_emit_logical_date` passes on both sides. Full `airflow-core/tests/unit/timetables/` run: 253 passed, 1 pre-existing failure in `test_workday_timetable.py` caused by `pandas` missing from my environment (it fails identically on unmodified `main`).

closes: #66754

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

