### PR TITLE
Remove unreachable break in get_bagged_dag

### DIFF
--- a/airflow-core/src/airflow/utils/cli.py
+++ b/airflow-core/src/airflow/utils/cli.py
@@ -316,8 +316,6 @@ def get_bagged_dag(bundle_names: list | None, dag_id: str, dagfile_path: str | N
             sync_bag_to_db(dagbag, bundle.name, bundle.version)
         if dag := dagbag.dags.get(dag_id):
             return dag
-        if dag:
-            break
     raise AirflowException(
         f"Dag {dag_id!r} could not be found; either it does not exist or it failed to parse."
     )


### PR DESCRIPTION
## Why

The second bundle loop in `get_bagged_dag` ends with:

```python
if dag := dagbag.dags.get(dag_id):
    return dag
if dag:
    break
```

The walrus assignment returns as soon as a Dag is found, so `if dag:` is only ever reached when `dag` is falsy — the `break` cannot run. The first bundle loop in the same function already uses the plain early return, so removing it also makes the two loops read the same way.

## What

- `airflow-core/src/airflow/utils/cli.py`: dropped the unreachable `if dag: break` from `get_bagged_dag`. No behavior change — the intent (stop searching once the Dag is found) is already served by the `return`, so no tests are added.