### PR TITLE
Remove redundant full-Dag TaskInstance query from the execution API task-states endpoint

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -1258,9 +1258,13 @@ def get_task_instance_states(
     """Get the states for Task Instances with the given criteria."""
     run_id_task_state_map: dict[str, dict[str, Any]] = defaultdict(dict)
 
-    query = select(TI).where(TI.dag_id == dag_id)
+    query = select(TI.run_id, TI.task_id, TI.map_index, TI.state).where(TI.dag_id == dag_id)
 
-    if task_ids:
+    if task_group_id:
+        group_task_ids = _get_group_task_ids(dag_id, task_group_id, session, dag_bag)
+        effective_task_ids = set(task_ids) | group_task_ids if task_ids else group_task_ids
+        query = query.where(TI.task_id.in_(effective_task_ids))
+    elif task_ids:
         query = query.where(TI.task_id.in_(task_ids))
 
     if logical_dates:
@@ -1272,23 +1276,9 @@ def get_task_instance_states(
     if map_index is not None:
         query = query.where(TI.map_index == map_index)
 
-    results = session.scalars(query).all()
-
-    if task_group_id:
-        group_tasks = _get_group_tasks(
-            dag_id, task_group_id, session, dag_bag, logical_dates, run_ids, map_index
-        )
-
-        results = results + group_tasks if task_ids else group_tasks
-
-    [
-        run_id_task_state_map[task.run_id].update(
-            {task.task_id: task.state}
-            if task.map_index < 0
-            else {f"{task.task_id}_{task.map_index}": task.state}
-        )
-        for task in results
-    ]
+    for ti in session.execute(query):
+        key = ti.task_id if ti.map_index < 0 else f"{ti.task_id}_{ti.map_index}"
+        run_id_task_state_map[ti.run_id][key] = ti.state
 
     return TaskStatesResponse(task_states=run_id_task_state_map)
 
@@ -1320,16 +1310,7 @@ def _is_eligible_to_retry(state: str, try_number: int, max_tries: int) -> bool:
     return max_tries != 0 and try_number <= max_tries
 
 
-def _get_group_tasks(
-    dag_id: str,
-    task_group_id: str,
-    session: SessionDep,
-    dag_bag: DagBagDep,
-    logical_dates=None,
-    run_ids=None,
-    map_index: int | None = None,
-):
-    # Get all tasks in the task group
+def _get_task_group(dag_id: str, task_group_id: str, session: SessionDep, dag_bag: DagBagDep):
     dag = get_latest_version_of_dag(dag_bag, dag_id, session, include_reason=True)
     task_group = dag.task_group_dict.get(task_group_id)
     if not task_group:
@@ -1340,6 +1321,29 @@ def _get_group_tasks(
                 "message": f"Task group {task_group_id} not found in DAG {dag_id}",
             },
         )
+    return task_group
+
+
+def _get_group_task_ids(
+    dag_id: str,
+    task_group_id: str,
+    session: SessionDep,
+    dag_bag: DagBagDep,
+) -> set[str]:
+    task_group = _get_task_group(dag_id, task_group_id, session, dag_bag)
+    return {task.task_id for task in task_group.iter_tasks()}
+
+
+def _get_group_tasks(
+    dag_id: str,
+    task_group_id: str,
+    session: SessionDep,
+    dag_bag: DagBagDep,
+    logical_dates=None,
+    run_ids=None,
+    map_index: int | None = None,
+):
+    task_group = _get_task_group(dag_id, task_group_id, session, dag_bag)
 
     # First get all task instances to get the task_id, map_index pairs
     group_tasks = session.scalars(

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -58,6 +58,7 @@ from airflow.sdk import Asset, TaskGroup, TriggerRule, task, task_group
 from airflow.state.metastore import MetastoreBackend
 from airflow.utils.state import DagRunState, State, TaskInstanceState, TerminalTIState
 
+from tests_common.test_utils.asserts import assert_queries_count
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import (
     clear_db_assets,
@@ -3949,6 +3950,40 @@ class TestGetTaskStates:
             "task_states": {
                 "test": {
                     "group1.task1": "success",
+                },
+            },
+        }
+
+    def test_get_task_states_with_task_group_id_query_count(self, client, session, dag_maker):
+        """Regression test: a task_group_id lookup must not also run a full, unfiltered TI query for the Dag."""
+        with dag_maker("test_get_task_states_with_task_group_id_query_count", serialized=True):
+            with TaskGroup("group1"):
+                EmptyOperator(task_id="task1")
+                EmptyOperator(task_id="task2")
+            EmptyOperator(task_id="task3")
+
+        dr = dag_maker.create_dagrun()
+
+        tis = dr.get_task_instances()
+        for ti in tis:
+            ti.state = State.SUCCESS
+            session.merge(ti)
+        session.commit()
+
+        with assert_queries_count(2):
+            response = client.get(
+                "/execution/task-instances/states",
+                params={
+                    "dag_id": "test_get_task_states_with_task_group_id_query_count",
+                    "task_group_id": "group1",
+                },
+            )
+        assert response.status_code == 200
+        assert response.json() == {
+            "task_states": {
+                "test": {
+                    "group1.task1": "success",
+                    "group1.task2": "success",
                 },
             },
         }


### PR DESCRIPTION
### Sumarry

`GET /execution/task-instances/states` (`get_task_instance_states` in `airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py`) is called by the worker/Task SDK whenever a task needs the states of sibling task instances (e.g. trigger-rule evaluation, `wait_for_downstream`, cross-task state checks). When the request is scoped with `task_group_id`, the handler was doing unnecessary DB work on every call:

1. It first ran a query selecting every `TaskInstance` row for the Dag (optionally narrowed by `task_ids`, `logical_dates`, `run_ids`, `map_index`), loading full ORM entities.
2. It then ran a second query to resolve the task group's members and fetch their `TaskInstance` rows.
3. If the caller had not also passed `task_ids`, the result of the first query was thrown away entirely and only the second query's rows were used — meaning step 1 was pure waste on every task-group-scoped call.

For Dags with many tasks and/or many Dag runs, that first discarded query could return and hydrate a large number of rows for nothing, adding an avoidable round trip and CPU/memory cost to a request that sits on the task execution hot path (workers call this while running tasks, so the extra latency is paid per task, not once).

This PR removes the wasted round trip:

- The task group's task IDs are now resolved from the already-parsed Dag definition (`task_group.iter_tasks()`), which requires no extra `TaskInstance` query — only the existing Dag-version lookup that was already being performed.
- Those IDs are unioned with any explicit `task_ids` from the request *before* building the query, so there is exactly one `TaskInstance` query per request, filtered with `task_id.in_(...)` — preserving the exact original semantics (task_ids alone, task_group_id alone, or the union of both).
- That single query now selects only the four columns actually used (`run_id`, `task_id`, `map_index`, `state`) instead of loading full `TaskInstance` ORM objects, cutting the amount of data hydrated per call further.
- The pre-existing `_get_group_tasks` helper (still used by the sibling `/count` endpoint, which needs actual `map_index` values from persisted rows for a different query shape) is left untouched aside from factoring out the shared "resolve the task group or 404" logic into `_get_task_group`.

### Change

- `get_task_instance_states`: replaced the "query everything, then maybe discard it" flow with a single `TaskInstance` query. The task group's task IDs are resolved up front (from `task_group.iter_tasks()`) and unioned with any request `task_ids` into one `task_id.in_(...)` filter before the query runs, instead of running one query filtered by `task_ids` and a second, separate query for the group, then conditionally throwing the first result set away.
- That single query now does `select(TI.run_id, TI.task_id, TI.map_index, TI.state)` instead of `select(TI)`, so it loads four scalar columns per row instead of hydrating full `TaskInstance` ORM objects.
- Added `_get_task_group` (Dag/task-group lookup + 404 handling) factored out of the pre-existing `_get_group_tasks`, and a new `_get_group_task_ids` that returns just the group's task IDs without touching the `TaskInstance` table. `_get_group_tasks` itself is unchanged in behavior — it's still used as-is by the `/count` endpoint, which needs real persisted `(task_id, map_index)` pairs for a different query shape.
- Added `test_get_task_states_with_task_group_id_query_count` (query-count regression test).

### Impact

For any `task_group_id`-scoped call to this endpoint, DB round trips drop from 2 (one of which was always discarded) down to 1, and that query is narrower (4 scalar columns instead of full-row ORM hydration). This directly reduces the RTT the worker/Task SDK pays on this call, and removes the redundant row hydration/network cost on the API server and DB — proportional to Dag size and Dag-run count, so the win scales with the DAGs that would have hit this path hardest.

### Testing

- Added `test_get_task_states_with_task_group_id_query_count`, a query-count regression test using `assert_queries_count`, which fails against the old code (3 queries) and passes against the fix (2 queries: one Dag-version lookup, one TaskInstance query).
- All existing tests in `TestGetTaskStates` and `TestGetCount` (the `/count` endpoint that shares the untouched helper) continue to pass, confirming the task_ids/task_group_id union semantics are unchanged, including the mixed `task_ids` + `task_group_id` case.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)