### PR TITLE
Fix incorrect documented defaults in Amazon operators and sensors

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/bedrock.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/bedrock.py
@@ -1225,7 +1225,7 @@ class BedrockBatchInferenceOperator(AwsBaseOperator[BedrockHook]):
         NOTE:  The way batch inference jobs work, your jobs are added to a queue and done "eventually"
         so using deferrable mode is much more practical than using wait_for_completion.
     :param waiter_delay: Time in seconds to wait between status checks. (default: 60)
-    :param waiter_max_attempts: Maximum number of attempts to check for job completion. (default: 10)
+    :param waiter_max_attempts: Maximum number of attempts to check for job completion. (default: 20)
     :param deferrable: If True, the operator will wait asynchronously for the cluster to stop.
         This implies waiting for completion. This mode requires aiobotocore module to be installed.
         (default: False)

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/glue.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/glue.py
@@ -140,7 +140,7 @@ class GlueJobOperator(ResumableJobMixin, AwsBaseOperator[GlueJobHook]):
         Glue job's ``--conf`` argument so the Glue Spark job sends OL events to the same backend as Airflow.
         Defaults to the ``openlineage.spark_inject_transport_info`` config value.
     :param waiter_delay: Time in seconds to wait between status checks. (default: 60)
-    :param waiter_max_attempts: Maximum number of attempts to check for job completion. (default: 20)
+    :param waiter_max_attempts: Maximum number of attempts to check for job completion. (default: 75)
     :param resume_glue_job_on_retry: deprecated, use ``durable`` instead.
     :param durable: When ``True``, the Glue job run id is persisted to task state before polling
         begins. A worker crash on retry reconnects to the existing run instead of starting a

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/sqs.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/sqs.py
@@ -41,7 +41,7 @@ class SqsPublishOperator(AwsBaseOperator[SqsHook]):
     :param message_content: The message content (templated)
     :param message_attributes: additional attributes for the message (default: None)
         For details of the attributes parameter see :py:meth:`botocore.client.SQS.send_message`
-    :param delay_seconds: message delay (templated) (default: 1 second)
+    :param delay_seconds: message delay (templated) (default: 0 second)
     :param message_group_id: This parameter applies only to FIFO (first-in-first-out) queues. (default: None)
         For details of the attributes parameter see :py:meth:`botocore.client.SQS.send_message`
     :param message_deduplication_id: This applies only to FIFO (first-in-first-out) queues.

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/bedrock.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/bedrock.py
@@ -407,8 +407,8 @@ class BedrockBatchInferenceSensor(BedrockBaseSensor[BedrockHook]):
     :param deferrable: If True, the sensor will operate in deferrable more. This mode requires aiobotocore
         module to be installed.
         (default: False, but can be overridden in config file by setting default_deferrable to True)
-    :param poke_interval: Polling period in seconds to check for the status of the job. (default: 5)
-    :param max_retries: Number of times before returning the current state (default: 24)
+    :param poke_interval: Polling period in seconds to check for the status of the job. (default: 120)
+    :param max_retries: Number of times before returning the current state (default: 75)
     :param aws_conn_id: The Airflow connection used for AWS credentials.
         If this is ``None`` or empty then the default boto3 behaviour is used. If
         running Airflow in a distributed manner and aws_conn_id is None or


### PR DESCRIPTION
The class docstring is different from class default value.

| Class | Parameter | Documented | Actual |
|---|---|---|---|
| `GlueJobOperator` | `waiter_max_attempts` | 20 | 75 |
| `BedrockBatchInferenceOperator` | `waiter_max_attempts` | 10 | 20 |
| `BedrockBatchInferenceSensor` | `poke_interval` | 5 | 120 |
| `BedrockBatchInferenceSensor` | `max_retries` | 24 | 75 |
| `SqsPublishOperator` | `delay_seconds` | 1 second | 0 |
 
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
