### PR TITLE
Remove stale is_async docstring param from await_pod_start

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -162,7 +162,6 @@ async def await_pod_start(
     :param schedule_timeout: Maximum time (in seconds) to wait for the pod to be scheduled.
     :param startup_timeout: Maximum time (in seconds) to wait for the pod to start running after being scheduled.
     :param check_interval: Interval (in seconds) between status checks.
-    :param is_async: Set to True if called in an async context; otherwise, False.
     """
     pod_manager.log.info("::group::Waiting up to %ss to get the POD scheduled...", schedule_timeout)
     pod_was_scheduled = False


### PR DESCRIPTION
### Sumarry

The function determines async mode internally via isinstance check rather than accepting an is_async parameter, so the docstring was describing an argument that doesn't exist in the signature.

### Change

Remove the `:param is_async:`

No any behavior be changed.