### PR TITLE
Fix Dag metrics dropped when a tag contains invalid characters

### DIFF
--- a/shared/observability/src/airflow_shared/observability/metrics/stats.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/stats.py
@@ -48,7 +48,9 @@ def build_dag_metric_tags(tag_names: Iterable[str]) -> dict[str, str]:
     result: dict[str, str] = {}
     for name in tag_names:
         key, _, value = name.partition(":")
-        result[key] = value
+        result[normalize_name_for_stats(key, log_warning=False)] = normalize_name_for_stats(
+            value, log_warning=False
+        )
     return result
 
 

--- a/shared/observability/tests/observability/metrics/test_stats.py
+++ b/shared/observability/tests/observability/metrics/test_stats.py
@@ -528,6 +528,10 @@ class TestStatsWithInfluxDBEnabled:
         self.stats.incr(stat, tags=tags)
         self.statsd_client.incr.assert_called_once_with(expected, 1, 1)
 
+    def test_increment_counter_with_dag_tags(self):
+        self.stats.incr("test_stats_run.delay", tags=build_dag_metric_tags(["my tag", "env:pro d"]))
+        self.statsd_client.incr.assert_called_once_with("test_stats_run.delay,my_tag=true,env=pro_d", 1, 1)
+
 
 def always_invalid(stat_name):
     raise InvalidStatsNameException(f"Invalid name: {stat_name}")
@@ -853,12 +857,23 @@ class TestCustomStatsName:
             {"production": "", "env": "prod", "team": "data"},
             id="mixed",
         ),
-        pytest.param(["a:b:c"], {"a": "b:c"}, id="value-with-colon"),
+        pytest.param(["a:b:c"], {"a": "b_c"}, id="value-with-colon"),
         pytest.param(["env:"], {"env": ""}, id="trailing-colon-is-standalone"),
+        pytest.param(["my tag"], {"my_tag": ""}, id="space-in-key"),
+        pytest.param(["env:pro d"], {"env": "pro_d"}, id="space-in-value"),
+        pytest.param(["a,b"], {"a_b": ""}, id="comma-in-key"),
+        pytest.param(["env:a=b"], {"env": "a_b"}, id="equals-in-value"),
+        pytest.param(["déjà"], {"d_j_": ""}, id="non-ascii"),
     ],
 )
 def test_build_dag_metric_tags(tag_names: list[str], expected: dict[str, str]) -> None:
     assert build_dag_metric_tags(tag_names) == expected
+
+
+@mock.patch.object(airflow_shared.observability.metrics.stats, "log", autospec=True)
+def test_build_dag_metric_tags_does_not_warn(mock_log) -> None:
+    build_dag_metric_tags(["my tag"])
+    mock_log.warning.assert_not_called()
 
 
 def test_build_dag_metric_tags_accepts_generator() -> None:


### PR DESCRIPTION
## Why

- Airflow drops every metric that carries a Dag tag with a space, colon  or non-ASCII character instead of emitting it.

https://github.com/apache/airflow/blob/a32662cc0ef6c877c883478fe7f09ee9574b2e57/shared/observability/src/airflow_shared/observability/metrics/validators.py#L47

https://github.com/apache/airflow/blob/a32662cc0ef6c877c883478fe7f09ee9574b2e57/shared/observability/src/airflow_shared/observability/metrics/validators.py#L115-L131

- `[metrics] dag_tags_in_metrics` turns Dag tags into metric tags. `DagTag.name` validates length only, so any character reaches the StatsD wire.
- With `statsd_influxdb_enabled`, `prepare_stat_with_tags` appends those tags to the stat name before `validate_stat` sees it. The validator then rejects the whole metric, not just the invalid tag.

## How

- Normalize both halves of each Dag tag in `build_dag_metric_tags()` with `normalize_name_for_stats`.

## Verification

- Unit test: `uv run --project shared/observability pytest shared/observability/tests/observability/metrics/test_stats.py -xvs`
- Integration test

1. Add a Dag with tags.
```sh
mkdir -p files/dags && cat > files/dags/dag_with_tag.py <<'PY'
from datetime import datetime

from airflow.sdk import DAG, task

with DAG(
    "dag_with_tag",
    schedule=None,
    start_date=datetime(2025, 1, 1),
    tags=["example", "edge", "integration test"],
):
    @task
    def noop():
        return 1

    noop()
PY
```

2. Start scheduler

```sh
breeze shell --backend sqlite --integration statsd
```

In container:
```sh
export AIRFLOW__METRICS__STATSD_ON=True
export AIRFLOW__METRICS__STATSD_HOST=statsd-exporter
export AIRFLOW__METRICS__STATSD_PORT=9125
export AIRFLOW__METRICS__STATSD_INFLUXDB_ENABLED=True
export AIRFLOW__METRICS__DAG_TAGS_IN_METRICS=True

airflow db reset -y && airflow dags reserialize && airflow scheduler &
```

3. Trigger the Dag

```sh
airflow dags unpause dag_with_tag
airflow dags trigger dag_with_tag
```

On main branch, the scheduler will show following error, but this doesn't happen in this branch.

```
2026-09-01T06:46:29.759401Z [error    ] Invalid stat name: dagrun.dependency-check.dag_with_tag,integration test=true,example=true,edge=true,run_type=manual. [airflow._shared.observability.metrics.validators] loc=validators.py:128
Traceback (most recent call last):
  File "/opt/airflow/airflow-core/src/airflow/_shared/observability/metrics/validators.py", line 125, in wrapper
    stat = handler_stat_name_func(stat)
  File "/opt/airflow/airflow-core/src/airflow/_shared/observability/metrics/validators.py", line 213, in stat_name_default_handler
    raise InvalidStatsNameException(
airflow._shared.observability.exceptions.InvalidStatsNameException: The stat name (dagrun.dependency-check.dag_with_tag,integration test=true,example=true,edge=true,run_type=manual) has to be composed of ASCII alphabets, numbers, or the underscore, dot, or dash characters.
```

4. Check metrics exist

```sh
curl -s http://statsd-exporter:9102/metrics | grep airflow_dagrun
```


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

* related: #68568

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
