### PR TITLE
Reconnect Synapse Spark batches on task retry

### DIFF
--- a/providers/microsoft/azure/docs/operators/azure_synapse.rst
+++ b/providers/microsoft/azure/docs/operators/azure_synapse.rst
@@ -31,6 +31,9 @@ Use the :class:`~airflow.providers.microsoft.azure.operators.synapse.AzureSynaps
 spark application within Synapse Analytics.
 By default, the operator will periodically check on the status of the executed Spark job to
 terminate with a "Succeeded" status.
+On Airflow 3.3 and later, retries reconnect to the submitted batch when ``wait_for_termination=True``
+rather than starting a duplicate.
+Set ``durable=False`` to submit a new batch on each attempt.
 
 Below is an example of using this operator to execute a Spark application on Azure Synapse.
 

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/synapse.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/synapse.py
@@ -173,9 +173,14 @@ class AzureSynapseHook(BaseHook):
         self.job_id = job.id
         return job
 
-    def get_job_run_status(self):
+    def get_job_run_status(self, job_id: int | None = None) -> str:
         """Get the job run status."""
-        job_run_status = self.get_conn().spark_batch.get_spark_batch_job(batch_id=self.job_id).state
+        resolved_job_id = self.job_id if job_id is None else job_id
+        if resolved_job_id is None:
+            raise ValueError("A job ID is required to get the job run status.")
+        job_run_status = self.get_conn().spark_batch.get_spark_batch_job(batch_id=resolved_job_id).state
+        if job_run_status is None:
+            raise ValueError(f"Job {resolved_job_id} returned no status.")
         return job_run_status
 
     def wait_for_job_run_status(
@@ -195,7 +200,7 @@ class AzureSynapseHook(BaseHook):
             status.
 
         """
-        job_run_status = self.get_job_run_status()
+        job_run_status = self.get_job_run_status(job_id=job_id)
         start_time = time.monotonic()
 
         while (
@@ -212,7 +217,7 @@ class AzureSynapseHook(BaseHook):
             self.log.info("Sleeping for %s seconds", check_interval)
             time.sleep(check_interval)
 
-            job_run_status = self.get_job_run_status()
+            job_run_status = self.get_job_run_status(job_id=job_id)
             self.log.info("Current spark job run status is %s", job_run_status)
 
         return job_run_status in expected_statuses

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/synapse.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/synapse.py
@@ -20,7 +20,7 @@ import time
 import warnings
 from collections.abc import Sequence
 from functools import cached_property
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlencode
 
 from airflow.providers.common.compat.sdk import (
@@ -42,14 +42,48 @@ from airflow.providers.microsoft.azure.triggers.synapse import (
     AzureSynapsePipelineTrigger,
 )
 
+_DURABLE_UNSET = object()
+
+
+def _warn_and_disable_durable_pre_3_3(durable: bool | object) -> bool:
+    if durable is not _DURABLE_UNSET:
+        warnings.warn(
+            "`durable` has no effect on Airflow versions below 3.3.",
+            UserWarning,
+            stacklevel=3,
+        )
+    return False
+
+
+try:
+    from airflow.sdk import ResumableJobMixin
+except ImportError:
+
+    class ResumableJobMixin:  # type: ignore[no-redef]
+        """Airflow <3.3 stub that always submits fresh work."""
+
+        external_id_key: str = "synapse_spark_batch_id"
+
+        def __init__(self, *, durable: bool | object = _DURABLE_UNSET, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+            self.durable = _warn_and_disable_durable_pre_3_3(durable)
+
+        def execute_resumable(self, context: Context) -> Any:
+            operator = cast("AzureSynapseRunSparkBatchOperator", self)
+            external_id = operator.submit_job(context)
+            operator.poll_until_complete(external_id, context)
+            return operator.get_job_result(external_id, context)
+
+
 if TYPE_CHECKING:
     from azure.synapse.spark.models import SparkBatchJobOptions
+    from pydantic import JsonValue
 
     from airflow.providers.common.compat.sdk import TaskInstanceKey
     from airflow.sdk import Context
 
 
-class AzureSynapseRunSparkBatchOperator(BaseOperator):
+class AzureSynapseRunSparkBatchOperator(ResumableJobMixin, BaseOperator):
     """
     Execute a Spark job on Azure Synapse.
 
@@ -65,6 +99,8 @@ class AzureSynapseRunSparkBatchOperator(BaseOperator):
         waits. Used only if ``wait_for_termination`` is True.
     :param check_interval: Time in seconds to check on a job run's status for non-asynchronous waits.
         Used only if ``wait_for_termination`` is True.
+    :param durable: When True, retries reconnect to an active Synapse Spark batch instead of submitting
+        a duplicate. Requires Airflow 3.3+ and applies only when ``wait_for_termination`` is True.
     """
 
     template_fields: Sequence[str] = (
@@ -74,6 +110,7 @@ class AzureSynapseRunSparkBatchOperator(BaseOperator):
     template_fields_renderers = {"parameters": "json"}
 
     ui_color = "#0678d4"
+    external_id_key: str = "synapse_spark_batch_id"
 
     def __init__(
         self,
@@ -84,10 +121,13 @@ class AzureSynapseRunSparkBatchOperator(BaseOperator):
         payload: SparkBatchJobOptions,
         timeout: int = 60 * 60 * 24 * 7,
         check_interval: int = 60,
-        **kwargs,
+        durable: bool | None = None,
+        **kwargs: Any,
     ) -> None:
+        if durable is not None:
+            kwargs["durable"] = durable
         super().__init__(**kwargs)
-        self.job_id: Any = None
+        self.job_id: int | None = None
         self.azure_synapse_conn_id = azure_synapse_conn_id
         self.wait_for_termination = wait_for_termination
         self.spark_pool = spark_pool
@@ -96,11 +136,18 @@ class AzureSynapseRunSparkBatchOperator(BaseOperator):
         self.check_interval = check_interval
 
     @cached_property
-    def hook(self):
+    def hook(self) -> AzureSynapseHook:
         """Create and return an AzureSynapseHook (cached)."""
         return AzureSynapseHook(azure_synapse_conn_id=self.azure_synapse_conn_id, spark_pool=self.spark_pool)
 
     def execute(self, context: Context) -> None:
+        if self.wait_for_termination:
+            self.execute_resumable(context)
+            return
+
+        self.submit_job(context)
+
+    def submit_job(self, context: Context) -> JsonValue:
         self.log.info("Executing the Synapse spark job.")
         response = self.hook.run_spark_job(payload=self.payload)
         self.log.info(response)
@@ -109,22 +156,37 @@ class AzureSynapseRunSparkBatchOperator(BaseOperator):
         # retrieval the executed job's ``id`` for downstream tasks especially if performing an
         # asynchronous wait.
         context["ti"].xcom_push(key="job_id", value=self.job_id)
+        return self.job_id
 
-        if self.wait_for_termination:
-            self.log.info("Waiting for job run %s to terminate.", self.job_id)
+    def get_job_status(self, external_id: JsonValue, context: Context) -> str:
+        self.job_id = cast("int", external_id)
+        context["ti"].xcom_push(key="job_id", value=self.job_id)
+        return self.hook.get_job_run_status(job_id=self.job_id)
 
-            if self.hook.wait_for_job_run_status(
-                job_id=self.job_id,
-                expected_statuses=AzureSynapseSparkBatchRunStatus.SUCCESS,
-                check_interval=self.check_interval,
-                timeout=self.timeout,
-            ):
-                self.log.info("Job run %s has completed successfully.", self.job_id)
-            else:
-                raise AirflowException(f"Job run {self.job_id} has failed or has been cancelled.")
+    def is_job_active(self, status: str) -> bool:
+        return status not in AzureSynapseSparkBatchRunStatus.TERMINAL_STATUSES
+
+    def is_job_succeeded(self, status: str) -> bool:
+        return status == AzureSynapseSparkBatchRunStatus.SUCCESS
+
+    def poll_until_complete(self, external_id: JsonValue, context: Context) -> None:
+        self.job_id = cast("int", external_id)
+        self.log.info("Waiting for job run %s to terminate.", self.job_id)
+        if self.hook.wait_for_job_run_status(
+            job_id=self.job_id,
+            expected_statuses=AzureSynapseSparkBatchRunStatus.SUCCESS,
+            check_interval=self.check_interval,
+            timeout=self.timeout,
+        ):
+            self.log.info("Job run %s has completed successfully.", self.job_id)
+            return
+        raise AirflowException(f"Job run {self.job_id} has failed or has been cancelled.")
+
+    def get_job_result(self, external_id: JsonValue, context: Context) -> None:
+        return None
 
     def on_kill(self) -> None:
-        if self.job_id:
+        if self.job_id is not None:
             self.hook.cancel_job_run(
                 job_id=self.job_id,
             )

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_synapse.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_synapse.py
@@ -35,7 +35,6 @@ DEFAULT_CONNECTION_DEFAULT_CREDENTIAL = "azure_synapse_test_default_credential"
 
 MODEL = object()
 NAME = "testName"
-ID = "testId"
 JOB_ID = 1
 
 MODULE = "airflow.providers.microsoft.azure.hooks.synapse"
@@ -137,12 +136,31 @@ def test_run_spark_job(hook: AzureSynapseHook):
         hook._conn.spark_batch.create_spark_batch_job.assert_called_with({})  # type: ignore[attr-defined]
 
 
-def test_get_job_run_status(hook: AzureSynapseHook):
+def test_get_job_run_status(hook: AzureSynapseHook) -> None:
+    hook.job_id = JOB_ID
     hook.get_job_run_status()
-    if hook._conn is not None and isinstance(hook._conn, SparkClient):
-        hook._conn.spark_batch.get_spark_batch_job.assert_called_with(  # type: ignore[attr-defined]
-            batch_id=JOB_ID
-        )
+    hook._conn.spark_batch.get_spark_batch_job.assert_called_once_with(batch_id=JOB_ID)  # type: ignore[union-attr]
+
+
+def test_get_job_run_status_uses_explicit_job_id(hook: AzureSynapseHook) -> None:
+    hook.job_id = 2
+    hook.get_job_run_status(job_id=JOB_ID)
+    hook._conn.spark_batch.get_spark_batch_job.assert_called_once_with(batch_id=JOB_ID)  # type: ignore[union-attr]
+
+
+def test_get_job_run_status_requires_job_id(hook: AzureSynapseHook) -> None:
+    hook.job_id = None
+
+    with pytest.raises(ValueError, match="job ID is required"):
+        hook.get_job_run_status()
+
+
+def test_get_job_run_status_requires_status(hook: AzureSynapseHook) -> None:
+    hook.job_id = JOB_ID
+    hook._conn.spark_batch.get_spark_batch_job.return_value.state = None  # type: ignore[union-attr]
+
+    with pytest.raises(ValueError, match=f"Job {JOB_ID} returned no status"):
+        hook.get_job_run_status()
 
 
 _wait_for_job_run_status_test_args = [
@@ -168,17 +186,34 @@ _wait_for_job_run_status_test_args = [
         for argval in _wait_for_job_run_status_test_args
     ],
 )
-def test_wait_for_job_run_status(hook, job_run_status, expected_status, expected_output):
-    config = {"job_id": ID, "timeout": 3, "check_interval": 1, "expected_statuses": expected_status}
-
-    with patch.object(AzureSynapseHook, "get_job_run_status") as mock_job_run:
+def test_wait_for_job_run_status(
+    hook: AzureSynapseHook,
+    job_run_status: str,
+    expected_status: str | set[str],
+    expected_output: bool | str,
+) -> None:
+    with patch.object(AzureSynapseHook, "get_job_run_status", autospec=True) as mock_job_run:
         mock_job_run.return_value = job_run_status
 
         if expected_output != "timeout":
-            assert hook.wait_for_job_run_status(**config) == expected_output
+            assert (
+                hook.wait_for_job_run_status(
+                    job_id=JOB_ID,
+                    timeout=3,
+                    check_interval=1,
+                    expected_statuses=expected_status,
+                )
+                == expected_output
+            )
         else:
             with pytest.raises(AirflowTaskTimeout):
-                hook.wait_for_job_run_status(**config)
+                hook.wait_for_job_run_status(
+                    job_id=JOB_ID,
+                    timeout=3,
+                    check_interval=1,
+                    expected_statuses=expected_status,
+                )
+        assert all(call.kwargs == {"job_id": JOB_ID} for call in mock_job_run.call_args_list)
 
 
 def test_cancel_job_run(hook: AzureSynapseHook):

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_synapse.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_synapse.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 import functools
 import time
+import warnings
+from typing import TYPE_CHECKING, Any, cast
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
@@ -29,20 +31,29 @@ from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance
 from airflow.providers.common.compat.sdk import AirflowException, TaskDeferred, timezone
 from airflow.providers.microsoft.azure.hooks.synapse import (
+    AzureSynapseHook,
     AzureSynapsePipelineHook,
     AzureSynapsePipelineRunException,
     AzureSynapsePipelineRunStatus,
+    AzureSynapseSparkBatchRunStatus,
 )
 from airflow.providers.microsoft.azure.operators.synapse import (
+    _DURABLE_UNSET,
     AzureSynapsePipelineRunLink,
     AzureSynapseRunPipelineOperator,
     AzureSynapseRunSparkBatchOperator,
+    _warn_and_disable_durable_pre_3_3,
 )
 from airflow.providers.microsoft.azure.triggers.synapse import AzureSynapsePipelineTrigger
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.taskinstance import create_task_instance as _create_task_instance
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_3_PLUS
+
+if TYPE_CHECKING:
+    from azure.synapse.spark.models import SparkBatchJobOptions
+
+    from airflow.providers.common.compat.sdk import Context
 
 if AIRFLOW_V_3_0_PLUS:
     from airflow.sdk.execution_time.comms import XComResult
@@ -72,6 +83,7 @@ class TestAzureSynapseRunSparkBatchOperator:
     @pytest.fixture(autouse=True)
     def setup_test_cases(self, create_mock_connection):
         self.mock_ti = MagicMock()
+        self.mock_ti.stats_tags = {}
         self.mock_context = {"ti": self.mock_ti}
         self.config = {
             "task_id": TASK_ID,
@@ -157,6 +169,221 @@ class TestAzureSynapseRunSparkBatchOperator:
         )
         op.execute(context=self.mock_context)
         assert op.job_id == 456
+
+    def test_submit_only_does_not_poll_or_persist(self) -> None:
+        task_state_store = MagicMock(spec=["get", "set"])
+        hook = MagicMock(spec=AzureSynapseHook)
+        hook.run_spark_job.return_value = MagicMock(spec=["id"], **JOB_RUN_RESPONSE)
+        op = AzureSynapseRunSparkBatchOperator(
+            task_id="test",
+            azure_synapse_conn_id=AZURE_SYNAPSE_CONN_ID,
+            spark_pool="test_pool",
+            payload=cast("SparkBatchJobOptions", {}),
+            wait_for_termination=False,
+        )
+        op.hook = hook
+
+        op.execute(context={**self.mock_context, "task_state_store": task_state_store})
+
+        hook.run_spark_job.assert_called_once_with(payload={})
+        hook.wait_for_job_run_status.assert_not_called()
+        task_state_store.get.assert_not_called()
+        task_state_store.set.assert_not_called()
+        self.mock_ti.xcom_push.assert_called_once_with(key="job_id", value=JOB_RUN_RESPONSE["id"])
+
+
+@pytest.mark.skipif(
+    not AIRFLOW_V_3_3_PLUS,
+    reason="ResumableJobMixin reconnect requires task_state_store, available in Airflow 3.3+",
+)
+class TestAzureSynapseRunSparkBatchOperatorResumable:
+    @staticmethod
+    def make_operator(**kwargs: Any) -> AzureSynapseRunSparkBatchOperator:
+        return AzureSynapseRunSparkBatchOperator(
+            task_id="synapse_resumable",
+            azure_synapse_conn_id=AZURE_SYNAPSE_CONN_ID,
+            spark_pool="test_pool",
+            payload=cast("SparkBatchJobOptions", {}),
+            check_interval=1,
+            timeout=3,
+            **kwargs,
+        )
+
+    @staticmethod
+    def make_context(stored_job_id: int | None = None) -> Context:
+        task_state_store = MagicMock(spec=["get", "set"])
+        task_state_store.get.return_value = stored_job_id
+        task_instance = MagicMock(spec=["stats_tags", "xcom_push"])
+        task_instance.stats_tags = {}
+        return cast("Context", {"task_state_store": task_state_store, "ti": task_instance})
+
+    @staticmethod
+    def make_hook(job_id: int = JOB_RUN_RESPONSE["id"]) -> MagicMock:
+        hook = MagicMock(spec=AzureSynapseHook)
+        hook.run_spark_job.return_value = MagicMock(spec=["id"], id=job_id)
+        return hook
+
+    def test_first_run_persists_job_id_before_polling(self) -> None:
+        operator = self.make_operator()
+        operator.hook = self.make_hook()
+        context = self.make_context()
+        task_state_store = cast("MagicMock", context["task_state_store"])
+        events: list[tuple[Any, ...]] = []
+        task_state_store.set.side_effect = lambda key, value: events.append(("persist", key, value))
+
+        with patch.object(
+            operator,
+            "poll_until_complete",
+            autospec=True,
+            side_effect=lambda external_id, context: events.append(("poll", external_id)),
+        ):
+            operator.execute(context=context)
+
+        assert events == [
+            ("persist", "synapse_spark_batch_id", JOB_RUN_RESPONSE["id"]),
+            ("poll", JOB_RUN_RESPONSE["id"]),
+        ]
+
+    @pytest.mark.parametrize(
+        ("prior_status", "expected_submit_count", "expected_poll_id"),
+        [
+            (AzureSynapseSparkBatchRunStatus.RUNNING, 0, 91),
+            (AzureSynapseSparkBatchRunStatus.SUCCESS, 0, None),
+            (AzureSynapseSparkBatchRunStatus.ERROR, 1, JOB_RUN_RESPONSE["id"]),
+        ],
+    )
+    def test_retry_behavior(
+        self,
+        prior_status: str,
+        expected_submit_count: int,
+        expected_poll_id: int | None,
+    ) -> None:
+        operator = self.make_operator()
+        operator.hook = self.make_hook()
+        operator.hook.get_job_run_status.return_value = prior_status
+        context = self.make_context(stored_job_id=91)
+
+        with patch.object(operator, "poll_until_complete", autospec=True) as mock_poll:
+            operator.execute(context=context)
+
+        assert operator.hook.run_spark_job.call_count == expected_submit_count
+        cast("MagicMock", context["ti"]).xcom_push.assert_any_call(key="job_id", value=91)
+        if expected_poll_id is None:
+            mock_poll.assert_not_called()
+        else:
+            mock_poll.assert_called_once_with(expected_poll_id, context)
+
+    def test_durable_false_submits_fresh(self) -> None:
+        operator = self.make_operator(durable=False)
+        operator.hook = self.make_hook()
+        context = self.make_context(stored_job_id=91)
+
+        with patch.object(operator, "poll_until_complete", autospec=True) as mock_poll:
+            operator.execute(context=context)
+
+        operator.hook.get_job_run_status.assert_not_called()
+        operator.hook.run_spark_job.assert_called_once_with(payload={})
+        mock_poll.assert_called_once_with(JOB_RUN_RESPONSE["id"], context)
+        cast("MagicMock", context["task_state_store"]).set.assert_not_called()
+
+    def test_missing_task_state_store_submits_fresh(self) -> None:
+        operator = self.make_operator()
+        operator.hook = self.make_hook()
+        task_instance = MagicMock(spec=["stats_tags", "xcom_push"])
+        task_instance.stats_tags = {}
+        context = cast("Context", {"ti": task_instance})
+
+        with patch.object(operator, "poll_until_complete", autospec=True) as mock_poll:
+            operator.execute(context=context)
+
+        operator.hook.run_spark_job.assert_called_once_with(payload={})
+        mock_poll.assert_called_once_with(JOB_RUN_RESPONSE["id"], context)
+
+    def test_default_args_durable_reaches_operator(self) -> None:
+        operator = AzureSynapseRunSparkBatchOperator(
+            task_id="synapse_default_args",
+            payload=cast("SparkBatchJobOptions", {}),
+            default_args={"durable": False},
+        )
+
+        assert operator.durable is False
+
+    @pytest.mark.parametrize(
+        ("status", "is_active", "is_succeeded"),
+        [
+            (
+                status,
+                status not in AzureSynapseSparkBatchRunStatus.TERMINAL_STATUSES,
+                status == AzureSynapseSparkBatchRunStatus.SUCCESS,
+            )
+            for status in (
+                AzureSynapseSparkBatchRunStatus.NOT_STARTED,
+                AzureSynapseSparkBatchRunStatus.STARTING,
+                AzureSynapseSparkBatchRunStatus.RUNNING,
+                AzureSynapseSparkBatchRunStatus.IDLE,
+                AzureSynapseSparkBatchRunStatus.BUSY,
+                AzureSynapseSparkBatchRunStatus.SHUTTING_DOWN,
+                AzureSynapseSparkBatchRunStatus.ERROR,
+                AzureSynapseSparkBatchRunStatus.DEAD,
+                AzureSynapseSparkBatchRunStatus.KILLED,
+                AzureSynapseSparkBatchRunStatus.SUCCESS,
+            )
+        ],
+    )
+    def test_status_helpers(self, status: str, is_active: bool, is_succeeded: bool) -> None:
+        operator = self.make_operator()
+
+        assert operator.is_job_active(status) is is_active
+        assert operator.is_job_succeeded(status) is is_succeeded
+
+    @pytest.mark.parametrize("job_id", [0, 91])
+    def test_poll_reconnects_job_id_for_wait_and_cancellation(self, job_id: int) -> None:
+        operator = self.make_operator()
+        operator.hook = self.make_hook()
+        operator.hook.wait_for_job_run_status.return_value = True
+        context = self.make_context(stored_job_id=job_id)
+
+        operator.poll_until_complete(job_id, context)
+        operator.on_kill()
+
+        assert operator.job_id == job_id
+        operator.hook.wait_for_job_run_status.assert_called_once_with(
+            job_id=job_id,
+            expected_statuses=AzureSynapseSparkBatchRunStatus.SUCCESS,
+            check_interval=1,
+            timeout=3,
+        )
+        operator.hook.cancel_job_run.assert_called_once_with(job_id=job_id)
+
+    def test_get_job_status_uses_persisted_job_id(self) -> None:
+        operator = self.make_operator()
+        operator.hook = self.make_hook()
+        operator.hook.get_job_run_status.return_value = AzureSynapseSparkBatchRunStatus.RUNNING
+        context = self.make_context(stored_job_id=91)
+
+        status = operator.get_job_status(91, context)
+
+        assert status == AzureSynapseSparkBatchRunStatus.RUNNING
+        assert operator.job_id == 91
+        operator.hook.get_job_run_status.assert_called_once_with(job_id=91)
+        cast("MagicMock", context["ti"]).xcom_push.assert_called_once_with(key="job_id", value=91)
+
+
+class TestWarnAndDisableDurableAirflowPre3_3:
+    def test_no_warning_when_unset(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = _warn_and_disable_durable_pre_3_3(_DURABLE_UNSET)
+
+        assert result is False
+        assert caught == []
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_warns_and_disables_when_explicitly_set(self, value: bool) -> None:
+        with pytest.warns(UserWarning, match="durable.*no effect"):
+            result = _warn_and_disable_durable_pre_3_3(value)
+
+        assert result is False
 
 
 class TestAzureSynapseRunPipelineOperator:

--- a/task-sdk/src/airflow/sdk/bases/resumablejobmixin.py
+++ b/task-sdk/src/airflow/sdk/bases/resumablejobmixin.py
@@ -146,7 +146,7 @@ class ResumableJobMixin(ABC):
                 )
             else:
                 external_id = task_state_store.get(self.external_id_key)
-                if external_id:
+                if external_id is not None:
                     stats.incr("resumable_job.reconnect_attempt", tags=stats_tags)
 
                     status = self.get_job_status(external_id, context)

--- a/task-sdk/tests/task_sdk/bases/test_resumablejobmixin.py
+++ b/task-sdk/tests/task_sdk/bases/test_resumablejobmixin.py
@@ -68,13 +68,13 @@ class ConcreteResumableOperator(ResumableJobMixin, BaseOperator):
 
 
 class FakeTaskState:
-    def __init__(self, stored: dict[str, str] | None = None):
-        self._store: dict[str, str] = stored or {}
+    def __init__(self, stored: dict[str, JsonValue] | None = None):
+        self._store: dict[str, JsonValue] = stored or {}
 
-    def get(self, key: str) -> str | None:
+    def get(self, key: str) -> JsonValue:
         return self._store.get(key)
 
-    def set(self, key: str, value: str) -> None:
+    def set(self, key: str, value: JsonValue) -> None:
         self._store[key] = value
 
 
@@ -139,6 +139,16 @@ class TestFirstSubmission:
 
 
 class TestRetryWithDifferentJobStatuses:
+    def test_zero_external_id_is_reconnected(self):
+        op = ConcreteResumableOperator(task_id="test_task")
+        op._status_map["0"] = "RUNNING"
+        task_state = FakeTaskState({"test_job_id": 0})
+
+        op.execute_resumable(make_context(task_state))
+
+        assert op.submitted_ids == []
+        assert op.polled_ids == ["0"]
+
     def test_skips_submission_when_job_active(self):
         op = ConcreteResumableOperator(task_id="test_task")
         op._status_map["job-001"] = "RUNNING"


### PR DESCRIPTION
A task retry currently submits a second Azure Synapse Spark batch even when the first batch is still running. This can duplicate remote work.

Synchronous `AzureSynapseRunSparkBatchOperator` tasks now store the submitted batch ID and reconnect to it on retry. A completed batch returns immediately; a failed batch is submitted again. `wait_for_termination=False` remains submit-only, and `durable=False` keeps the previous always-submit behavior. Airflow versions before 3.3 continue without task-state recovery.

The shared resumable-job path also treats numeric external ID `0` as a valid ID.

## Testing

- [x] Synapse hook and operator tests: 68 passed.
- [x] Shared `ResumableJobMixin` tests: 41 passed.
- [x] Local retry harness: the baseline submitted batches `0` and `1`; the changed operator submitted batch `0` once, reconnected to it, and restored its XCom.

<details>
<summary>Commands and raw output</summary>

```console
$ set -o pipefail; AIRFLOW_HOME="$(mktemp -d)/airflow" .venv/bin/uv run --project providers/microsoft/azure pytest providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_synapse.py providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_synapse.py -q 2>&1 | tail -1
======================== 68 passed, 1 warning in 27.39s ========================

$ set -o pipefail; AIRFLOW_HOME="$(mktemp -d)/airflow" .venv/bin/uv run --project task-sdk pytest task-sdk/tests/task_sdk/bases/test_resumablejobmixin.py -q 2>&1 | tail -1
======================== 41 passed, 1 warning in 1.44s =========================

$ AIRFLOW_HOME="$(mktemp -d)/airflow" AIRFLOW__LOGGING__LOGGING_LEVEL=ERROR .venv/bin/uv run --project providers/microsoft/azure python - <<'PY'
import json
import subprocess
from types import ModuleType, SimpleNamespace
from unittest.mock import MagicMock

from airflow.providers.microsoft.azure.hooks.synapse import AzureSynapseSparkBatchRunStatus
from airflow.providers.microsoft.azure.operators.synapse import AzureSynapseRunSparkBatchOperator

PATH = "providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/synapse.py"


class Store(dict):
    def set(self, key, value):
        self[key] = value


class TI:
    stats_tags = {}

    def __init__(self):
        self.xcom = {}

    def xcom_push(self, *, key, value):
        self.xcom[key] = value


def load_baseline():
    source = subprocess.run(
        ["git", "show", f"upstream/main:{PATH}"], check=True, capture_output=True, text=True
    ).stdout
    module = ModuleType("baseline_synapse")
    module.__package__ = "airflow.providers.microsoft.azure.operators"
    exec(compile(source, PATH, "exec"), module.__dict__)
    return module.AzureSynapseRunSparkBatchOperator


def run(operator_type):
    submissions, waited_for = [], []
    store = Store()

    def make_hook():
        hook = MagicMock()

        def submit(*, payload):
            job_id = len(submissions)
            submissions.append(job_id)
            return SimpleNamespace(id=job_id)

        hook.run_spark_job.side_effect = submit
        hook.get_job_run_status.return_value = AzureSynapseSparkBatchRunStatus.RUNNING
        hook.wait_for_job_run_status.side_effect = (
            lambda *, job_id, **_: waited_for.append(job_id) or True
        )
        return hook

    retry_ti = None
    retry = None
    for ti in (TI(), TI()):
        retry_ti = ti
        retry = operator_type(
            task_id=f"synapse_{len(submissions)}",
            azure_synapse_conn_id="unused",
            spark_pool="unused",
            payload={},
            check_interval=0,
        )
        retry.hook = make_hook()
        retry.execute(context={"task_state_store": store, "ti": ti})
    return {
        "submissions": submissions,
        "persisted_job_id": store.get("synapse_spark_batch_id"),
        "retry_job_id": retry.job_id,
        "retry_xcom_job_id": retry_ti.xcom["job_id"],
        "waited_for": waited_for,
    }


result = {"before": run(load_baseline()), "after": run(AzureSynapseRunSparkBatchOperator)}
assert result["before"]["submissions"] == [0, 1]
assert result["after"]["submissions"] == [0]
assert result["after"]["persisted_job_id"] == result["after"]["retry_xcom_job_id"] == 0
print(json.dumps(result, indent=2))
PY
{
  "before": {
    "submissions": [0, 1],
    "persisted_job_id": null,
    "retry_job_id": 1,
    "retry_xcom_job_id": 1,
    "waited_for": [0, 1]
  },
  "after": {
    "submissions": [0],
    "persisted_job_id": 0,
    "retry_job_id": 0,
    "retry_xcom_job_id": 0,
    "waited_for": [0, 0]
  }
}
```

The retry harness used the real baseline operator, changed operator, and `ResumableJobMixin`. It replaced Azure with an in-process hook substitute; no Azure service was contacted.

</details>

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes - GitHub Copilot CLI (GPT-5.6 Sol)

Generated-by: GitHub Copilot CLI (GPT-5.6 Sol) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.