### PR TITLE
Trace the dag-processor job instead of its parent process with memray

### DIFF
--- a/airflow-core/src/airflow/cli/commands/dag_processor_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_processor_command.py
@@ -47,6 +47,10 @@ def _create_dag_processor_job_runner(args: Any) -> DagProcessorJobRunner:
 
 
 @enable_memray_trace(component=MemrayTraceComponents.dag_processor)
+def _run_dag_processor_job(job_runner: DagProcessorJobRunner) -> None:
+    run_job(job=job_runner.job, execute_callable=job_runner._execute)
+
+
 @cli_utils.action_cli
 @providers_configuration_loaded
 def dag_processor(args):
@@ -58,7 +62,7 @@ def dag_processor(args):
         from airflow.cli.hot_reload import run_with_reloader
 
         run_with_reloader(
-            lambda: run_job(job=job_runner.job, execute_callable=job_runner._execute),
+            lambda: _run_dag_processor_job(job_runner),
             process_name="dag-processor",
         )
         return
@@ -66,6 +70,6 @@ def dag_processor(args):
     run_command_with_daemon_option(
         args=args,
         process_name="dag-processor",
-        callback=lambda: run_job(job=job_runner.job, execute_callable=job_runner._execute),
+        callback=lambda: _run_dag_processor_job(job_runner),
         should_setup_logging=True,
     )

--- a/airflow-core/tests/unit/cli/commands/test_dag_processor_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_processor_command.py
@@ -91,3 +91,20 @@ class TestDagProcessorCommand:
         mock_reloader.assert_called_once()
         # The callback function should be callable
         assert callable(mock_reloader.call_args[0][0])
+
+    @conf_vars(
+        {("core", "load_examples"): "False", ("profiling", "memray_trace_components"): "dag_processor"}
+    )
+    @mock.patch("airflow.cli.commands.dag_processor_command.run_command_with_daemon_option")
+    @mock.patch("airflow.cli.commands.dag_processor_command.DagProcessorJobRunner")
+    def test_memray_traces_the_job_and_not_the_parent_process(self, mock_runner, mock_daemon_option):
+        """The callback runs on the far side of the daemon fork, so the tracer has to start there."""
+        mock_runner.return_value.job_type = "DagProcessorJob"
+        memray = mock.MagicMock()
+
+        with mock.patch.dict("sys.modules", {"memray": memray}):
+            dag_processor_command.dag_processor(self.parser.parse_args(["dag-processor"]))
+            memray.Tracker.assert_not_called()
+
+            mock_daemon_option.call_args.kwargs["callback"]()
+            memray.Tracker.assert_called_once()


### PR DESCRIPTION
`@enable_memray_trace` was on the dag-processor's outer CLI function. Both paths
that function takes — `run_command_with_daemon_option` and, under `--dev`,
`run_with_reloader` — fork before the job runs, and `memray.Tracker` defaults to
`follow_fork=False`. So the tracer stayed with the parent while every allocation
worth measuring happened in the child, and an opted-in user got a capture file
containing interpreter startup instead of the profile they asked for. 
It fails silently: the file looks perfectly normal.

The three sibling components already decorate their inner run function —
`_run_scheduler_job`, `triggerer_run`, `_run_api_server`. This makes
dag-processor match them by extracting `_run_dag_processor_job` and moving the
decorator onto it.

`set_component_mp_start_method()` and `_create_dag_processor_job_runner()`
deliberately stay in the parent. The latter calls `validate_dag_bundle_arg`,
which raises `SystemExit` on an unknown `--bundle-name`; moving it past the fork
would bury that error in a daemonized child where the user never sees it.

No behaviour change for anyone who has not opted in — `[profiling]
memray_trace_components` is unset by default.

The regression test asserts the invariant behaviourally rather than structurally:
no `memray.Tracker` may be constructed while the CLI function runs, and exactly
one must be constructed when the callback that lands on the far side of the fork
is invoked. Verified failing against the unfixed code both whole-file and in isolation.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
