### PR TITLE
Export AIRFLOW_TEST_MODE from airflow tasks test without --env-vars

### DIFF
--- a/airflow-core/src/airflow/cli/commands/task_command.py
+++ b/airflow-core/src/airflow/cli/commands/task_command.py
@@ -417,7 +417,7 @@ def task_test(args, dag: DAG | None = None) -> None:
     env_vars = {"AIRFLOW_TEST_MODE": "True"}
     if args.env_vars:
         env_vars.update(args.env_vars)
-        os.environ.update(env_vars)
+    os.environ.update(env_vars)
 
     if dag:
         sdk_dag = dag

--- a/airflow-core/tests/unit/cli/commands/test_task_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_task_command.py
@@ -218,15 +218,15 @@ class TestCliTasks:
     @pytest.mark.parametrize(
         ("env_var_args", "expected_foo"),
         [
-            pytest.param([], "foo=None", id="without-env-vars"),
+            pytest.param([], "foo=sentinel", id="without-env-vars"),
             pytest.param(["--env-vars", '{"foo":"bar"}'], "foo=bar", id="with-env-vars"),
         ],
     )
     def test_cli_test_with_env_vars(self, monkeypatch, env_var_args, expected_foo):
-        # task_test writes both keys into the real process environment and never restores them;
-        # clear them so this case sees only what this invocation exported.
-        monkeypatch.delenv("AIRFLOW_TEST_MODE", raising=False)
-        monkeypatch.delenv("foo", raising=False)
+        # setenv (unlike delenv) always records an undo entry, so task_test's writes to the real
+        # process environment cannot leak out; the sentinel proves the command overwrote the key.
+        monkeypatch.setenv("AIRFLOW_TEST_MODE", "sentinel")
+        monkeypatch.setenv("foo", "sentinel")
         with redirect_stdout(io.StringIO()) as stdout:
             task_command.task_test(
                 self.parser.parse_args(

--- a/airflow-core/tests/unit/cli/commands/test_task_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_task_command.py
@@ -215,7 +215,18 @@ class TestCliTasks:
             )
         )
 
-    def test_cli_test_with_env_vars(self):
+    @pytest.mark.parametrize(
+        ("env_var_args", "expected_foo"),
+        [
+            pytest.param([], "foo=None", id="without-env-vars"),
+            pytest.param(["--env-vars", '{"foo":"bar"}'], "foo=bar", id="with-env-vars"),
+        ],
+    )
+    def test_cli_test_with_env_vars(self, monkeypatch, env_var_args, expected_foo):
+        # task_test writes both keys into the real process environment and never restores them;
+        # clear them so this case sees only what this invocation exported.
+        monkeypatch.delenv("AIRFLOW_TEST_MODE", raising=False)
+        monkeypatch.delenv("foo", raising=False)
         with redirect_stdout(io.StringIO()) as stdout:
             task_command.task_test(
                 self.parser.parse_args(
@@ -225,13 +236,12 @@ class TestCliTasks:
                         "example_passing_params_via_test_command",
                         "env_var_test_task",
                         DEFAULT_DATE.isoformat(),
-                        "--env-vars",
-                        '{"foo":"bar"}',
+                        *env_var_args,
                     ]
                 )
             )
         output = stdout.getvalue()
-        assert "foo=bar" in output
+        assert expected_foo in output
         assert "AIRFLOW_TEST_MODE=True" in output
 
     @mock.patch(


### PR DESCRIPTION
`airflow tasks test` never exported `AIRFLOW_TEST_MODE` unless `--env-vars` was also passed: the `os.environ.update()` call sat inside the `if args.env_vars:` guard, while the dict it writes was built outside it. The variable has been hostage to an unrelated flag since it was introduced in #7639 (2020).

This matters more than it looks on Airflow 3: the `test_mode` task-context variable is currently commented out in `task_runner.py`, so `AIRFLOW_TEST_MODE` is the only working way for a task to tell it is running under a test command — and it is the only channel that crosses the process boundary into `BashOperator` shells and user subprocesses. The official `example_passing_params_via_test_command` Dag prints it and has been showing `None` the whole time.

The `monkeypatch.delenv` calls in the test are load-bearing: `task_test` writes to the real process environment, so without clearing the keys first the `with-env-vars` case leaks `AIRFLOW_TEST_MODE=True` and the new case would pass against unfixed code — recreating the same blind spot.

Dag code that reads `AIRFLOW_TEST_MODE` during `tasks test` will now see `True` where it previously saw nothing. 

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)