### PR TITLE
fix(openlineage,trino,common.sql): handle missing host and optional sqlalchemy gracefully

### DIFF
--- a/providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py
@@ -1148,7 +1148,7 @@ class DbApiHook(BaseHook):
         """
 
     @staticmethod
-    def get_openlineage_authority_part(connection, default_port: int | None = None) -> str:
+    def get_openlineage_authority_part(connection, default_port: int | None = None) -> str | None:
         """
         Get authority part from Airflow Connection.
 
@@ -1156,14 +1156,15 @@ class DbApiHook(BaseHook):
         and conforms OpenLineage naming convention for a number of databases (e.g. MySQL, Postgres, Trino).
 
         :param default_port: (optional) used if no port parsed from connection URI
+        :return: authority string (host:port or host) or None if no host is configured
         """
         parsed = urlparse(connection.get_uri())
+        if not parsed.hostname:
+            return None
         port = parsed.port or default_port
         if port:
-            authority = f"{parsed.hostname}:{port}"
-        else:
-            authority = parsed.hostname
-        return authority
+            return f"{parsed.hostname}:{port}"
+        return parsed.hostname
 
     def get_db_log_messages(self, conn) -> None:
         """

--- a/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
@@ -776,6 +776,10 @@ if not AIRFLOW_V_3_0_PLUS:
 def safe_getattr(obj: Any, attr: str, default: Any = None) -> Any:
     """Get attribute from object, returning default if DetachedInstanceError is raised."""
     try:
+        from sqlalchemy.orm.exc import DetachedInstanceError
+    except ImportError:
+        return getattr(obj, attr, default)
+    try:
         return getattr(obj, attr, default)
     except DetachedInstanceError:
         return default

--- a/providers/trino/src/airflow/providers/trino/hooks/trino.py
+++ b/providers/trino/src/airflow/providers/trino/hooks/trino.py
@@ -399,11 +399,17 @@ class TrinoHook(DbApiHook):
         """Return Trino specific information for OpenLineage."""
         from airflow.providers.openlineage.sqlparser import DatabaseInfo
 
+        authority = DbApiHook.get_openlineage_authority_part(
+            connection, default_port=trino.constants.DEFAULT_PORT
+        )
+        if not authority:
+            raise AirflowOptionalProviderFeatureException(
+                "Cannot determine OpenLineage authority from connection: "
+                "connection host is required. Please set the host in your Trino connection."
+            )
         return DatabaseInfo(
             scheme="trino",
-            authority=DbApiHook.get_openlineage_authority_part(
-                connection, default_port=trino.constants.DEFAULT_PORT
-            ),
+            authority=authority,
             information_schema_columns=[
                 "table_schema",
                 "table_name",


### PR DESCRIPTION
## What
Three related fixes bundled into one PR:

1. **`providers/common/sql/hooks/sql.py`**: `get_openlineage_authority_part()` now returns `None` when hostname is missing instead of crashing, and the return type is updated to `str | None`.

2. **`providers/trino/hooks/trino.py`**: `get_openlineage_database_info()` raises `AirflowOptionalProviderFeatureException` with a clear message when connection host is missing.

3. **`providers/openlineage/utils/utils.py`**: `DetachedInstanceError` is now a lazy import inside `safe_getattr()` — only imported when sqlalchemy is installed, preventing import errors when sqlalchemy is not present.

## Test plan
- Existing provider tests continue to pass
- Manual testing confirms graceful fallback when host is not configured

Fixes #52419, #52243, #51780