### PR TITLE
Resolve the dag once per dag and batch the per-TI lookups when clearing task instances

### DIFF
--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -100,6 +100,7 @@ from airflow.task.priority_strategy import validate_and_load_priority_weight_str
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_deps import REQUEUEABLE_DEPS, RUNNING_DEPS
 from airflow.ti_deps.deps.ready_to_reschedule import ReadyToRescheduleDep
+from airflow.utils.helpers import chunks
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.net import get_hostname
 from airflow.utils.platform import getuser
@@ -373,6 +374,22 @@ def _pin_versionless_tis_to_run_version(dag_run: DagRun, dag_version_id: UUID, s
     )
 
 
+def _prepare_db_for_next_try(tis: Collection[TaskInstance], session: Session) -> None:
+    """
+    Archive the current try of each task instance, drop its reschedules and give it a fresh id.
+
+    The lookups and the delete are done in bulk (chunked), so clearing many task instances
+    costs a few statements, not three per task instance.
+    """
+    from airflow.models.taskinstancehistory import TaskInstanceHistory
+
+    TaskInstanceHistory.record_tis(tis, session=session)
+    for ti_ids in chunks([ti.id for ti in tis], 1000):
+        session.execute(delete(TaskReschedule).where(TaskReschedule.ti_id.in_(ti_ids)))
+    for ti in tis:
+        ti.id = uuid7()
+
+
 def clear_task_instances(
     tis: list[TaskInstance],
     session: Session,
@@ -403,9 +420,34 @@ def clear_task_instances(
     from airflow.models.dagbag import DBDagBag
 
     scheduler_dagbag = DBDagBag(load_op_links=False)
-    for ti in tis:
-        ti.prepare_db_for_next_try(session)
 
+    # What varies per task instance is looked up in bulk; what is shared by every task
+    # instance of a dag (or of a run) is resolved once. Fetching and deserializing the
+    # serialized dag for each task instance was the bulk of the cost of clearing a wide
+    # mapped task.
+    latest_dags: dict[str, SerializedDAG | None] = {}
+    latest_dag_versions: dict[str, DagVersion | None] = {}
+    dags_for_run: dict[tuple[str, str], SerializedDAG | None] = {}
+
+    def _latest_dag(dag_id: str) -> SerializedDAG | None:
+        if dag_id not in latest_dags:
+            latest_dags[dag_id] = scheduler_dagbag.get_latest_version_of_dag(dag_id, session=session)
+        return latest_dags[dag_id]
+
+    def _latest_dag_version(dag_id: str) -> DagVersion | None:
+        if dag_id not in latest_dag_versions:
+            latest_dag_versions[dag_id] = DagVersion.get_latest_version(dag_id, session=session)
+        return latest_dag_versions[dag_id]
+
+    def _dag_for_run(dag_run: DagRun) -> SerializedDAG | None:
+        key = (dag_run.dag_id, dag_run.run_id)
+        if key not in dags_for_run:
+            dags_for_run[key] = scheduler_dagbag.get_dag_for_run(dag_run=dag_run, session=session)
+        return dags_for_run[key]
+
+    _prepare_db_for_next_try(tis, session)
+
+    for ti in tis:
         if ti.state == TaskInstanceState.RUNNING:
             if prevent_running_task:
                 raise AirflowClearRunningTaskException(
@@ -423,9 +465,9 @@ def clear_task_instances(
             # run loop below moves it there.
             use_latest_version = run_on_latest_version or dr.created_dag_version_id is None
             if use_latest_version:
-                ti_dag = scheduler_dagbag.get_latest_version_of_dag(ti.dag_id, session=session)
+                ti_dag = _latest_dag(ti.dag_id)
             else:
-                ti_dag = scheduler_dagbag.get_dag_for_run(dag_run=dr, session=session)
+                ti_dag = _dag_for_run(dr)
             if not ti_dag:
                 log.warning("No serialized dag found for dag '%s'", dr.dag_id)
             task_id = ti.task_id
@@ -446,7 +488,7 @@ def clear_task_instances(
             ti.clear_next_method_args()
             # Match DagVersion to latest serialized DAG when running on the latest version.
             if use_latest_version:
-                latest_dag_version = DagVersion.get_latest_version(ti.dag_id, session=session)
+                latest_dag_version = _latest_dag_version(ti.dag_id)
                 if latest_dag_version is not None:
                     ti.dag_version_id = latest_dag_version.id
             elif ti.dag_version_id is None:
@@ -499,8 +541,8 @@ def clear_task_instances(
                 dr.state = dag_run_state
                 dr.start_date = timezone.utcnow()
                 if use_latest_version:
-                    dr_dag = scheduler_dagbag.get_latest_version_of_dag(dr.dag_id, session=session)
-                    dag_version = DagVersion.get_latest_version(dr.dag_id, session=session)
+                    dr_dag = _latest_dag(dr.dag_id)
+                    dag_version = _latest_dag_version(dr.dag_id)
                     if dag_version:
                         # Change the dr.created_dag_version_id so the scheduler doesn't reject this
                         # version when it sets the dag_run.dag
@@ -509,7 +551,7 @@ def clear_task_instances(
                         dr.verify_integrity(session=session, dag_version_id=dag_version.id)
                         # Only cleared TIs get latest dag_version_id above; do not rewrite others.
                 else:
-                    dr_dag = scheduler_dagbag.get_dag_for_run(dag_run=dr, session=session)
+                    dr_dag = _dag_for_run(dr)
                 if not dr_dag:
                     log.warning("No serialized dag found for dag '%s'", dr.dag_id)
                 if dr_dag and not dr_dag.disable_bundle_versioning and use_latest_version:
@@ -521,9 +563,9 @@ def clear_task_instances(
                     dr.start_date = None
             elif use_latest_version:
                 # Queued/running DagRun: update DR to latest version/bundle for workloads that use it.
-                dag_version = DagVersion.get_latest_version(dr.dag_id, session=session)
+                dag_version = _latest_dag_version(dr.dag_id)
                 if dag_version and dr.created_dag_version_id != dag_version.id:
-                    dr_dag = scheduler_dagbag.get_latest_version_of_dag(dr.dag_id, session=session)
+                    dr_dag = _latest_dag(dr.dag_id)
                     if not dr_dag:
                         log.warning("No serialized dag found for dag '%s'", dr.dag_id)
                     else:
@@ -1069,11 +1111,7 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
 
     def prepare_db_for_next_try(self, session: Session):
         """Update the metadata with all the records needed to put this TI in queued for the next try."""
-        from airflow.models.taskinstancehistory import TaskInstanceHistory
-
-        TaskInstanceHistory.record_ti(self, session=session)
-        session.execute(delete(TaskReschedule).filter_by(ti_id=self.id))
-        self.id = uuid7()
+        _prepare_db_for_next_try([self], session)
 
     @provide_session
     def are_dependents_done(self, *, session: Session = NEW_SESSION) -> bool:

--- a/airflow-core/src/airflow/models/taskinstancehistory.py
+++ b/airflow-core/src/airflow/models/taskinstancehistory.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+from collections.abc import Collection
 from datetime import datetime
 from typing import TYPE_CHECKING
 from uuid import UUID
@@ -33,8 +34,8 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
     Uuid,
-    func,
     select,
+    tuple_,
 )
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.mutable import MutableDict
@@ -44,6 +45,7 @@ from airflow._shared.timezones import timezone
 from airflow.models.base import Base, StringID
 from airflow.models.hitl import HITLDetail
 from airflow.models.hitl_history import HITLDetailHistory
+from airflow.utils.helpers import chunks
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.sqlalchemy import (
     ExecutorConfigType,
@@ -193,31 +195,61 @@ class TaskInstanceHistory(Base):
     @provide_session
     def record_ti(ti: TaskInstance, *, session: Session = NEW_SESSION) -> None:
         """Record a TaskInstance to TaskInstanceHistory."""
-        exists_q = session.scalar(
-            select(func.count(TaskInstanceHistory.task_id)).where(
-                TaskInstanceHistory.dag_id == ti.dag_id,
-                TaskInstanceHistory.task_id == ti.task_id,
-                TaskInstanceHistory.run_id == ti.run_id,
-                TaskInstanceHistory.map_index == ti.map_index,
-                TaskInstanceHistory.try_number == ti.try_number,
-            )
-        )
-        if exists_q:
-            return
-        ti_history_state = ti.state
-        if ti.state not in State.finished:
-            ti_history_state = TaskInstanceState.FAILED
-            # Callers that know when the try actually ended (e.g. the Execution API
-            # retry path) pre-set end_date and duration; only stamp archive time when unset.
-            if ti.end_date is None:
-                ti.end_date = timezone.utcnow()
-                ti.set_duration()
-        ti_history = TaskInstanceHistory(ti, state=ti_history_state)
-        session.add(ti_history)
+        TaskInstanceHistory.record_tis([ti], session=session)
 
-        ti_hitl_detail = session.scalar(select(HITLDetail).where(HITLDetail.ti_id == ti.id))
-        if ti_hitl_detail is not None:
-            session.add(HITLDetailHistory(ti_hitl_detail))
+    @staticmethod
+    @provide_session
+    def record_tis(tis: Collection[TaskInstance], *, session: Session = NEW_SESSION) -> None:
+        """
+        Record TaskInstances to TaskInstanceHistory, skipping the tries already archived.
+
+        The tries already archived and the HITL details are looked up in bulk (chunked),
+        so recording many task instances at once costs a few queries, not two per task
+        instance -- and recording a single one costs the same two it always did.
+        """
+        archived_keys: set[tuple[str, str, str, int, int]] = set()
+        hitl_details: dict[UUID, HITLDetail] = {}
+        for chunk in chunks(list(tis), 1000):
+            archived_keys.update(
+                session.execute(
+                    select(
+                        TaskInstanceHistory.dag_id,
+                        TaskInstanceHistory.run_id,
+                        TaskInstanceHistory.task_id,
+                        TaskInstanceHistory.map_index,
+                        TaskInstanceHistory.try_number,
+                    ).where(
+                        tuple_(
+                            TaskInstanceHistory.dag_id,
+                            TaskInstanceHistory.run_id,
+                            TaskInstanceHistory.task_id,
+                            TaskInstanceHistory.map_index,
+                            TaskInstanceHistory.try_number,
+                        ).in_(
+                            [(ti.dag_id, ti.run_id, ti.task_id, ti.map_index, ti.try_number) for ti in chunk]
+                        )
+                    )
+                ).all()
+            )
+            for hitl_detail in session.scalars(
+                select(HITLDetail).where(HITLDetail.ti_id.in_([ti.id for ti in chunk]))
+            ):
+                hitl_details[hitl_detail.ti_id] = hitl_detail
+
+        for ti in tis:
+            if (ti.dag_id, ti.run_id, ti.task_id, ti.map_index, ti.try_number) in archived_keys:
+                continue
+            ti_history_state = ti.state
+            if ti.state not in State.finished:
+                ti_history_state = TaskInstanceState.FAILED
+                # Callers that know when the try actually ended (e.g. the Execution API
+                # retry path) pre-set end_date and duration; only stamp archive time when unset.
+                if ti.end_date is None:
+                    ti.end_date = timezone.utcnow()
+                    ti.set_duration()
+            session.add(TaskInstanceHistory(ti, state=ti_history_state))
+            if (hitl_detail := hitl_details.get(ti.id)) is not None:
+                session.add(HITLDetailHistory(hitl_detail))
 
     @provide_session
     def get_dagrun(self, *, session: Session = NEW_SESSION) -> DagRun:

--- a/airflow-core/tests/unit/models/test_cleartasks.py
+++ b/airflow-core/tests/unit/models/test_cleartasks.py
@@ -36,7 +36,9 @@ from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 from tests_common.test_utils import db
+from tests_common.test_utils.asserts import count_queries
 from tests_common.test_utils.dag import sync_dag_to_db
+from tests_common.test_utils.mock_operators import MockOperator
 from tests_common.test_utils.taskinstance import run_task_instance
 from unit.models import DEFAULT_DATE
 
@@ -53,6 +55,40 @@ class TestClearTasks:
 
         db.clear_db_runs()
         db.clear_db_serialized_dags()
+
+    @pytest.mark.parametrize("run_on_latest_version", [False, True])
+    def test_clear_task_instances_query_count_does_not_grow_with_task_instances(
+        self, dag_maker, run_on_latest_version
+    ):
+        """Clearing a wide mapped task must not look the dag up once per task instance."""
+
+        def clear_mapped_run(width: int) -> int:
+            with dag_maker(f"test_clear_query_count_{width}", serialized=True):
+                MockOperator.partial(task_id="mapped").expand(arg2=list(range(width)))
+            dr = dag_maker.create_dagrun(state=State.RUNNING, run_type=DagRunType.MANUAL)
+            with create_session() as session:
+                tis = session.scalars(select(TI).where(TI.dag_id == dr.dag_id)).all()
+                assert len(tis) == width
+                for ti in tis:
+                    ti.state = TaskInstanceState.SUCCESS
+                session.flush()
+                with count_queries(session=session) as queries:
+                    clear_task_instances(tis, session=session, run_on_latest_version=run_on_latest_version)
+                    session.flush()
+                count = sum(queries.values())
+                assert all(ti.state is None for ti in tis)
+                archived = (
+                    select(func.count())
+                    .select_from(TaskInstanceHistory)
+                    .where(TaskInstanceHistory.dag_id == dr.dag_id)
+                )
+                assert session.scalar(archived) == width
+            return count
+
+        narrow, wide = clear_mapped_run(3), clear_mapped_run(30)
+        # The flush emits the per-row UPDATEs and INSERTs in batches; everything else is
+        # per dag or per run. A handful of extra statements is tolerated, not one per TI.
+        assert wide - narrow < 10, f"{narrow} queries for 3 TIs, {wide} for 30"
 
     def test_clear_task_instances(self, dag_maker):
         # Explicitly needs catchup as True as test is creating history runs


### PR DESCRIPTION
related: #71488 (its follow-up — “`clear_task_instances` has the same per-TI shape”)

`clear_task_instances` did, for **every** task instance:

- fetch the serialized dag row (data column included) and deserialize it — `DBDagBag.get_latest_version_of_dag` reads and deserializes on every call;
- look the latest `DagVersion` up;
- count its archived tries in `task_instance_history`, and look its `HITLDetail` up (`record_ti`);
- delete its `task_reschedule` rows.

Five round-trips and one full dag deserialization per task instance, inside one transaction that holds the locks of everything already touched. Measured on a run with 3,000 mapped task instances (Airflow 3.3.1, PostgreSQL 17 behind pgbouncer, 2.5 ms RTT, a 2-task dag): `POST clearTaskInstances` took **81 s** (finished run) to **123 s** (failed run) server-side. On a real dag the deserialization alone costs 5–30 ms per call (hundreds of ms cold), so it scales with the dag, not only with the run.

This change resolves once per call what is shared by every task instance of a dag or of a run (the serialized dag, the latest `DagVersion`, the dag of a run), and looks up in bulk what varies per task instance: `TaskInstanceHistory.record_tis` finds the archived tries with one query per dag run and the HITL details with one query, and the reschedules are deleted with one statement (chunked). The outcome per task instance is unchanged — `record_ti` keeps its shape for the single-TI callers and shares the recording code.

Same run, same machine: **81 s → 23 s** and **123 s → 21 s**. The new test locks the query count in: **15 → 123 queries from 3 to 30 task instances before** (19 → 154 with `run_on_latest_version`), bounded now.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

The shapes used here already exist in core, this change only brings `clear_task_instances` in line with them:

- chunked composite-key bulk lookups (`tuple_(...).in_(...)`) — e.g. `api_fastapi/common/db/dag_runs.py` resolves dag versions for a page of runs with one query over `TaskInstance` and one over `TaskInstanceHistory` keyed by `(dag_id, run_id)`, and the bulk PATCH service (`api_fastapi/core_api/services/public/task_instances.py`) fetches TIs by `(dag_id, run_id, task_id, map_index)` tuples;
- the chunking itself is `airflow.utils.helpers.chunks`, used here for the `TaskReschedule` delete;
- resolving a dag once and reusing it is what `DBDagBag` does globally (cache keyed by `dag_version_id`); this change applies the same resolve-once idea at call scope for the latest-version/per-run lookups;
- `Trigger.bulk_fetch` is the existing "fetch many by key → dict" precedent for the shape of `TaskInstanceHistory.record_tis`;
- #68666 did the equivalent set-based rework for the mark-success path.
