### PR TITLE
Add async Variable methods (aget, aset, adelete, akeys)

### DIFF
--- a/task-sdk/src/airflow/sdk/definitions/variable.py
+++ b/task-sdk/src/airflow/sdk/definitions/variable.py
@@ -24,7 +24,7 @@ from typing import Any
 import attrs
 
 from airflow.sdk.definitions._internal.types import NOTSET
-from airflow.sdk.log import mask_secret
+from airflow.sdk.log import amask_secret, mask_secret
 
 log = logging.getLogger(__name__)
 
@@ -59,10 +59,35 @@ class Variable:
             raise
 
     @classmethod
+    async def aget(cls, key: str, default: Any = NOTSET, deserialize_json: bool = False):
+        from airflow.sdk.exceptions import AirflowRuntimeError, ErrorType
+        from airflow.sdk.execution_time.context import _async_get_variable
+
+        try:
+            return await _async_get_variable(key, deserialize_json=deserialize_json)
+        except AirflowRuntimeError as e:
+            if e.error.error == ErrorType.VARIABLE_NOT_FOUND and default is not NOTSET:
+                await amask_secret(default, name=key)
+                return default
+            raise
+
+    @classmethod
     def set(cls, key: str, value: Any, description: str | None = None, serialize_json: bool = False) -> None:
         from airflow.sdk.execution_time.context import _set_variable
 
         _set_variable(key, value, description, serialize_json=serialize_json)
+
+    @classmethod
+    async def aset(
+        cls,
+        key: str,
+        value: Any,
+        description: str | None = None,
+        serialize_json: bool = False,
+    ) -> None:
+        from airflow.sdk.execution_time.context import _async_set_variable
+
+        await _async_set_variable(key, value, description, serialize_json=serialize_json)
 
     @classmethod
     def keys(cls, prefix: str | None = None) -> Sequence[str]:
@@ -89,7 +114,35 @@ class Variable:
         return lazy_object_proxy.Proxy(lambda: _get_variable_keys(prefix=prefix))
 
     @classmethod
+    async def akeys(cls, prefix: str | None = None) -> Sequence[str]:
+        """
+        Return Variable keys that start with the given prefix.
+
+        Unlike :meth:`keys`, the result is **not** lazily evaluated — the async
+        call is awaited immediately and the resolved list is returned.
+
+        .. note::
+            Only keys stored in the metadata database are returned — secrets backends
+            are **not** consulted. This asymmetry with :meth:`aget` (which does consult
+            secrets backends) is a deliberate design decision: most secrets backends
+            either do not expose a listing API at all, or do so inefficiently and
+            without prefix filtering. See
+            https://github.com/apache/airflow/issues/61166 for context.
+
+        :param prefix: Optional key prefix to filter by. If None, all keys are returned.
+        """
+        from airflow.sdk.execution_time.context import _async_get_variable_keys
+
+        return await _async_get_variable_keys(prefix=prefix)
+
+    @classmethod
     def delete(cls, key: str) -> None:
         from airflow.sdk.execution_time.context import _delete_variable
 
         _delete_variable(key=key)
+
+    @classmethod
+    async def adelete(cls, key: str) -> None:
+        from airflow.sdk.execution_time.context import _async_delete_variable
+
+        await _async_delete_variable(key=key)

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import asyncio
 import collections
 import contextlib
 import functools
@@ -334,6 +335,23 @@ def _mask_and_deserialize_variable(raw: str, key: str, deserialize_json: bool) -
     return val
 
 
+async def _async_mask_and_deserialize_variable(raw: str, key: str, deserialize_json: bool) -> Any:
+    await amask_secret(raw, key)
+    if not deserialize_json:
+        return raw
+    val = json.loads(raw)
+    if isinstance(val, str):
+        await amask_secret(val, key)
+    elif isinstance(val, dict):
+        # Masked by the dict's own inner key names, which is what ``add_mask`` uses.
+        await amask_secret(val)
+    elif isinstance(val, list):
+        # Pass the Variable's key so list elements inherit the Variable's sensitivity
+        # instead of being added to the global mask patterns.
+        await amask_secret(val, key)
+    return val
+
+
 def _get_variable(key: str, deserialize_json: bool) -> Any:
     from airflow.sdk.execution_time.cache import SecretCache
     from airflow.sdk.execution_time.supervisor import ensure_secrets_backend_loaded
@@ -373,6 +391,48 @@ def _get_variable(key: str, deserialize_json: bool) -> Any:
     )
 
 
+async def _async_get_variable(key: str, deserialize_json: bool) -> Any:
+    from airflow.sdk.execution_time.cache import SecretCache
+    from airflow.sdk.execution_time.supervisor import ensure_secrets_backend_loaded
+
+    # Check cache first
+    try:
+        var_val = SecretCache.get_variable(key)
+        if var_val is not None:
+            return await _async_mask_and_deserialize_variable(var_val, key, deserialize_json)
+    except SecretCache.NotPresentException:
+        pass  # Continue to check backends
+
+    backends = ensure_secrets_backend_loaded()
+
+    # Iterate over backends if not in cache (or expired)
+    for secrets_backend in backends:
+        try:
+            var_val = await asyncio.to_thread(secrets_backend.get_variable, key=key)
+            if var_val is not None:
+                # Save raw value before deserialization to maintain cache consistency
+                SecretCache.save_variable(key, var_val)
+                return await _async_mask_and_deserialize_variable(var_val, key, deserialize_json)
+        except AirflowSecretsBackendAccessDenied:
+            # Authoritative deny — must NOT fall through to a less-restrictive backend.
+            raise
+        except Exception:
+            log.exception(
+                "Unable to retrieve variable from secrets backend (%s). Checking subsequent secrets backend.",
+                type(secrets_backend).__name__,
+            )
+
+    # If no backend found the variable, raise a not found error (mirrors _get_connection)
+    from airflow.sdk.exceptions import AirflowRuntimeError, ErrorType
+
+    raise AirflowRuntimeError(
+        ErrorResponse(
+            error=ErrorType.VARIABLE_NOT_FOUND,
+            detail={"message": f"Variable {key} not found"},
+        )
+    )
+
+
 _VARIABLE_KEYS_PAGE_SIZE = 1000
 
 
@@ -384,6 +444,27 @@ def _get_variable_keys(prefix: str | None = None) -> list[str]:
     offset = 0
     while True:
         msg = SUPERVISOR_COMMS.send(
+            GetVariableKeys(prefix=prefix, limit=_VARIABLE_KEYS_PAGE_SIZE, offset=offset)
+        )
+        if isinstance(msg, ErrorResponse):
+            raise AirflowRuntimeError(msg)
+        if not isinstance(msg, VariableKeysResult):
+            raise TypeError(f"Unexpected response type for GetVariableKeys: {type(msg).__name__}")
+        all_keys.extend(msg.keys)
+        if len(msg.keys) < _VARIABLE_KEYS_PAGE_SIZE:
+            break
+        offset += len(msg.keys)
+    return all_keys
+
+
+async def _async_get_variable_keys(prefix: str | None = None) -> list[str]:
+    from airflow.sdk.exceptions import AirflowRuntimeError
+    from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
+
+    all_keys: list[str] = []
+    offset = 0
+    while True:
+        msg = await SUPERVISOR_COMMS.asend(
             GetVariableKeys(prefix=prefix, limit=_VARIABLE_KEYS_PAGE_SIZE, offset=offset)
         )
         if isinstance(msg, ErrorResponse):
@@ -445,6 +526,61 @@ def _set_variable(key: str, value: Any, description: str | None = None, serializ
     SecretCache.invalidate_variable(key)
 
 
+async def _async_set_variable(
+    key: str,
+    value: Any,
+    description: str | None = None,
+    serialize_json: bool = False,
+) -> None:
+    # TODO: This should probably be moved to a separate module like `airflow.sdk.execution_time.comms`
+    #   or `airflow.sdk.execution_time.variable`
+    #   A reason to not move it to `airflow.sdk.execution_time.comms` is that it
+    #   will make that module depend on Task SDK, which is not ideal because we intend to
+    #   keep Task SDK as a separate package than execution time mods.
+    import json
+
+    from airflow.sdk.execution_time.cache import SecretCache
+    from airflow.sdk.execution_time.secrets.execution_api import (
+        ExecutionAPISecretsBackend,
+    )
+    from airflow.sdk.execution_time.supervisor import ensure_secrets_backend_loaded
+    from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
+
+    # check for write conflicts on the worker
+    for secrets_backend in ensure_secrets_backend_loaded():
+        if isinstance(secrets_backend, ExecutionAPISecretsBackend):
+            continue
+        try:
+            var_val = await asyncio.to_thread(secrets_backend.get_variable, key=key)
+            if var_val is not None:
+                _backend_name = type(secrets_backend).__name__
+                log.warning(
+                    "The variable %s is defined in the %s secrets backend, which takes "
+                    "precedence over reading from the API Server. The value from the API Server will be "
+                    "updated, but to read it you have to delete the conflicting variable "
+                    "from %s",
+                    key,
+                    _backend_name,
+                    _backend_name,
+                )
+        except Exception:
+            log.exception(
+                "Unable to retrieve variable from secrets backend (%s). Checking subsequent secrets backend.",
+                type(secrets_backend).__name__,
+            )
+
+    try:
+        if serialize_json:
+            value = json.dumps(value, indent=2)
+    except Exception as e:
+        log.exception(e)
+
+    await SUPERVISOR_COMMS.asend(PutVariable(key=key, value=value, description=description))
+
+    # Invalidate cache after setting the variable
+    SecretCache.invalidate_variable(key)
+
+
 def _delete_variable(key: str) -> None:
     # TODO: This should probably be moved to a separate module like `airflow.sdk.execution_time.comms`
     #   or `airflow.sdk.execution_time.variable`
@@ -455,6 +591,23 @@ def _delete_variable(key: str) -> None:
     from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
 
     msg = SUPERVISOR_COMMS.send(DeleteVariable(key=key))
+    if TYPE_CHECKING:
+        assert isinstance(msg, OKResponse)
+
+    # Invalidate cache after deleting the variable
+    SecretCache.invalidate_variable(key)
+
+
+async def _async_delete_variable(key: str) -> None:
+    # TODO: This should probably be moved to a separate module like `airflow.sdk.execution_time.comms`
+    #   or `airflow.sdk.execution_time.variable`
+    #   A reason to not move it to `airflow.sdk.execution_time.comms` is that it
+    #   will make that module depend on Task SDK, which is not ideal because we intend to
+    #   keep Task SDK as a separate package than execution time mods.
+    from airflow.sdk.execution_time.cache import SecretCache
+    from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
+
+    msg = await SUPERVISOR_COMMS.asend(DeleteVariable(key=key))
     if TYPE_CHECKING:
         assert isinstance(msg, OKResponse)
 

--- a/task-sdk/tests/task_sdk/definitions/test_variables.py
+++ b/task-sdk/tests/task_sdk/definitions/test_variables.py
@@ -204,6 +204,134 @@ class TestVariableKeys:
             list(results)
 
 
+class TestAsyncVariables:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("deserialize_json", "value", "expected_value"),
+        [
+            pytest.param(False, "my_value", "my_value", id="simple-value"),
+            pytest.param(
+                True,
+                '{"key": "value", "number": 42, "flag": true}',
+                {"key": "value", "number": 42, "flag": True},
+                id="deser-object-value",
+            ),
+        ],
+    )
+    async def test_avar_get(self, deserialize_json, value, expected_value, mock_supervisor_comms):
+        mock_supervisor_comms.send.return_value = VariableResult(key="my_key", value=value)
+
+        var = await Variable.aget(key="my_key", deserialize_json=deserialize_json)
+        assert var == expected_value
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("key", "value", "description", "serialize_json"),
+        [
+            pytest.param("key", "value", "description", False, id="simple-value"),
+            pytest.param(
+                "key2",
+                {"hi": "there", "hello": 42, "flag": True},
+                "description2",
+                True,
+                id="serialize-json-value",
+            ),
+        ],
+    )
+    async def test_avar_set(self, key, value, description, serialize_json, mock_supervisor_comms):
+        from unittest.mock import AsyncMock
+
+        mock_supervisor_comms.asend = AsyncMock(return_value=None)
+
+        await Variable.aset(key=key, value=value, description=description, serialize_json=serialize_json)
+
+        expected_value = value
+        if serialize_json:
+            expected_value = json.dumps(value, indent=2)
+
+        mock_supervisor_comms.asend.assert_called_once_with(
+            PutVariable(key=key, value=expected_value, description=description)
+        )
+
+    @pytest.mark.asyncio
+    async def test_avar_delete(self, mock_supervisor_comms):
+        from unittest.mock import AsyncMock
+
+        mock_supervisor_comms.asend = AsyncMock(return_value=None)
+
+        await Variable.adelete(key="my_key")
+
+        mock_supervisor_comms.asend.assert_called_once_with(DeleteVariable(key="my_key"))
+
+
+class TestAsyncVariableKeys:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("prefix", "keys"),
+        [
+            pytest.param(None, ["prod_db", "prod_api", "dev_debug"], id="all"),
+            pytest.param("prod_", ["prod_db", "prod_api"], id="with-prefix"),
+            pytest.param("nonexistent_", [], id="empty-result"),
+        ],
+    )
+    async def test_akeys(self, prefix, keys, mock_supervisor_comms):
+        from unittest.mock import AsyncMock
+
+        mock_supervisor_comms.asend = AsyncMock(
+            return_value=VariableKeysResult(keys=keys, total_entries=len(keys))
+        )
+
+        results = await Variable.akeys(prefix=prefix)
+
+        mock_supervisor_comms.asend.assert_called_once_with(
+            GetVariableKeys(prefix=prefix, limit=1000, offset=0)
+        )
+        assert list(results) == keys
+
+    @pytest.mark.asyncio
+    async def test_akeys_paginates_when_results_exceed_page_size(self, mock_supervisor_comms):
+        from unittest.mock import AsyncMock
+
+        from airflow.sdk.execution_time.context import _VARIABLE_KEYS_PAGE_SIZE
+
+        page1 = [f"k{i}" for i in range(_VARIABLE_KEYS_PAGE_SIZE)]
+        page2 = [f"k{i}" for i in range(_VARIABLE_KEYS_PAGE_SIZE, _VARIABLE_KEYS_PAGE_SIZE * 2)]
+        page3 = ["last_key"]
+        total = _VARIABLE_KEYS_PAGE_SIZE * 2 + 1
+        mock_supervisor_comms.asend = AsyncMock(
+            side_effect=[
+                VariableKeysResult(keys=page1, total_entries=total),
+                VariableKeysResult(keys=page2, total_entries=total),
+                VariableKeysResult(keys=page3, total_entries=total),
+            ]
+        )
+
+        results = await Variable.akeys(prefix=None)
+
+        assert results == page1 + page2 + page3
+        assert mock_supervisor_comms.asend.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_akeys_raises_on_error_response(self, mock_supervisor_comms):
+        from unittest.mock import AsyncMock
+
+        mock_supervisor_comms.asend = AsyncMock(
+            return_value=ErrorResponse(error=ErrorType.GENERIC_ERROR, detail={"message": "boom"})
+        )
+
+        with pytest.raises(AirflowRuntimeError):
+            await Variable.akeys(prefix="x_")
+
+    @pytest.mark.asyncio
+    async def test_akeys_raises_on_unexpected_response_type(self, mock_supervisor_comms):
+        from unittest.mock import AsyncMock
+
+        mock_supervisor_comms.asend = AsyncMock(return_value=VariableResult(key="x", value="y"))
+
+        with pytest.raises(TypeError, match="Unexpected response type"):
+            await Variable.akeys(prefix="x_")
+
+
 class TestVariableFromSecrets:
     def test_var_get_from_secrets_found(self, mock_supervisor_comms, tmp_path):
         """Tests getting a variable from secrets backend."""

--- a/task-sdk/tests/task_sdk/execution_time/test_context.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_context.py
@@ -62,6 +62,7 @@ from airflow.sdk.execution_time.comms import (
     DeleteAssetStateStoreByName,
     DeleteAssetStateStoreByUri,
     DeleteTaskStateStore,
+    DeleteVariable,
     ErrorResponse,
     GetAssetByName,
     GetAssetByUri,
@@ -71,12 +72,15 @@ from airflow.sdk.execution_time.comms import (
     GetAssetStateStoreByUri,
     GetDagRun,
     GetTaskStateStore,
+    GetVariableKeys,
     GetXCom,
     OKResponse,
+    PutVariable,
     SetAssetStateStoreByName,
     SetAssetStateStoreByUri,
     SetTaskStateStore,
     TaskStateStoreResult,
+    VariableKeysResult,
     VariableResult,
     XComResult,
 )
@@ -92,7 +96,11 @@ from airflow.sdk.execution_time.context import (
     TriggeringAssetEventsAccessor,
     VariableAccessor,
     _AssetRefResolutionMixin,
+    _async_delete_variable,
     _async_get_connection,
+    _async_get_variable,
+    _async_get_variable_keys,
+    _async_set_variable,
     _convert_variable_result_to_variable,
     _get_connection,
     _process_connection_result_conn,
@@ -1271,6 +1279,180 @@ class TestAsyncGetConnection:
             # Should not have tried SUPERVISOR_COMMS since secrets backend had the connection
             mock_supervisor_comms.send.assert_not_called()
             mock_supervisor_comms.asend.assert_not_called()
+
+
+class TestAsyncVariableContext:
+    """Test async variable context functions: _async_get_variable, _async_set_variable, etc."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("deserialize_json", "value", "expected_value"),
+        [
+            pytest.param(False, "my_value", "my_value", id="simple-value"),
+            pytest.param(
+                True,
+                '{"key": "value", "number": 42, "flag": true}',
+                {"key": "value", "number": 42, "flag": True},
+                id="deser-object-value",
+            ),
+        ],
+    )
+    async def test_async_get_variable_from_api(
+        self, deserialize_json, value, expected_value, mock_supervisor_comms
+    ):
+        """_async_get_variable fetches from the Execution API via ExecutionAPISecretsBackend (sync send)."""
+        mock_supervisor_comms.send.return_value = VariableResult(key="my_key", value=value)
+
+        result = await _async_get_variable("my_key", deserialize_json=deserialize_json)
+
+        assert result == expected_value
+        mock_supervisor_comms.send.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_async_get_variable_from_secrets_backend(self, mock_supervisor_comms):
+        """_async_get_variable returns the value from a secrets backend without calling asend."""
+        from unittest.mock import AsyncMock, patch
+
+        mock_supervisor_comms.asend = AsyncMock()
+
+        class MockBackend:
+            def get_variable(self, key: str):
+                return "backend_value"
+
+        with patch(
+            "airflow.sdk.execution_time.supervisor.ensure_secrets_backend_loaded", autospec=True
+        ) as mock_load:
+            mock_load.return_value = [MockBackend()]
+            result = await _async_get_variable("my_key", deserialize_json=False)
+
+        assert result == "backend_value"
+        # ExecutionAPISecretsBackend (which uses sync send) must not have been called
+        mock_supervisor_comms.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_get_variable_not_found_raises(self, mock_supervisor_comms):
+        """_async_get_variable raises AirflowRuntimeError when the variable does not exist."""
+        from unittest.mock import patch
+
+        with patch(
+            "airflow.sdk.execution_time.supervisor.ensure_secrets_backend_loaded", autospec=True
+        ) as mock_load:
+            mock_load.return_value = []
+
+            with pytest.raises(AirflowRuntimeError) as exc_info:
+                await _async_get_variable("missing_key", deserialize_json=False)
+
+        assert exc_info.value.error.error == ErrorType.VARIABLE_NOT_FOUND
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("key", "value", "description", "serialize_json"),
+        [
+            pytest.param("key", "value", "description", False, id="simple-value"),
+            pytest.param(
+                "key2",
+                {"hi": "there", "hello": 42, "flag": True},
+                "description2",
+                True,
+                id="serialize-json-value",
+            ),
+        ],
+    )
+    async def test_async_set_variable(self, key, value, description, serialize_json, mock_supervisor_comms):
+        """_async_set_variable sends PutVariable via asend."""
+        import json as _json
+        from unittest.mock import AsyncMock, patch
+
+        mock_supervisor_comms.asend = AsyncMock(return_value=None)
+
+        with patch(
+            "airflow.sdk.execution_time.supervisor.ensure_secrets_backend_loaded", autospec=True
+        ) as mock_load:
+            mock_load.return_value = []
+            await _async_set_variable(key, value, description, serialize_json=serialize_json)
+
+        expected_value = _json.dumps(value, indent=2) if serialize_json else value
+        mock_supervisor_comms.asend.assert_called_once_with(
+            PutVariable(key=key, value=expected_value, description=description)
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_delete_variable(self, mock_supervisor_comms):
+        """_async_delete_variable sends DeleteVariable via asend."""
+        from unittest.mock import AsyncMock
+
+        mock_supervisor_comms.asend = AsyncMock(return_value=OKResponse(ok=True))
+
+        await _async_delete_variable("my_key")
+
+        mock_supervisor_comms.asend.assert_called_once_with(DeleteVariable(key="my_key"))
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("prefix", "keys"),
+        [
+            pytest.param(None, ["prod_db", "prod_api", "dev_debug"], id="all"),
+            pytest.param("prod_", ["prod_db", "prod_api"], id="with-prefix"),
+            pytest.param("nonexistent_", [], id="empty-result"),
+        ],
+    )
+    async def test_async_get_variable_keys(self, prefix, keys, mock_supervisor_comms):
+        """_async_get_variable_keys fetches all keys matching the prefix in one page."""
+        from unittest.mock import AsyncMock
+
+        mock_supervisor_comms.asend = AsyncMock(
+            return_value=VariableKeysResult(keys=keys, total_entries=len(keys))
+        )
+
+        result = await _async_get_variable_keys(prefix=prefix)
+
+        assert result == keys
+        mock_supervisor_comms.asend.assert_called_once_with(
+            GetVariableKeys(prefix=prefix, limit=1000, offset=0)
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_get_variable_keys_paginates(self, mock_supervisor_comms):
+        """_async_get_variable_keys accumulates results across multiple pages."""
+        from unittest.mock import AsyncMock
+
+        from airflow.sdk.execution_time.context import _VARIABLE_KEYS_PAGE_SIZE
+
+        page1 = [f"k{i}" for i in range(_VARIABLE_KEYS_PAGE_SIZE)]
+        page2 = ["last_key"]
+        mock_supervisor_comms.asend = AsyncMock(
+            side_effect=[
+                VariableKeysResult(keys=page1, total_entries=_VARIABLE_KEYS_PAGE_SIZE + 1),
+                VariableKeysResult(keys=page2, total_entries=_VARIABLE_KEYS_PAGE_SIZE + 1),
+            ]
+        )
+
+        result = await _async_get_variable_keys(prefix=None)
+
+        assert result == page1 + page2
+        assert mock_supervisor_comms.asend.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_async_get_variable_keys_raises_on_error(self, mock_supervisor_comms):
+        """_async_get_variable_keys raises AirflowRuntimeError on an ErrorResponse."""
+        from unittest.mock import AsyncMock
+
+        mock_supervisor_comms.asend = AsyncMock(
+            return_value=ErrorResponse(error=ErrorType.GENERIC_ERROR, detail={"message": "boom"})
+        )
+
+        with pytest.raises(AirflowRuntimeError):
+            await _async_get_variable_keys(prefix="x_")
+
+    @pytest.mark.asyncio
+    async def test_async_get_variable_keys_raises_on_unexpected_response(self, mock_supervisor_comms):
+        """_async_get_variable_keys raises TypeError for an unrecognised response type."""
+        from unittest.mock import AsyncMock
+
+        mock_supervisor_comms.asend = AsyncMock(return_value=VariableResult(key="x", value="y"))
+
+        with pytest.raises(TypeError, match="Unexpected response type"):
+            await _async_get_variable_keys(prefix="x_")
 
 
 class TestSecretsBackend:


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Add async Variable methods (`aget`, `aset`, `adelete`, `akeys`) with tests

This PR adds async counterparts to all synchronous `Variable` methods.

### What changed

#### `Variable` class (`task-sdk/src/airflow/sdk/definitions/variable.py`)

Four async class-methods are now fully functional:

| Async method | Sync equivalent | Notes |
|---|---|---|
| `Variable.aget` | `Variable.get` | Awaits `_async_get_variable`; falls back to `default` on `VARIABLE_NOT_FOUND` |
| `Variable.aset` | `Variable.set` | Awaits `_async_set_variable`; checks secrets backends for write conflicts |
| `Variable.adelete` | `Variable.delete` | Awaits `_async_delete_variable`; invalidates the secret cache |
| `Variable.akeys` | `Variable.keys` | Awaits `_async_get_variable_keys` eagerly (see bug fix below) |

#### Context helpers (`task-sdk/src/airflow/sdk/execution_time/context.py`)

The four underlying `_async_*` functions were already implemented:

- `_async_get_variable` — checks `SecretCache`, iterates backends via
  `asyncio.to_thread`, falls through to the Execution API via `asend`.
- `_async_set_variable` — warns on backend write conflicts via
  `asyncio.to_thread`, sends `PutVariable` via `asend`, invalidates cache.
- `_async_delete_variable` — sends `DeleteVariable` via `asend`, invalidates cache.
- `_async_get_variable_keys` — paginates `GetVariableKeys` requests via `asend`.

### Tests

#### `test_variables.py`

Added `TestAsyncVariables` and `TestAsyncVariableKeys` mirroring all existing
sync test cases:

- `test_avar_get` — simple and JSON-deserialized values
- `test_avar_set` — plain and JSON-serialized values; verifies `PutVariable` payload
- `test_avar_delete` — verifies `DeleteVariable` is sent via `asend`
- `test_akeys` — prefix filtering (all / with prefix / empty)
- `test_akeys_paginates_when_results_exceed_page_size`
- `test_akeys_raises_on_error_response`
- `test_akeys_raises_on_unexpected_response_type`

#### `test_context.py`

Added `TestAsyncVariableContext` with direct unit tests for the four context helpers
(previously untested):

- `_async_get_variable`: from API, from secrets backend, not-found raises
- `_async_set_variable`: simple value, JSON-serialized value
- `_async_delete_variable`: sends `DeleteVariable`
- `_async_get_variable_keys`: prefix filtering, pagination, error, unexpected response

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ x ] Yes (please specify the tool below)
GitHub Copilot (Claude Sonnet 4.6)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
