### PR TITLE
Avoid retrying XCom expand actions

### DIFF
--- a/airflow-core/src/airflow/ui/tests/e2e/pages/XComsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/XComsPage.ts
@@ -99,10 +99,9 @@ export class XComsPage extends BasePage {
   public async verifyExpandCollapse(): Promise<void> {
     await this.navigate();
 
-    await expect(async () => {
-      await this.expandAllButton.first().click({ timeout: 5000 });
-      await expect(this.collapseAllButton.first()).toBeVisible({ timeout: 3000 });
-    }).toPass({ intervals: [2000], timeout: 15_000 });
+    await expect(this.expandAllButton.first()).toBeVisible({ timeout: 5000 });
+    await this.expandAllButton.first().click();
+    await expect(this.collapseAllButton.first()).toBeVisible({ timeout: 15_000 });
 
     await this.collapseAllButton.first().click();
   }


### PR DESCRIPTION
Move the XCom expand action out of the Playwright retry callback so a transient assertion does not click the action repeatedly. The test now waits for the button, clicks it once, and retries only the resulting visibility assertion.

This addresses the expand/collapse pattern tracked by #63036 and keeps the change limited to the XCom page object.

Validation:

- `git diff --check`
- `prek install` was attempted; hook initialization was blocked by a transient network failure while fetching `codespell`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — OpenAI Codex

Generated-by: OpenAI Codex following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

Drafted-by: OpenAI Codex (no human review before posting)
