### PR TITLE
Fix SageMakerUnifiedStudioNotebookOperator workflow_name under MWAA Serverless

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/sagemaker_unified_studio_notebook.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/sagemaker_unified_studio_notebook.py
@@ -173,7 +173,11 @@ class SageMakerUnifiedStudioNotebookOperator(AwsBaseOperator[SageMakerUnifiedStu
             region_name=self.hook.conn_region_name,
             aws_partition=self.hook.conn_partition,
         )
-        workflow_name = context["dag"].dag_id  # Workflow name is the same as the dag_id
+        # MWAA Serverless overwrites dag_id with the execution ID for tenant isolation and
+        # injects the real workflow name as a DAG param, so prefer that when set. For standard
+        # Workflows and open-source Airflow, dag_id is the workflow name.
+        params = context.get("params") or {}
+        workflow_name = params.get("mwaa_serverless_workflow_id") or context["dag"].dag_id
         response = self.hook.start_notebook_run(
             notebook_identifier=self.notebook_identifier,
             domain_identifier=self.domain_identifier,

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_sagemaker_unified_studio_notebook.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_sagemaker_unified_studio_notebook.py
@@ -42,12 +42,12 @@ HOOK_PATH = (
 )
 
 
-def _make_context(dag_id=DAG_ID):
+def _make_context(dag_id=DAG_ID, params=None):
     """Build a minimal mock context with a dag that has a dag_id."""
     dag = MagicMock()
     dag.dag_id = dag_id
     ti = MagicMock()
-    return {"dag": dag, "ti": ti}
+    return {"dag": dag, "ti": ti, "params": params if params is not None else {}}
 
 
 class TestSageMakerUnifiedStudioNotebookOperator:
@@ -172,6 +172,57 @@ class TestSageMakerUnifiedStudioNotebookOperator:
 
         call_kwargs = mock_hook.start_notebook_run.call_args[1]
         assert call_kwargs["workflow_name"] == "my_custom_dag"
+
+    @patch(HOOK_PATH, new_callable=PropertyMock)
+    def test_execute_prefers_mwaa_serverless_workflow_id_param(self, mock_hook_prop):
+        """Under MWAA Serverless, dag_id is the per-execution UUID; the real workflow name is
+        injected as the `mwaa_serverless_workflow_id` DAG param and must be preferred."""
+        mock_hook = MagicMock()
+        mock_hook_prop.return_value = mock_hook
+        mock_hook.start_notebook_run.return_value = {"id": NOTEBOOK_RUN_ID}
+        mock_hook.wait_for_notebook_run.return_value = {}
+        mock_hook.get_notebook_outputs.return_value = {}
+
+        op = SageMakerUnifiedStudioNotebookOperator(
+            task_id=TASK_ID,
+            notebook_identifier=NOTEBOOK_ID,
+            domain_identifier=DOMAIN_ID,
+            owning_project_identifier=PROJECT_ID,
+        )
+        op.execute(
+            _make_context(
+                dag_id="execution-uuid-12345",
+                params={"mwaa_serverless_workflow_id": "my-real-workflow-a1b2c3d4"},
+            )
+        )
+
+        call_kwargs = mock_hook.start_notebook_run.call_args[1]
+        assert call_kwargs["workflow_name"] == "my-real-workflow-a1b2c3d4"
+
+    @patch(HOOK_PATH, new_callable=PropertyMock)
+    def test_execute_falls_back_to_dag_id_when_param_empty(self, mock_hook_prop):
+        """An empty-string or missing `mwaa_serverless_workflow_id` param falls back to dag_id."""
+        mock_hook = MagicMock()
+        mock_hook_prop.return_value = mock_hook
+        mock_hook.start_notebook_run.return_value = {"id": NOTEBOOK_RUN_ID}
+        mock_hook.wait_for_notebook_run.return_value = {}
+        mock_hook.get_notebook_outputs.return_value = {}
+
+        op = SageMakerUnifiedStudioNotebookOperator(
+            task_id=TASK_ID,
+            notebook_identifier=NOTEBOOK_ID,
+            domain_identifier=DOMAIN_ID,
+            owning_project_identifier=PROJECT_ID,
+        )
+        op.execute(
+            _make_context(
+                dag_id="fallback_dag",
+                params={"mwaa_serverless_workflow_id": ""},
+            )
+        )
+
+        call_kwargs = mock_hook.start_notebook_run.call_args[1]
+        assert call_kwargs["workflow_name"] == "fallback_dag"
 
     # --- execute propagates hook failures ---
 


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

## Description 

Under MWAA Serverless (Overdrive), `dag_id` is overwritten with a per-execution UUID for
tenant isolation, so the operator was passing the execution UUID as `workflow_name` to
`StartNotebookRun` instead of the actual workflow name. This breaks the SMUS UI's ability
to link a notebook run back to the workflow that triggered it.

MWAA Serverless now injects the workflow name as a DAG param under the key
`mwaa_serverless_workflow_id`. Read from that param when set, fall back to
`context["dag"].dag_id` for standard SMUS Workflows and open-source Airflow.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)
Claude Opus 4.7

## Testing

Ran system test:

```
qashikin@c889f3b847e4 airflow % .venv/bin/python -m pytest --system -v --with-db-init \
  --setup-timeout=3600 --execution-timeout=3600 --teardown-timeout=3600 \
  providers/amazon/tests/system/amazon/aws/example_sagemaker_unified_studio_notebook.py
======================================== test session starts =========================================
platform darwin -- Python 3.11.14, pytest-9.1.1, pluggy-1.6.0 -- /Volumes/workplace/airflow/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Volumes/workplace/airflow
configfile: pyproject.toml
plugins: mock-3.15.1, instafail-0.5.0, time-machine-3.4.0, unordered-0.8.0, cov-7.1.0, timeouts-1.2.1, xdist-3.8.0, asyncio-1.4.0, custom-exit-code-0.3.0, anyio-4.14.2, icdiff-0.9, rerunfailures-16.6, kgb-7.3, requests-mock-1.12.1
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
setup timeout: 3600.0s, execution timeout: 3600.0s, teardown timeout: 3600.0s
collected 1 item                                                                                     

providers/amazon/tests/system/amazon/aws/example_sagemaker_unified_studio_notebook.py::test_runel-common/src/tests_common/test_utils/system_tests.py PASSED [100%]

========================== 1 passed, 1 warning in 290.96s (0:04:50) ===========================
```

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
