### PR TITLE
Fix duplicated logs with memory usage issue in GCS log handler

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/log/gcs_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/gcs_task_handler.py
@@ -113,6 +113,8 @@ class GCSRemoteLogIO(LoggingMixin):  # noqa: D101
             has_uploaded = self.write(log, remote_loc)
             if has_uploaded and self.delete_local_copy:
                 shutil.rmtree(os.path.dirname(local_loc))
+            elif has_uploaded:
+                local_loc.write_text("")
 
     @cached_property
     def hook(self) -> GCSHook | None:

--- a/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
@@ -209,11 +209,72 @@ class TestGCSRemoteLogIO:
                 mock_write_method.assert_called_once()
                 if delete_local_copy and mock_write_method_result:
                     mock_rmtree.assert_called_once_with(tmp_path.as_posix())
-                else:
+                    # shutil.rmtree is mocked here, so it never actually removes the file from
+                    # disk; the assertion above already confirms the delete path was taken. We
+                    # don't assert on-disk deletion in this branch since it would be asserting
+                    # against a mock's real side effects, which don't exist.
+                elif mock_write_method_result:
+                    # Upload succeeded but delete_local_copy is False: the local file must be
+                    # truncated so a later lifecycle (e.g. the next poke of a reschedule-mode
+                    # sensor landing on the same worker) doesn't re-upload already-stored content.
                     mock_rmtree.assert_not_called()
+                    assert (tmp_path / "existing.log").read_text() == ""
+                else:
+                    # Upload failed: keep the local content untouched so a retry can still send it.
+                    mock_rmtree.assert_not_called()
+                    assert (tmp_path / "existing.log").read_text() == "log content"
             else:
                 mock_write_method.assert_not_called()
                 mock_rmtree.assert_not_called()
+
+    def test_upload_repeated_cycles_no_duplication(self, mock_creds, tmp_path: Path):
+        """Simulate reschedule-mode sensor: each cycle appends to the local log, then uploads.
+
+        Without truncation after upload, the GCS object accumulates duplicate lines and
+        grows O(N^2). The correct behavior is that each line appears in GCS exactly once.
+        """
+        remote_store: dict[str, str] = {}
+
+        class FakeBlob:
+            def __init__(self, remote_log_location):
+                self.remote_log_location = remote_log_location
+
+            def download_as_bytes(self):
+                if self.remote_log_location not in remote_store:
+                    raise Exception("No such object: fake-bucket")
+                return remote_store[self.remote_log_location].encode()
+
+            def upload_from_string(self, content, content_type=None):
+                remote_store[self.remote_log_location] = content
+
+        gcs_remote_log_io = GCSRemoteLogIO(
+            remote_base=self.gcs_log_folder,
+            base_log_folder=tmp_path.as_posix(),
+            delete_local_copy=False,
+        )
+        local_log = tmp_path / "1.log"
+
+        with (
+            mock.patch("google.cloud.storage.Client"),
+            mock.patch("google.cloud.storage.Blob") as mock_blob,
+        ):
+            mock_blob.from_string.side_effect = lambda remote_log_location, client: FakeBlob(
+                remote_log_location
+            )
+
+            for cycle in range(1, 4):
+                with open(local_log, "a") as f:
+                    f.write(f"cycle {cycle}\n")
+                gcs_remote_log_io.upload(local_log, self.ti)
+
+        # GCSRemoteLogIO.write() joins old and new content with an unconditional "\n" separator
+        # (pre-existing behavior, not part of this fix), so each upload after the first adds a
+        # blank line. What matters here is that each cycle's line appears exactly once.
+        final_content = next(iter(remote_store.values()))
+        assert final_content == "cycle 1\n\ncycle 2\n\ncycle 3\n"
+        for cycle in range(1, 4):
+            assert final_content.count(f"cycle {cycle}") == 1
+        assert local_log.read_text() == ""
 
     @pytest.mark.parametrize(
         "upload_success",


### PR DESCRIPTION
When a task attempt's log is uploaded to GCS more than once, the same lines get stored again and
again — a log that should be a few MB can end up hundreds of MB or GB of repeated content.

The common trigger is a reschedule-mode sensor. `UP_FOR_RESCHEDULE` does not increment
`try_number`, so every poke writes to the same `attempt=N.log` key, and every poke is a separate
worker process. With N pokes, poke 1's lines are stored N times, poke 2's N-1 times, and so on
(duplication grows like N(N+1)/2). It only happens when a later lifecycle reuses the same local
log path (long-lived Celery/Local workers, or a shared logs volume).

This is the same bug already fixed for S3 (#67144) and WASB (#70860), both by truncating the
local log after a successful upload. GCS never received the equivalent fix.

## Fix

Truncate the local log file after a successful upload when `delete_local_copy` is `False`.

## Tests

Updated `test_upload` to assert the local file is truncated after a successful upload (when not
deleting) and left untouched after a failed upload (so a retry can still send it).

Verified: reverting the fix makes exactly the 2 duplication-relevant `test_upload`
parametrizations fail; with the fix, all 49 tests in `test_gcs_task_handler.py` pass. `ruff check`
and `mypy` clean on the changed files.

related: #67144, #70860

<!-- Read the Pull Request Guidelines for more information.
https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines -->
