### PR TITLE
Fix deferrable Kubernetes 401s with a default exec-based kubeconfig

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -870,7 +870,7 @@ class AsyncKubernetesHook(KubernetesHook):
         return any("exec" in (u.get("user") or {}) for u in users)
 
     async def _kubeconfig_file_uses_exec_auth(self, kubeconfig_path: str, context: str | None) -> bool:
-        """Detect exec-based authentication in the kubeconfig at ``kubeconfig_path``."""
+        """Detect exec auth in the kubeconfig at ``kubeconfig_path``; an unreadable file counts as exec."""
         try:
             async with aiofiles.open(kubeconfig_path) as f:
                 kubeconfig_data = yaml.safe_load(await f.read())
@@ -900,11 +900,11 @@ class AsyncKubernetesHook(KubernetesHook):
         return existing[0]
 
     async def _default_kubeconfig_uses_exec_auth(self, context: str | None) -> bool:
-        """Detect exec-based authentication in the kubeconfig loaded from the default location."""
+        """Detect exec auth in the default kubeconfig; anything but one readable file counts as exec."""
         kubeconfig_path = self._resolve_default_kubeconfig_path()
         if kubeconfig_path is None:
-            # KUBECONFIG names several files; reimplementing the merge rules kubernetes_asyncio
-            # applies to them would be a second source of truth, so leave the config uncached.
+            # No single file to read: which user is active is kubernetes_asyncio's to decide,
+            # so leave the config uncached rather than reimplementing its merge rules here.
             return True
         return await self._kubeconfig_file_uses_exec_auth(kubeconfig_path, context)
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import os
 import tempfile
 from collections.abc import AsyncGenerator
 from functools import cached_property
@@ -868,6 +869,45 @@ class AsyncKubernetesHook(KubernetesHook):
         # fallback to check all users if active context user cannot be resolved; this is a safe fallback since it errs on the side of not caching
         return any("exec" in (u.get("user") or {}) for u in users)
 
+    async def _kubeconfig_file_uses_exec_auth(self, kubeconfig_path: str, context: str | None) -> bool:
+        """Detect exec-based authentication in the kubeconfig at ``kubeconfig_path``."""
+        try:
+            async with aiofiles.open(kubeconfig_path) as f:
+                kubeconfig_data = yaml.safe_load(await f.read())
+            return self._uses_exec_auth(kubeconfig_data, context=context)
+        except Exception as exc:
+            self.log.warning(
+                "Error while parsing kube_config from %s to detect exec auth; "
+                "continuing without caching the config: %s",
+                kubeconfig_path,
+                exc,
+            )
+            return True
+
+    @staticmethod
+    def _resolve_default_kubeconfig_path() -> str | None:
+        """Return the kubeconfig loaded from the default location, if it resolves to a single file."""
+        paths = [
+            os.path.expanduser(path)
+            for path in async_config.KUBE_CONFIG_DEFAULT_LOCATION.split(os.pathsep)
+            if path
+        ]
+        # kubernetes_asyncio skips the paths that do not exist, so only the surviving ones
+        # decide whether the active user can be read from a single file.
+        existing = [path for path in paths if os.path.exists(path)]
+        if len(existing) != 1:
+            return None
+        return existing[0]
+
+    async def _default_kubeconfig_uses_exec_auth(self, context: str | None) -> bool:
+        """Detect exec-based authentication in the kubeconfig loaded from the default location."""
+        kubeconfig_path = self._resolve_default_kubeconfig_path()
+        if kubeconfig_path is None:
+            # KUBECONFIG names several files; reimplementing the merge rules kubernetes_asyncio
+            # applies to them would be a second source of truth, so leave the config uncached.
+            return True
+        return await self._kubeconfig_file_uses_exec_auth(kubeconfig_path, context)
+
     async def _load_config(self):
         """
         Load Kubernetes configuration.
@@ -932,19 +972,9 @@ class AsyncKubernetesHook(KubernetesHook):
             )
 
             if self._is_exec_auth is None:
-                try:
-                    async with aiofiles.open(kubeconfig_path) as f:
-                        content = await f.read()
-                        data = yaml.safe_load(content)
-                    self._is_exec_auth = self._uses_exec_auth(data, context=cluster_context)
-                except Exception as exc:
-                    self.log.warning(
-                        "Error while parsing kube_config from %s to detect exec auth; "
-                        "continuing without caching the config: %s",
-                        kubeconfig_path,
-                        exc,
-                    )
-                    self._is_exec_auth = True
+                self._is_exec_auth = await self._kubeconfig_file_uses_exec_auth(
+                    kubeconfig_path, cluster_context
+                )
 
             if not self._is_exec_auth:
                 self._config_loaded = True
@@ -993,7 +1023,12 @@ class AsyncKubernetesHook(KubernetesHook):
             client_configuration=self.client_configuration,
             context=cluster_context,
         )
-        self._config_loaded = True
+
+        if self._is_exec_auth is None:
+            self._is_exec_auth = await self._default_kubeconfig_uses_exec_auth(cluster_context)
+
+        if not self._is_exec_auth:
+            self._config_loaded = True
 
     async def get_conn_extras(self) -> dict:
         if self._extras is None:

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
@@ -1348,6 +1348,107 @@ class TestAsyncKubernetesHook:
         assert hook._config_loaded is expected_cached
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("kubeconfig_content", "extra_default_paths", "expected_cached"),
+        [
+            pytest.param(
+                (
+                    "current-context: ctx1\n"
+                    "contexts:\n- name: ctx1\n  context:\n    user: user1\n"
+                    "users:\n- name: user1\n  user:\n    exec:\n      command: aws eks get-token\n"
+                ),
+                0,
+                False,
+                id="default_kubeconfig_with_exec",
+            ),
+            pytest.param(
+                (
+                    "current-context: ctx1\n"
+                    "contexts:\n- name: ctx1\n  context:\n    user: user1\n"
+                    "users:\n- name: user1\n  user:\n    token: static-token\n"
+                ),
+                0,
+                True,
+                id="default_kubeconfig_no_exec",
+            ),
+            pytest.param(
+                (
+                    "current-context: ctx1\n"
+                    "contexts:\n- name: ctx1\n  context:\n    user: user1\n"
+                    "users:\n- name: user1\n  user:\n    token: static-token\n"
+                ),
+                1,
+                False,
+                id="default_kubeconfig_merged_from_several_files",
+            ),
+        ],
+    )
+    @mock.patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.async_config.load_kube_config")
+    async def test_load_config_caching_behavior_default_kubeconfig(
+        self, mock_load_file, tmp_path, kubeconfig_content, extra_default_paths, expected_cached
+    ):
+        mock_load_file.return_value = None
+        kubeconfig_file = tmp_path / "config"
+        kubeconfig_file.write_text(kubeconfig_content)
+        extra_files = []
+        for index in range(extra_default_paths):
+            extra_file = tmp_path / f"extra{index}.yaml"
+            extra_file.write_text(kubeconfig_content)
+            extra_files.append(str(extra_file))
+        default_location = os.pathsep.join([str(kubeconfig_file), *extra_files])
+
+        hook = AsyncKubernetesHook(conn_id=None, in_cluster=False)
+        hook._get_field = mock.AsyncMock(return_value=None)
+        with mock.patch(f"{HOOK_MODULE}.async_config.KUBE_CONFIG_DEFAULT_LOCATION", default_location):
+            await hook._load_config()
+
+        mock_load_file.assert_awaited_once()
+        assert hook._config_loaded is expected_cached
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.async_config.load_kube_config")
+    async def test_load_config_default_kubeconfig_ignores_paths_that_do_not_exist(
+        self, mock_load_file, tmp_path
+    ):
+        mock_load_file.return_value = None
+        kubeconfig_file = tmp_path / "config"
+        kubeconfig_file.write_text(
+            "current-context: ctx1\n"
+            "contexts:\n- name: ctx1\n  context:\n    user: user1\n"
+            "users:\n- name: user1\n  user:\n    token: static-token\n"
+        )
+        default_location = os.pathsep.join([str(kubeconfig_file), str(tmp_path / "missing.yaml")])
+
+        hook = AsyncKubernetesHook(conn_id=None, in_cluster=False)
+        hook._get_field = mock.AsyncMock(return_value=None)
+        with mock.patch(f"{HOOK_MODULE}.async_config.KUBE_CONFIG_DEFAULT_LOCATION", default_location):
+            await hook._load_config()
+
+        assert hook._config_loaded is True
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.async_config.load_kube_config")
+    async def test_load_config_default_kubeconfig_expands_home_directory(
+        self, mock_load_file, tmp_path, monkeypatch
+    ):
+        mock_load_file.return_value = None
+        kube_dir = tmp_path / ".kube"
+        kube_dir.mkdir()
+        (kube_dir / "config").write_text(
+            "current-context: ctx1\n"
+            "contexts:\n- name: ctx1\n  context:\n    user: user1\n"
+            "users:\n- name: user1\n  user:\n    token: static-token\n"
+        )
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        hook = AsyncKubernetesHook(conn_id=None, in_cluster=False)
+        hook._get_field = mock.AsyncMock(return_value=None)
+        with mock.patch(f"{HOOK_MODULE}.async_config.KUBE_CONFIG_DEFAULT_LOCATION", "~/.kube/config"):
+            await hook._load_config()
+
+        assert hook._config_loaded is True
+
+    @pytest.mark.asyncio
     @mock.patch(KUBE_API.format("list_namespaced_event"))
     async def test_async_get_pod_events_with_resource_version(
         self, mock_list_namespaced_event, kube_config_loader


### PR DESCRIPTION
## Summary

`AsyncKubernetesHook` caches the kubeconfig it loads, and both the pod and job triggers keep that hook as a `cached_property`. This causes a problem with exec-based credentials such as `aws eks get-token`, which mint tokens that expire after about fifteen minutes. The cached token can therefore expire during a long-running deferrable task, causing subsequent Kubernetes API requests to fail with `401 Unauthorized`.

#65212 fixed this for exec auth loaded through `config_dict`, `kube_config`, and `kube_config_path`, but missed the fall-through branch where `kubernetes_asyncio` loads the kubeconfig from `~/.kube/config` or `$KUBECONFIG`.

This branch is used when:
- the operator does not set `config_file`,
- the worker does not set `KUBECONFIG`, and
- the connection does not provide a kubeconfig field.

This is also the typical setup when an EKS kubeconfig is mounted at the default location.

This PR applies the same caching decision to the default kubeconfig path: **exec-based credentials are not cached, while static credentials remain cached**. This allows the exec plugin to be invoked again and obtain a fresh token when the trigger polls later.

When `$KUBECONFIG` contains multiple existing files, the config is left uncached rather than reimplementing `kubernetes_asyncio`'s merge rules. This adds one kubeconfig read per poll in that case.

In-cluster configuration continues to be cached because `load_incluster_config()` installs a `refresh_api_key_hook` that re-reads the rotated service account token.

Closes #61737

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)