### PR TITLE
Document Managed Agents as a first-party feature

### DIFF
--- a/providers/anthropic/src/airflow/providers/anthropic/hooks/anthropic.py
+++ b/providers/anthropic/src/airflow/providers/anthropic/hooks/anthropic.py
@@ -71,7 +71,7 @@ if TYPE_CHECKING:
 DEFAULT_MODEL = "claude-opus-4-8"
 
 #: Platforms that serve the first-party-only endpoints (Message Batches, token
-#: counting, the Models API). Amazon Bedrock, Google Vertex AI and Microsoft
+#: counting, the Models API and Managed Agents). Amazon Bedrock, Google Vertex AI and Microsoft
 #: Foundry do not serve these, so the hook fails fast rather than surfacing a
 #: raw ``404`` from the SDK.
 FIRST_PARTY_PLATFORMS = frozenset({"anthropic", "aws"})


### PR DESCRIPTION
Update the Anthropic hook's `FIRST_PARTY_PLATFORMS` module comment to include Managed Agents. The connection documentation and the hook's runtime guard already treat Managed Agents as first-party-only features, so this keeps the source comment aligned with the implemented boundary.

This is a provider-only documentation comment change and does not alter runtime behavior.

Validation:

- `git diff --check`
- Confirmed the connection documentation already documents Managed Agents and the hook guard enforces the same platform boundary.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — OpenAI Codex

Generated-by: OpenAI Codex following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

Drafted-by: OpenAI Codex (no human review before posting)
