### PR TITLE
Fix plugin registration returning early on duplicate names in Task SDK

### DIFF
--- a/task-sdk/src/airflow/sdk/plugins_manager.py
+++ b/task-sdk/src/airflow/sdk/plugins_manager.py
@@ -85,7 +85,11 @@ def _get_plugins() -> tuple[list[AirflowPlugin], dict[str, str]]:
     def __register_plugins(plugin_instances: list[AirflowPlugin], errors: dict[str, str]) -> None:
         for plugin_instance in plugin_instances:
             if plugin_instance.name in loaded_plugins:
-                return
+                message = f"Plugin {plugin_instance.name!r} already registered, skipping"
+                log.warning(message)
+                name = str(plugin_instance.source) if plugin_instance.source else plugin_instance.name or ""
+                import_errors[name] = message
+                continue
 
             loaded_plugins.add(plugin_instance.name)
             try:

--- a/task-sdk/tests/task_sdk/test_plugins_manager.py
+++ b/task-sdk/tests/task_sdk/test_plugins_manager.py
@@ -1,0 +1,112 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from airflow.sdk import plugins_manager
+from airflow.sdk.plugins_manager import AirflowPlugin
+
+# ``_disable_ol_plugin`` in ``task-sdk/tests/conftest.py`` is a session-scoped autouse fixture that
+# replaces ``_get_plugins`` with a stub returning no plugins. Capture the real, ``@cache``-wrapped
+# function here at collection time — before any fixture runs — so these tests can put it back.
+_REAL_GET_PLUGINS = plugins_manager._get_plugins
+
+
+class TestGetPlugins:
+    """Mirrors ``TestPluginsManager`` in ``airflow-core/tests/unit/plugins/test_plugins_manager.py``."""
+
+    @pytest.fixture(autouse=True)
+    def _use_real_get_plugins(self, monkeypatch):
+        monkeypatch.setattr(plugins_manager, "_get_plugins", _REAL_GET_PLUGINS)
+        _REAL_GET_PLUGINS.cache_clear()
+        yield
+        _REAL_GET_PLUGINS.cache_clear()
+
+    def test_duplicate_plugin_name_does_not_prevent_loading_subsequent_plugins(self):
+        """
+        A duplicate name must skip that one plugin, not abandon the rest of the batch.
+
+        ``__register_plugins`` used to ``return`` on the first duplicate, so every plugin
+        enumerated after it was dropped without an error. Here ``plugin_b`` is loaded from
+        the plugins directory and again from an entry point; ``plugin_c`` follows the
+        duplicate in that second batch and is the one that used to disappear.
+        """
+
+        class PluginA(AirflowPlugin):
+            name = "plugin_a"
+
+        class PluginB(AirflowPlugin):
+            name = "plugin_b"
+
+        class PluginC(AirflowPlugin):
+            name = "plugin_c"
+
+        plugin_a = PluginA()
+        plugin_b = PluginB()
+        plugin_b_dup = PluginB()
+        plugin_c = PluginC()
+
+        with (
+            mock.patch.object(plugins_manager.settings, "PLUGINS_FOLDER", "/dev/null"),
+            mock.patch.object(plugins_manager.settings, "LAZY_LOAD_PROVIDERS", False),
+            mock.patch.object(
+                plugins_manager,
+                "_load_plugins_from_plugin_directory",
+                return_value=([plugin_a, plugin_b], {}),
+            ),
+            mock.patch.object(
+                plugins_manager, "_load_entrypoint_plugins", return_value=([plugin_b_dup, plugin_c], {})
+            ),
+            mock.patch.object(plugins_manager, "_load_providers_plugins", return_value=([], {})),
+        ):
+            plugins, _ = plugins_manager._get_plugins()
+
+        plugin_names = [plugin.name for plugin in plugins]
+        assert "plugin_a" in plugin_names
+        assert "plugin_b" in plugin_names
+        assert "plugin_c" in plugin_names
+        assert len(plugins) == 3
+
+    def test_duplicate_plugin_name_is_reported_as_import_error(self):
+        """The skipped duplicate is surfaced to the caller rather than dropped silently."""
+
+        class PluginA(AirflowPlugin):
+            name = "plugin_a"
+
+        class PluginADuplicateName(AirflowPlugin):
+            name = "plugin_a"
+
+        plugin_a = PluginA()
+        plugin_a_dup = PluginADuplicateName()
+
+        with (
+            mock.patch.object(plugins_manager.settings, "PLUGINS_FOLDER", "/dev/null"),
+            mock.patch.object(plugins_manager.settings, "LAZY_LOAD_PROVIDERS", False),
+            mock.patch.object(
+                plugins_manager, "_load_plugins_from_plugin_directory", return_value=([plugin_a], {})
+            ),
+            mock.patch.object(plugins_manager, "_load_entrypoint_plugins", return_value=([plugin_a_dup], {})),
+            mock.patch.object(plugins_manager, "_load_providers_plugins", return_value=([], {})),
+        ):
+            plugins, import_errors = plugins_manager._get_plugins()
+
+        assert [plugin.name for plugin in plugins] == ["plugin_a"]
+        assert len(import_errors) == 1


### PR DESCRIPTION
`__register_plugins` in `task-sdk/src/airflow/sdk/plugins_manager.py` uses `return` where it means
`continue`:

```python
if plugin_instance.name in loaded_plugins:
    return
```

The first duplicate plugin name therefore abandons the rest of the batch, and every plugin after it is
dropped — silently, since nothing is logged and `_get_plugins()` still returns an empty `import_errors`.

`airflow-core` carries a copy of this function and fixed it in #60498, then hardened it in #66649 (record
the duplicate in `import_errors`). Neither fix reached the Task SDK copy. This PR applies both, so the
block becomes byte-identical to the core one.

It matters because the Task SDK copy is the one the task-running process uses. While the two disagree,
plugins load for the scheduler and API server but go missing inside tasks — most sharply, a plugin
registering `on_task_instance_running` / `on_task_instance_failed` after a duplicate name never fires,
with no error anywhere to attribute it to. Duplicate names are not exotic: the same plugin shipped both
flattened and as a package, or present in the plugins folder and as an entry point, is enough.

Covered by a new `task-sdk/tests/task_sdk/test_plugins_manager.py` carrying the two cases the core suite
already has for this branch; both fail on `main` and pass with the change.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
