### PR TITLE
Stop airflow providers get --full mutating cached provider metadata

### DIFF
--- a/airflow-core/src/airflow/cli/commands/provider_command.py
+++ b/airflow-core/src/airflow/cli/commands/provider_command.py
@@ -44,9 +44,8 @@ def provider_get(args):
         provider_version = providers[args.provider_name].version
         provider_info = providers[args.provider_name].data
         if args.full:
-            provider_info["description"] = _remove_rst_syntax(provider_info["description"])
             AirflowConsole().print_as(
-                data=[provider_info],
+                data=[{**provider_info, "description": _remove_rst_syntax(provider_info["description"])}],
                 output=args.output,
             )
         else:

--- a/airflow-core/tests/unit/cli/commands/test_provider_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_provider_command.py
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from airflow.cli import cli_parser
+from airflow.cli.commands import provider_command
+from airflow.providers_manager import ProviderInfo
+
+RST_DESCRIPTION = "`Apache Beam <https://beam.apache.org/>`__.\n"
+PLAIN_DESCRIPTION = "Apache Beam https://beam.apache.org/"
+
+
+class TestCliProviderGet:
+    @classmethod
+    def setup_class(cls):
+        cls.parser = cli_parser.get_parser()
+
+    @pytest.fixture
+    def provider_info(self):
+        return ProviderInfo(
+            version="1.0.0",
+            data={"package-name": "apache-airflow-providers-beam", "description": RST_DESCRIPTION},
+        )
+
+    @mock.patch("airflow.cli.commands.provider_command.AirflowConsole", autospec=True)
+    @mock.patch("airflow.cli.commands.provider_command.ProvidersManager", autospec=True)
+    def test_provider_get_full_keeps_providers_manager_data_intact(
+        self, mock_providers_manager, mock_console, provider_info
+    ):
+        mock_providers_manager.return_value.providers = {
+            "apache-airflow-providers-beam": provider_info,
+        }
+
+        provider_command.provider_get(
+            self.parser.parse_args(["providers", "get", "apache-airflow-providers-beam", "--full"])
+        )
+
+        assert mock_console.return_value.print_as.call_args.kwargs["data"] == [
+            {"package-name": "apache-airflow-providers-beam", "description": PLAIN_DESCRIPTION}
+        ]
+        assert provider_info.data["description"] == RST_DESCRIPTION


### PR DESCRIPTION
`ProvidersManager` is a process-wide singleton, and its `providers` property hands
out the live `_provider_dict` without copying — so `ProviderInfo.data` is the cached
dict itself, not a copy.

`airflow providers get <name> --full` was assigning its de-RST'd description straight
back into that dict, so a command whose only job is to format data for display
permanently rewrote global provider metadata as a side effect. It now builds a copy
to render instead.

### How reachable is it?

Latent rather than user-visible, and worth being explicit about:

- the `airflow` CLI is a one-shot process — nothing reads the description again
  before it exits
- the API server reads the same cache, but runs in a different process
- the two other in-tree readers (`providers_list` and the public API's provider
  service) re-sanitize the description themselves, and `_remove_rst_syntax` is
  idempotent for every description shipped today

Where it *is* reachable is a pytest process: the singleton persists across tests and
`cleanup_providers_manager` is opt-in rather than autouse, so a test exercising the
unmocked command would leak a sanitized description into the rest of the session. No
test does that today, which is why nothing has caught it.

### Test

`provider_command` was the only module under `airflow/cli/commands/` without a
matching test file, so the regression test starts one. It asserts both that the
rendered payload still has the RST stripped and that the source dict is untouched —
the second assertion is the one that fails without this change.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)