### PR TITLE
More human readable duration strings

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceConfirmationDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceConfirmationDialog.tsx
@@ -27,7 +27,7 @@ import type { ClearTaskInstancesBody } from "openapi/requests/types.gen";
 import { Dialog } from "src/system-components";
 
 import { useClearTaskInstancesDryRun } from "src/queries/useClearTaskInstancesDryRun";
-import { getRelativeTime } from "src/utils/datetimeUtils";
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 type Props = {
   readonly dagDetails?: {
@@ -56,6 +56,7 @@ const ClearTaskInstanceConfirmationDialog = ({
   preventRunningTask,
 }: Props) => {
   const { t: translate } = useTranslation();
+  const { formatRelative } = useDurationFormat();
   const useExplicitTaskIds = dagDetails?.taskIds !== undefined;
   const { data, isFetching } = useClearTaskInstancesDryRun({
     dagId: dagDetails?.dagId ?? "",
@@ -127,7 +128,7 @@ const ClearTaskInstanceConfirmationDialog = ({
                         state: taskCurrentState,
                         time:
                           firstInstance?.start_date !== null && firstInstance?.start_date !== undefined
-                            ? getRelativeTime(firstInstance.start_date)
+                            ? formatRelative(firstInstance.start_date)
                             : undefined,
                         user:
                           (firstInstance?.unixname?.trim().length ?? 0) > 0

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceConfirmationDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceConfirmationDialog.tsx
@@ -27,7 +27,7 @@ import type { ClearTaskInstancesBody } from "openapi/requests/types.gen";
 import { Dialog } from "src/system-components";
 
 import { useClearTaskInstancesDryRun } from "src/queries/useClearTaskInstancesDryRun";
-import { useDurationFormat } from "src/utils/useDurationFormat";
+import { useDurationFormat } from "src/utils";
 
 type Props = {
   readonly dagDetails?: {

--- a/airflow-core/src/airflow/ui/src/components/DagRunInfo.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagRunInfo.tsx
@@ -25,7 +25,7 @@ import { Tooltip } from "src/system-components";
 
 import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
-import { getRelativeTime } from "src/utils/datetimeUtils";
+
 import { useDurationFormat } from "src/utils/useDurationFormat";
 
 type Props = {
@@ -38,7 +38,7 @@ type Props = {
 
 const DagRunInfo = ({ endDate, logicalDate, runAfter, startDate, state }: Props) => {
   const { t: translate } = useTranslation();
-  const { formatElapsed } = useDurationFormat();
+  const { formatElapsed, formatRelative } = useDurationFormat();
 
   return (
     <Tooltip
@@ -46,7 +46,7 @@ const DagRunInfo = ({ endDate, logicalDate, runAfter, startDate, state }: Props)
         <VStack align="left" gap={0}>
           {state === undefined ? (
             <Text>
-              {translate("dagDetails.nextRun")}: {getRelativeTime(runAfter)}
+              {translate("dagDetails.nextRun")}: {formatRelative(runAfter)}
             </Text>
           ) : (
             <>

--- a/airflow-core/src/airflow/ui/src/components/DagRunInfo.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagRunInfo.tsx
@@ -25,9 +25,8 @@ import { Tooltip } from "src/system-components";
 
 import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
-
-import { getDuration } from "src/utils";
 import { getRelativeTime } from "src/utils/datetimeUtils";
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 type Props = {
   readonly endDate?: string | null;
@@ -39,6 +38,7 @@ type Props = {
 
 const DagRunInfo = ({ endDate, logicalDate, runAfter, startDate, state }: Props) => {
   const { t: translate } = useTranslation();
+  const { formatElapsed } = useDurationFormat();
 
   return (
     <Tooltip
@@ -70,7 +70,7 @@ const DagRunInfo = ({ endDate, logicalDate, runAfter, startDate, state }: Props)
               )}
               {Boolean(startDate) && (
                 <Text>
-                  {translate("duration")}: {getDuration(startDate, endDate)}
+                  {translate("duration")}: {formatElapsed(startDate, endDate)}
                 </Text>
               )}
             </>

--- a/airflow-core/src/airflow/ui/src/components/DagRunInfo.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagRunInfo.tsx
@@ -26,7 +26,7 @@ import { Tooltip } from "src/system-components";
 import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
 
-import { useDurationFormat } from "src/utils/useDurationFormat";
+import { useDurationFormat } from "src/utils";
 
 type Props = {
   readonly endDate?: string | null;

--- a/airflow-core/src/airflow/ui/src/components/DurationCell.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DurationCell.tsx
@@ -1,0 +1,36 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useDurationFormat } from "src/utils/useDurationFormat";
+
+type Props = {
+  readonly duration: number | null | undefined;
+};
+
+/**
+ * A duration in a list column: rounded for scanning, exact on hover.
+ *
+ * The rounded form loses up to half a unit ("1h 2m" spans a minute), which is too coarse when the
+ * point is comparing two similar runs, so the unrounded value rides along in the title. Columns
+ * should use this rather than formatting inline, so the pair stays consistent everywhere.
+ */
+export const DurationCell = ({ duration }: Props) => {
+  const { renderDuration, renderExactDuration } = useDurationFormat();
+
+  return <span title={renderExactDuration(duration)}>{renderDuration(duration)}</span>;
+};

--- a/airflow-core/src/airflow/ui/src/components/DurationCell.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DurationCell.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useDurationFormat } from "src/utils/useDurationFormat";
+import { useDurationFormat } from "src/utils";
 
 type Props = {
   readonly duration: number | null | undefined;

--- a/airflow-core/src/airflow/ui/src/components/DurationChart.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DurationChart.tsx
@@ -41,11 +41,11 @@ import { getComputedCSSVariableValue } from "src/theme";
 import {
   formatDate,
   getDurationTickStep,
-  renderCompactDuration,
-  renderDuration,
+  getElapsedSeconds,
 } from "src/utils/datetimeUtils";
 import { buildTaskInstanceUrl } from "src/utils/links";
 import { median } from "src/utils/median";
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 ChartJS.register(
   CategoryScale,
@@ -63,23 +63,12 @@ const CHART_HEIGHT = "280px";
 
 type RunResponse = GridRunsResponse | TaskInstanceResponse;
 
-const getDuration = (start: string, end: string | null) => {
-  const startDate = dayjs(start);
-  const endDate = end === null ? dayjs() : dayjs(end);
-
-  if (!startDate.isValid() || !endDate.isValid()) {
-    return 0;
-  }
-
-  return dayjs.duration(endDate.diff(startDate)).asSeconds();
-};
-
 const getQueuedDuration = (entry: RunResponse, kind: "Dag Run" | "Task Instance") => {
   if (kind === "Dag Run") {
     const run = entry as GridRunsResponse;
 
     return run.queued_at !== null && run.start_date !== null && run.queued_at < run.start_date
-      ? getDuration(run.queued_at, run.start_date)
+      ? (getElapsedSeconds(run.queued_at, run.start_date) ?? 0)
       : 0;
   }
 
@@ -88,7 +77,7 @@ const getQueuedDuration = (entry: RunResponse, kind: "Dag Run" | "Task Instance"
   return taskInstance.queued_when !== null &&
     taskInstance.start_date !== null &&
     taskInstance.queued_when < taskInstance.start_date
-    ? getDuration(taskInstance.queued_when, taskInstance.start_date)
+    ? (getElapsedSeconds(taskInstance.queued_when, taskInstance.start_date) ?? 0)
     : 0;
 };
 
@@ -119,6 +108,7 @@ export const DurationChart = ({
   readonly kind: "Dag Run" | "Task Instance";
 }) => {
   const { t: translate } = useTranslation(["components", "common"]);
+  const { renderDuration } = useDurationFormat();
   const navigate = useNavigate();
   const { selectedTimezone } = useTimezone();
   const [queuedColorToken] = useToken("colors", ["queued.solid"]);
@@ -145,7 +135,7 @@ export const DurationChart = ({
 
   const queuedDurations = entries.map((entry) => getQueuedDuration(entry, kind));
   const runDurations = entries.map((entry) =>
-    entry.start_date === null ? 0 : getDuration(entry.start_date, entry.end_date),
+    entry.start_date === null ? 0 : (getElapsedSeconds(entry.start_date, entry.end_date) ?? 0),
   );
   // Bars stack queued under run, so the reference line tracks the same total the
   // reader sees at the top of each bar.
@@ -158,7 +148,7 @@ export const DurationChart = ({
     borderWidth: 1,
     label: {
       content: translate("durationChart.medianTotalDuration", {
-        duration: renderCompactDuration(medianTotal),
+        duration: renderDuration(medianTotal) ?? "0s",
       }),
       display: true,
       position: "start",
@@ -256,7 +246,7 @@ export const DurationChart = ({
                   label: (context) => {
                     const datasetLabel = context.dataset.label ?? "";
 
-                    const formatted = renderDuration(context.parsed.y, false) ?? "0";
+                    const formatted = renderDuration(context.parsed.y) ?? "0s";
 
                     return datasetLabel ? `${datasetLabel}: ${formatted}` : formatted;
                   },
@@ -279,7 +269,7 @@ export const DurationChart = ({
                 stacked: true,
                 ticks: {
                   callback: (value) =>
-                    renderCompactDuration(typeof value === "number" ? value : Number(value)),
+                    renderDuration(typeof value === "number" ? value : Number(value)) ?? "0s",
                   stepSize: getDurationTickStep(Math.max(...totalDurations, 0)),
                 },
                 title: { align: "end", display: true, text: translate("common:duration") },

--- a/airflow-core/src/airflow/ui/src/components/DurationChart.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DurationChart.tsx
@@ -38,11 +38,7 @@ import type { TaskInstanceResponse, GridRunsResponse } from "openapi/requests/ty
 
 import { useTimezone } from "src/context/timezone";
 import { getComputedCSSVariableValue } from "src/theme";
-import {
-  formatDate,
-  getDurationTickStep,
-  getElapsedSeconds,
-} from "src/utils/datetimeUtils";
+import { formatDate, getDurationTickStep, getElapsedSeconds } from "src/utils/datetimeUtils";
 import { buildTaskInstanceUrl } from "src/utils/links";
 import { median } from "src/utils/median";
 import { useDurationFormat } from "src/utils/useDurationFormat";

--- a/airflow-core/src/airflow/ui/src/components/DurationChart.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DurationChart.tsx
@@ -38,10 +38,10 @@ import type { TaskInstanceResponse, GridRunsResponse } from "openapi/requests/ty
 
 import { useTimezone } from "src/context/timezone";
 import { getComputedCSSVariableValue } from "src/theme";
+import { useDurationFormat } from "src/utils";
 import { formatDate, getDurationTickStep, getElapsedSeconds } from "src/utils/datetimeUtils";
 import { buildTaskInstanceUrl } from "src/utils/links";
 import { median } from "src/utils/median";
-import { useDurationFormat } from "src/utils/useDurationFormat";
 
 ChartJS.register(
   CategoryScale,

--- a/airflow-core/src/airflow/ui/src/components/HITLReview/HITLReviewDetailSummary.tsx
+++ b/airflow-core/src/airflow/ui/src/components/HITLReview/HITLReviewDetailSummary.tsx
@@ -27,8 +27,8 @@ import { RouterLink } from "src/system-components";
 
 import Time from "src/components/Time.tsx";
 
-import { getRelativeTime } from "src/utils/datetimeUtils.ts";
 import { getTaskInstanceLink } from "src/utils/links.ts";
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 const HITLReviewRow = ({ label, value }: { readonly label: string; readonly value: ReactNode }) => (
   <Table.Row>
@@ -45,6 +45,7 @@ export const HITLReviewDetailSummary = ({
   readonly onOpenTask: () => void;
 }) => {
   const { t: translate } = useTranslation(["hitl", "common"]);
+  const { formatRelative } = useDurationFormat();
   const ti = detail.task_instance;
   const mappedIndex = ti.rendered_map_index ?? (ti.map_index >= 0 ? ti.map_index : undefined);
 
@@ -67,7 +68,7 @@ export const HITLReviewDetailSummary = ({
           value={
             <Text>
               <Time datetime={detail.created_at} />
-              {` (${getRelativeTime(detail.created_at)})`}
+              {` (${formatRelative(detail.created_at)})`}
             </Text>
           }
         />

--- a/airflow-core/src/airflow/ui/src/components/HITLReview/HITLReviewDetailSummary.tsx
+++ b/airflow-core/src/airflow/ui/src/components/HITLReview/HITLReviewDetailSummary.tsx
@@ -27,8 +27,8 @@ import { RouterLink } from "src/system-components";
 
 import Time from "src/components/Time.tsx";
 
+import { useDurationFormat } from "src/utils";
 import { getTaskInstanceLink } from "src/utils/links.ts";
-import { useDurationFormat } from "src/utils/useDurationFormat";
 
 const HITLReviewRow = ({ label, value }: { readonly label: string; readonly value: ReactNode }) => (
   <Table.Row>

--- a/airflow-core/src/airflow/ui/src/components/SlowestTaskInstancesChart.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SlowestTaskInstancesChart.tsx
@@ -31,6 +31,25 @@ import { useDurationFormat } from "src/utils/useDurationFormat";
 ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip);
 
 const CHART_HEIGHT = "340px";
+const BAR_END_LABEL_FONT = "11px system-ui, sans-serif";
+const BAR_END_LABEL_GUTTER_PX = 16;
+const BAR_END_LABEL_FALLBACK_RESERVE_PX = 96;
+
+const measureContext = document.createElement("canvas").getContext("2d");
+
+// The old fixed 64px reserve was sized for the always-English "1h 2m". CLDR narrow is far wider in
+// several shipped locales (German "1 Std., 2 Min." is roughly 80px), so measure what is drawn.
+const measureBarEndLabelReserve = (labels: Array<string>): number => {
+  if (measureContext === null) {
+    return BAR_END_LABEL_FALLBACK_RESERVE_PX;
+  }
+
+  measureContext.font = BAR_END_LABEL_FONT;
+
+  const widest = labels.reduce((max, label) => Math.max(max, measureContext.measureText(label).width), 0);
+
+  return Math.ceil(widest) + BAR_END_LABEL_GUTTER_PX;
+};
 const RUN_LABEL_FORMAT = "MMM DD HH:mm";
 
 export const SlowestTaskInstancesChart = ({
@@ -74,13 +93,17 @@ export const SlowestTaskInstancesChart = ({
   const durations = taskInstances.map((taskInstance) => taskInstance.duration ?? 0);
   const maxDuration = Math.max(...durations, 0);
 
+  const barEndLabelReserve = measureBarEndLabelReserve(
+    durations.map((duration) => renderDuration(duration) ?? "0s"),
+  );
+
   const barEndLabels: Plugin<"bar"> = {
     afterDatasetsDraw: (chart) => {
       const { ctx } = chart;
       const meta = chart.getDatasetMeta(0);
 
       ctx.save();
-      ctx.font = "11px system-ui, sans-serif";
+      ctx.font = BAR_END_LABEL_FONT;
       ctx.fillStyle = getComputedCSSVariableValue(labelColorToken ?? "oklch(0.5 0 0)");
       ctx.textBaseline = "middle";
       meta.data.forEach((bar, index) => {
@@ -120,7 +143,7 @@ export const SlowestTaskInstancesChart = ({
           }}
           options={{
             indexAxis: "y",
-            layout: { padding: { right: 64 } },
+            layout: { padding: { right: barEndLabelReserve } },
             maintainAspectRatio: false,
             plugins: {
               legend: { display: false },

--- a/airflow-core/src/airflow/ui/src/components/SlowestTaskInstancesChart.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SlowestTaskInstancesChart.tsx
@@ -25,12 +25,8 @@ import type { TaskInstanceResponse } from "openapi/requests/types.gen";
 
 import { useTimezone } from "src/context/timezone";
 import { getComputedCSSVariableValue } from "src/theme";
-import {
-  formatDate,
-  getDurationTickStep,
-  renderCompactDuration,
-  renderDuration,
-} from "src/utils/datetimeUtils";
+import { formatDate, getDurationTickStep } from "src/utils/datetimeUtils";
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip);
 
@@ -43,6 +39,7 @@ export const SlowestTaskInstancesChart = ({
   readonly taskInstances: Array<TaskInstanceResponse>;
 }) => {
   const { t: translate } = useTranslation(["components", "common"]);
+  const { renderDuration } = useDurationFormat();
   const { selectedTimezone } = useTimezone();
   const [labelColorToken, fallbackColorToken] = useToken("colors", ["fg.muted", "gray.solid"]);
 
@@ -90,7 +87,7 @@ export const SlowestTaskInstancesChart = ({
         const duration = durations[index];
 
         if (duration !== undefined) {
-          ctx.fillText(renderCompactDuration(duration), bar.x + 6, bar.y);
+          ctx.fillText(renderDuration(duration) ?? "0s", bar.x + 6, bar.y);
         }
       });
       ctx.restore();
@@ -129,7 +126,7 @@ export const SlowestTaskInstancesChart = ({
               legend: { display: false },
               tooltip: {
                 callbacks: {
-                  label: (context) => renderDuration(context.parsed.x, false) ?? "0",
+                  label: (context) => renderDuration(context.parsed.x) ?? "0s",
                   title: ([context]) => {
                     const taskInstance = context === undefined ? undefined : taskInstances[context.dataIndex];
 
@@ -146,7 +143,7 @@ export const SlowestTaskInstancesChart = ({
                 beginAtZero: true,
                 ticks: {
                   callback: (value) =>
-                    renderCompactDuration(typeof value === "number" ? value : Number(value)),
+                    renderDuration(typeof value === "number" ? value : Number(value)) ?? "0s",
                   stepSize: getDurationTickStep(maxDuration),
                 },
                 title: { align: "end", display: true, text: translate("common:duration") },

--- a/airflow-core/src/airflow/ui/src/components/SlowestTaskInstancesChart.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SlowestTaskInstancesChart.tsx
@@ -25,8 +25,8 @@ import type { TaskInstanceResponse } from "openapi/requests/types.gen";
 
 import { useTimezone } from "src/context/timezone";
 import { getComputedCSSVariableValue } from "src/theme";
+import { useDurationFormat } from "src/utils";
 import { formatDate, getDurationTickStep } from "src/utils/datetimeUtils";
-import { useDurationFormat } from "src/utils/useDurationFormat";
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip);
 

--- a/airflow-core/src/airflow/ui/src/components/TaskInstanceTooltip.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TaskInstanceTooltip.test.tsx
@@ -112,10 +112,9 @@ describe("TaskInstanceTooltip", () => {
 
     const durationText = screen.getByText(/duration/iu).parentElement?.textContent;
 
-    // The calculated duration should be around 2 hours (e.g., "02:00:00" or similar)
-    // It should definitely NOT be "00:00:50.000" which is what `renderDuration(50)` gives
-    expect(durationText).not.toContain("00:00:50");
-    expect(durationText).toContain("02:00:");
+    // The live start_date is two hours old; the stale `duration: 50` field must not win.
+    expect(durationText).not.toContain("50s");
+    expect(durationText).toContain("2h");
   });
 
   it("shows only start date when max_end_date is null", () => {

--- a/airflow-core/src/airflow/ui/src/components/TaskInstanceTooltip.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TaskInstanceTooltip.tsx
@@ -28,8 +28,8 @@ import type {
 import { Tooltip, type TooltipProps } from "src/system-components";
 
 import Time from "src/components/Time";
-
-import { getDuration, renderDuration, sortStateEntries } from "src/utils";
+import { sortStateEntries } from "src/utils";
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 /** Grid summary plus optional schedule/queue hints (e.g. Gantt segment tooltips). */
 type LightGridTaskInstanceSummaryWithWhen = {
@@ -46,6 +46,7 @@ type Props = {
 
 const TaskInstanceTooltip = ({ children, positioning, runId, taskInstance, tooltip, ...rest }: Props) => {
   const { t: translate } = useTranslation();
+  const { formatElapsed, renderDuration } = useDurationFormat();
 
   const hasTooltip = tooltip !== undefined && tooltip !== null;
 
@@ -108,7 +109,7 @@ const TaskInstanceTooltip = ({ children, positioning, runId, taskInstance, toolt
                   <Text>
                     {translate("duration")}:{" "}
                     {taskInstance.state === "running" || taskInstance.state === "deferred"
-                      ? getDuration(
+                      ? formatElapsed(
                           taskInstance.start_date,
                           taskInstance.end_date ?? new Date().toISOString(),
                         )
@@ -128,7 +129,7 @@ const TaskInstanceTooltip = ({ children, positioning, runId, taskInstance, toolt
                       </Text>
                       <Text>
                         {translate("duration")}:{" "}
-                        {getDuration(taskInstance.min_start_date, taskInstance.max_end_date, false)}
+                        {formatElapsed(taskInstance.min_start_date, taskInstance.max_end_date)}
                       </Text>
                     </>
                   )}

--- a/airflow-core/src/airflow/ui/src/components/TaskInstanceTooltip.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TaskInstanceTooltip.tsx
@@ -28,6 +28,7 @@ import type {
 import { Tooltip, type TooltipProps } from "src/system-components";
 
 import Time from "src/components/Time";
+
 import { sortStateEntries } from "src/utils";
 import { useDurationFormat } from "src/utils/useDurationFormat";
 

--- a/airflow-core/src/airflow/ui/src/components/TaskInstanceTooltip.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TaskInstanceTooltip.tsx
@@ -29,8 +29,7 @@ import { Tooltip, type TooltipProps } from "src/system-components";
 
 import Time from "src/components/Time";
 
-import { sortStateEntries } from "src/utils";
-import { useDurationFormat } from "src/utils/useDurationFormat";
+import { sortStateEntries, useDurationFormat } from "src/utils";
 
 /** Grid summary plus optional schedule/queue hints (e.g. Gantt segment tooltips). */
 type LightGridTaskInstanceSummaryWithWhen = {

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/GanttTimeline.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/GanttTimeline.tsx
@@ -33,10 +33,11 @@ import {
   TASK_BAR_HEIGHT_PX,
 } from "src/layouts/Details/Grid/constants";
 import type { GridTask } from "src/layouts/Details/Grid/utils";
-import { useDurationFormat } from "src/utils/useDurationFormat";
 
 import { StateIcon } from "src/components/StateIcon";
 import TaskInstanceTooltip from "src/components/TaskInstanceTooltip";
+
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 import {
   type GanttDataItem,
@@ -57,7 +58,9 @@ const MIN_BAR_WIDTH_PX = GANTT_STATE_ICON_SIZE_PX;
 const MIN_SEGMENT_RENDER_PX = 5;
 
 /** Minimum horizontal gap (px) between time-axis labels before one is dropped. */
-const MIN_TICK_SPACING_PX = 80;
+// Sized for the widest CLDR narrow label, not the old "HH:MM:SS": German runs ~14 chars
+// ("1 Std., 2 Min."), roughly 84px at font-size xs, so 80px let ticks collide in wider locales.
+const MIN_TICK_SPACING_PX = 110;
 
 /** Short mark above the axis bottom border, aligned with each timestamp. */
 const GANTT_AXIS_TICK_HEIGHT_PX = 6;
@@ -150,7 +153,7 @@ export const GanttTimeline = ({
   const spanMs = Math.max(1, maxMs - minMs);
 
   // Derive tick count from available width so labels never overlap.
-  // Each "HH:MM:SS" label is ~8 chars at font-size xs; allow MIN_TICK_SPACING_PX per tick.
+  // Allow MIN_TICK_SPACING_PX per tick so labels never overlap.
   const tickCount =
     bodyWidthPx > 0 ? Math.max(2, Math.floor(bodyWidthPx / MIN_TICK_SPACING_PX)) : GANTT_TIME_AXIS_TICK_COUNT;
   const timeTicks = buildGanttTimeAxisTicks(minMs, maxMs, { locale, tickCount });

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/GanttTimeline.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/GanttTimeline.tsx
@@ -33,6 +33,7 @@ import {
   TASK_BAR_HEIGHT_PX,
 } from "src/layouts/Details/Grid/constants";
 import type { GridTask } from "src/layouts/Details/Grid/utils";
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 import { StateIcon } from "src/components/StateIcon";
 import TaskInstanceTooltip from "src/components/TaskInstanceTooltip";
@@ -115,6 +116,7 @@ export const GanttTimeline = ({
   scrollContainerRef,
   virtualizerScrollPaddingStart,
 }: Props) => {
+  const { locale } = useDurationFormat();
   const location = useLocation();
   const { groupId: selectedGroupId, taskId: selectedTaskId } = useParams();
   const [bodyWidthPx, setBodyWidthPx] = useState(0);
@@ -151,7 +153,7 @@ export const GanttTimeline = ({
   // Each "HH:MM:SS" label is ~8 chars at font-size xs; allow MIN_TICK_SPACING_PX per tick.
   const tickCount =
     bodyWidthPx > 0 ? Math.max(2, Math.floor(bodyWidthPx / MIN_TICK_SPACING_PX)) : GANTT_TIME_AXIS_TICK_COUNT;
-  const timeTicks = buildGanttTimeAxisTicks(minMs, maxMs, tickCount);
+  const timeTicks = buildGanttTimeAxisTicks(minMs, maxMs, { locale, tickCount });
 
   const rowVirtualizer = useVirtualizer({
     count: flatNodes.length,

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/GanttTimeline.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/GanttTimeline.tsx
@@ -37,7 +37,7 @@ import type { GridTask } from "src/layouts/Details/Grid/utils";
 import { StateIcon } from "src/components/StateIcon";
 import TaskInstanceTooltip from "src/components/TaskInstanceTooltip";
 
-import { useDurationFormat } from "src/utils/useDurationFormat";
+import { useDurationFormat } from "src/utils";
 
 import {
   type GanttDataItem,

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.test.ts
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.test.ts
@@ -50,6 +50,23 @@ describe("buildGanttTimeAxisTicks", () => {
     expect(ticks.every((tick) => typeof tick.label === "string" && tick.label.length > 0)).toBe(true);
   });
 
+  it("localizes tick labels with the given locale", () => {
+    const ticks = buildGanttTimeAxisTicks(0, 60_000, { locale: "de", tickCount: 2 });
+    const inEnglish = buildGanttTimeAxisTicks(0, 60_000, { locale: "en", tickCount: 2 });
+
+    expect(ticks.at(-1)?.label).toBe(
+      new Intl.NumberFormat("de", { style: "unit", unit: "minute", unitDisplay: "narrow" }).format(1),
+    );
+    expect(ticks.at(-1)?.label).not.toBe(inEnglish.at(-1)?.label);
+  });
+
+  it("snaps ticks to counted units rather than dividing the raw span", () => {
+    // A 7s span divided evenly used to read 0s | 1.17s | 2.33s | 3.5s ...
+    const labels = buildGanttTimeAxisTicks(0, 7000, { locale: "en", tickCount: 8 }).map((tick) => tick.label);
+
+    expect(labels).toStrictEqual(["0s", "1s", "2s", "3s", "4s", "5s", "6s", "7s"]);
+  });
+
   it("supports a single tick", () => {
     const ticks = buildGanttTimeAxisTicks(1000, 1000, { tickCount: 1 });
 

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.test.ts
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.test.ts
@@ -41,22 +41,22 @@ describe("buildGanttTimeAxisTicks", () => {
 
     expect(ticks).toHaveLength(GANTT_TIME_AXIS_TICK_COUNT);
     expect(ticks[0]?.leftPct).toBe(0);
-    expect(ticks[0]?.label).toBe("00:00:00");
+    expect(ticks[0]?.label).toBe("0s");
     expect(ticks[0]?.labelAlign).toBe("left");
     expect(ticks[GANTT_TIME_AXIS_TICK_COUNT - 1]?.leftPct).toBe(100);
     expect(ticks[GANTT_TIME_AXIS_TICK_COUNT - 1]?.labelAlign).toBe("right");
-    expect(ticks[GANTT_TIME_AXIS_TICK_COUNT - 1]?.label).toBe("00:01:00");
+    expect(ticks[GANTT_TIME_AXIS_TICK_COUNT - 1]?.label).toBe("1m");
     expect(ticks[1]?.labelAlign).toBe("center");
     expect(ticks.every((tick) => typeof tick.label === "string" && tick.label.length > 0)).toBe(true);
   });
 
   it("supports a single tick", () => {
-    const ticks = buildGanttTimeAxisTicks(1000, 1000, 1);
+    const ticks = buildGanttTimeAxisTicks(1000, 1000, { tickCount: 1 });
 
     expect(ticks).toHaveLength(1);
     expect(ticks[0]?.leftPct).toBe(0);
     expect(ticks[0]?.labelAlign).toBe("left");
-    expect(ticks[0]?.label).toBe("00:00:00");
+    expect(ticks[0]?.label).toBe("0s");
   });
 });
 

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.ts
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.ts
@@ -26,7 +26,7 @@ import type { GridTask } from "src/layouts/Details/Grid/utils";
 
 import { SearchParamsKeys } from "src/constants/searchParams";
 import { isStatePending } from "src/utils";
-import { renderDuration } from "src/utils/datetimeUtils";
+import { getDurationTickStep, renderDuration } from "src/utils/datetimeUtils";
 import { buildTaskInstanceUrl } from "src/utils/links";
 
 export type GanttDataItem = {
@@ -367,16 +367,21 @@ export const buildGanttTimeAxisTicks = (
   const denominator = Math.max(1, tickCount - 1);
   const lastIndex = tickCount - 1;
   const ticks: Array<GanttAxisTick> = [];
+  // Snap to the units people count in, the way the Chart.js duration axes do. Evenly dividing the
+  // raw span reads fine at truncated whole seconds but not at this precision: a 7s span became
+  // "0s | 1.17s | 2.33s | 3.5s". The last tick keeps the true span so the axis still ends at it.
+  const stepMs = getDurationTickStep(spanMs / 1000, denominator) * 1000;
 
   for (let tickIndex = 0; tickIndex < tickCount; tickIndex += 1) {
-    const elapsedMs = (tickIndex / denominator) * spanMs;
+    const elapsedMs =
+      tickCount > 1 && tickIndex === lastIndex ? spanMs : Math.min(tickIndex * stepMs, spanMs);
     const labelAlign: GanttAxisTickLabelAlign =
       tickCount === 1 ? "left" : tickIndex === 0 ? "left" : tickIndex === lastIndex ? "right" : "center";
 
     ticks.push({
       label: formatElapsedMsForGanttAxis(elapsedMs, locale),
       labelAlign,
-      leftPct: (tickIndex / denominator) * 100,
+      leftPct: (elapsedMs / spanMs) * 100,
     });
   }
 

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.ts
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.ts
@@ -352,20 +352,16 @@ export type GanttAxisTick = {
 };
 
 /** Elapsed time from the chart origin (`minMs`), formatted like grid duration labels (no wall-clock). */
-const formatElapsedMsForGanttAxis = (elapsedMs: number): string => {
+const formatElapsedMsForGanttAxis = (elapsedMs: number, locale?: string): string => {
   const seconds = Math.max(0, elapsedMs / 1000);
 
-  if (seconds <= 0.01) {
-    return "00:00:00";
-  }
-
-  return renderDuration(seconds, false) ?? "00:00:00";
+  return renderDuration(seconds, locale) ?? "0s";
 };
 
 export const buildGanttTimeAxisTicks = (
   minMs: number,
   maxMs: number,
-  tickCount: number = GANTT_TIME_AXIS_TICK_COUNT,
+  { locale, tickCount = GANTT_TIME_AXIS_TICK_COUNT }: { locale?: string; tickCount?: number } = {},
 ): Array<GanttAxisTick> => {
   const spanMs = Math.max(1, maxMs - minMs);
   const denominator = Math.max(1, tickCount - 1);
@@ -378,7 +374,7 @@ export const buildGanttTimeAxisTicks = (
       tickCount === 1 ? "left" : tickIndex === 0 ? "left" : tickIndex === lastIndex ? "right" : "center";
 
     ticks.push({
-      label: formatElapsedMsForGanttAxis(elapsedMs),
+      label: formatElapsedMsForGanttAxis(elapsedMs, locale),
       labelAlign,
       leftPct: (tickIndex / denominator) * 100,
     });

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/DurationTick.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/DurationTick.tsx
@@ -18,14 +18,18 @@
  */
 import { Text, type TextProps } from "@chakra-ui/react";
 
-import { renderDuration } from "src/utils";
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 type Props = {
   readonly duration: number;
 } & TextProps;
 
-export const DurationTick = ({ duration, ...rest }: Props) => (
-  <Text color="border.emphasized" fontSize="xs" position="absolute" right={1} whiteSpace="nowrap" {...rest}>
-    {renderDuration(duration)}
-  </Text>
-);
+export const DurationTick = ({ duration, ...rest }: Props) => {
+  const { renderDuration } = useDurationFormat();
+
+  return (
+    <Text color="border.emphasized" fontSize="xs" position="absolute" right={1} whiteSpace="nowrap" {...rest}>
+      {renderDuration(duration)}
+    </Text>
+  );
+};

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/DurationTick.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/DurationTick.tsx
@@ -18,7 +18,7 @@
  */
 import { Text, type TextProps } from "@chakra-ui/react";
 
-import { useDurationFormat } from "src/utils/useDurationFormat";
+import { useDurationFormat } from "src/utils";
 
 type Props = {
   readonly duration: number;

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridButton.test.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridButton.test.tsx
@@ -54,7 +54,7 @@ describe("GridButton", () => {
     expect(screen.getByTestId("basic-tooltip")).toHaveTextContent(
       "common:runId: manual__2026-04-21T00:00:00+00:00",
     );
-    expect(screen.getByTestId("basic-tooltip")).toHaveTextContent("duration: 01:01:01");
+    expect(screen.getByTestId("basic-tooltip")).toHaveTextContent("duration: 1h 1m");
 
     vi.useRealTimers();
   });

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridButton.tsx
@@ -24,8 +24,7 @@ import type { DagRunState, TaskInstanceState } from "openapi/requests/types.gen"
 
 import { BasicTooltip } from "src/components/BasicTooltip";
 import Time from "src/components/Time";
-
-import { renderDuration } from "src/utils/datetimeUtils";
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 type Props = {
   readonly dagId: string;
@@ -51,6 +50,7 @@ export const GridButton = ({
   ...rest
 }: Props) => {
   const { t: translate } = useTranslation();
+  const { renderDuration } = useDurationFormat();
 
   const tooltipContent = (
     <>

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridButton.tsx
@@ -24,6 +24,7 @@ import type { DagRunState, TaskInstanceState } from "openapi/requests/types.gen"
 
 import { BasicTooltip } from "src/components/BasicTooltip";
 import Time from "src/components/Time";
+
 import { useDurationFormat } from "src/utils/useDurationFormat";
 
 type Props = {

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridButton.tsx
@@ -25,7 +25,7 @@ import type { DagRunState, TaskInstanceState } from "openapi/requests/types.gen"
 import { BasicTooltip } from "src/components/BasicTooltip";
 import Time from "src/components/Time";
 
-import { useDurationFormat } from "src/utils/useDurationFormat";
+import { useDurationFormat } from "src/utils";
 
 type Props = {
   readonly dagId: string;

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Backfills/Backfills.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Backfills/Backfills.tsx
@@ -31,7 +31,7 @@ import { ErrorAlert } from "src/components/ErrorAlert";
 import Time from "src/components/Time";
 
 import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
-import { useDurationFormat } from "src/utils/useDurationFormat";
+import { type DurationFormat, useDurationFormat } from "src/utils/useDurationFormat";
 
 import { BackfillDagRunsModal } from "./BackfillDagRunsModal";
 import { BackfillsFilters } from "./BackfillsFilters";
@@ -60,10 +60,9 @@ const isReprocessBehavior = (value: string | null): value is ReprocessBehavior =
   (REPROCESS_BEHAVIOR_VALUES as ReadonlyArray<string | null>).includes(value);
 
 type ColumnProps = {
-  readonly formatElapsed: (startDate?: string | null, endDate?: string | null) => string | undefined;
   readonly onSelectBackfill: (backfillId: number) => void;
   readonly translate: TFunction;
-};
+} & Pick<DurationFormat, "formatElapsed">;
 
 const getColumns = ({
   formatElapsed,

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Backfills/Backfills.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Backfills/Backfills.tsx
@@ -59,11 +59,17 @@ const REPROCESS_BEHAVIOR_VALUES = [
 const isReprocessBehavior = (value: string | null): value is ReprocessBehavior =>
   (REPROCESS_BEHAVIOR_VALUES as ReadonlyArray<string | null>).includes(value);
 
-const getColumns = (
-  onSelectBackfill: (backfillId: number) => void,
-  translate: TFunction,
-  formatElapsed: (startDate?: string | null, endDate?: string | null) => string | undefined,
-): Array<ColumnDef<BackfillResponse>> => [
+type ColumnProps = {
+  readonly formatElapsed: (startDate?: string | null, endDate?: string | null) => string | undefined;
+  readonly onSelectBackfill: (backfillId: number) => void;
+  readonly translate: TFunction;
+};
+
+const getColumns = ({
+  formatElapsed,
+  onSelectBackfill,
+  translate,
+}: ColumnProps): Array<ColumnDef<BackfillResponse>> => [
   {
     accessorKey: "date_from",
     cell: ({ row }) => (
@@ -209,7 +215,7 @@ export const Backfills = () => {
       ),
     );
   };
-  const columns = getColumns(onSelectBackfill, translate, formatElapsed);
+  const columns = getColumns({ formatElapsed, onSelectBackfill, translate });
 
   return (
     <>

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Backfills/Backfills.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Backfills/Backfills.tsx
@@ -31,7 +31,7 @@ import { ErrorAlert } from "src/components/ErrorAlert";
 import Time from "src/components/Time";
 
 import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
-import { type DurationFormat, useDurationFormat } from "src/utils/useDurationFormat";
+import { type DurationFormat, useDurationFormat } from "src/utils";
 
 import { BackfillDagRunsModal } from "./BackfillDagRunsModal";
 import { BackfillsFilters } from "./BackfillsFilters";

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Backfills/Backfills.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Backfills/Backfills.tsx
@@ -31,7 +31,7 @@ import { ErrorAlert } from "src/components/ErrorAlert";
 import Time from "src/components/Time";
 
 import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
-import { getDuration } from "src/utils";
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 import { BackfillDagRunsModal } from "./BackfillDagRunsModal";
 import { BackfillsFilters } from "./BackfillsFilters";
@@ -62,6 +62,7 @@ const isReprocessBehavior = (value: string | null): value is ReprocessBehavior =
 const getColumns = (
   onSelectBackfill: (backfillId: number) => void,
   translate: TFunction,
+  formatElapsed: (startDate?: string | null, endDate?: string | null) => string | undefined,
 ): Array<ColumnDef<BackfillResponse>> => [
   {
     accessorKey: "date_from",
@@ -129,7 +130,7 @@ const getColumns = (
       <Text>
         {row.original.completed_at === null
           ? ""
-          : getDuration(row.original.created_at, row.original.completed_at)}
+          : formatElapsed(row.original.created_at, row.original.completed_at)}
       </Text>
     ),
     enableSorting: false,
@@ -144,6 +145,7 @@ const getColumns = (
 
 export const Backfills = () => {
   const { t: translate } = useTranslation();
+  const { formatElapsed } = useDurationFormat();
   const { setTableURLState, tableURLState } = useTableURLState();
   const location = useLocation();
   const navigate = useNavigate();
@@ -207,7 +209,7 @@ export const Backfills = () => {
       ),
     );
   };
-  const columns = getColumns(onSelectBackfill, translate);
+  const columns = getColumns(onSelectBackfill, translate, formatElapsed);
 
   return (
     <>

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
@@ -44,7 +44,7 @@ import { SHORTCUTS } from "src/context/keyboardShortcuts";
 import useSelectedVersion from "src/hooks/useSelectedVersion";
 import { useShortcut } from "src/hooks/useShortcut";
 import { useConfig } from "src/queries/useConfig";
-import { renderDuration } from "src/utils";
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 import { CodeDiffViewer } from "./CodeDiffViewer";
 import { FileLocation } from "./FileLocation";
@@ -52,6 +52,7 @@ import { VersionCompareSelect } from "./VersionCompareSelect";
 
 export const Code = () => {
   const { t: translate } = useTranslation(["dag", "common", "components"]);
+  const { renderDuration } = useDurationFormat();
   const { dagId } = useParams();
 
   const selectedVersion = useSelectedVersion();

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
@@ -44,7 +44,7 @@ import { SHORTCUTS } from "src/context/keyboardShortcuts";
 import useSelectedVersion from "src/hooks/useSelectedVersion";
 import { useShortcut } from "src/hooks/useShortcut";
 import { useConfig } from "src/queries/useConfig";
-import { useDurationFormat } from "src/utils/useDurationFormat";
+import { useDurationFormat } from "src/utils";
 
 import { CodeDiffViewer } from "./CodeDiffViewer";
 import { FileLocation } from "./FileLocation";

--- a/airflow-core/src/airflow/ui/src/pages/Dag/DeadlineAlertsBadge.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/DeadlineAlertsBadge.test.tsx
@@ -55,7 +55,7 @@ vi.mock("openapi/queries", async (importOriginal) => {
 const { useDeadlinesServiceGetDagDeadlineAlerts } = await import("openapi/queries");
 
 // Defaults to a VariableInterval alert, whose interval only the scheduler resolves at evaluation
-// time. Without a rule of its own, dayjs humanizes that null interval as "a few seconds" and the
+// time. Without a rule of its own, a null interval would be named as some concrete length and the
 // popover claims the run must complete within a few seconds of its logical date.
 const baseAlert: DeadlineAlertResponse = {
   created_at: "2025-01-01T00:00:00Z",
@@ -67,7 +67,7 @@ const baseAlert: DeadlineAlertResponse = {
 
 const REFERENCE = "deadlineAlerts.referenceType.DagRunLogicalDateDeadline";
 const DYNAMIC_RULE = `deadlineAlerts.completionRuleDynamic:${REFERENCE}`;
-const FIXED_RULE = `deadlineAlerts.completionRule:an hour:${REFERENCE}`;
+const FIXED_RULE = `deadlineAlerts.completionRule:1 hour:${REFERENCE}`;
 
 describe("DeadlineAlertsBadge", () => {
   it.each([

--- a/airflow-core/src/airflow/ui/src/pages/Dag/DeadlineAlertsBadge.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/DeadlineAlertsBadge.tsx
@@ -26,14 +26,16 @@ import type { DeadlineAlertResponse } from "openapi/requests/types.gen";
 import { Popover } from "src/system-components";
 
 import { translateCompletionRule } from "src/utils/deadlines";
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 const AlertRow = ({ alert }: { readonly alert: DeadlineAlertResponse }) => {
   const { t: translate } = useTranslation("dag");
+  const { locale } = useDurationFormat();
 
   return (
     <Box py={2} width="100%">
       <Text color="fg.muted" fontSize="xs">
-        {translateCompletionRule(translate, alert)}
+        {translateCompletionRule(translate, alert, locale)}
         {Boolean(alert.name) && (
           <Text as="span" color="fg.subtle" fontSize="xs">
             {" "}

--- a/airflow-core/src/airflow/ui/src/pages/Dag/DeadlineAlertsBadge.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/DeadlineAlertsBadge.tsx
@@ -25,8 +25,8 @@ import type { DeadlineAlertResponse } from "openapi/requests/types.gen";
 
 import { Popover } from "src/system-components";
 
+import { useDurationFormat } from "src/utils";
 import { translateCompletionRule } from "src/utils/deadlines";
-import { useDurationFormat } from "src/utils/useDurationFormat";
 
 const AlertRow = ({ alert }: { readonly alert: DeadlineAlertResponse }) => {
   const { t: translate } = useTranslation("dag");

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Details.tsx
@@ -30,10 +30,11 @@ import { TeamName } from "src/components/TeamName";
 import Time from "src/components/Time";
 
 import { useShowTeam } from "src/hooks/useShowTeam";
-import { renderDuration } from "src/utils";
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 export const Details = () => {
   const { t: translate } = useTranslation(["common", "dag"]);
+  const { renderDuration } = useDurationFormat();
   const { dagId = "" } = useParams();
 
   const { data: dag } = useDagServiceGetDagDetails({

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Details.tsx
@@ -30,7 +30,7 @@ import { TeamName } from "src/components/TeamName";
 import Time from "src/components/Time";
 
 import { useShowTeam } from "src/hooks/useShowTeam";
-import { useDurationFormat } from "src/utils/useDurationFormat";
+import { useDurationFormat } from "src/utils";
 
 export const Details = () => {
   const { t: translate } = useTranslation(["common", "dag"]);

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Overview/DeadlineRow.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Overview/DeadlineRow.tsx
@@ -27,6 +27,7 @@ import { RouterLink } from "src/system-components";
 import Time from "src/components/Time";
 
 import { translateCompletionRule } from "src/utils/deadlines";
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 type DeadlineRowProps = {
   readonly alert?: DeadlineAlertResponse;
@@ -35,8 +36,9 @@ type DeadlineRowProps = {
 
 export const DeadlineRow = ({ alert, deadline }: DeadlineRowProps) => {
   const { t: translate } = useTranslation("dag");
+  const { locale } = useDurationFormat();
 
-  const completionRule = translateCompletionRule(translate, alert);
+  const completionRule = translateCompletionRule(translate, alert, locale);
 
   return (
     <HStack justifyContent="space-between" px={2} py={1.5} width="100%">

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Overview/DeadlineRow.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Overview/DeadlineRow.tsx
@@ -26,8 +26,8 @@ import { RouterLink } from "src/system-components";
 
 import Time from "src/components/Time";
 
+import { useDurationFormat } from "src/utils";
 import { translateCompletionRule } from "src/utils/deadlines";
-import { useDurationFormat } from "src/utils/useDurationFormat";
 
 type DeadlineRowProps = {
   readonly alert?: DeadlineAlertResponse;

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Overview/Overview.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Overview/Overview.test.tsx
@@ -67,7 +67,11 @@ vi.mock("src/pages/ReactPlugin", () => ({
   ReactPlugin: ({ reactApp }: { readonly reactApp: ReactAppResponse }) => <div>{reactApp.name}</div>,
 }));
 vi.mock("src/queries/useGridRuns.ts", () => ({ useGridRuns: () => ({ data: [], isLoading: false }) }));
-vi.mock("src/utils", () => ({ isStatePending: () => false, useAutoRefresh: () => false }));
+vi.mock("src/utils", () => ({
+  isStatePending: () => false,
+  useAutoRefresh: () => false,
+  useDurationFormat: () => ({ locale: "en" }),
+}));
 vi.mock("./DagDeadlines", () => ({ DagDeadlines: () => null }));
 vi.mock("./FailedLogs", () => ({ default: () => null }));
 

--- a/airflow-core/src/airflow/ui/src/pages/DagRuns/DagRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagRuns/DagRuns.tsx
@@ -95,6 +95,7 @@ type ColumnProps = {
   readonly dagId?: string;
   readonly open: boolean;
   readonly renderDuration: (duration: number | null | undefined) => string | undefined;
+  readonly renderExactDuration: (duration: number | null | undefined) => string | undefined;
   readonly translate: TFunction;
 } & GetColumnsParams;
 
@@ -103,6 +104,7 @@ const runColumns = ({
   multiTeam,
   open,
   renderDuration,
+  renderExactDuration,
   translate,
 }: ColumnProps): Array<ColumnDef<DAGRunResponse>> => [
   {
@@ -195,7 +197,9 @@ const runColumns = ({
   },
   {
     accessorKey: "duration",
-    cell: ({ row: { original } }) => renderDuration(original.duration),
+    cell: ({ row: { original } }) => (
+      <span title={renderExactDuration(original.duration)}>{renderDuration(original.duration)}</span>
+    ),
     header: translate("duration"),
   },
   {
@@ -245,7 +249,7 @@ const runColumns = ({
 
 export const DagRuns = () => {
   const { t: translate } = useTranslation();
-  const { renderDuration } = useDurationFormat();
+  const { renderDuration, renderExactDuration } = useDurationFormat();
   const { dagId } = useParams();
 
   // Only the standalone list page owns the tab title; the Dag-scoped tab inherits the Dag page's title.
@@ -370,6 +374,7 @@ export const DagRuns = () => {
     multiTeam: multiTeamEnabled,
     open,
     renderDuration,
+    renderExactDuration,
     translate,
   });
 

--- a/airflow-core/src/airflow/ui/src/pages/DagRuns/DagRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagRuns/DagRuns.tsx
@@ -52,7 +52,8 @@ import { TruncatedText } from "src/components/TruncatedText";
 import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
 import { useAdvancedSearchArg } from "src/hooks/useAdvancedSearch";
 import { useConfig } from "src/queries/useConfig";
-import { renderDuration, useAutoRefresh, isStatePending, useDocumentTitle } from "src/utils";
+import { useAutoRefresh, isStatePending, useDocumentTitle } from "src/utils";
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 import BulkClearDagRunsButton from "./BulkClearDagRunsButton";
 import BulkDeleteDagRunsButton from "./BulkDeleteDagRunsButton";
@@ -93,10 +94,17 @@ const {
 type ColumnProps = {
   readonly dagId?: string;
   readonly open: boolean;
+  readonly renderDuration: (duration: number | null | undefined) => string | undefined;
   readonly translate: TFunction;
 } & GetColumnsParams;
 
-const runColumns = ({ dagId, multiTeam, open, translate }: ColumnProps): Array<ColumnDef<DAGRunResponse>> => [
+const runColumns = ({
+  dagId,
+  multiTeam,
+  open,
+  renderDuration,
+  translate,
+}: ColumnProps): Array<ColumnDef<DAGRunResponse>> => [
   {
     accessorKey: "select",
     cell: ({ row }) => <SelectionRowCheckbox colorPalette="brand" rowKey={getRowKey(row.original)} />,
@@ -237,6 +245,7 @@ const runColumns = ({ dagId, multiTeam, open, translate }: ColumnProps): Array<C
 
 export const DagRuns = () => {
   const { t: translate } = useTranslation();
+  const { renderDuration } = useDurationFormat();
   const { dagId } = useParams();
 
   // Only the standalone list page owns the tab title; the Dag-scoped tab inherits the Dag page's title.
@@ -360,6 +369,7 @@ export const DagRuns = () => {
     dagId,
     multiTeam: multiTeamEnabled,
     open,
+    renderDuration,
     translate,
   });
 

--- a/airflow-core/src/airflow/ui/src/pages/DagRuns/DagRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagRuns/DagRuns.tsx
@@ -38,6 +38,7 @@ import {
   type GetColumnsParams,
 } from "src/components/DataTable/useRowSelection";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
+import { DurationCell } from "src/components/DurationCell";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { ExpandCollapseButtons } from "src/components/ExpandCollapseButtons";
 import { LimitedItemsList } from "src/components/LimitedItemsList";
@@ -53,7 +54,6 @@ import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searc
 import { useAdvancedSearchArg } from "src/hooks/useAdvancedSearch";
 import { useConfig } from "src/queries/useConfig";
 import { useAutoRefresh, isStatePending, useDocumentTitle } from "src/utils";
-import { useDurationFormat } from "src/utils/useDurationFormat";
 
 import BulkClearDagRunsButton from "./BulkClearDagRunsButton";
 import BulkDeleteDagRunsButton from "./BulkDeleteDagRunsButton";
@@ -94,19 +94,10 @@ const {
 type ColumnProps = {
   readonly dagId?: string;
   readonly open: boolean;
-  readonly renderDuration: (duration: number | null | undefined) => string | undefined;
-  readonly renderExactDuration: (duration: number | null | undefined) => string | undefined;
   readonly translate: TFunction;
 } & GetColumnsParams;
 
-const runColumns = ({
-  dagId,
-  multiTeam,
-  open,
-  renderDuration,
-  renderExactDuration,
-  translate,
-}: ColumnProps): Array<ColumnDef<DAGRunResponse>> => [
+const runColumns = ({ dagId, multiTeam, open, translate }: ColumnProps): Array<ColumnDef<DAGRunResponse>> => [
   {
     accessorKey: "select",
     cell: ({ row }) => <SelectionRowCheckbox colorPalette="brand" rowKey={getRowKey(row.original)} />,
@@ -197,9 +188,7 @@ const runColumns = ({
   },
   {
     accessorKey: "duration",
-    cell: ({ row: { original } }) => (
-      <span title={renderExactDuration(original.duration)}>{renderDuration(original.duration)}</span>
-    ),
+    cell: ({ row: { original } }) => <DurationCell duration={original.duration} />,
     header: translate("duration"),
   },
   {
@@ -249,7 +238,6 @@ const runColumns = ({
 
 export const DagRuns = () => {
   const { t: translate } = useTranslation();
-  const { renderDuration, renderExactDuration } = useDurationFormat();
   const { dagId } = useParams();
 
   // Only the standalone list page owns the tab title; the Dag-scoped tab inherits the Dag page's title.
@@ -373,8 +361,6 @@ export const DagRuns = () => {
     dagId,
     multiTeam: multiTeamEnabled,
     open,
-    renderDuration,
-    renderExactDuration,
     translate,
   });
 

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/RecentRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/RecentRuns.tsx
@@ -26,8 +26,7 @@ import type { DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
 
 import { StateIcon } from "src/components/StateIcon";
 import Time from "src/components/Time";
-
-import { renderDuration } from "src/utils";
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 dayjs.extend(duration);
 
@@ -37,6 +36,7 @@ type LatestRun = DAGWithLatestDagRunsResponse["latest_dag_runs"][number];
 
 const RecentRunTooltipContent = ({ run }: { readonly run: LatestRun }) => {
   const { t: translate } = useTranslation();
+  const { renderDuration } = useDurationFormat();
 
   return (
     <Box>

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/RecentRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/RecentRuns.tsx
@@ -26,6 +26,7 @@ import type { DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
 
 import { StateIcon } from "src/components/StateIcon";
 import Time from "src/components/Time";
+
 import { useDurationFormat } from "src/utils/useDurationFormat";
 
 dayjs.extend(duration);

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/RecentRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/RecentRuns.tsx
@@ -27,7 +27,7 @@ import type { DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
 import { StateIcon } from "src/components/StateIcon";
 import Time from "src/components/Time";
 
-import { useDurationFormat } from "src/utils/useDurationFormat";
+import { useDurationFormat } from "src/utils";
 
 dayjs.extend(duration);
 

--- a/airflow-core/src/airflow/ui/src/pages/GroupTaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/GroupTaskInstance/Header.tsx
@@ -27,11 +27,11 @@ import { ClearTaskInstanceButton } from "src/components/Clear";
 import { HeaderCard } from "src/components/HeaderCard";
 import { MarkTaskGroupAsButton } from "src/components/MarkAs";
 import Time from "src/components/Time";
-
-import { getDuration } from "src/utils";
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 export const Header = ({ taskInstance }: { readonly taskInstance: LightGridTaskInstanceSummary }) => {
   const { t: translate } = useTranslation();
+  const { formatElapsed } = useDurationFormat();
   const entries: Array<{ label: string; value: number | ReactNode | string }> = [];
 
   Object.entries(taskInstance.child_states ?? {}).forEach(([state, count]) => {
@@ -48,7 +48,7 @@ export const Header = ({ taskInstance }: { readonly taskInstance: LightGridTaskI
       ? [
           {
             label: translate("duration"),
-            value: getDuration(taskInstance.min_start_date, taskInstance.max_end_date),
+            value: formatElapsed(taskInstance.min_start_date, taskInstance.max_end_date),
           },
         ]
       : []),

--- a/airflow-core/src/airflow/ui/src/pages/GroupTaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/GroupTaskInstance/Header.tsx
@@ -27,6 +27,7 @@ import { ClearTaskInstanceButton } from "src/components/Clear";
 import { HeaderCard } from "src/components/HeaderCard";
 import { MarkTaskGroupAsButton } from "src/components/MarkAs";
 import Time from "src/components/Time";
+
 import { useDurationFormat } from "src/utils/useDurationFormat";
 
 export const Header = ({ taskInstance }: { readonly taskInstance: LightGridTaskInstanceSummary }) => {

--- a/airflow-core/src/airflow/ui/src/pages/GroupTaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/GroupTaskInstance/Header.tsx
@@ -28,7 +28,7 @@ import { HeaderCard } from "src/components/HeaderCard";
 import { MarkTaskGroupAsButton } from "src/components/MarkAs";
 import Time from "src/components/Time";
 
-import { useDurationFormat } from "src/utils/useDurationFormat";
+import { useDurationFormat } from "src/utils";
 
 export const Header = ({ taskInstance }: { readonly taskInstance: LightGridTaskInstanceSummary }) => {
   const { t: translate } = useTranslation();

--- a/airflow-core/src/airflow/ui/src/pages/MappedTaskInstance/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/MappedTaskInstance/Details.tsx
@@ -25,6 +25,7 @@ import type { LightGridTaskInstanceSummary } from "openapi/requests/types.gen";
 
 import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
+
 import { useDurationFormat } from "src/utils/useDurationFormat";
 
 export const Details = () => {

--- a/airflow-core/src/airflow/ui/src/pages/MappedTaskInstance/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/MappedTaskInstance/Details.tsx
@@ -25,12 +25,12 @@ import type { LightGridTaskInstanceSummary } from "openapi/requests/types.gen";
 
 import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
-
-import { getDuration } from "src/utils";
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 export const Details = () => {
   const { dagId = "", taskId = "" } = useParams();
   const { t: translate } = useTranslation();
+  const { formatElapsed } = useDurationFormat();
 
   // The aggregate summary (per-state counts, dates) is streamed once by the parent page and
   // shared through the router outlet, so this tab does not re-open the TI summaries stream.
@@ -129,7 +129,7 @@ export const Details = () => {
           </Table.Row>
           <Table.Row>
             <Table.Cell>{translate("duration")}</Table.Cell>
-            <Table.Cell>{getDuration(taskInstance?.min_start_date, taskInstance?.max_end_date)}</Table.Cell>
+            <Table.Cell>{formatElapsed(taskInstance?.min_start_date, taskInstance?.max_end_date)}</Table.Cell>
           </Table.Row>
           <Table.Row>
             <Table.Cell>{translate("taskInstance.dagVersion")}</Table.Cell>

--- a/airflow-core/src/airflow/ui/src/pages/MappedTaskInstance/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/MappedTaskInstance/Details.tsx
@@ -26,7 +26,7 @@ import type { LightGridTaskInstanceSummary } from "openapi/requests/types.gen";
 import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
 
-import { useDurationFormat } from "src/utils/useDurationFormat";
+import { useDurationFormat } from "src/utils";
 
 export const Details = () => {
   const { dagId = "", taskId = "" } = useParams();

--- a/airflow-core/src/airflow/ui/src/pages/MappedTaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/MappedTaskInstance/Header.tsx
@@ -28,6 +28,7 @@ import type { LightGridTaskInstanceSummary } from "openapi/requests/types.gen";
 import { ClearTaskInstanceButton } from "src/components/Clear";
 import { HeaderCard } from "src/components/HeaderCard";
 import Time from "src/components/Time";
+
 import { useDurationFormat } from "src/utils/useDurationFormat";
 
 export const Header = ({ taskInstance }: { readonly taskInstance: LightGridTaskInstanceSummary }) => {

--- a/airflow-core/src/airflow/ui/src/pages/MappedTaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/MappedTaskInstance/Header.tsx
@@ -28,12 +28,12 @@ import type { LightGridTaskInstanceSummary } from "openapi/requests/types.gen";
 import { ClearTaskInstanceButton } from "src/components/Clear";
 import { HeaderCard } from "src/components/HeaderCard";
 import Time from "src/components/Time";
-
-import { getDuration } from "src/utils";
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 export const Header = ({ taskInstance }: { readonly taskInstance: LightGridTaskInstanceSummary }) => {
   const { dagId = "", runId = "" } = useParams();
   const { t: translate } = useTranslation();
+  const { formatElapsed } = useDurationFormat();
   const entries: Array<{ key?: string; label: string; value: number | ReactNode | string }> = [];
   let taskCount: number = 0;
 
@@ -65,7 +65,7 @@ export const Header = ({ taskInstance }: { readonly taskInstance: LightGridTaskI
       ? [
           {
             label: translate("duration"),
-            value: getDuration(taskInstance.min_start_date, taskInstance.max_end_date),
+            value: formatElapsed(taskInstance.min_start_date, taskInstance.max_end_date),
           },
         ]
       : []),

--- a/airflow-core/src/airflow/ui/src/pages/MappedTaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/MappedTaskInstance/Header.tsx
@@ -29,7 +29,7 @@ import { ClearTaskInstanceButton } from "src/components/Clear";
 import { HeaderCard } from "src/components/HeaderCard";
 import Time from "src/components/Time";
 
-import { useDurationFormat } from "src/utils/useDurationFormat";
+import { useDurationFormat } from "src/utils";
 
 export const Header = ({ taskInstance }: { readonly taskInstance: LightGridTaskInstanceSummary }) => {
   const { dagId = "", runId = "" } = useParams();

--- a/airflow-core/src/airflow/ui/src/pages/Run/DeadlineStatus.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/DeadlineStatus.tsx
@@ -29,6 +29,7 @@ import type { DeadlineAlertResponse } from "openapi/requests/types.gen";
 import { Tooltip } from "src/system-components";
 
 import Time from "src/components/Time";
+
 import { translateCompletionRule } from "src/utils/deadlines";
 import { useDurationFormat } from "src/utils/useDurationFormat";
 

--- a/airflow-core/src/airflow/ui/src/pages/Run/DeadlineStatus.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/DeadlineStatus.tsx
@@ -29,9 +29,8 @@ import type { DeadlineAlertResponse } from "openapi/requests/types.gen";
 import { Tooltip } from "src/system-components";
 
 import Time from "src/components/Time";
-
-import { renderDuration } from "src/utils/datetimeUtils";
 import { translateCompletionRule } from "src/utils/deadlines";
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 import { DeadlineStatusModal } from "./DeadlineStatusModal";
 
@@ -43,6 +42,7 @@ type DeadlineStatusProps = {
 
 export const DeadlineStatus = ({ dagId, dagRunId, endDate }: DeadlineStatusProps) => {
   const { t: translate } = useTranslation("dag");
+  const { locale, renderDuration } = useDurationFormat();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const { data: deadlineData, isLoading: isLoadingDeadlines } = useDeadlinesServiceGetDeadlines({
@@ -84,7 +84,7 @@ export const DeadlineStatus = ({ dagId, dagRunId, endDate }: DeadlineStatusProps
       <VStack alignItems="flex-start" gap={0.5}>
         {(alertData?.deadline_alerts ?? []).map((deadlineAlert) => (
           <Text fontSize="xs" key={deadlineAlert.id}>
-            {translateCompletionRule(translate, deadlineAlert)}
+            {translateCompletionRule(translate, deadlineAlert, locale)}
           </Text>
         ))}
       </VStack>
@@ -151,14 +151,14 @@ export const DeadlineStatus = ({ dagId, dagRunId, endDate }: DeadlineStatusProps
   }
 
   const alert = dl.alert_id !== undefined && dl.alert_id !== null ? alertMap.get(dl.alert_id) : undefined;
-  const completionRule = translateCompletionRule(translate, alert);
+  const completionRule = translateCompletionRule(translate, alert, locale);
   const deadlineTime = dayjs(dl.deadline_time);
 
   let actualDurationLabel: string | undefined;
 
   if (dl.missed && runEndDate !== undefined) {
     const diff = dayjs(runEndDate).diff(deadlineTime);
-    const dur = renderDuration(Math.abs(diff) / 1000, false);
+    const dur = renderDuration(Math.abs(diff) / 1000);
 
     if (dur !== undefined) {
       actualDurationLabel =

--- a/airflow-core/src/airflow/ui/src/pages/Run/DeadlineStatus.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/DeadlineStatus.tsx
@@ -30,8 +30,8 @@ import { Tooltip } from "src/system-components";
 
 import Time from "src/components/Time";
 
+import { useDurationFormat } from "src/utils";
 import { translateCompletionRule } from "src/utils/deadlines";
-import { useDurationFormat } from "src/utils/useDurationFormat";
 
 import { DeadlineStatusModal } from "./DeadlineStatusModal";
 

--- a/airflow-core/src/airflow/ui/src/pages/Run/DeadlineStatusModal.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/DeadlineStatusModal.tsx
@@ -30,9 +30,8 @@ import { Modal, Pagination } from "src/system-components";
 
 import { ErrorAlert } from "src/components/ErrorAlert";
 import Time from "src/components/Time";
-
-import { renderDuration } from "src/utils/datetimeUtils";
 import { translateCompletionRule } from "src/utils/deadlines";
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 const PAGE_LIMIT = 10;
 
@@ -54,6 +53,7 @@ export const DeadlineStatusModal = ({
   runEndDate,
 }: DeadlineStatusModalProps) => {
   const { t: translate } = useTranslation("dag");
+  const { locale, renderDuration } = useDurationFormat();
   const [page, setPage] = useState(1);
   const offset = (page - 1) * PAGE_LIMIT;
 
@@ -117,14 +117,14 @@ export const DeadlineStatusModal = ({
           {deadlines.map((dl) => {
             const alert =
               dl.alert_id !== undefined && dl.alert_id !== null ? alertMap.get(dl.alert_id) : undefined;
-            const completionRule = translateCompletionRule(translate, alert);
+            const completionRule = translateCompletionRule(translate, alert, locale);
             const deadlineTime = dayjs(dl.deadline_time);
 
             let actualDurationLabel: string | undefined;
 
             if (dl.missed && runEndDate !== undefined) {
               const diff = dayjs(runEndDate).diff(deadlineTime);
-              const dur = renderDuration(Math.abs(diff) / 1000, false);
+              const dur = renderDuration(Math.abs(diff) / 1000);
 
               if (dur !== undefined) {
                 actualDurationLabel =

--- a/airflow-core/src/airflow/ui/src/pages/Run/DeadlineStatusModal.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/DeadlineStatusModal.tsx
@@ -30,6 +30,7 @@ import { Modal, Pagination } from "src/system-components";
 
 import { ErrorAlert } from "src/components/ErrorAlert";
 import Time from "src/components/Time";
+
 import { translateCompletionRule } from "src/utils/deadlines";
 import { useDurationFormat } from "src/utils/useDurationFormat";
 

--- a/airflow-core/src/airflow/ui/src/pages/Run/DeadlineStatusModal.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/DeadlineStatusModal.tsx
@@ -31,8 +31,8 @@ import { Modal, Pagination } from "src/system-components";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import Time from "src/components/Time";
 
+import { useDurationFormat } from "src/utils";
 import { translateCompletionRule } from "src/utils/deadlines";
-import { useDurationFormat } from "src/utils/useDurationFormat";
 
 const PAGE_LIMIT = 10;
 

--- a/airflow-core/src/airflow/ui/src/pages/Run/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Details.tsx
@@ -32,10 +32,12 @@ import { TeamName } from "src/components/TeamName";
 import Time from "src/components/Time";
 
 import { useShowTeam } from "src/hooks/useShowTeam";
-import { getDuration, isStatePending, renderDuration, useAutoRefresh } from "src/utils";
+import { isStatePending, useAutoRefresh } from "src/utils";
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 export const Details = () => {
   const { t: translate } = useTranslation(["common", "components"]);
+  const { formatElapsed, renderDuration } = useDurationFormat();
   const { dagId = "", runId = "" } = useParams();
 
   const refetchInterval = useAutoRefresh({ dagId });
@@ -99,7 +101,7 @@ export const Details = () => {
         ) : undefined}
         <Table.Row>
           <Table.Cell>{translate("duration")}</Table.Cell>
-          <Table.Cell>{getDuration(dagRun.start_date, dagRun.end_date)}</Table.Cell>
+          <Table.Cell>{formatElapsed(dagRun.start_date, dagRun.end_date)}</Table.Cell>
         </Table.Row>
         {dagRunStats?.duration ? (
           <Table.Row>

--- a/airflow-core/src/airflow/ui/src/pages/Run/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Details.tsx
@@ -32,8 +32,7 @@ import { TeamName } from "src/components/TeamName";
 import Time from "src/components/Time";
 
 import { useShowTeam } from "src/hooks/useShowTeam";
-import { isStatePending, useAutoRefresh } from "src/utils";
-import { useDurationFormat } from "src/utils/useDurationFormat";
+import { isStatePending, useAutoRefresh, useDurationFormat } from "src/utils";
 
 export const Details = () => {
   const { t: translate } = useTranslation(["common", "components"]);

--- a/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
@@ -41,12 +41,13 @@ import Time from "src/components/Time";
 import { SearchParamsKeys } from "src/constants/searchParams";
 import { useShowTeam } from "src/hooks/useShowTeam";
 import { useDagRunNote } from "src/queries/useDagRunNote";
-import { getDuration } from "src/utils";
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 import { DeadlineStatus } from "./DeadlineStatus";
 
 export const Header = ({ dagRun }: { readonly dagRun: DAGRunResponse }) => {
   const { t: translate } = useTranslation();
+  const { formatElapsed } = useDurationFormat();
   const { isPending, note, onOpen, onSave, setNote } = useDagRunNote(dagRun);
   const showTeam = useShowTeam(dagRun.team_name);
 
@@ -97,7 +98,7 @@ export const Header = ({ dagRun }: { readonly dagRun: DAGRunResponse }) => {
           },
           { label: translate("startDate"), value: <Time datetime={dagRun.start_date} /> },
           { label: translate("endDate"), value: <Time datetime={dagRun.end_date} /> },
-          { label: translate("duration"), value: getDuration(dagRun.start_date, dagRun.end_date) },
+          { label: translate("duration"), value: formatElapsed(dagRun.start_date, dagRun.end_date) },
           ...(dagRun.triggering_user_name === null
             ? []
             : [

--- a/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
@@ -41,7 +41,7 @@ import Time from "src/components/Time";
 import { SearchParamsKeys } from "src/constants/searchParams";
 import { useShowTeam } from "src/hooks/useShowTeam";
 import { useDagRunNote } from "src/queries/useDagRunNote";
-import { useDurationFormat } from "src/utils/useDurationFormat";
+import { useDurationFormat } from "src/utils";
 
 import { DeadlineStatus } from "./DeadlineStatus";
 

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Details.tsx
@@ -38,7 +38,8 @@ import Time from "src/components/Time";
 
 import { SearchParamsKeys } from "src/constants/searchParams";
 import { useShowTeam } from "src/hooks/useShowTeam";
-import { useAutoRefresh, isStatePending, renderDuration } from "src/utils";
+import { useAutoRefresh, isStatePending } from "src/utils";
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 import { BlockingDeps } from "./BlockingDeps";
 import { ExtraLinks } from "./ExtraLinks";
@@ -46,6 +47,7 @@ import { TriggererInfo } from "./TriggererInfo";
 
 export const Details = () => {
   const { t: translate } = useTranslation();
+  const { renderDuration } = useDurationFormat();
   const { dagId = "", mapIndex = "-1", runId = "", taskId = "" } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
 

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Details.tsx
@@ -38,8 +38,7 @@ import Time from "src/components/Time";
 
 import { SearchParamsKeys } from "src/constants/searchParams";
 import { useShowTeam } from "src/hooks/useShowTeam";
-import { useAutoRefresh, isStatePending } from "src/utils";
-import { useDurationFormat } from "src/utils/useDurationFormat";
+import { isStatePending, useAutoRefresh, useDurationFormat } from "src/utils";
 
 import { BlockingDeps } from "./BlockingDeps";
 import { ExtraLinks } from "./ExtraLinks";

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
@@ -35,10 +35,11 @@ import Time from "src/components/Time";
 
 import { useShowTeam } from "src/hooks/useShowTeam";
 import { useTaskInstanceNote } from "src/queries/useTaskInstanceNote";
-import { getDuration, renderDuration } from "src/utils";
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 export const Header = ({ taskInstance }: { readonly taskInstance: TaskInstanceResponse }) => {
   const { t: translate } = useTranslation();
+  const { formatElapsed, renderDuration } = useDurationFormat();
   const { isPending, note, onOpen, onSave, setNote } = useTaskInstanceNote(taskInstance);
   const showTeam = useShowTeam(taskInstance.team_name);
 
@@ -58,7 +59,7 @@ export const Header = ({ taskInstance }: { readonly taskInstance: TaskInstanceRe
             label: translate("duration"),
             value: Boolean(taskInstance.duration)
               ? renderDuration(taskInstance.duration)
-              : getDuration(taskInstance.start_date, taskInstance.end_date),
+              : formatElapsed(taskInstance.start_date, taskInstance.end_date),
           },
         ]
       : []),

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
@@ -35,7 +35,7 @@ import Time from "src/components/Time";
 
 import { useShowTeam } from "src/hooks/useShowTeam";
 import { useTaskInstanceNote } from "src/queries/useTaskInstanceNote";
-import { useDurationFormat } from "src/utils/useDurationFormat";
+import { useDurationFormat } from "src/utils";
 
 export const Header = ({ taskInstance }: { readonly taskInstance: TaskInstanceResponse }) => {
   const { t: translate } = useTranslation();

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -90,6 +90,7 @@ const {
 type ColumnProps = {
   readonly dagId?: string;
   readonly renderDuration: (duration: number | null | undefined) => string | undefined;
+  readonly renderExactDuration: (duration: number | null | undefined) => string | undefined;
   readonly runId?: string;
   readonly taskId?: string;
   readonly translate: TFunction;
@@ -99,6 +100,7 @@ const taskInstanceColumns = ({
   dagId,
   multiTeam,
   renderDuration,
+  renderExactDuration,
   runId,
   taskId,
   translate,
@@ -242,7 +244,9 @@ const taskInstanceColumns = ({
   },
   {
     accessorKey: "duration",
-    cell: ({ row: { original } }) => renderDuration(original.duration),
+    cell: ({ row: { original } }) => (
+      <span title={renderExactDuration(original.duration)}>{renderDuration(original.duration)}</span>
+    ),
     header: translate("duration"),
   },
   {
@@ -271,7 +275,7 @@ const taskInstanceColumns = ({
 
 export const TaskInstances = () => {
   const { t: translate } = useTranslation();
-  const { renderDuration } = useDurationFormat();
+  const { renderDuration, renderExactDuration } = useDurationFormat();
   const { dagId, groupId, runId, taskId } = useParams();
 
   // Only the standalone list page owns the tab title; nested tabs inherit their parent page's title.
@@ -411,6 +415,7 @@ export const TaskInstances = () => {
     dagId,
     multiTeam: multiTeamEnabled,
     renderDuration,
+    renderExactDuration,
     runId,
     taskId: Boolean(groupId) ? undefined : taskId,
     translate,

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -48,8 +48,9 @@ import { TruncatedText } from "src/components/TruncatedText";
 import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
 import { useAdvancedSearchArg } from "src/hooks/useAdvancedSearch";
 import { useConfig } from "src/queries/useConfig";
-import { useAutoRefresh, isStatePending, renderDuration, useDocumentTitle } from "src/utils";
+import { useAutoRefresh, isStatePending, useDocumentTitle } from "src/utils";
 import { getTaskInstanceLink } from "src/utils/links";
+import { useDurationFormat } from "src/utils/useDurationFormat";
 
 import BulkClearTaskInstancesButton from "./BulkClearTaskInstancesButton";
 import BulkDeleteTaskInstancesButton from "./BulkDeleteTaskInstancesButton";
@@ -88,6 +89,7 @@ const {
 
 type ColumnProps = {
   readonly dagId?: string;
+  readonly renderDuration: (duration: number | null | undefined) => string | undefined;
   readonly runId?: string;
   readonly taskId?: string;
   readonly translate: TFunction;
@@ -96,6 +98,7 @@ type ColumnProps = {
 const taskInstanceColumns = ({
   dagId,
   multiTeam,
+  renderDuration,
   runId,
   taskId,
   translate,
@@ -268,6 +271,7 @@ const taskInstanceColumns = ({
 
 export const TaskInstances = () => {
   const { t: translate } = useTranslation();
+  const { renderDuration } = useDurationFormat();
   const { dagId, groupId, runId, taskId } = useParams();
 
   // Only the standalone list page owns the tab title; nested tabs inherit their parent page's title.
@@ -406,6 +410,7 @@ export const TaskInstances = () => {
   const columns = taskInstanceColumns({
     dagId,
     multiTeam: multiTeamEnabled,
+    renderDuration,
     runId,
     taskId: Boolean(groupId) ? undefined : taskId,
     translate,

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -38,6 +38,7 @@ import {
   type GetColumnsParams,
 } from "src/components/DataTable/useRowSelection";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
+import { DurationCell } from "src/components/DurationCell";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { MarkTaskInstanceAsButton } from "src/components/MarkAs";
 import { StateBadge } from "src/components/StateBadge";
@@ -50,7 +51,6 @@ import { useAdvancedSearchArg } from "src/hooks/useAdvancedSearch";
 import { useConfig } from "src/queries/useConfig";
 import { useAutoRefresh, isStatePending, useDocumentTitle } from "src/utils";
 import { getTaskInstanceLink } from "src/utils/links";
-import { useDurationFormat } from "src/utils/useDurationFormat";
 
 import BulkClearTaskInstancesButton from "./BulkClearTaskInstancesButton";
 import BulkDeleteTaskInstancesButton from "./BulkDeleteTaskInstancesButton";
@@ -89,8 +89,6 @@ const {
 
 type ColumnProps = {
   readonly dagId?: string;
-  readonly renderDuration: (duration: number | null | undefined) => string | undefined;
-  readonly renderExactDuration: (duration: number | null | undefined) => string | undefined;
   readonly runId?: string;
   readonly taskId?: string;
   readonly translate: TFunction;
@@ -99,8 +97,6 @@ type ColumnProps = {
 const taskInstanceColumns = ({
   dagId,
   multiTeam,
-  renderDuration,
-  renderExactDuration,
   runId,
   taskId,
   translate,
@@ -244,9 +240,7 @@ const taskInstanceColumns = ({
   },
   {
     accessorKey: "duration",
-    cell: ({ row: { original } }) => (
-      <span title={renderExactDuration(original.duration)}>{renderDuration(original.duration)}</span>
-    ),
+    cell: ({ row: { original } }) => <DurationCell duration={original.duration} />,
     header: translate("duration"),
   },
   {
@@ -275,7 +269,6 @@ const taskInstanceColumns = ({
 
 export const TaskInstances = () => {
   const { t: translate } = useTranslation();
-  const { renderDuration, renderExactDuration } = useDurationFormat();
   const { dagId, groupId, runId, taskId } = useParams();
 
   // Only the standalone list page owns the tab title; nested tabs inherit their parent page's title.
@@ -414,8 +407,6 @@ export const TaskInstances = () => {
   const columns = taskInstanceColumns({
     dagId,
     multiTeam: multiTeamEnabled,
-    renderDuration,
-    renderExactDuration,
     runId,
     taskId: Boolean(groupId) ? undefined : taskId,
     translate,

--- a/airflow-core/src/airflow/ui/src/utils/datetimeUtils.test.ts
+++ b/airflow-core/src/airflow/ui/src/utils/datetimeUtils.test.ts
@@ -26,6 +26,7 @@ import {
   getElapsedSeconds,
   humanizeSeconds,
   renderDuration,
+  renderExactDuration,
   getRelativeTime,
 } from "./datetimeUtils";
 
@@ -178,7 +179,12 @@ describe("renderDuration", () => {
     expect(renderDuration(14.846, "fr")).toContain("14,8");
     expect(renderDuration(14.846, "en")).toContain("14.8");
     expect(renderDuration(3725.4, "ru")).toMatch(/\p{Script=Cyrillic}/u);
-    expect(renderDuration(3725.4, "de")).not.toBe(renderDuration(3725.4, "en"));
+    expect(renderDuration(3725.4, "de")).toBe(
+      expectDuration("de", "narrow", [
+        ["hour", 1],
+        ["minute", 2],
+      ]),
+    );
   });
 
   it.each([["en"], ["de"], ["ru"]])("marks sub-millisecond durations as under 1ms in %s", (locale) => {
@@ -227,6 +233,40 @@ describe("getDuration", () => {
     expect(getDuration(start, undefined, "en")).toBe("10s");
 
     vi.useRealTimers();
+  });
+});
+
+describe("renderExactDuration", () => {
+  // renderDuration rounds to two units, so "1h 2m" spans a full minute. The exact form backs the
+  // `title` on the duration columns, where two similar runs have to be told apart.
+  it.each([
+    [3725.412, "1h 2m 5.412s"],
+    [102_600, "1d 4h 30m"],
+    [281_445, "3d 6h 10m 45s"],
+    [3600, "1h"],
+    [45.5, "45.5s"],
+    [0.083, "83ms"],
+  ])("renders %s seconds in full as %s", (seconds, expected) => {
+    expect(renderExactDuration(seconds, "en")).toBe(expected);
+  });
+
+  it("keeps precision the rounded form drops", () => {
+    expect(renderDuration(3725.412, "en")).toBe("1h 2m");
+    expect(renderExactDuration(3725.412, "en")).toBe("1h 2m 5.412s");
+  });
+
+  it.each([[null], [undefined], [Number.NaN], [-5]])("returns undefined for %s", (seconds) => {
+    expect(renderExactDuration(seconds, "en")).toBeUndefined();
+  });
+
+  it("localizes like the rounded form", () => {
+    expect(renderExactDuration(3725.412, "de")).toBe(
+      expectDuration("de", "narrow", [
+        ["hour", 1],
+        ["minute", 2],
+        ["second", 5.412, 3],
+      ]),
+    );
   });
 });
 
@@ -279,6 +319,19 @@ describe("getRelativeTime", () => {
     ["2024-01-14T10:00:10.000Z", "2 months ago"],
     ["2022-03-14T10:00:10.000Z", "2 years ago"],
   ])("describes %s as %s", (date, expected) => {
+    expect(getRelativeTime(date, "en")).toBe(expected);
+  });
+
+  // Rounding used to saturate the unit the magnitude was picked from, printing the unit's own
+  // ceiling instead of promoting: "60 minutes ago" where dayjs's fromNow said "an hour ago".
+  it.each([
+    // 59.7 minutes: rounds to 60, which used to print "60 minutes ago".
+    ["2024-03-14T09:00:28.000Z", "1 hour ago"],
+    // 23.9 hours -> "24 hours ago" before.
+    ["2024-03-13T10:06:50.000Z", "yesterday"],
+    // 365.2 days -> "12 months ago" before.
+    ["2023-03-15T04:10:10.000Z", "last year"],
+  ])("promotes %s to the next unit up rather than saturating", (date, expected) => {
     expect(getRelativeTime(date, "en")).toBe(expected);
   });
 

--- a/airflow-core/src/airflow/ui/src/utils/datetimeUtils.test.ts
+++ b/airflow-core/src/airflow/ui/src/utils/datetimeUtils.test.ts
@@ -23,55 +23,198 @@ import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
 import {
   getDuration,
   getDurationTickStep,
+  getElapsedSeconds,
   humanizeSeconds,
-  renderCompactDuration,
   renderDuration,
   getRelativeTime,
 } from "./datetimeUtils";
 
 dayjs.extend(dayjsDuration);
 
-describe("getDuration & formatDuration", () => {
-  it("handles durations less than 60 seconds", () => {
-    const start = "2024-03-14T10:00:00.000Z";
-    const end = "2024-03-14T10:00:05.5111111Z";
+// CLDR's own strings shift between ICU releases — de narrow "1 Std." became "1h" in ICU 78 — and the
+// runtime ICU differs across CI, contributor machines and browsers. So localized cases assert the
+// composition we control (which units, what precision, which style, joined in order) and leave the
+// wording to the platform. Only the English cases pin literals, as those encode our band policy.
+const expectDuration = (
+  locale: string,
+  style: "long" | "narrow",
+  parts: Array<[Intl.NumberFormatOptions["unit"], number, number?]>,
+) => {
+  const formatted = parts.map(([unit, value, fractionDigits = 0]) =>
+    new Intl.NumberFormat(locale, {
+      maximumFractionDigits: fractionDigits,
+      style: "unit",
+      unit,
+      unitDisplay: style,
+    }).format(value),
+  );
 
-    expect(getDuration(start, end)).toBe("00:00:05.511");
+  return formatted.length > 1
+    ? new Intl.ListFormat(locale, { style, type: "unit" }).format(formatted)
+    : formatted[0];
+};
+
+describe("renderDuration", () => {
+  it.each([
+    [0, "0s"],
+    [0.0000004, "<1ms"],
+    [0.0009, "<1ms"],
+    [0.001, "1ms"],
+    [0.083, "83ms"],
+    [0.9994, "999ms"],
+    // Rounding up out of the millisecond band must promote to seconds, not print "1000ms".
+    [0.9996, "1s"],
+    [1, "1s"],
+    [1.5, "1.5s"],
+    [9.87456, "9.87s"],
+    // Three significant digits means one decimal from 10s up, two below it.
+    [14.846, "14.8s"],
+    [15, "15s"],
+    [45, "45s"],
+    [59.9, "59.9s"],
+    // Rounding at the band's precision spills into the next band.
+    [59.96, "1m"],
+    [60, "1m"],
+    [65.25, "1m 5s"],
+    [545, "9m 5s"],
+    [540, "9m"],
+    [3599.6, "1h"],
+    [3600, "1h"],
+    [3725.4, "1h 2m"],
+    [5400, "1h 30m"],
+    [86_399.6, "1d"],
+    [86_400, "1d"],
+    [90_061.2, "1d 1h"],
+    // Rounds rather than truncates: 1d 4h 30m is nearer 1d 5h.
+    [102_600, "1d 5h"],
+    [281_445, "3d 6h"],
+  ])("formats %s seconds as %s", (seconds, expected) => {
+    expect(renderDuration(seconds, "en")).toBe(expected);
   });
 
-  it("handles durations spanning multiple days", () => {
-    const start = "2024-03-14T10:00:00.000Z";
-    const end = "2024-03-17T15:30:45.000Z";
+  it.each([[null], [undefined], [Number.NaN], [Number.POSITIVE_INFINITY], [-5]])(
+    "returns undefined without a usable duration (%s)",
+    (seconds) => {
+      expect(renderDuration(seconds, "en")).toBeUndefined();
+    },
+  );
 
-    expect(getDuration(start, end)).toBe("3d05:30:45");
+  it("accepts dayjs durations as well as numbers", () => {
+    expect(renderDuration(dayjs.duration(10, "seconds"), "en")).toBe("10s");
+    expect(renderDuration(dayjs.duration(0.083, "seconds"), "en")).toBe("83ms");
+    expect(renderDuration(dayjs.duration(3725.4, "seconds"), "en")).toBe("1h 2m");
   });
 
-  it("handles exactly 24 hours", () => {
-    const start = "2024-03-14T10:00:00.000Z";
-    const end = "2024-03-15T10:00:00.000Z";
+  it.each([
+    ["de", 0.083, [["millisecond", 83]]],
+    ["de", 14.846, [["second", 14.8, 1]]],
+    [
+      "de",
+      3725.4,
+      [
+        ["hour", 1],
+        ["minute", 2],
+      ],
+    ],
+    [
+      "fr",
+      281_445,
+      [
+        ["day", 3],
+        ["hour", 6],
+      ],
+    ],
+    [
+      "ru",
+      3725.4,
+      [
+        ["hour", 1],
+        ["minute", 2],
+      ],
+    ],
+    [
+      "ja",
+      65.25,
+      [
+        ["minute", 1],
+        ["second", 5],
+      ],
+    ],
+    [
+      "ar",
+      3725.4,
+      [
+        ["hour", 1],
+        ["minute", 2],
+      ],
+    ],
+    [
+      "pl",
+      545,
+      [
+        ["minute", 9],
+        ["second", 5],
+      ],
+    ],
+    [
+      "zh-CN",
+      545,
+      [
+        ["minute", 9],
+        ["second", 5],
+      ],
+    ],
+    ["pt", 604_800, [["day", 7]]],
+    ["it", 604_800, [["day", 7]]],
+  ] as Array<[string, number, Array<[Intl.NumberFormatOptions["unit"], number, number?]>]>)(
+    "localizes %s duration of %s seconds",
+    (locale, seconds, parts) => {
+      expect(renderDuration(seconds, locale)).toBe(expectDuration(locale, "narrow", parts));
+    },
+  );
 
-    expect(getDuration(start, end)).toBe("1d00:00:00");
+  // Properties CLDR has held stable for decades, unlike the unit abbreviations themselves.
+  it("uses the locale's decimal separator and script", () => {
+    expect(renderDuration(14.846, "fr")).toContain("14,8");
+    expect(renderDuration(14.846, "en")).toContain("14.8");
+    expect(renderDuration(3725.4, "ru")).toMatch(/\p{Script=Cyrillic}/u);
+    expect(renderDuration(3725.4, "de")).not.toBe(renderDuration(3725.4, "en"));
   });
 
-  it("handles hours and minutes without days", () => {
-    const start = "2024-03-14T10:00:00.000Z";
-    const end = "2024-03-14T12:30:00.000Z";
-
-    expect(getDuration(start, end)).toBe("02:30:00");
+  it.each([["en"], ["de"], ["ru"]])("marks sub-millisecond durations as under 1ms in %s", (locale) => {
+    expect(renderDuration(0.0004, locale)).toBe(`<${expectDuration(locale, "narrow", [["millisecond", 1]])}`);
   });
 
-  it("omits milliseconds when withMilliseconds is false", () => {
-    const start = "2024-03-14T10:00:00.000Z";
-    const end = "2024-03-14T10:00:05.511Z";
+  it("falls back to English rather than throwing on a language Intl rejects", () => {
+    expect(renderDuration(3725.4, "not a locale!")).toBe("1h 2m");
+  });
+});
 
-    expect(getDuration(start, end, false)).toBe("00:00:05");
+describe("getDuration", () => {
+  it.each([
+    ["2024-03-14T10:00:00.000Z", "2024-03-14T10:00:00.083Z", "83ms"],
+    ["2024-03-14T10:00:00.000Z", "2024-03-14T10:00:05.5111111Z", "5.51s"],
+    ["2024-03-14T10:00:00.000Z", "2024-03-14T10:00:14.846Z", "14.8s"],
+    ["2024-03-14T10:00:00.000Z", "2024-03-14T12:30:00.000Z", "2h 30m"],
+    ["2024-03-14T10:00:00.000Z", "2024-03-15T10:00:00.000Z", "1d"],
+    ["2024-03-14T10:00:00.000Z", "2024-03-17T15:30:45.000Z", "3d 6h"],
+  ])("renders %s to %s as %s", (start, end, expected) => {
+    expect(getDuration(start, end, "en")).toBe(expected);
   });
 
-  it("handles small, null or undefined values", () => {
+  it("forwards the locale to the formatter", () => {
+    expect(getDuration("2024-03-14T10:00:00.000Z", "2024-03-14T12:30:00.000Z", "de")).toBe(
+      expectDuration("de", "narrow", [
+        ["hour", 2],
+        ["minute", 30],
+      ]),
+    );
+  });
+
+  it("handles null or undefined values", () => {
     expect(getDuration(null, null)).toBe(undefined);
     expect(getDuration(undefined, undefined)).toBe(undefined);
     expect(getDuration(null, "2024-03-14T10:00:10.000Z")).toBe(undefined);
-    expect(renderDuration(0.00001)).toBe(undefined);
   });
 
   it("falls back to current time when endDate is null (running task)", () => {
@@ -80,24 +223,36 @@ describe("getDuration & formatDuration", () => {
 
     const start = "2024-03-14T10:00:00.000Z";
 
-    expect(getDuration(start, null)).toBe("00:00:10");
-    expect(getDuration(start, undefined)).toBe("00:00:10");
+    expect(getDuration(start, null, "en")).toBe("10s");
+    expect(getDuration(start, undefined, "en")).toBe("10s");
 
     vi.useRealTimers();
   });
+});
 
-  it("handles both numbers and duration objects", () => {
-    expect(renderDuration(dayjs.duration(10, "seconds"))).toBe("00:00:10");
-    expect(renderDuration(10)).toBe("00:00:10");
+describe("getElapsedSeconds", () => {
+  it.each([
+    ["2024-03-14T10:00:00.000Z", "2024-03-14T10:00:14.846Z", 14.846],
+    ["2024-03-14T10:00:00.000Z", "2024-03-14T12:30:00.000Z", 9000],
+  ])("measures %s to %s as %s seconds", (start, end, expected) => {
+    expect(getElapsedSeconds(start, end)).toBe(expected);
   });
 
-  it("handles floating point milliseconds", () => {
-    expect(renderDuration(dayjs.duration(10.000499738, "seconds"))).toBe("00:00:10");
-    expect(renderDuration(10.000499738)).toBe("00:00:10");
-    expect(renderDuration(dayjs.duration(10.0005, "seconds"))).toBe("00:00:10.001");
-    expect(renderDuration(10.0005)).toBe("00:00:10.001");
-    expect(renderDuration(dayjs.duration(10.838999738, "seconds"))).toBe("00:00:10.839");
-    expect(renderDuration(10.838999738)).toBe("00:00:10.839");
+  it.each([[null], [undefined], ["not a date"]])("returns undefined without a usable start (%s)", (start) => {
+    expect(getElapsedSeconds(start, "2024-03-14T10:00:10.000Z")).toBeUndefined();
+  });
+
+  it("returns undefined when the end date is unparsable", () => {
+    expect(getElapsedSeconds("2024-03-14T10:00:00.000Z", "not a date")).toBeUndefined();
+  });
+
+  it("measures against now when the end date is absent (running task)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-03-14T10:00:10.000Z"));
+
+    expect(getElapsedSeconds("2024-03-14T10:00:00.000Z", null)).toBe(10);
+
+    vi.useRealTimers();
   });
 });
 
@@ -113,40 +268,35 @@ describe("getRelativeTime", () => {
     vi.useRealTimers();
   });
 
-  it("returns relative time for a valid date", () => {
-    const date = "2024-03-14T10:00:00.000Z";
-
-    expect(getRelativeTime(date)).toBe("a few seconds ago");
-  });
-
-  it("returns an empty string for undefined dates", () => {
-    expect(getRelativeTime(undefined)).toBe("");
-  });
-
-  it("handles future dates", () => {
-    const futureDate = "2024-03-14T10:00:20.000Z";
-
-    expect(getRelativeTime(futureDate)).toBe("in a few seconds");
-  });
-});
-
-describe("renderCompactDuration", () => {
   it.each([
-    [0, "0s"],
-    [-5, "0s"],
-    [Number.NaN, "0s"],
-    [Number.POSITIVE_INFINITY, "0s"],
-    [0.25, "250ms"],
-    [45, "45s"],
-    [540, "9m"],
-    [545, "9m 5s"],
-    [3600, "1h"],
-    [5400, "1h 30m"],
-    [86_400, "1d"],
-    [102_600, "1d 4h"],
-  ])("formats %s seconds as %s", (seconds, expected) => {
-    expect(renderCompactDuration(seconds)).toBe(expected);
+    ["2024-03-14T10:00:00.000Z", "10 seconds ago"],
+    ["2024-03-14T10:00:20.000Z", "in 10 seconds"],
+    // The largest unit the gap reaches wins, rather than "2700 seconds ago".
+    ["2024-03-14T09:15:10.000Z", "45 minutes ago"],
+    ["2024-03-14T07:00:10.000Z", "3 hours ago"],
+    ["2024-03-11T10:00:10.000Z", "3 days ago"],
+    ["2024-02-14T10:00:10.000Z", "4 weeks ago"],
+    ["2024-01-14T10:00:10.000Z", "2 months ago"],
+    ["2022-03-14T10:00:10.000Z", "2 years ago"],
+  ])("describes %s as %s", (date, expected) => {
+    expect(getRelativeTime(date, "en")).toBe(expected);
   });
+
+  it.each([["de"], ["fr"], ["ru"], ["ja"]])("localizes relative time for %s", (locale) => {
+    expect(getRelativeTime("2024-03-14T10:00:00.000Z", locale)).toBe(
+      new Intl.RelativeTimeFormat(locale, { numeric: "auto" }).format(-10, "second"),
+    );
+    expect(getRelativeTime("2024-03-14T10:00:00.000Z", locale)).not.toBe(
+      getRelativeTime("2024-03-14T10:00:00.000Z", "en"),
+    );
+  });
+
+  it.each([[undefined], [null], [""], ["not a date"]])(
+    "returns an empty string without a usable date (%s)",
+    (date) => {
+      expect(getRelativeTime(date, "en")).toBe("");
+    },
+  );
 });
 
 describe("getDurationTickStep", () => {
@@ -174,16 +324,43 @@ describe("getDurationTickStep", () => {
 
 describe("humanizeSeconds", () => {
   it.each([
-    [3600, "an hour"],
-    [86_400, "a day"],
-  ])("humanizes %s seconds as %s", (seconds, expected) => {
-    expect(humanizeSeconds(seconds)).toBe(expected);
+    [3600, "1 hour"],
+    [86_400, "1 day"],
+    [3725.4, "1 hour, 2 minutes"],
+    [0.083, "83 milliseconds"],
+  ])("spells out %s seconds as %s in English", (seconds, expected) => {
+    expect(humanizeSeconds(seconds, "en")).toBe(expected);
   });
 
-  it.each([[null], [undefined], [Number.NaN], [Number.POSITIVE_INFINITY]])(
-    "returns undefined without a finite interval (%s)",
+  // The prose form is localized by the same CLDR data as the compact one.
+  it.each([
+    ["de", 3600, [["hour", 1]]],
+    ["de", 86_400, [["day", 1]]],
+    ["ru", 3600, [["hour", 1]]],
+    [
+      "fr",
+      3725.4,
+      [
+        ["hour", 1],
+        ["minute", 2],
+      ],
+    ],
+  ] as Array<[string, number, Array<[Intl.NumberFormatOptions["unit"], number, number?]>]>)(
+    "spells out %s duration of %s seconds",
+    (locale, seconds, parts) => {
+      expect(humanizeSeconds(seconds, locale)).toBe(expectDuration(locale, "long", parts));
+    },
+  );
+
+  it("differs from the compact form and from English", () => {
+    expect(humanizeSeconds(3600, "en")).not.toBe(renderDuration(3600, "en"));
+    expect(humanizeSeconds(3600, "de")).not.toBe(humanizeSeconds(3600, "en"));
+  });
+
+  it.each([[null], [undefined], [Number.NaN], [Number.POSITIVE_INFINITY], [-5]])(
+    "returns undefined without a usable interval (%s)",
     (seconds) => {
-      expect(humanizeSeconds(seconds)).toBeUndefined();
+      expect(humanizeSeconds(seconds, "en")).toBeUndefined();
     },
   );
 });

--- a/airflow-core/src/airflow/ui/src/utils/datetimeUtils.ts
+++ b/airflow-core/src/airflow/ui/src/utils/datetimeUtils.ts
@@ -42,62 +42,63 @@ type DurationPart = { fractionDigits?: number; unit: DurationUnit; value: number
 /** `narrow` ("1h 2m") suits dense tables and charts; `long` ("1 hour, 2 minutes") suits prose. */
 type DurationStyle = "long" | "narrow";
 
-// Durations render in every table row and chart tick callback, and Intl formatters are costly to
-// construct, so instances are reused. A stored language Intl rejects must not blank out every
-// duration in the UI, hence the fallback instead of letting the RangeError escape.
-const unitFormatters = new Map<string, Intl.NumberFormat>();
+// Intl constructors are costly and durations render in every table row and chart tick callback, so
+// instances are reused. A stored language Intl rejects must not blank out every duration in the UI,
+// hence the fallback to DEFAULT_LOCALE rather than letting the RangeError escape.
+const createIntlCache = <T>() => {
+  const cache = new Map<string, T>();
+
+  return (variant: string, locale: string, construct: (forLocale: string) => T): T => {
+    const key = `${locale}|${variant}`;
+    const cached = cache.get(key);
+
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    let formatter: T;
+
+    try {
+      formatter = construct(locale);
+    } catch {
+      formatter = construct(DEFAULT_LOCALE);
+    }
+
+    cache.set(key, formatter);
+
+    return formatter;
+  };
+};
+
+const unitFormatter = createIntlCache<Intl.NumberFormat>();
+const listFormatter = createIntlCache<Intl.ListFormat>();
+const relativeTimeFormatter = createIntlCache<Intl.RelativeTimeFormat>();
 
 const getUnitFormatter = (locale: string, style: DurationStyle, part: DurationPart): Intl.NumberFormat => {
   const { fractionDigits = 0, unit } = part;
-  const key = `${locale}|${unit}|${fractionDigits}|${style}`;
-  const cached = unitFormatters.get(key);
 
-  if (cached !== undefined) {
-    return cached;
-  }
-
-  const options: Intl.NumberFormatOptions = {
-    maximumFractionDigits: fractionDigits,
-    style: "unit",
-    unit,
-    unitDisplay: style,
-  };
-  let formatter: Intl.NumberFormat;
-
-  try {
-    formatter = new Intl.NumberFormat(locale, options);
-  } catch {
-    formatter = new Intl.NumberFormat(DEFAULT_LOCALE, options);
-  }
-
-  unitFormatters.set(key, formatter);
-
-  return formatter;
+  return unitFormatter(
+    `${unit}|${fractionDigits}|${style}`,
+    locale,
+    (forLocale) =>
+      new Intl.NumberFormat(forLocale, {
+        maximumFractionDigits: fractionDigits,
+        style: "unit",
+        unit,
+        unitDisplay: style,
+      }),
+  );
 };
 
-const listFormatters = new Map<string, Intl.ListFormat>();
+const getListFormatter = (locale: string, style: DurationStyle): Intl.ListFormat =>
+  listFormatter(style, locale, (forLocale) => new Intl.ListFormat(forLocale, { style, type: "unit" }));
 
-const getListFormatter = (locale: string, style: DurationStyle): Intl.ListFormat => {
-  const key = `${locale}|${style}`;
-  const cached = listFormatters.get(key);
-
-  if (cached !== undefined) {
-    return cached;
-  }
-
-  const options: Intl.ListFormatOptions = { style, type: "unit" };
-  let formatter: Intl.ListFormat;
-
-  try {
-    formatter = new Intl.ListFormat(locale, options);
-  } catch {
-    formatter = new Intl.ListFormat(DEFAULT_LOCALE, options);
-  }
-
-  listFormatters.set(key, formatter);
-
-  return formatter;
-};
+const getRelativeTimeFormatter = (locale: string): Intl.RelativeTimeFormat =>
+  relativeTimeFormatter(
+    "auto",
+    locale,
+    (forLocale) => new Intl.RelativeTimeFormat(forLocale, { numeric: "auto" }),
+  );
 
 // Unit names, decimal separators, plural forms and the joiner all come from CLDR, so "1h 2m" is
 // "1 ч 2 мин" in ru. This reproduces Intl.DurationFormat's narrow style exactly (verified across
@@ -281,31 +282,6 @@ const RELATIVE_TIME_UNITS: Array<{ seconds: number; unit: Intl.RelativeTimeForma
   { seconds: 1, unit: "second" },
 ];
 
-const RELATIVE_TIME_FALLBACK_UNIT = { seconds: 1, unit: "second" } as const;
-
-const relativeTimeFormatters = new Map<string, Intl.RelativeTimeFormat>();
-
-const getRelativeTimeFormatter = (locale: string): Intl.RelativeTimeFormat => {
-  const cached = relativeTimeFormatters.get(locale);
-
-  if (cached !== undefined) {
-    return cached;
-  }
-
-  const options: Intl.RelativeTimeFormatOptions = { numeric: "auto" };
-  let formatter: Intl.RelativeTimeFormat;
-
-  try {
-    formatter = new Intl.RelativeTimeFormat(locale, options);
-  } catch {
-    formatter = new Intl.RelativeTimeFormat(DEFAULT_LOCALE, options);
-  }
-
-  relativeTimeFormatters.set(locale, formatter);
-
-  return formatter;
-};
-
 export const getRelativeTime = (
   date: string | null | undefined,
   locale: string = i18n.language || DEFAULT_LOCALE,
@@ -317,7 +293,8 @@ export const getRelativeTime = (
   const elapsed = dayjs(date).diff(dayjs(), "second", true);
   const magnitude = Math.abs(elapsed);
   const index = RELATIVE_TIME_UNITS.findIndex((entry) => magnitude >= entry.seconds);
-  const candidate = RELATIVE_TIME_UNITS[index] ?? RELATIVE_TIME_FALLBACK_UNIT;
+  // Anything under a minute falls through to the smallest unit in the table.
+  const candidate = RELATIVE_TIME_UNITS[index] ?? RELATIVE_TIME_UNITS.at(-1)!;
   const rounded = Math.round(elapsed / candidate.seconds);
 
   // Rounding can saturate the unit the magnitude was picked from -- 59.7 minutes rounds to 60 -- so

--- a/airflow-core/src/airflow/ui/src/utils/datetimeUtils.ts
+++ b/airflow-core/src/airflow/ui/src/utils/datetimeUtils.ts
@@ -20,6 +20,7 @@ import dayjs from "dayjs";
 import dayjsDuration from "dayjs/plugin/duration";
 import relativeTime from "dayjs/plugin/relativeTime";
 import tz from "dayjs/plugin/timezone";
+import i18n from "i18next";
 
 dayjs.extend(dayjsDuration);
 dayjs.extend(relativeTime);
@@ -29,70 +30,198 @@ export const DATE_FORMAT = "YYYY-MM-DD";
 export const DEFAULT_DATETIME_FORMAT = `${DATE_FORMAT} HH:mm:ss`;
 export const DEFAULT_DATETIME_FORMAT_WITH_TZ = `${DEFAULT_DATETIME_FORMAT} z`;
 
-export const renderDuration = (
-  durationSeconds: dayjsDuration.Duration | number | null | undefined,
-  withMilliseconds: boolean = true,
+const DEFAULT_LOCALE = "en";
+const SECONDS_PER_MINUTE = 60;
+const SECONDS_PER_HOUR = 3600;
+const SECONDS_PER_DAY = 86_400;
+
+type DurationUnit = "day" | "hour" | "millisecond" | "minute" | "second";
+
+type DurationPart = { fractionDigits?: number; unit: DurationUnit; value: number };
+
+/** `narrow` ("1h 2m") suits dense tables and charts; `long` ("1 hour, 2 minutes") suits prose. */
+type DurationStyle = "long" | "narrow";
+
+// Durations render in every table row and chart tick callback, and Intl formatters are costly to
+// construct, so instances are reused. A stored language Intl rejects must not blank out every
+// duration in the UI, hence the fallback instead of letting the RangeError escape.
+const unitFormatters = new Map<string, Intl.NumberFormat>();
+
+const getUnitFormatter = (locale: string, style: DurationStyle, part: DurationPart): Intl.NumberFormat => {
+  const { fractionDigits = 0, unit } = part;
+  const key = `${locale}|${unit}|${fractionDigits}|${style}`;
+  const cached = unitFormatters.get(key);
+
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const options: Intl.NumberFormatOptions = {
+    maximumFractionDigits: fractionDigits,
+    style: "unit",
+    unit,
+    unitDisplay: style,
+  };
+  let formatter: Intl.NumberFormat;
+
+  try {
+    formatter = new Intl.NumberFormat(locale, options);
+  } catch {
+    formatter = new Intl.NumberFormat(DEFAULT_LOCALE, options);
+  }
+
+  unitFormatters.set(key, formatter);
+
+  return formatter;
+};
+
+const listFormatters = new Map<string, Intl.ListFormat>();
+
+const getListFormatter = (locale: string, style: DurationStyle): Intl.ListFormat => {
+  const key = `${locale}|${style}`;
+  const cached = listFormatters.get(key);
+
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const options: Intl.ListFormatOptions = { style, type: "unit" };
+  let formatter: Intl.ListFormat;
+
+  try {
+    formatter = new Intl.ListFormat(locale, options);
+  } catch {
+    formatter = new Intl.ListFormat(DEFAULT_LOCALE, options);
+  }
+
+  listFormatters.set(key, formatter);
+
+  return formatter;
+};
+
+// Unit names, decimal separators, plural forms and the joiner all come from CLDR, so "1h 2m" is
+// "1 ч 2 мин" in ru. This reproduces Intl.DurationFormat's narrow style exactly (verified across
+// every locale we ship) without requiring it: that API needs Node 23+, above this package's
+// engines floor, and Node 23 was never an LTS line. Exact wording also varies by the runtime's ICU
+// version, so nothing may depend on a specific CLDR string.
+const formatParts = (parts: Array<DurationPart>, locale: string, style: DurationStyle): string => {
+  const formatted = parts.map((part) => getUnitFormatter(locale, style, part).format(part.value));
+
+  return formatted.length > 1 ? getListFormatter(locale, style).format(formatted) : (formatted[0] ?? "");
+};
+
+// Durations carry roughly three significant digits at every magnitude, so a 83ms task and a
+// three-day backfill are both legible without decoding zero-padded clock groups. Rounding at a
+// band's precision can spill into the next band (59.96s is a minute, not "60.0s"), hence the
+// recursion on the promoted value. Callers needing the unrounded number should surface it separately.
+const getDurationParts = (seconds: number): Array<DurationPart> => {
+  if (seconds === 0) {
+    return [{ unit: "second", value: 0 }];
+  }
+
+  if (seconds < 1) {
+    const milliseconds = Math.round(seconds * 1000);
+
+    return milliseconds < 1000 ? [{ unit: "millisecond", value: milliseconds }] : getDurationParts(1);
+  }
+
+  if (seconds < SECONDS_PER_MINUTE) {
+    // Two decimals under 10s, one above, keeps three significant digits either way.
+    const fractionDigits = seconds < 10 ? 2 : 1;
+    const rounded = Number(seconds.toFixed(fractionDigits));
+
+    return rounded < SECONDS_PER_MINUTE
+      ? [{ fractionDigits, unit: "second", value: rounded }]
+      : getDurationParts(SECONDS_PER_MINUTE);
+  }
+
+  if (seconds < SECONDS_PER_HOUR) {
+    const minutes = Math.floor(seconds / SECONDS_PER_MINUTE);
+    const remainingSeconds = Math.round(seconds - minutes * SECONDS_PER_MINUTE);
+
+    if (remainingSeconds === SECONDS_PER_MINUTE) {
+      return getDurationParts((minutes + 1) * SECONDS_PER_MINUTE);
+    }
+
+    return remainingSeconds > 0
+      ? [
+          { unit: "minute", value: minutes },
+          { unit: "second", value: remainingSeconds },
+        ]
+      : [{ unit: "minute", value: minutes }];
+  }
+
+  if (seconds < SECONDS_PER_DAY) {
+    const hours = Math.floor(seconds / SECONDS_PER_HOUR);
+    const remainingMinutes = Math.round((seconds - hours * SECONDS_PER_HOUR) / SECONDS_PER_MINUTE);
+
+    if (remainingMinutes === SECONDS_PER_MINUTE) {
+      return getDurationParts((hours + 1) * SECONDS_PER_HOUR);
+    }
+
+    return remainingMinutes > 0
+      ? [
+          { unit: "hour", value: hours },
+          { unit: "minute", value: remainingMinutes },
+        ]
+      : [{ unit: "hour", value: hours }];
+  }
+
+  const days = Math.floor(seconds / SECONDS_PER_DAY);
+  const remainingHours = Math.round((seconds - days * SECONDS_PER_DAY) / SECONDS_PER_HOUR);
+
+  if (remainingHours === 24) {
+    return getDurationParts((days + 1) * SECONDS_PER_DAY);
+  }
+
+  return remainingHours > 0
+    ? [
+        { unit: "day", value: days },
+        { unit: "hour", value: remainingHours },
+      ]
+    : [{ unit: "day", value: days }];
+};
+
+const formatDuration = (
+  duration: dayjsDuration.Duration | number | null | undefined,
+  locale: string,
+  style: DurationStyle,
 ): string | undefined => {
-  if (durationSeconds === null || durationSeconds === undefined) {
+  if (duration === null || duration === undefined) {
     return undefined;
   }
 
-  // Handle floating point milliseconds
-  const duration = dayjs.isDuration(durationSeconds)
-    ? dayjs.duration(Math.round(durationSeconds.asMilliseconds()))
-    : dayjs.duration(Number(durationSeconds.toFixed(3)), "seconds");
+  const seconds = dayjs.isDuration(duration) ? duration.asSeconds() : Number(duration);
 
-  if (duration.asMilliseconds() < 1) {
+  if (!Number.isFinite(seconds) || seconds < 0) {
     return undefined;
   }
 
-  // If under 60 seconds, render milliseconds
-  if (duration.asSeconds() < 60 && duration.milliseconds() > 0 && withMilliseconds) {
-    return duration.format("HH:mm:ss.SSS");
+  // Below a millisecond the digits are timestamp resolution and clock skew rather than signal. "<"
+  // is mathematical notation, not prose, so CLDR has no pattern for it and none is needed.
+  if (seconds > 0 && seconds < 0.001) {
+    return `<${formatParts([{ unit: "millisecond", value: 1 }], locale, style)}`;
   }
 
-  // If under 1 day, render as HH:mm:ss otherwise include the number of days
-  return duration.asSeconds() < 86_400 ? duration.format("HH:mm:ss") : duration.format("D[d]HH:mm:ss");
+  return formatParts(getDurationParts(seconds), locale, style);
 };
 
-// dayjs humanizes a missing or non-finite input as "a few seconds", so callers with no duration
-// to name get undefined instead of a made-up one.
-export const humanizeSeconds = (seconds: number | null | undefined): string | undefined =>
-  typeof seconds === "number" && Number.isFinite(seconds)
-    ? dayjs.duration(seconds, "seconds").humanize()
-    : undefined;
+/**
+ * Formats a duration for display, localized to the active UI language.
+ *
+ * `locale` defaults to the current i18next language and exists so tests and callers outside React
+ * can pin it; pass it rather than reaching for the raw seconds.
+ */
+export const renderDuration = (
+  duration: dayjsDuration.Duration | number | null | undefined,
+  locale: string = i18n.language || DEFAULT_LOCALE,
+): string | undefined => formatDuration(duration, locale, "narrow");
 
-// Chart axes need whole units at a glance; HH:mm:ss forces the reader to decode
-// every tick to work out the magnitude.
-export const renderCompactDuration = (durationSeconds: number): string => {
-  if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) {
-    return "0s";
-  }
-
-  if (durationSeconds < 1) {
-    return `${Math.round(durationSeconds * 1000)}ms`;
-  }
-
-  const duration = dayjs.duration(Math.round(durationSeconds), "seconds");
-  const days = Math.floor(duration.asDays());
-  const hours = duration.hours();
-  const minutes = duration.minutes();
-  const seconds = duration.seconds();
-
-  if (days > 0) {
-    return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
-  }
-
-  if (hours > 0) {
-    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
-  }
-
-  if (minutes > 0) {
-    return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
-  }
-
-  return `${seconds}s`;
-};
+/** Spelled-out duration for prose, where "1 hour" reads better than the table form "1h". */
+export const humanizeSeconds = (
+  seconds: number | null | undefined,
+  locale: string = i18n.language || DEFAULT_LOCALE,
+): string | undefined => formatDuration(seconds, locale, "long");
 
 // Chart.js picks decimal steps, which on a time axis reads as 26m 40s / 33m 20s.
 // Snapping to units people actually count in keeps the ticks legible.
@@ -112,20 +241,20 @@ export const getDurationTickStep = (maxSeconds: number, maxTicks = 8): number =>
   );
 };
 
-export const getDuration = (
-  startDate?: string | null,
-  endDate?: string | null,
-  withMilliseconds: boolean = true,
-) => {
+/** Elapsed seconds between two timestamps, counting an absent `endDate` as still running. */
+export const getElapsedSeconds = (startDate?: string | null, endDate?: string | null): number | undefined => {
   if (startDate === undefined || startDate === null) {
     return undefined;
   }
 
-  const end = endDate ?? dayjs().toISOString();
-  const milliseconds = dayjs.duration(dayjs(end).diff(startDate));
+  const start = dayjs(startDate);
+  const end = endDate === undefined || endDate === null ? dayjs() : dayjs(endDate);
 
-  return renderDuration(milliseconds, withMilliseconds);
+  return start.isValid() && end.isValid() ? dayjs.duration(end.diff(start)).asSeconds() : undefined;
 };
+
+export const getDuration = (startDate?: string | null, endDate?: string | null, locale?: string) =>
+  renderDuration(getElapsedSeconds(startDate, endDate), locale);
 
 export const formatDate = (
   date: number | string | null | undefined,
@@ -139,12 +268,58 @@ export const formatDate = (
   return dayjs(date).tz(timezone).format(format);
 };
 
-export const getRelativeTime = (date: string | null | undefined): string => {
-  if (date === null || date === "" || date === undefined) {
+// Ordered largest first so the first unit the difference reaches wins: "45 minutes ago" rather than
+// "2700 seconds ago". Months and years use the mean Gregorian lengths CLDR assumes for relative
+// phrasing. Anything under a minute falls through to seconds.
+const RELATIVE_TIME_UNITS: Array<{ seconds: number; unit: Intl.RelativeTimeFormatUnit }> = [
+  { seconds: 31_557_600, unit: "year" },
+  { seconds: 2_629_800, unit: "month" },
+  { seconds: SECONDS_PER_DAY * 7, unit: "week" },
+  { seconds: SECONDS_PER_DAY, unit: "day" },
+  { seconds: SECONDS_PER_HOUR, unit: "hour" },
+  { seconds: SECONDS_PER_MINUTE, unit: "minute" },
+  { seconds: 1, unit: "second" },
+];
+
+const RELATIVE_TIME_FALLBACK_UNIT = { seconds: 1, unit: "second" } as const;
+
+const relativeTimeFormatters = new Map<string, Intl.RelativeTimeFormat>();
+
+const getRelativeTimeFormatter = (locale: string): Intl.RelativeTimeFormat => {
+  const cached = relativeTimeFormatters.get(locale);
+
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const options: Intl.RelativeTimeFormatOptions = { numeric: "auto" };
+  let formatter: Intl.RelativeTimeFormat;
+
+  try {
+    formatter = new Intl.RelativeTimeFormat(locale, options);
+  } catch {
+    formatter = new Intl.RelativeTimeFormat(DEFAULT_LOCALE, options);
+  }
+
+  relativeTimeFormatters.set(locale, formatter);
+
+  return formatter;
+};
+
+export const getRelativeTime = (
+  date: string | null | undefined,
+  locale: string = i18n.language || DEFAULT_LOCALE,
+): string => {
+  if (date === null || date === "" || date === undefined || !dayjs(date).isValid()) {
     return "";
   }
 
-  return dayjs(date).fromNow();
+  const elapsed = dayjs(date).diff(dayjs(), "second", true);
+  const magnitude = Math.abs(elapsed);
+  const { seconds, unit } =
+    RELATIVE_TIME_UNITS.find((candidate) => magnitude >= candidate.seconds) ?? RELATIVE_TIME_FALLBACK_UNIT;
+
+  return getRelativeTimeFormatter(locale).format(Math.round(elapsed / seconds), unit);
 };
 
 export const getTimezoneOffsetString = (timezone: string): string => dayjs().tz(timezone).format("Z");

--- a/airflow-core/src/airflow/ui/src/utils/datetimeUtils.ts
+++ b/airflow-core/src/airflow/ui/src/utils/datetimeUtils.ts
@@ -18,12 +18,10 @@
  */
 import dayjs from "dayjs";
 import dayjsDuration from "dayjs/plugin/duration";
-import relativeTime from "dayjs/plugin/relativeTime";
 import tz from "dayjs/plugin/timezone";
 import i18n from "i18next";
 
 dayjs.extend(dayjsDuration);
-dayjs.extend(relativeTime);
 dayjs.extend(tz);
 
 export const DATE_FORMAT = "YYYY-MM-DD";
@@ -34,6 +32,8 @@ const DEFAULT_LOCALE = "en";
 const SECONDS_PER_MINUTE = 60;
 const SECONDS_PER_HOUR = 3600;
 const SECONDS_PER_DAY = 86_400;
+const MINUTES_PER_HOUR = 60;
+const HOURS_PER_DAY = 24;
 
 type DurationUnit = "day" | "hour" | "millisecond" | "minute" | "second";
 
@@ -155,7 +155,7 @@ const getDurationParts = (seconds: number): Array<DurationPart> => {
     const hours = Math.floor(seconds / SECONDS_PER_HOUR);
     const remainingMinutes = Math.round((seconds - hours * SECONDS_PER_HOUR) / SECONDS_PER_MINUTE);
 
-    if (remainingMinutes === SECONDS_PER_MINUTE) {
+    if (remainingMinutes === MINUTES_PER_HOUR) {
       return getDurationParts((hours + 1) * SECONDS_PER_HOUR);
     }
 
@@ -170,7 +170,7 @@ const getDurationParts = (seconds: number): Array<DurationPart> => {
   const days = Math.floor(seconds / SECONDS_PER_DAY);
   const remainingHours = Math.round((seconds - days * SECONDS_PER_DAY) / SECONDS_PER_HOUR);
 
-  if (remainingHours === 24) {
+  if (remainingHours === HOURS_PER_DAY) {
     return getDurationParts((days + 1) * SECONDS_PER_DAY);
   }
 
@@ -316,10 +316,55 @@ export const getRelativeTime = (
 
   const elapsed = dayjs(date).diff(dayjs(), "second", true);
   const magnitude = Math.abs(elapsed);
+  const index = RELATIVE_TIME_UNITS.findIndex((entry) => magnitude >= entry.seconds);
+  const candidate = RELATIVE_TIME_UNITS[index] ?? RELATIVE_TIME_FALLBACK_UNIT;
+  const rounded = Math.round(elapsed / candidate.seconds);
+
+  // Rounding can saturate the unit the magnitude was picked from -- 59.7 minutes rounds to 60 -- so
+  // promote to the next unit up rather than printing "60 minutes ago" where "an hour ago" is meant.
+  const larger = index > 0 ? RELATIVE_TIME_UNITS[index - 1] : undefined;
   const { seconds, unit } =
-    RELATIVE_TIME_UNITS.find((candidate) => magnitude >= candidate.seconds) ?? RELATIVE_TIME_FALLBACK_UNIT;
+    larger !== undefined && Math.abs(rounded) * candidate.seconds >= larger.seconds ? larger : candidate;
 
   return getRelativeTimeFormatter(locale).format(Math.round(elapsed / seconds), unit);
+};
+
+/**
+ * Every non-zero unit down to fractional seconds, for a `title` alongside the rounded form.
+ *
+ * `renderDuration` deliberately rounds to two units, which makes "1h 2m" cover a 60-second band --
+ * too coarse to compare two similar runs. This keeps the exact number one hover away.
+ */
+export const renderExactDuration = (
+  duration: number | null | undefined,
+  locale: string = i18n.language || DEFAULT_LOCALE,
+): string | undefined => {
+  if (duration === null || duration === undefined) {
+    return undefined;
+  }
+
+  const total = Number(duration);
+
+  if (!Number.isFinite(total) || total < 0) {
+    return undefined;
+  }
+
+  if (total < 1) {
+    return formatParts(getDurationParts(total), locale, "narrow");
+  }
+
+  const days = Math.floor(total / SECONDS_PER_DAY);
+  const hours = Math.floor((total % SECONDS_PER_DAY) / SECONDS_PER_HOUR);
+  const minutes = Math.floor((total % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE);
+  const seconds = Number((total % SECONDS_PER_MINUTE).toFixed(3));
+  const parts: Array<DurationPart> = [
+    { unit: "day" as const, value: days },
+    { unit: "hour" as const, value: hours },
+    { unit: "minute" as const, value: minutes },
+    { fractionDigits: 3, unit: "second" as const, value: seconds },
+  ].filter((part) => part.value > 0);
+
+  return formatParts(parts, locale, "narrow");
 };
 
 export const getTimezoneOffsetString = (timezone: string): string => dayjs().tz(timezone).format("Z");

--- a/airflow-core/src/airflow/ui/src/utils/deadlines.test.ts
+++ b/airflow-core/src/airflow/ui/src/utils/deadlines.test.ts
@@ -40,7 +40,7 @@ const REFERENCE = "deadlineAlerts.referenceType.DagRunLogicalDateDeadline";
 
 describe("translateCompletionRule", () => {
   it.each([
-    [3600, `deadlineAlerts.completionRule:an hour:${REFERENCE}`],
+    [3600, `deadlineAlerts.completionRule:1 hour:${REFERENCE}`],
     [null, `deadlineAlerts.completionRuleDynamic::${REFERENCE}`],
   ])("names the rule for an interval of %s seconds", (interval, expected) => {
     expect(translateCompletionRule(translate, { ...baseAlert, interval })).toBe(expected);

--- a/airflow-core/src/airflow/ui/src/utils/deadlines.ts
+++ b/airflow-core/src/airflow/ui/src/utils/deadlines.ts
@@ -29,6 +29,7 @@ import { humanizeSeconds } from "src/utils/datetimeUtils";
 export const translateCompletionRule = (
   translate: TFunction,
   alert: DeadlineAlertResponse | undefined,
+  locale?: string,
 ): string | undefined => {
   if (alert === undefined) {
     return undefined;
@@ -37,7 +38,7 @@ export const translateCompletionRule = (
   const reference = translate(`deadlineAlerts.referenceType.${alert.reference_type}`, {
     defaultValue: alert.reference_type,
   });
-  const interval = humanizeSeconds(alert.interval);
+  const interval = humanizeSeconds(alert.interval, locale);
 
   return interval === undefined
     ? translate("deadlineAlerts.completionRuleDynamic", { reference })

--- a/airflow-core/src/airflow/ui/src/utils/index.ts
+++ b/airflow-core/src/airflow/ui/src/utils/index.ts
@@ -18,7 +18,6 @@
  */
 
 export { capitalize } from "./capitalize";
-export { getDuration, renderDuration } from "./datetimeUtils";
 export { createErrorToaster, getErrorStatus } from "./errorHandling";
 export { getMetaKey } from "./getMetaKey";
 export { toNullablePartitionKey } from "./partitionKey";

--- a/airflow-core/src/airflow/ui/src/utils/index.ts
+++ b/airflow-core/src/airflow/ui/src/utils/index.ts
@@ -23,6 +23,7 @@ export { getMetaKey } from "./getMetaKey";
 export { toNullablePartitionKey } from "./partitionKey";
 export { useContainerWidth } from "./useContainerWidth";
 export { useDocumentTitle } from "./useDocumentTitle";
+export { type DurationFormat, useDurationFormat } from "./useDurationFormat";
 export { DocumentTitleProvider } from "./useDocumentTitleProvider";
 export { useFiltersHandler, type FilterableSearchParamsKeys } from "./useFiltersHandler";
 export * from "./query";

--- a/airflow-core/src/airflow/ui/src/utils/useDurationFormat.test.tsx
+++ b/airflow-core/src/airflow/ui/src/utils/useDurationFormat.test.tsx
@@ -1,0 +1,80 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render, screen, act } from "@testing-library/react";
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
+
+import { useDurationFormat } from "./useDurationFormat";
+
+// A component that shows a duration and nothing else. Before this hook existed the formatters read
+// the language straight off the i18next singleton, so a component like this — with no reason of its
+// own to subscribe to `languageChanged` — never re-rendered and kept the previous locale forever.
+const DurationOnly = () => {
+  const { renderDuration } = useDurationFormat();
+
+  return <span data-testid="duration">{renderDuration(3725.4)}</span>;
+};
+
+const LocaleProbe = () => <span data-testid="locale">{useDurationFormat().locale}</span>;
+
+const expected = (locale: string) => {
+  const unit = (unitName: Intl.NumberFormatOptions["unit"], value: number) =>
+    new Intl.NumberFormat(locale, { style: "unit", unit: unitName, unitDisplay: "narrow" }).format(value);
+
+  return new Intl.ListFormat(locale, { style: "narrow", type: "unit" }).format([
+    unit("hour", 1),
+    unit("minute", 2),
+  ]);
+};
+
+describe("useDurationFormat", () => {
+  beforeAll(async () => {
+    await i18n.use(initReactI18next).init({ fallbackLng: "en", lng: "en", resources: { de: {}, en: {} } });
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      await i18n.changeLanguage("en");
+    });
+  });
+
+  it("re-formats a duration when the language changes, without any other subscription", async () => {
+    render(<DurationOnly />);
+    expect(screen.getByTestId("duration")).toHaveTextContent(expected("en"));
+
+    await act(async () => {
+      await i18n.changeLanguage("de");
+    });
+
+    expect(screen.getByTestId("duration")).toHaveTextContent(expected("de"));
+    expect(expected("de")).not.toBe(expected("en"));
+  });
+
+  it("exposes the active locale so callers can key their own memos on it", async () => {
+    render(<LocaleProbe />);
+    expect(screen.getByTestId("locale")).toHaveTextContent("en");
+
+    await act(async () => {
+      await i18n.changeLanguage("de");
+    });
+
+    expect(screen.getByTestId("locale")).toHaveTextContent("de");
+  });
+});

--- a/airflow-core/src/airflow/ui/src/utils/useDurationFormat.ts
+++ b/airflow-core/src/airflow/ui/src/utils/useDurationFormat.ts
@@ -21,13 +21,7 @@ import { useMemo } from "react";
 import type dayjsDuration from "dayjs/plugin/duration";
 import { useTranslation } from "react-i18next";
 
-import {
-  getDuration,
-  getRelativeTime,
-  humanizeSeconds,
-  renderDuration,
-  renderExactDuration,
-} from "./datetimeUtils";
+import { getDuration, getRelativeTime, renderDuration, renderExactDuration } from "./datetimeUtils";
 
 /**
  * Duration formatters bound to the language currently on screen.
@@ -41,6 +35,12 @@ import {
  * Components should always format durations through this hook. Reach for the raw functions in
  * `datetimeUtils` only outside React, and pass a locale explicitly there.
  */
+/**
+ * The formatters this hook returns. Column builders and other helpers that receive them should
+ * `Pick` from this rather than restating the signatures, so they cannot drift from the hook.
+ */
+export type DurationFormat = ReturnType<typeof useDurationFormat>;
+
 export const useDurationFormat = () => {
   const { i18n } = useTranslation();
   const locale = i18n.language;
@@ -52,8 +52,6 @@ export const useDurationFormat = () => {
         getDuration(startDate, endDate, locale),
       /** Relative wall-clock time, e.g. "2 hours ago". */
       formatRelative: (date: string | null | undefined) => getRelativeTime(date, locale),
-      /** Spelled-out duration for prose, e.g. "1 hour, 2 minutes". */
-      humanizeDuration: (seconds: number | null | undefined) => humanizeSeconds(seconds, locale),
       locale,
       /** Compact duration for tables, charts and tooltips, e.g. "1h 2m". */
       renderDuration: (duration: dayjsDuration.Duration | number | null | undefined) =>

--- a/airflow-core/src/airflow/ui/src/utils/useDurationFormat.ts
+++ b/airflow-core/src/airflow/ui/src/utils/useDurationFormat.ts
@@ -16,11 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import type dayjsDuration from "dayjs/plugin/duration";
 import { useMemo } from "react";
+
+import type dayjsDuration from "dayjs/plugin/duration";
 import { useTranslation } from "react-i18next";
 
-import { getDuration, humanizeSeconds, renderDuration } from "./datetimeUtils";
+import {
+  getDuration,
+  getRelativeTime,
+  humanizeSeconds,
+  renderDuration,
+  renderExactDuration,
+} from "./datetimeUtils";
 
 /**
  * Duration formatters bound to the language currently on screen.
@@ -43,12 +50,16 @@ export const useDurationFormat = () => {
       /** Elapsed time between two timestamps, counting an absent end as still running. */
       formatElapsed: (startDate?: string | null, endDate?: string | null) =>
         getDuration(startDate, endDate, locale),
+      /** Relative wall-clock time, e.g. "2 hours ago". */
+      formatRelative: (date: string | null | undefined) => getRelativeTime(date, locale),
       /** Spelled-out duration for prose, e.g. "1 hour, 2 minutes". */
       humanizeDuration: (seconds: number | null | undefined) => humanizeSeconds(seconds, locale),
       locale,
       /** Compact duration for tables, charts and tooltips, e.g. "1h 2m". */
       renderDuration: (duration: dayjsDuration.Duration | number | null | undefined) =>
         renderDuration(duration, locale),
+      /** Every unit down to fractional seconds, for a `title` beside the rounded form. */
+      renderExactDuration: (duration: number | null | undefined) => renderExactDuration(duration, locale),
     }),
     [locale],
   );

--- a/airflow-core/src/airflow/ui/src/utils/useDurationFormat.ts
+++ b/airflow-core/src/airflow/ui/src/utils/useDurationFormat.ts
@@ -1,0 +1,55 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import type dayjsDuration from "dayjs/plugin/duration";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import { getDuration, humanizeSeconds, renderDuration } from "./datetimeUtils";
+
+/**
+ * Duration formatters bound to the language currently on screen.
+ *
+ * The plain formatters read the language from the i18next singleton, which React does not track, so
+ * a component that shows a duration but never subscribes to `languageChanged` keeps rendering the
+ * previous locale. Reading the language through `useTranslation` here makes it an ordinary render
+ * input: switching language re-renders every consumer, and `locale` can be added to a caller's memo
+ * dependencies so derived columns, chart options and tick callbacks rebuild with it.
+ *
+ * Components should always format durations through this hook. Reach for the raw functions in
+ * `datetimeUtils` only outside React, and pass a locale explicitly there.
+ */
+export const useDurationFormat = () => {
+  const { i18n } = useTranslation();
+  const locale = i18n.language;
+
+  return useMemo(
+    () => ({
+      /** Elapsed time between two timestamps, counting an absent end as still running. */
+      formatElapsed: (startDate?: string | null, endDate?: string | null) =>
+        getDuration(startDate, endDate, locale),
+      /** Spelled-out duration for prose, e.g. "1 hour, 2 minutes". */
+      humanizeDuration: (seconds: number | null | undefined) => humanizeSeconds(seconds, locale),
+      locale,
+      /** Compact duration for tables, charts and tooltips, e.g. "1h 2m". */
+      renderDuration: (duration: dayjsDuration.Duration | number | null | undefined) =>
+        renderDuration(duration, locale),
+    }),
+    [locale],
+  );
+};


### PR DESCRIPTION
Problem:

our duration format was dd:hh:mm:ss.ms, which for short durations had a lot of excessive zeros or with many ms had floating point overflow.

<img width="482" height="923" alt="Screenshot 2026-08-31 at 3 45 37 PM" src="https://github.com/user-attachments/assets/3f275249-a244-40f6-8aeb-b320a16c5e79" />



Solution:
Switch to a more human readable format string that can be set per locale

<img width="445" height="977" alt="Screenshot 2026-08-31 at 3 41 33 PM" src="https://github.com/user-attachments/assets/28ff0aa0-b982-414a-a508-e9a02c10b3d4" />

<img width="360" height="1001" alt="Screenshot 2026-08-31 at 3 41 56 PM" src="https://github.com/user-attachments/assets/a669edff-ccaa-4fe4-ad72-ba549d194864" />

<img width="440" height="994" alt="Screenshot 2026-08-31 at 3 41 45 PM" src="https://github.com/user-attachments/assets/9f6ac708-9257-41ac-a8ba-ad7956f08583" />


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
Claude Opus 5

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
