### PR TITLE
UI: Translate durations and relative times in the selected language

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -813,6 +813,7 @@ repos:
           ^providers/common/ai/src/airflow/providers/common/ai/plugins/www/pnpm-lock\.yaml$|
           ^airflow-core/src/airflow/ui/public/i18n/locales/de/README\.md$|
           ^airflow-core/src/airflow/ui/src/i18n/config\.ts$|
+          ^airflow-core/src/airflow/ui/src/i18n/dayjsLocale\.ts$|
           ^\.agents/skills/airflow-translations/|
           ^\.agents/skills/magpie-setup/|
           ^airflow-core/src/airflow/utils/db\.py$|

--- a/airflow-core/src/airflow/ui/src/i18n/config.ts
+++ b/airflow-core/src/airflow/ui/src/i18n/config.ts
@@ -23,6 +23,8 @@ import { initReactI18next } from "react-i18next";
 
 import { VersionService } from "openapi/requests/services.gen";
 
+import { registerDayjsLocaleSync } from "./dayjsLocale";
+
 export const supportedLanguages = [
   { code: "en", name: "English" },
   { code: "ar", name: "العربية" },
@@ -131,6 +133,10 @@ export const i18nBaseOptions = {
 
 const initI18n = (version: string) => {
   const queryString = version ? `?v=${version}` : "";
+
+  // Subscribed before init so it precedes every react-i18next component listener, and
+  // because i18next emits `languageChanged` from init itself for the detected language.
+  registerDayjsLocaleSync(i18n);
 
   void i18n
     .use(Backend)

--- a/airflow-core/src/airflow/ui/src/i18n/dayjsLocale.test.ts
+++ b/airflow-core/src/airflow/ui/src/i18n/dayjsLocale.test.ts
@@ -1,0 +1,86 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import dayjs from "dayjs";
+import dayjsDuration from "dayjs/plugin/duration";
+import relativeTime from "dayjs/plugin/relativeTime";
+import { createInstance } from "i18next";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { i18nBaseOptions, supportedLanguages } from "./config";
+import { dayjsLocaleCodes, registerDayjsLocaleSync, syncDayjsLocale } from "./dayjsLocale";
+
+dayjs.extend(dayjsDuration);
+dayjs.extend(relativeTime);
+
+const humanizeTwoHours = () => dayjs.duration(2, "hours").humanize();
+
+// dayjs keeps the locale in module-global state, so a test that switched it would
+// otherwise decide what every later test formats.
+afterEach(() => {
+  dayjs.locale("en");
+});
+
+describe("dayjs locale", () => {
+  it("covers exactly the languages the UI offers", () => {
+    expect([...dayjsLocaleCodes].sort()).toStrictEqual(
+      supportedLanguages.map((language) => language.code).sort(),
+    );
+  });
+
+  it.each(supportedLanguages.filter((language) => language.code !== "en"))(
+    "humanizes a duration in $code rather than English",
+    ({ code }) => {
+      syncDayjsLocale(code);
+
+      expect(humanizeTwoHours()).not.toBe("2 hours");
+    },
+  );
+
+  it("renders the reported Arabic case", () => {
+    syncDayjsLocale("ar");
+
+    expect(humanizeTwoHours()).toBe("2 ساعات");
+  });
+
+  it("falls back to English for a language dayjs does not ship", () => {
+    syncDayjsLocale("ar");
+    syncDayjsLocale("cy");
+
+    expect(humanizeTwoHours()).toBe("2 hours");
+  });
+
+  it("applies the language i18next resolves during init", async () => {
+    const instance = createInstance();
+
+    registerDayjsLocaleSync(instance);
+    await instance.init({ ...i18nBaseOptions, lng: "ar", resources: {} });
+
+    expect(humanizeTwoHours()).toBe("2 ساعات");
+  });
+
+  it("follows a later language switch", async () => {
+    const instance = createInstance();
+
+    registerDayjsLocaleSync(instance);
+    await instance.init({ ...i18nBaseOptions, lng: "ar", resources: {} });
+    await instance.changeLanguage("zh-CN");
+
+    expect(humanizeTwoHours()).toBe("2 小时");
+  });
+});

--- a/airflow-core/src/airflow/ui/src/i18n/dayjsLocale.ts
+++ b/airflow-core/src/airflow/ui/src/i18n/dayjsLocale.ts
@@ -1,0 +1,90 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import dayjs from "dayjs";
+import "dayjs/locale/ar";
+import "dayjs/locale/ca";
+import "dayjs/locale/de";
+import "dayjs/locale/el";
+import "dayjs/locale/es";
+import "dayjs/locale/fr";
+import "dayjs/locale/he";
+import "dayjs/locale/hi";
+import "dayjs/locale/hu";
+import "dayjs/locale/it";
+import "dayjs/locale/ja";
+import "dayjs/locale/ko";
+import "dayjs/locale/nl";
+import "dayjs/locale/pl";
+import "dayjs/locale/pt";
+import "dayjs/locale/ru";
+import "dayjs/locale/th";
+import "dayjs/locale/tr";
+import "dayjs/locale/zh-cn";
+import "dayjs/locale/zh-tw";
+import type { i18n as I18nInstance } from "i18next";
+
+// dayjs holds a single global locale and bundles only `en`, so `.humanize()` and
+// `.fromNow()` rendered English durations ("2 hours") inside otherwise translated
+// sentences. The locale data is registered eagerly rather than fetched per language:
+// a dynamic import resolves after react-i18next has already re-rendered on
+// `languageChanged`, which would leave the previous language's durations on screen
+// until something else triggered a render. The twenty files cost ~7.6 kB gzipped.
+//
+// Keys are i18next codes from `supportedLanguages`; values are dayjs locale names,
+// which are lower-cased and so differ for the Chinese variants. `pt` maps to European
+// Portuguese because that is what the bare `pt` code asks for.
+const DAYJS_LOCALES: Record<string, string> = {
+  ar: "ar",
+  ca: "ca",
+  de: "de",
+  el: "el",
+  en: "en",
+  es: "es",
+  fr: "fr",
+  he: "he",
+  hi: "hi",
+  hu: "hu",
+  it: "it",
+  ja: "ja",
+  ko: "ko",
+  nl: "nl",
+  pl: "pl",
+  pt: "pt",
+  ru: "ru",
+  th: "th",
+  tr: "tr",
+  "zh-CN": "zh-cn",
+  "zh-TW": "zh-tw",
+};
+
+export const dayjsLocaleCodes = Object.keys(DAYJS_LOCALES);
+
+const FALLBACK_DAYJS_LOCALE = "en";
+
+export const syncDayjsLocale = (language: string): void => {
+  dayjs.locale(DAYJS_LOCALES[language] ?? FALLBACK_DAYJS_LOCALE);
+};
+
+// Register this on i18next before `init()`: the emitter runs `languageChanged`
+// callbacks in subscription order and react-i18next subscribes each component as it
+// mounts, so subscribing first is what guarantees dayjs has switched by the time any
+// component re-renders in the new language.
+export const registerDayjsLocaleSync = (instance: I18nInstance): void => {
+  instance.on("languageChanged", syncDayjsLocale);
+};


### PR DESCRIPTION
closes: #72307

The deadline tooltip was assembled from two separate catalogues: the sentence
template and the reference point come from i18next, but the interval came from
dayjs. Since the UI never called `dayjs.locale()`, dayjs stayed on its built-in
English and rendered "2 hours" inside an otherwise fully translated sentence.
No translation key was missing, which is why the completeness checks never
caught it.

This syncs dayjs's locale to the language i18next resolves, which also fixes
every relative time in the UI (e.g. "Next Run") which is the same root cause.




### Before (e.g., ARABIC)

<img width="533" height="158" alt="image" src="https://github.com/user-attachments/assets/2c1cf6f4-462c-411d-af84-67e76dc93cd4" />

### After

<img width="532" height="216" alt="image" src="https://github.com/user-attachments/assets/288a2b87-2caa-4a81-b2ee-53003a836bc8" />


### Before (e.g., FRENCH)

<img width="821" height="301" alt="image" src="https://github.com/user-attachments/assets/f678c78c-8313-436e-a26d-c23691cf59e2" />

### After

<img width="678" height="232" alt="image" src="https://github.com/user-attachments/assets/a73b09dc-5441-41cd-93a2-19051d895b6e" />

### Notes

- The locale data is imported eagerly rather than on demand. react-i18next
  re-renders synchronously on `languageChanged`, so a dynamic import would
  resolve after that render and leave the previous language's durations on
  screen. All 20 locale files together are ~7.6 kB gzipped.
- The listener is registered before `init()` because i18next emits
  `languageChanged` from init itself, and because emitter callbacks run in
  subscription order. 
- The fourth file is a one-line addition to the `check-for-inclusive-language`
  exclude list. In fact, the hook rejects the bare Hebrew code `he`. `config.ts` is
  already excluded for the same reason.

### Known limitation. cc @hussein-awala 
dayjs's Arabic locale has no dual form. It only defines `%d ساعات`. 
So **two hours** renders as **"2 ساعات"** rather than **"ساعتان"**. The language is now correct;
the grammar is as good as dayjs's own locale data allows. Fixing that properly
means moving durations to `Intl.DurationFormat` or to i18next plural keys,
which have their own trade-offs and are out of scope here.

I am happy to work on the follow-up if maintainers agree on the approach.

`renderCompactDuration` still emits hardcoded English unit letters (`2h 30m`)
and is untouched by this change.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)