### PR TITLE
Fix DatabricksSqlHook deprecation warning on every connection

### DIFF
--- a/providers/databricks/docs/changelog.rst
+++ b/providers/databricks/docs/changelog.rst
@@ -39,6 +39,7 @@ Features
 Bug Fixes
 ~~~~~~~~~
 
+* ``Fix DatabricksSqlHook.get_conn() deprecation warning by passing user_agent_entry without leading underscore (#72102)``
 * ``Make 'durable' reach 'default_args' and warn when set below Airflow 3.3 (#71531)``
 
 Doc-only

--- a/providers/databricks/src/airflow/providers/databricks/hooks/databricks_sql.py
+++ b/providers/databricks/src/airflow/providers/databricks/hooks/databricks_sql.py
@@ -241,7 +241,7 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
                 "catalog": self.catalog,
                 "session_configuration": session_config or None,
                 "http_headers": self.http_headers,
-                "_user_agent_entry": self.user_agent_value,
+                "user_agent_entry": self.user_agent_value,
                 **self._get_extra_config(),
                 **self.additional_params,
             }

--- a/providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py
+++ b/providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py
@@ -931,6 +931,23 @@ def test_get_conn_does_not_leak_proxies_into_connector(mock_connect, mock_get_re
     assert "proxies" not in mock_connect.call_args.kwargs
 
 
+@mock.patch("airflow.providers.databricks.hooks.databricks_sql.sql.connect")
+def test_get_conn_passes_user_agent_entry_without_underscore(mock_connect, mock_get_requests):
+    """get_conn() must pass ``user_agent_entry`` (no leading underscore) to sql.connect().
+
+    databricks-sql-connector deprecated the ``_user_agent_entry`` alias and logs a warning
+    on every connection when the old name is used.
+    """
+    hook = DatabricksSqlHook(databricks_conn_id=DEFAULT_CONN_ID, http_path=HTTP_PATH)
+
+    hook.get_conn()
+
+    mock_connect.assert_called_once()
+    call_kwargs = mock_connect.call_args.kwargs
+    assert "user_agent_entry" in call_kwargs
+    assert "_user_agent_entry" not in call_kwargs
+
+
 class TestFormatQueryTags:
     def test_simple_values(self):
         result = _format_query_tags({"dag_id": "my_dag", "task_id": "my_task"})


### PR DESCRIPTION
databricks-sql-connector deprecated the ``_user_agent_entry`` keyword argument in favour of ``user_agent_entry`` (no leading underscore). Passing the old name logs a warning on every call to get_conn(), which fires for every DatabricksSqlOperator / sensor execution. Switch to the current parameter name so the warning is no longer emitted.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
