### PR TITLE
Fix deferrable autofix inserting a forbidden conf import in providers

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/deferring.rst
+++ b/airflow-core/docs/authoring-and-scheduling/deferring.rst
@@ -86,8 +86,7 @@ When writing a deferrable operators these are the main points to consider:
     from datetime import timedelta
     from typing import Any
 
-    from airflow.configuration import conf
-    from airflow.sdk import BaseSensorOperator, Context
+    from airflow.sdk import BaseSensorOperator, Context, conf
     from airflow.providers.standard.triggers.temporal import TimeDeltaTrigger
 
 

--- a/scripts/ci/prek/check_deferrable_default.py
+++ b/scripts/ci/prek/check_deferrable_default.py
@@ -99,7 +99,7 @@ def iter_check_deferrable_default_errors(module_filename: str) -> Iterator[str]:
 
 def _fix_invalid_deferrable_default_value(module_filename: str) -> None:
     context = CodemodContext(filename=module_filename)
-    AddImportsVisitor.add_needed_import(context, "airflow.configuration", "conf")
+    AddImportsVisitor.add_needed_import(context, "airflow.providers.common.compat.sdk", "conf")
     transformer = DefaultDeferrableTransformer()
 
     source_cst_tree = cst.parse_module(open(module_filename).read())

--- a/scripts/tests/ci/prek/test_check_deferrable_default.py
+++ b/scripts/tests/ci/prek/test_check_deferrable_default.py
@@ -1,0 +1,96 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import ast
+
+import pytest
+from check_deferrable_default import _fix_invalid_deferrable_default_value
+
+COMPAT_CONF_MODULE = "airflow.providers.common.compat.sdk"
+
+# ``ast.unparse`` normalises to single quotes, matching ``_is_valid_deferrable_default``.
+EXPECTED_DEFAULT = "conf.getboolean('operators', 'default_deferrable', fallback=False)"
+
+INVALID_OPERATOR = """
+    from __future__ import annotations
+
+
+    class MyOperator:
+        def __init__(self, *, deferrable: bool = False, **kwargs) -> None:
+            self.deferrable = deferrable
+    """
+
+
+def get_conf_import_modules(code: str) -> list[str]:
+    """Return the module each ``conf`` import in *code* comes from."""
+    return [
+        node.module or ""
+        for node in ast.walk(ast.parse(code))
+        if isinstance(node, ast.ImportFrom) and any(alias.name == "conf" for alias in node.names)
+    ]
+
+
+def get_deferrable_default(code: str) -> str | None:
+    """Return the unparsed default of the keyword-only ``deferrable`` parameter in *code*."""
+    for node in ast.walk(ast.parse(code)):
+        if isinstance(node, ast.FunctionDef) and node.name == "__init__":
+            for argument, default in zip(node.args.kwonlyargs, node.args.kw_defaults):
+                if argument.arg == "deferrable" and default is not None:
+                    return ast.unparse(default)
+    return None
+
+
+class TestFixInvalidDeferrableDefaultValue:
+    def test_invalid_default_is_rewritten_with_compat_import(self, write_python_file):
+        path = write_python_file(INVALID_OPERATOR)
+
+        _fix_invalid_deferrable_default_value(str(path))
+
+        code = path.read_text()
+        assert get_deferrable_default(code) == EXPECTED_DEFAULT
+        assert get_conf_import_modules(code) == [COMPAT_CONF_MODULE]
+
+    @pytest.mark.parametrize(
+        "existing_import",
+        [
+            pytest.param(f"from {COMPAT_CONF_MODULE} import conf", id="conf-only"),
+            pytest.param(
+                f"from {COMPAT_CONF_MODULE} import AirflowException, BaseOperator, conf",
+                id="combined-import",
+            ),
+        ],
+    )
+    def test_existing_compat_import_is_not_shadowed(self, write_python_file, existing_import: str):
+        path = write_python_file(
+            f"""
+            from __future__ import annotations
+
+            {existing_import}
+
+
+            class MyOperator:
+                def __init__(self, *, deferrable: bool = False, **kwargs) -> None:
+                    self.deferrable = deferrable
+            """
+        )
+
+        _fix_invalid_deferrable_default_value(str(path))
+
+        code = path.read_text()
+        assert get_deferrable_default(code) == EXPECTED_DEFAULT
+        assert get_conf_import_modules(code) == [COMPAT_CONF_MODULE]


### PR DESCRIPTION
## Why

- `check-deferrable-default` rewrites operator and sensor files in place and adds `from airflow.configuration import conf`. `check-conf-import-in-providers` forbids that import in provider code, so the two hooks contradict each other.

## How

- Change `check-deferrable-default` to `from airflow.providers.common.compat.sdk to conf`.

## Verification

- `uv run --project scripts pytest scripts/tests/ci/prek/test_check_deferrable_default.py`

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
