### PR TITLE
Prevent Dag CLI subcommands from being silently dropped

### DIFF
--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -2348,24 +2348,24 @@ core_commands: list[CLICommand] = [
 
 def _remove_dag_id_opt(command: ActionCommand):
     cmd = command._asdict()
-    cmd["args"] = (arg for arg in command.args if arg is not ARG_DAG_ID)
+    cmd["args"] = tuple(arg for arg in command.args if arg is not ARG_DAG_ID)
     return ActionCommand(**cmd)
 
+
+# Subcommands ``DAG.cli()`` exposes, via ``get_parser(dag_parser=True)``.
+DAG_CLI_DAGS_SUBCOMMANDS = ("list-runs", "pause", "unpause", "test")
+DAG_CLI_TASKS_SUBCOMMANDS = ("list", "test")
 
 dag_cli_commands: list[CLICommand] = [
     GroupCommand(
         name="dags",
         help="Manage DAGs",
-        subcommands=[
-            _remove_dag_id_opt(sp)
-            for sp in DAGS_COMMANDS
-            if sp.name in ["backfill", "list-runs", "pause", "unpause", "test"]
-        ],
+        subcommands=[_remove_dag_id_opt(sp) for sp in DAGS_COMMANDS if sp.name in DAG_CLI_DAGS_SUBCOMMANDS],
     ),
     GroupCommand(
         name="tasks",
         help="Manage tasks",
-        subcommands=[_remove_dag_id_opt(sp) for sp in TASKS_COMMANDS if sp.name in ["list", "test", "run"]],
+        subcommands=[_remove_dag_id_opt(sp) for sp in TASKS_COMMANDS if sp.name in DAG_CLI_TASKS_SUBCOMMANDS],
     ),
 ]
 DAG_CLI_DICT: dict[str, CLICommand] = {sp.name: sp for sp in dag_cli_commands}

--- a/airflow-core/tests/unit/cli/test_cli_parser.py
+++ b/airflow-core/tests/unit/cli/test_cli_parser.py
@@ -496,6 +496,26 @@ class TestCli:
             with pytest.raises(SystemExit):
                 parser.parse_args([*cmd_args, "--help"])
 
+    @pytest.mark.parametrize(
+        ("selected_names", "source_commands"),
+        [
+            pytest.param(cli_config.DAG_CLI_DAGS_SUBCOMMANDS, cli_config.DAGS_COMMANDS, id="dags"),
+            pytest.param(cli_config.DAG_CLI_TASKS_SUBCOMMANDS, cli_config.TASKS_COMMANDS, id="tasks"),
+        ],
+    )
+    def test_dag_cli_subcommands_all_exist(self, selected_names, source_commands):
+        """A name that no longer exists is silently dropped, so guard against stale entries."""
+        assert set(selected_names) <= {command.name for command in source_commands}
+
+    def test_dag_cli_parser_keeps_args_when_rebuilt(self):
+        """``_remove_dag_id_opt`` must not hand argparse a one-shot generator."""
+        cli_parser.get_parser.cache_clear()
+        first = vars(cli_parser.get_parser(dag_parser=True).parse_args(["dags", "pause"]))
+        cli_parser.get_parser.cache_clear()
+        second = vars(cli_parser.get_parser(dag_parser=True).parse_args(["dags", "pause"]))
+
+        assert first.keys() == second.keys()
+
     def test_positive_int(self):
         assert cli_config.positive_int(allow_zero=True)("1") == 1
         assert cli_config.positive_int(allow_zero=True)("0") == 0

--- a/airflow-core/tests/unit/cli/test_cli_parser.py
+++ b/airflow-core/tests/unit/cli/test_cli_parser.py
@@ -513,7 +513,7 @@ class TestCli:
         first = vars(cli_parser.get_parser(dag_parser=True).parse_args(["dags", "pause"]))
         cli_parser.get_parser.cache_clear()
         second = vars(cli_parser.get_parser(dag_parser=True).parse_args(["dags", "pause"]))
-
+        assert "treat_dag_id_as_regex" in first
         assert first.keys() == second.keys()
 
     def test_positive_int(self):


### PR DESCRIPTION
`DAG.cli()` turns a Dag file into its own CLI entry point
(`python my_dag.py tasks test ...`). The subcommands it exposes are picked by
matching command names against a hardcoded list — a construct where a stale
name matches nothing and disappears without any error.

Two of those names were stale:

- `dags backfill` — moved out to the top-level `backfill create` command
- `tasks run` — removed

Both had been silently dropping out of the Dag CLI. The names now live in
`DAG_CLI_DAGS_SUBCOMMANDS` / `DAG_CLI_TASKS_SUBCOMMANDS` so a test can check
them against the real command tables.

While in there, `_remove_dag_id_opt` built each command's `args` as a generator
expression, which can only be walked once. `get_parser` is cached so this
normally goes unnoticed, but any rebuild produced subcommands with every
argument missing — `dags pause` went from 6 parsed attributes down to 2, and
`set_is_paused` would then fail on the absent `args.treat_dag_id_as_regex`.

Both failure modes are silent, so each gets a regression test.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
