### PR TITLE
Fix connection hook metadata test failing on Python 3.11 and newer

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/core_api/services/ui/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/services/ui/test_connections.py
@@ -350,11 +350,10 @@ class TestGetHooksWithMockedFab:
 
     def test_patched_helpers_return_the_mock_substitutes(self):
         """
-        The substitutes are reached through ``wtforms.validators``, not ``sys.modules``.
+        Exactly one of the two ``wtforms.validators`` mocks receives the substitute.
 
-        ``mock.patch`` resolves ``wtforms.validators.any_of`` by attribute lookup on the ``wtforms``
-        mock, which is a different object from the ``sys.modules["wtforms.validators"]`` mock that
-        ``from wtforms.validators import any_of`` would return.
+        Different Python versions can resolve the dotted patch target to either object, so check
+        both paths without relying on a particular resolution strategy.
         """
         captured = {}
 
@@ -363,14 +362,17 @@ class TestGetHooksWithMockedFab:
             import wtforms
 
             captured["label"] = flask_babel.lazy_gettext("Some label")
-            captured["validator"] = wtforms.validators.any_of(["a", "b"])
+            captured["validators"] = [
+                sys.modules["wtforms.validators"].any_of(["a", "b"]),
+                wtforms.validators.any_of(["a", "b"]),
+            ]
             return mock.MagicMock(spec=ProvidersManager)
 
         self.call_without_fab_modules(find_spec_raises, read_patched_helpers)
 
         assert captured["label"] == "Some label"
-        assert isinstance(captured["validator"], HookMetaService.MockEnum)
-        assert captured["validator"].allowed_values == ["a", "b"]
+        substitutes = [v for v in captured["validators"] if isinstance(v, HookMetaService.MockEnum)]
+        assert [substitute.allowed_values for substitute in substitutes] == [["a", "b"]]
 
 
 class TestHookMetaData:


### PR DESCRIPTION
related: #72248

`test_patched_helpers_return_the_mock_substitutes` fails on Python 3.11 and newer, which turned the canary build red on `main`.

https://github.com/apache/airflow/actions/runs/33299458686

`_get_hooks_with_mocked_fab` puts a separate `MagicMock` into `sys.modules` for every mocked name, so `sys.modules["wtforms.validators"]` and the `validators` attribute of the `wtforms` mock are two different objects. `mock.patch` only ever lands on one of them, and which one changed in Python 3.11, when `unittest.mock._get_target` moved from attribute lookup to `pkgutil.resolve_name`. The test read the object that only carries the substitute up to 3.10.

Pull requests run the core test jobs on the default Python (3.10) only, so this was invisible until the canary matrix exercised 3.11-3.14.

The test now reads both objects and asserts the substitute is on exactly one of them, which holds on every supported version.

### Verification

```python
breeze --answer yes testing core-tests --use-xdist --skip-db-tests --backend none --parallel-test-types "API" --python 3.11
```

Also run on 3.10, 3.12, 3.13 and 3.14.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: [Claude Opus 5] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
