### PR TITLE
Fix AttributeError in branch operators when dag_run is None with use_…

### DIFF
--- a/providers/standard/docs/changelog.rst
+++ b/providers/standard/docs/changelog.rst
@@ -38,6 +38,11 @@ Changelog
 1.18.0
 ......
 
+Bug Fixes
+~~~~~~~~~
+
+* ``Fix AttributeError in BranchDayOfWeekOperator and BranchDateTimeOperator when dag_run is None with use_task_logical_date=True (#72031)``
+
 Features
 ~~~~~~~~
 

--- a/providers/standard/src/airflow/providers/standard/operators/datetime.py
+++ b/providers/standard/src/airflow/providers/standard/operators/datetime.py
@@ -72,8 +72,13 @@ class BranchDateTimeOperator(BaseBranchOperator):
     def choose_branch(self, context: Context) -> str | Iterable[str]:
         if self.use_task_logical_date:
             now = context.get("logical_date")
+            dag_run = context.get("dag_run")
+            if not (now or (dag_run and dag_run.run_after)):
+                raise ValueError(
+                    "Either `logical_date` or `run_after` should be provided in the task context when "
+                    "`use_task_logical_date` is True"
+                )
             if not now:
-                dag_run = context.get("dag_run")
                 now = dag_run.run_after  # type: ignore[union-attr, assignment]
         else:
             now = timezone.coerce_datetime(timezone.utcnow())

--- a/providers/standard/src/airflow/providers/standard/operators/weekday.py
+++ b/providers/standard/src/airflow/providers/standard/operators/weekday.py
@@ -112,8 +112,13 @@ class BranchDayOfWeekOperator(BaseBranchOperator):
     def choose_branch(self, context: Context) -> str | Iterable[str]:
         if self.use_task_logical_date:
             now = context.get("logical_date")
+            dag_run = context.get("dag_run")
+            if not (now or (dag_run and dag_run.run_after)):
+                raise ValueError(
+                    "Either `logical_date` or `run_after` should be provided in the task context when "
+                    "`use_task_logical_date` is True"
+                )
             if not now:
-                dag_run = context.get("dag_run")
                 now = dag_run.run_after  # type: ignore[union-attr, assignment]
         else:
             now = timezone.make_naive(timezone.utcnow(), self.dag.timezone)

--- a/providers/standard/tests/unit/standard/operators/test_datetime.py
+++ b/providers/standard/tests/unit/standard/operators/test_datetime.py
@@ -344,3 +344,21 @@ class TestBranchDateTimeOperator:
             **{"run_after": timezone.datetime(2020, 8, 7)},
         )
         assert branch_op.choose_branch(context={"dag_run": dr}) == "branch_1"
+
+    def test_choose_branch_raises_when_both_logical_date_and_dag_run_are_none(self, dag_maker):
+        with dag_maker(
+            "branch_datetime_operator_test",
+            default_args={"owner": "airflow", "start_date": DEFAULT_DATE},
+            schedule=INTERVAL,
+            serialized=True,
+        ):
+            branch_op = BranchDateTimeOperator(
+                task_id="datetime_branch",
+                follow_task_ids_if_true="branch_1",
+                follow_task_ids_if_false="branch_2",
+                target_upper=datetime.datetime(2020, 9, 7, 11, 0, 0),
+                target_lower=datetime.datetime(2020, 6, 7, 10, 0, 0),
+                use_task_logical_date=True,
+            )
+        with pytest.raises(ValueError, match="Either `logical_date` or `run_after` should be provided"):
+            branch_op.choose_branch(context={})

--- a/providers/standard/tests/unit/standard/operators/test_weekday.py
+++ b/providers/standard/tests/unit/standard/operators/test_weekday.py
@@ -206,6 +206,20 @@ class TestBranchDayOfWeekOperator:
         )
         assert branch_op.choose_branch(context={"dag_run": dr}) == "branch_1"
 
+    def test_choose_branch_raises_when_both_logical_date_and_dag_run_are_none(self, dag_maker):
+        with dag_maker(
+            "branch_day_of_week_operator_test", start_date=DEFAULT_DATE, schedule=INTERVAL, serialized=True
+        ):
+            branch_op = BranchDayOfWeekOperator(
+                task_id="make_choice",
+                follow_task_ids_if_true="branch_1",
+                follow_task_ids_if_false="branch_2",
+                week_day="Wednesday",
+                use_task_logical_date=True,
+            )
+        with pytest.raises(ValueError, match="Either `logical_date` or `run_after` should be provided"):
+            branch_op.choose_branch(context={})
+
     @time_machine.travel("2021-01-25")  # Monday
     def test_branch_follow_false(self, dag_maker):
         """Checks if BranchDayOfWeekOperator follow false branch"""


### PR DESCRIPTION
…task_logical_date=True

BranchDayOfWeekOperator and BranchDateTimeOperator both crashed with an unhandled AttributeError when use_task_logical_date=True and the context contained neither a logical_date nor a dag_run (e.g. standalone task execution or unit tests). DayOfWeekSensor already handled this safely by guarding the access and raising a clear ValueError. Apply the same defensive check to both operators so callers get an actionable error instead of a confusing NoneType traceback.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
