### PR TITLE
fix: validate connection port is in range 0-65535

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
@@ -191,7 +191,7 @@ class ConnectionBody(StrictBaseModel):
     host: str | None = Field(default=None)
     login: str | None = Field(default=None)
     schema_: str | None = Field(None, alias="schema")
-    port: int | None = Field(default=None)
+    port: int | None = Field(default=None, ge=0, le=65535)
     password: str | None = Field(default=None)
     extra: str | None = Field(default=None)
     team_name: str | None = Field(max_length=50, default=None)

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -12674,7 +12674,9 @@ components:
           title: Schema
         port:
           anyOf:
-          - type: integer
+          - maximum: 65535
+            minimum: 0
+            type: integer
           - type: 'null'
           title: Port
         password:
@@ -12829,7 +12831,9 @@ components:
           title: Schema
         port:
           anyOf:
-          - type: integer
+          - maximum: 65535
+            minimum: 0
+            type: integer
           - type: 'null'
           title: Port
         password:

--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/connection.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/connection.py
@@ -31,5 +31,5 @@ class ConnectionResponse(BaseModel):
     schema_: str | None = Field(alias="schema")
     login: str | None
     password: str | None
-    port: int | None
+    port: int | None = Field(default=None, ge=0, le=65535)
     extra: str | None

--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/connection_test.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/connection_test.py
@@ -46,5 +46,5 @@ class ConnectionTestConnectionResponse(BaseModel):
     login: str | None = None
     password: str | None = None
     schema_: str | None = Field(None, alias="schema")
-    port: int | None = None
+    port: int | None = Field(default=None, ge=0, le=65535)
     extra: str | None = None

--- a/airflow-core/src/airflow/cli/commands/connection_command.py
+++ b/airflow-core/src/airflow/cli/commands/connection_command.py
@@ -341,27 +341,30 @@ def connections_add(args):
                 f"the --conn-{'uri' if has_uri else 'json'} flag: {invalid_args!r}"
             )
 
-    if args.conn_uri:
-        new_conn = Connection(conn_id=args.conn_id, description=args.conn_description, uri=args.conn_uri)
-        if args.conn_extra is not None:
-            new_conn.set_extra(args.conn_extra)
-    elif args.conn_json:
-        new_conn = Connection.from_json(conn_id=args.conn_id, value=args.conn_json)
-        if not new_conn.conn_type:
-            raise SystemExit("conn-json is invalid; must supply conn-type")
-    else:
-        new_conn = Connection(
-            conn_id=args.conn_id,
-            conn_type=args.conn_type,
-            description=args.conn_description,
-            host=args.conn_host,
-            login=args.conn_login,
-            password=args.conn_password,
-            schema=args.conn_schema,
-            port=args.conn_port,
-        )
-        if args.conn_extra is not None:
-            new_conn.set_extra(args.conn_extra)
+    try:
+        if args.conn_uri:
+            new_conn = Connection(conn_id=args.conn_id, description=args.conn_description, uri=args.conn_uri)
+            if args.conn_extra is not None:
+                new_conn.set_extra(args.conn_extra)
+        elif args.conn_json:
+            new_conn = Connection.from_json(conn_id=args.conn_id, value=args.conn_json)
+            if not new_conn.conn_type:
+                raise SystemExit("conn-json is invalid; must supply conn-type")
+        else:
+            new_conn = Connection(
+                conn_id=args.conn_id,
+                conn_type=args.conn_type,
+                description=args.conn_description,
+                host=args.conn_host,
+                login=args.conn_login,
+                password=args.conn_password,
+                schema=args.conn_schema,
+                port=args.conn_port,
+            )
+            if args.conn_extra is not None:
+                new_conn.set_extra(args.conn_extra)
+    except (ValueError, AirflowException) as e:
+        raise SystemExit(f"Could not create connection. {e}")
 
     with create_session() as session:
         if not session.scalar(select(Connection).where(Connection.conn_id == new_conn.conn_id).limit(1)):

--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -190,6 +190,9 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
             self.port = port
             self.extra = extra
 
+        if self.port is not None:
+            self.port = self._validate_port(self.port)
+
         if conn_id is not None:
             sanitized_id = sanitize_conn_id(conn_id)
             if sanitized_id is not None:
@@ -201,6 +204,22 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
             mask_secret(self.password)
             mask_secret(quote(self.password))
         self.team_name = team_name
+
+    @staticmethod
+    def _validate_port(port: Any) -> int:
+        """Verify that `port` is an integer between 0 and 65535."""
+        if isinstance(port, str):
+            try:
+                port = int(port)
+            except ValueError:
+                raise ValueError(
+                    f"Expected integer value between 0 and 65535 for `port`, but got {port!r} instead."
+                )
+        if isinstance(port, bool) or not isinstance(port, int) or not (0 <= port <= 65535):
+            raise ValueError(
+                f"Expected integer value between 0 and 65535 for `port`, but got {port!r} instead."
+            )
+        return port
 
     @staticmethod
     def _validate_extra(extra, conn_id) -> None:

--- a/airflow-core/tests/unit/api_fastapi/core_api/datamodels/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/datamodels/test_connections.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from airflow.api_fastapi.core_api.datamodels.connections import ConnectionResponse
+from airflow.api_fastapi.core_api.datamodels.connections import ConnectionBody, ConnectionResponse
 
 
 def _payload(**overrides):
@@ -56,3 +56,15 @@ def test_redact_extra_rejects_non_json(extra):
     """
     with pytest.raises(ValidationError):
         ConnectionResponse.model_validate(_payload(extra=extra))
+
+
+@pytest.mark.parametrize("port", [0, 80, 5432, 65535, None])
+def test_connection_body_valid_port(port):
+    conn = ConnectionBody(connection_id="test_conn", conn_type="http", port=port)
+    assert conn.port == port
+
+
+@pytest.mark.parametrize("port", [-1, 65536, 99999999, "invalid"])
+def test_connection_body_invalid_port(port):
+    with pytest.raises(ValidationError):
+        ConnectionBody(connection_id="test_conn", conn_type="http", port=port)

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -2254,3 +2254,26 @@ class TestPostConnectionExtraBackwardCompatibility(TestConnectionEndpoint):
                 "method": "POST",
             },
         )
+
+
+class TestConnectionPortValidation(TestConnectionEndpoint):
+    @pytest.mark.parametrize("port", [-1, 65536, 99999999])
+    def test_post_connection_rejects_invalid_port(self, test_client, port):
+        body = {"connection_id": TEST_CONN_ID, "conn_type": TEST_CONN_TYPE, "port": port}
+        response = test_client.post("/connections", json=body)
+        assert response.status_code == 422
+
+    @pytest.mark.parametrize("port", [0, 80, 5432, 65535, None])
+    def test_post_connection_accepts_valid_port(self, test_client, session, port):
+        body = {"connection_id": TEST_CONN_ID, "conn_type": TEST_CONN_TYPE, "port": port}
+        response = test_client.post("/connections", json=body)
+        assert response.status_code == 201
+        assert response.json()["port"] == port
+
+    @pytest.mark.parametrize("port", [-1, 65536, 99999999])
+    def test_patch_connection_rejects_invalid_port(self, test_client, session, port):
+        session.add(Connection(conn_id=TEST_CONN_ID, conn_type=TEST_CONN_TYPE))
+        session.commit()
+        body = {"connection_id": TEST_CONN_ID, "conn_type": TEST_CONN_TYPE, "port": port}
+        response = test_client.patch(f"/connections/{TEST_CONN_ID}", json=body)
+        assert response.status_code == 422

--- a/airflow-core/tests/unit/cli/commands/test_connection_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_connection_command.py
@@ -788,6 +788,24 @@ class TestCliAddConnections:
         )
 
 
+    @pytest.mark.db_test
+    @pytest.mark.parametrize("invalid_port", [-1, 65536, 99999999])
+    def test_cli_connection_add_rejects_invalid_port(self, invalid_port):
+        """connections add should exit with a user-friendly error for out-of-range ports."""
+        with pytest.raises(SystemExit) as exc_info:
+            connection_command.connections_add(
+                self.parser.parse_args(
+                    [
+                        "connections",
+                        "add",
+                        "bad-port-conn",
+                        "--conn-type=http",
+                        f"--conn-port={invalid_port}",
+                    ]
+                )
+            )
+        assert "Could not create connection" in str(exc_info.value)
+
 class TestCliDeleteConnections:
     parser = cli_parser.get_parser()
 

--- a/airflow-core/tests/unit/models/test_connection.py
+++ b/airflow-core/tests/unit/models/test_connection.py
@@ -540,3 +540,22 @@ class TestConnection:
             "test_conn2": None,
         }
         clear_db_connections()
+
+    @pytest.mark.parametrize("valid_port", [0, 80, 5432, 65535, None])
+    def test_connection_valid_port(self, valid_port):
+        conn = Connection(conn_id="test_conn", conn_type="http", port=valid_port)
+        assert conn.port == valid_port
+
+    @pytest.mark.parametrize("invalid_port", [-1, 65536, 99999999, "invalid", 80.5, True, False])
+    def test_connection_invalid_port(self, invalid_port):
+        with pytest.raises(ValueError, match="Expected integer value between 0 and 65535 for port"):
+            Connection(conn_id="test_conn", conn_type="http", port=invalid_port)
+
+    def test_connection_from_json_port_validation(self):
+        valid_json = json.dumps({"conn_type": "http", "port": "8080"})
+        conn = Connection.from_json(valid_json, conn_id="test_conn")
+        assert conn.port == 8080
+
+        invalid_json = json.dumps({"conn_type": "http", "port": 70000})
+        with pytest.raises(ValueError, match="Expected integer value between 0 and 65535 for port"):
+            Connection.from_json(invalid_json, conn_id="test_conn")

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -349,7 +349,7 @@ class ConnectionBody(BaseModel):
     host: Annotated[str | None, Field(title="Host")] = None
     login: Annotated[str | None, Field(title="Login")] = None
     schema_: Annotated[str | None, Field(alias="schema", title="Schema")] = None
-    port: Annotated[int | None, Field(title="Port")] = None
+    port: Annotated[int | None, Field(ge=0, le=65535, title="Port")] = None
     password: Annotated[str | None, Field(title="Password")] = None
     extra: Annotated[str | None, Field(title="Extra")] = None
     team_name: Annotated[TeamName | None, Field(title="Team Name")] = None
@@ -400,7 +400,7 @@ class ConnectionTestRequestBody(BaseModel):
     host: Annotated[str | None, Field(title="Host")] = None
     login: Annotated[str | None, Field(title="Login")] = None
     schema_: Annotated[str | None, Field(alias="schema", title="Schema")] = None
-    port: Annotated[int | None, Field(title="Port")] = None
+    port: Annotated[int | None, Field(ge=0, le=65535, title="Port")] = None
     password: Annotated[str | None, Field(title="Password")] = None
     extra: Annotated[str | None, Field(title="Extra")] = None
     team_name: Annotated[TeamName | None, Field(title="Team Name")] = None

--- a/task-sdk/src/airflow/sdk/definitions/connection.py
+++ b/task-sdk/src/airflow/sdk/definitions/connection.py
@@ -93,6 +93,21 @@ def _prune_dict(val: Any, mode="strict"):
     return val
 
 
+def _validate_port(instance: Any, attribute: Any, value: Any) -> None:
+    if value is not None:
+        if isinstance(value, str):
+            try:
+                value = int(value)
+            except ValueError:
+                raise ValueError(
+                    f"Expected integer value between 0 and 65535 for port, but got {value!r} instead."
+                )
+        if isinstance(value, bool) or not isinstance(value, int) or not (0 <= value <= 65535):
+            raise ValueError(
+                f"Expected integer value between 0 and 65535 for port, but got {value!r} instead."
+            )
+
+
 @attrs.define(slots=False)
 class Connection:
     """
@@ -118,7 +133,7 @@ class Connection:
     schema: str | None = None
     login: str | None = None
     password: str | None = None
-    port: int | None = None
+    port: int | None = attrs.field(default=None, validator=_validate_port)
     extra: str | None = None
 
     EXTRA_KEY = "__extra__"

--- a/task-sdk/src/airflow/sdk/execution_time/schema/schema.json
+++ b/task-sdk/src/airflow/sdk/execution_time/schema/schema.json
@@ -571,6 +571,8 @@
         "port": {
           "anyOf": [
             {
+              "maximum": 65535,
+              "minimum": 0,
               "type": "integer"
             },
             {
@@ -661,6 +663,8 @@
         "port": {
           "anyOf": [
             {
+              "maximum": 65535,
+              "minimum": 0,
               "type": "integer"
             },
             {

--- a/task-sdk/tests/task_sdk/definitions/test_connection.py
+++ b/task-sdk/tests/task_sdk/definitions/test_connection.py
@@ -430,3 +430,22 @@ class TestConnectionFromUri:
             original_extra = json.loads(conn_from_original.extra)
             roundtrip_extra = json.loads(conn_from_roundtrip.extra)
             assert original_extra == roundtrip_extra
+
+    @pytest.mark.parametrize("valid_port", [0, 80, 5432, 65535, None])
+    def test_connection_valid_port(self, valid_port):
+        conn = Connection(conn_id="test_conn", conn_type="http", port=valid_port)
+        assert conn.port == valid_port
+
+    @pytest.mark.parametrize("invalid_port", [-1, 65536, 99999999, "invalid", 80.5, True, False])
+    def test_connection_invalid_port(self, invalid_port):
+        with pytest.raises(ValueError, match="Expected integer value between 0 and 65535 for port"):
+            Connection(conn_id="test_conn", conn_type="http", port=invalid_port)
+
+    def test_connection_from_json_port_validation(self):
+        valid_json = json.dumps({"conn_type": "http", "port": "8080"})
+        conn = Connection.from_json(valid_json, conn_id="test_conn")
+        assert conn.port == 8080
+
+        invalid_json = json.dumps({"conn_type": "http", "port": 70000})
+        with pytest.raises(ValueError, match="Expected integer value between 0 and 65535 for port"):
+            Connection.from_json(invalid_json, conn_id="test_conn")


### PR DESCRIPTION
Fixes #68382

<html>
<body>
<!--StartFragment--><html><head></head><body><h1>Add validation for the <code>port</code> field on Connection objects</h1>
<p>Fixes #68382</p>
<h2>What does this PR do?</h2>
<p>Adds validation to the <code>port</code> field on Connection objects so that only valid TCP/UDP port numbers (integers in the range 0–65535, or <code>None</code>) are accepted. Previously, any value — including negative numbers, integers above 65535, non-integer strings, floats, and booleans — was silently stored and propagated to workers without any error.</p>
<h2>Why is this change needed?</h2>
<p>A user can currently create a connection with <code>port = -1</code> or <code>port = 99999999</code> through the CLI, the REST API, or direct model construction, and Airflow accepts and persists it with no warning.</p>
<p>Invalid port values cause confusing failures at runtime, inside task workers, far from where the bad value was entered. This fix surfaces the error immediately at the point of input, regardless of which entry point is used.</p>
<h2>What are the changes?</h2>
<p><strong>1. Core model — <code>airflow/models/connection.py</code></strong></p>
<ul>
<li>Added a <code>_validate_port(port)</code> static method.</li>
<li>Accepts integers in <code>[0, 65535]</code> and digit-strings like <code>"8080"</code> (coerced to int, for backward compatibility with URI parsing).</li>
<li>Rejects negative values, values above 65535, booleans, floats, and non-numeric strings.</li>
<li>Raises <code>ValueError</code> with a consistent, human-readable message.</li>
<li>Called in <code>__init__</code> (when port is not <code>None</code>) and in <code>from_json</code>.</li>
</ul>
<p><strong>2. Task SDK — <code>task-sdk/src/airflow/sdk/definitions/connection.py</code></strong></p>
<ul>
<li>Added a <code>_validate_port</code> <code>attrs</code> validator with equivalent logic.</li>
<li>Task SDK is strictly decoupled from <code>airflow-core</code> and cannot import from <code>airflow.models</code>, so the validator is implemented independently using the <code>attrs</code> validator protocol.</li>
<li>Attached to the field: <code>port = attrs.field(default=None, validator=_validate_port)</code>.</li>
</ul>
<p><strong>3. Public REST API — <code>airflow/api_fastapi/core_api/datamodels/connections.py</code></strong></p>
<ul>
<li>Added <code>ge=0, le=65535</code> Pydantic <code>Field</code> constraints to <code>ConnectionBody.port</code>.</li>
<li><code>ConnectionBodyPartial</code> (PATCH) and <code>ConnectionTestRequestBody</code> (test-connection) both inherit from <code>ConnectionBody</code>, so they receive the constraint automatically.</li>
<li>Invalid port values now return <code>422 Unprocessable Entity</code> from the API.</li>
</ul>
<p><strong>4. Execution API — <code>airflow/api_fastapi/execution_api/datamodels/connection.py</code></strong></p>
<ul>
<li>Added <code>ge=0, le=65535</code> to <code>ConnectionResponse.port</code>.</li>
</ul>
<p><strong>5. CLI — <code>airflow/cli/commands/connection_command.py</code></strong></p>
<ul>
<li>Wrapped the <code>Connection(...)</code> construction block in <code>try/except</code> (<code>ValueError</code>, <code>AirflowException</code>).</li>
<li>Re-raises as <code>SystemExit(f"Could not create connection. {e}")</code> for a clean, user-readable CLI error.</li>
<li>The range check is <strong>not</strong> duplicated in the CLI — it delegates entirely to the model and catches the resulting <code>ValueError</code>.</li>
</ul>
<p><strong>6. Task SDK JSON schema — <code>task-sdk/src/airflow/sdk/execution_time/schema/schema.json</code></strong></p>
<ul>
<li>Added <code>"minimum": 0</code> and <code>"maximum": 65535</code> to the <code>port</code> integer branch in <code>ConnectionResponse</code> and <code>ConnectionResult</code>.</li>
</ul>
<p><strong>7. OpenAPI snapshot — <code>airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml</code></strong></p>
<ul>
<li>Updated <code>port</code> under <code>ConnectionBody</code> and <code>ConnectionTestRequestBody</code> to include <code>minimum: 0</code> and <code>maximum: 65535</code>.</li>
<li><code>ConnectionResponse.port</code> is left without bounds in the snapshot, since responses may reflect legacy data already in the DB.</li>
</ul>
<p><strong>8. airflowctl generated client — <code>airflow-ctl/src/airflowctl/api/datamodels/generated.py</code></strong></p>
<ul>
<li>Updated <code>ConnectionBody.port</code> and <code>ConnectionTestRequestBody.port</code> with <code>Field(ge=0, le=65535)</code> to match the updated OpenAPI schema.</li>
<li><code>airflow-ctl</code> interacts with Airflow only through the REST API, so it inherits validation at the API boundary automatically; the client-side constraint is additional defense-in-depth.</li>
</ul>
<h2>Tests</h2>

File | What is tested
-- | --
tests/unit/models/test_connection.py | Valid ports (0, 80, 5432, 65535, None) are accepted. Invalid ports (-1, 65536, 99999999, "invalid", 80.5, True, False) raise ValueError. from_json validates as well.
task-sdk/tests/task_sdk/definitions/test_connection.py | Same boundary cases via the attrs validator and from_json.
tests/unit/api_fastapi/core_api/datamodels/test_connections.py | ConnectionBody accepts valid ports and raises ValidationError on invalid ones.
tests/unit/api_fastapi/core_api/routes/public/test_connections.py | POST /connections and PATCH /connections/{id} return 422 for out-of-range ports. Valid boundary values (0, 65535) return 201/200.
tests/unit/cli/commands/test_connection_command.py | connections add --conn-port=-1 exits with a SystemExit containing the message "Could not create connection".


<h2>Notes for reviewers</h2>
<ul>
<li>The error message is uniform across all layers: <code>"Expected integer value between 0 and 65535 for 'port', but got X instead."</code> This keeps test assertions consistent and gives users a single, recognizable message regardless of entry point.</li>
<li><code>bool</code> values are explicitly rejected before the <code>isinstance(port, int)</code> check, since <code>bool</code> is a subclass of <code>int</code> in Python (<code>True == 1</code>, <code>False == 0</code>). Without this guard, <code>True</code> would pass as port <code>1</code> and <code>False</code> as port <code>0</code>, which is never intentional.</li>
<li>String coercion (<code>"8080"</code> → <code>8080</code>) is intentional. Existing URI parsing already produces string ports in some code paths; strict rejection would be a silent regression there.</li>
<li>The OpenAPI snapshot is hand-updated to match what the spec-generation script produces after the <code>ConnectionBody</code> Pydantic change. If CI runs the generation script, the output should be identical.</li>
<li>Scope is intentionally minimal — no refactoring beyond what the issue asks for.</li>
</ul>
<hr>
</p></body></html><!--EndFragment-->
</body>
</html>
