### PR TITLE
Fix timedelta serde to accept int payloads

### DIFF
--- a/task-sdk/src/airflow/sdk/serde/serializers/datetime.py
+++ b/task-sdk/src/airflow/sdk/serde/serializers/datetime.py
@@ -98,7 +98,7 @@ def deserialize(cls: type, version: int, data: dict | str) -> datetime.date | da
     if cls is DateTime and isinstance(data, dict):
         return DateTime.fromtimestamp(float(data[TIMESTAMP]), tz=tz)
 
-    if cls is datetime.timedelta and isinstance(data, str | float):
+    if cls is datetime.timedelta and isinstance(data, str | float | int):
         return datetime.timedelta(seconds=float(data))
 
     if cls is Date and isinstance(data, str):

--- a/task-sdk/tests/task_sdk/serde/test_serializers.py
+++ b/task-sdk/tests/task_sdk/serde/test_serializers.py
@@ -147,6 +147,18 @@ class TestSerializers:
             assert deserialize(serialize(deserialized_dt)) == deserialized_dt
 
     @pytest.mark.parametrize(
+        ("payload", "expected"),
+        [
+            pytest.param(2700, datetime.timedelta(minutes=45), id="int"),
+            pytest.param(2700.0, datetime.timedelta(minutes=45), id="float"),
+            pytest.param("2700", datetime.timedelta(minutes=45), id="str"),
+        ],
+    )
+    def test_deserialize_timedelta_numeric_payloads(self, payload, expected):
+        """Timedelta payloads may arrive as int (e.g. DeadlineAlert interval); see #72319."""
+        assert deserialize({CLASSNAME: "datetime.timedelta", VERSION: 2, DATA: payload}) == expected
+
+    @pytest.mark.parametrize(
         ("expr", "expected"),
         [("1", "1"), ("52e4", "520000"), ("2e0", "2"), ("12e-2", "0.12"), ("12.34", "12.34")],
     )


### PR DESCRIPTION
Closes #72319

The datetime deserializer only accepted `str|float` for `datetime.timedelta`, so integer second values (e.g. `2700` for 45 minutes) raised `TypeError: unknown date/time format datetime.timedelta` and crashed the scheduler during DeadlineAlert Dag-run creation.

Fix: accept `int` alongside `str|float` — `isinstance(data, str|float|int)`.

Repro:

```python
from datetime import timedelta
from airflow.sdk.serde import CLASSNAME, DATA, VERSION, deserialize
assert deserialize({CLASSNAME: 'datetime.timedelta', VERSION: 2, DATA: 2700}) == timedelta(minutes=45)
```
