### PR TITLE
Add prek check comparing pnpm.overrides against UI workspace lockfiles and Fixes a pre-existing overrides drift in fab's lockfile that the new check caught.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -627,6 +627,27 @@ repos:
         language: python
         pass_filenames: false
         files: ^dev/registry/registry_tools/types\.py$|^registry/src/_data/types\.json$
+      - id: check-pnpm-overrides-lockfile-sync
+        name: Check pnpm.overrides is mirrored in each UI workspace's lockfile
+        description: |
+          Each UI workspace pins security-advisory overrides via `pnpm.overrides` in its
+          package.json, which pnpm mirrors into an `overrides:` block at the top of that
+          workspace's pnpm-lock.yaml. Some regenerated lockfiles (notably from grouped
+          dependabot updates) come back without that block, which silently drops the pins
+          and later fails a frozen install with a bare ERR_PNPM_LOCKFILE_CONFIG_MISMATCH.
+          This check compares the two sides directly and names the drift up front.
+        entry: ./scripts/ci/prek/check_pnpm_overrides_lockfile_sync.py
+        language: python
+        pass_filenames: false
+        additional_dependencies: ['pyyaml', 'rich>=13.6.0']
+        files: >
+          (?x)
+          ^airflow-core/src/airflow/ui/(package\.json|pnpm-lock\.yaml)$|
+          ^airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/(package\.json|pnpm-lock\.yaml)$|
+          ^providers/edge3/src/airflow/providers/edge3/plugins/www/(package\.json|pnpm-lock\.yaml)$|
+          ^providers/fab/src/airflow/providers/fab/www/(package\.json|pnpm-lock\.yaml)$|
+          ^providers/common/ai/src/airflow/providers/common/ai/plugins/www/(package\.json|pnpm-lock\.yaml)$|
+          ^dev/react-plugin-tools/react_plugin_template/(package\.json|pnpm-lock\.yaml)$
       - id: ruff
         name: Run 'ruff' for extremely fast Python linting
         description: "Run 'ruff' for extremely fast Python linting"

--- a/providers/fab/src/airflow/providers/fab/www/package.json
+++ b/providers/fab/src/airflow/providers/fab/www/package.json
@@ -69,6 +69,7 @@
     "minimumReleaseAge": 5760,
     "onlyBuiltDependencies": [],
     "overrides": {
+      "moment-timezone": ">=0.5.35",
       "minimatch@>=10.0.0 <10.2.3": ">=10.2.3",
       "serialize-javascript@<=7.0.2": ">=7.0.3",
       "svgo@<4.0.1": ">=4.0.1",

--- a/scripts/ci/prek/check_pnpm_overrides_lockfile_sync.py
+++ b/scripts/ci/prek/check_pnpm_overrides_lockfile_sync.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Check that each UI workspace's ``pnpm.overrides`` in package.json is mirrored by the
+``overrides:`` block pnpm writes at the top of that workspace's pnpm-lock.yaml.
+
+Six UI workspaces pin security-advisory overrides this way. In some grouped dependabot
+updates the regenerated lockfile comes back without the ``overrides:`` section at all,
+while package.json still declares it. That silently drops the pins, and a frozen install
+of the mismatched pair fails anyway with a bare ERR_PNPM_LOCKFILE_CONFIG_MISMATCH buried
+in a hook log. This check compares the two sides directly and names exactly what drifted,
+so the failure is legible without having to reproduce the frozen install locally first.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import yaml
+from common_prek_utils import AIRFLOW_ROOT_PATH, console
+from rich.markup import escape
+
+# Workspaces that pin security-advisory overrides via `pnpm.overrides` in package.json,
+# mirrored into `overrides:` at the top of their own pnpm-lock.yaml. Keep this list in
+# sync with .github/dependabot.yml's npm entries and .pre-commit-config.yaml's excludes
+# for these same lockfiles.
+UI_WORKSPACES = (
+    "airflow-core/src/airflow/ui",
+    "airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui",
+    "providers/edge3/src/airflow/providers/edge3/plugins/www",
+    "providers/fab/src/airflow/providers/fab/www",
+    "providers/common/ai/src/airflow/providers/common/ai/plugins/www",
+    "dev/react-plugin-tools/react_plugin_template",
+)
+
+
+def _load_package_json_overrides(workspace: Path) -> dict[str, str]:
+    package_json = json.loads((workspace / "package.json").read_text())
+    return package_json.get("pnpm", {}).get("overrides", {}) or {}
+
+
+def _load_lockfile_overrides(workspace: Path) -> dict[str, str]:
+    lockfile_path = workspace / "pnpm-lock.yaml"
+    if not lockfile_path.exists():
+        return {}
+    lockfile = yaml.safe_load(lockfile_path.read_text())
+    return (lockfile or {}).get("overrides") or {}
+
+
+def diff_workspace_overrides(workspace_rel: str) -> list[str]:
+    """Return human-readable diff lines for one workspace, empty when the two sides agree."""
+    workspace = AIRFLOW_ROOT_PATH / workspace_rel
+    package_json_overrides = _load_package_json_overrides(workspace)
+    lockfile_overrides = _load_lockfile_overrides(workspace)
+
+    if not package_json_overrides and not lockfile_overrides:
+        return []
+
+    missing_from_lockfile = sorted(set(package_json_overrides) - set(lockfile_overrides))
+    extra_in_lockfile = sorted(set(lockfile_overrides) - set(package_json_overrides))
+    mismatched_values = sorted(
+        key
+        for key in set(package_json_overrides) & set(lockfile_overrides)
+        if package_json_overrides[key] != lockfile_overrides[key]
+    )
+
+    errors = []
+    if missing_from_lockfile:
+        errors.append(
+            "declared in package.json pnpm.overrides but missing from the pnpm-lock.yaml "
+            f"overrides: block: {', '.join(missing_from_lockfile)}"
+        )
+    if extra_in_lockfile:
+        errors.append(
+            "present in the pnpm-lock.yaml overrides: block but not in package.json "
+            f"pnpm.overrides: {', '.join(extra_in_lockfile)}"
+        )
+    for key in mismatched_values:
+        errors.append(
+            f"{key!r} differs: package.json wants {package_json_overrides[key]!r}, "
+            f"lockfile has {lockfile_overrides[key]!r}"
+        )
+    return errors
+
+
+def main() -> int:
+    failed = False
+    for workspace_rel in UI_WORKSPACES:
+        if errors := diff_workspace_overrides(workspace_rel):
+            failed = True
+            console.print(f"\n[red]pnpm.overrides drift in {workspace_rel}:[/]\n")
+            for error in errors:
+                console.print(f"  {escape(error)}")
+    if failed:
+        console.print(
+            "\n[bright_yellow]Each affected workspace's `pnpm.overrides` in package.json is a "
+            "security-advisory pin, and pnpm mirrors it into the `overrides:` block at the top of "
+            "that workspace's own pnpm-lock.yaml. A frozen install of a mismatched pair fails anyway, "
+            "but as a bare ERR_PNPM_LOCKFILE_CONFIG_MISMATCH - this check just names the drift instead.\n"
+            "Regenerate the lockfile from the workspace's pinned pnpm version (see its "
+            "package.json `packageManager` field) so it picks the overrides back up, for example:\n"
+            "  npx pnpm@<pinned-version> --dir <workspace> install --no-frozen-lockfile\n"
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

Picks up the third item from the follow-up checklist on #72298 : a prek check that compares each UI workspace's `pnpm.overrides` (package.json) against the `overrides:` block pnpm mirrors into that workspace's pnpm-lock.yaml, and fails with a clear message naming the exact keys that drifted, instead of surfacing as `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` deep in a hook log.

This does not fix the underlying issue. It doesn't identify why dependabot drops the block on some updates (checklist item 1) and doesn't implement a durable fix (item 2). A grouped dependabot PR that hits the bug will still fail static checks and still need a human to regenerate the lockfile , this only makes that failure legible instead of cryptic. Leaving 1 and 2 open for separate discussion.

While testing this against `main`, the check caught a pre-existing drift: `providers/fab/.../www/pnpm-lock.yaml` carries a `moment-timezone` override that was missing from `package.json`'s `pnpm.overrides` (leftover from an old
yarn `resolutions` setup, before this workspace moved to pnpm). Fixed that in this PR since the new check would otherwise fail on `main` immediately.

related: #72298

---
##### Was generative AI tooling used to co-author this PR?
- [X] Yes (Claude)
<!--
Generated-by: Claude following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->
---
* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.