### PR TITLE
Fix misleading error for malformed version in airflow db downgrade

### DIFF
--- a/airflow-core/src/airflow/cli/commands/db_command.py
+++ b/airflow-core/src/airflow/cli/commands/db_command.py
@@ -174,10 +174,18 @@ def run_db_downgrade_command(args, command, revision_heads_map: dict[str, str]):
     if args.from_revision:
         from_revision = args.from_revision
     elif args.from_version:
+        try:
+            parse_version(args.from_version)
+        except InvalidVersion:
+            raise SystemExit(f"Invalid version {args.from_version!r} supplied as `--from-version`.")
         from_revision = _get_version_revision(args.from_version, revision_heads_map=revision_heads_map)
         if not from_revision:
             raise SystemExit(f"Unknown version {args.from_version!r} supplied as `--from-version`.")
     if args.to_version:
+        try:
+            parse_version(args.to_version)
+        except InvalidVersion:
+            raise SystemExit(f"Invalid version {args.to_version!r} supplied as `--to-version`.")
         to_revision = _get_version_revision(args.to_version, revision_heads_map=revision_heads_map)
         if not to_revision:
             raise SystemExit(f"Downgrading to version {args.to_version} is not supported.")

--- a/airflow-core/tests/unit/cli/commands/test_db_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_db_command.py
@@ -644,6 +644,28 @@ class TestCliDb:
             (
                 {
                     "to_revision": None,
+                    "to_version": "abc",
+                    "from_revision": None,
+                    "from_version": None,
+                    "show_sql_only": False,
+                    "yes": True,
+                },
+                "Invalid version 'abc' supplied as `--to-version`",
+            ),
+            (
+                {
+                    "to_revision": "abc1",
+                    "to_version": None,
+                    "from_revision": None,
+                    "from_version": "abc",
+                    "show_sql_only": True,
+                    "yes": True,
+                },
+                "Invalid version 'abc' supplied as `--from-version`",
+            ),
+            (
+                {
+                    "to_revision": None,
                     "to_version": None,
                     "from_revision": "abc",
                     "from_version": None,
@@ -726,7 +748,12 @@ class TestCliDb:
                 ["-y", "--to-revision", "abc", "--from-version", "2.2.0", "--from-revision", "abc"],
                 "may not be combined",
             ),
-            (["-y", "--to-version", "abc"], r"Downgrading to .* not supported\."),
+            (["-y", "--to-version", "2.1.25"], r"Downgrading to .* not supported\."),
+            (["-y", "--to-version", "abc"], "Invalid version 'abc' supplied as `--to-version`"),
+            (
+                ["-y", "--to-revision", "abc1", "--from-version", "abc", "-s"],
+                "Invalid version 'abc' supplied as `--from-version`",
+            ),
             (["-y"], "Must provide either"),
         ],
     )


### PR DESCRIPTION
## Why

`airflow db migrate` validates `--to-version` / `--from-version` with `parse_version` before resolving them to an Alembic revision, but `airflow db downgrade` does not. A malformed value therefore falls through to the revision lookup, which fails to parse it and returns `None`, and the user gets:

```
Downgrading to version abc is not supported.
```

That reads as though `abc` is a real version that downgrade refuses to target, pointing users at the docs instead of at their typo. `migrate` reports `Invalid version 'abc' supplied as --to-version.` for the same input.

## What

- `airflow-core/src/airflow/cli/commands/db_command.py`: `run_db_downgrade_command` now validates `--from-version` and `--to-version` with `parse_version` before the revision lookup, raising the same `Invalid version ...` message as `run_db_migrate_command`. The existing `Unknown version` / `not supported` messages are unchanged and now only fire for well-formed versions with no matching revision.
- `airflow-core/tests/unit/cli/commands/test_db_command.py`: added malformed-version cases for both flags at the function and CLI level; the existing CLI case for `not supported` now uses `2.1.25` (well-formed but unknown, matching the `migrate` tests) so that path stays covered.

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code