### PR TITLE
Fix email callback bundle_version for unpinned Dag runs

### DIFF
--- a/airflow-core/newsfragments/72370.bugfix.rst
+++ b/airflow-core/newsfragments/72370.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed failure/retry emails inheriting a stale pinned bundle version for Dag runs with ``disable_bundle_versioning`` enabled, instead of following the unpinned ``dag_run.bundle_version`` like the equivalent task callbacks do.

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1680,8 +1680,12 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     _email_bundle_name = (
                         ti.dag_version.bundle_name if ti.dag_version else ti.dag_model.bundle_name
                     )
+                    # Mirror dag_run pinning: if the run wasn't pinned (e.g. dag.disable_bundle_versioning=True),
+                    # leave the callback unpinned so it runs against the same code as the task.
                     _email_bundle_version = (
-                        ti.dag_version.bundle_version if ti.dag_version else ti.dag_run.bundle_version
+                        ti.dag_version.bundle_version
+                        if ti.dag_version and ti.dag_run.bundle_version is not None
+                        else ti.dag_run.bundle_version
                     )
                     _email_version_data = _resolve_version_data(ti.dag_version, ti.dag_run.bundle_version)
                     # Backfill dag_version_id for legacy tasks (Pydantic requires uuid.UUID).

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -9445,6 +9445,51 @@ class TestSchedulerJob:
         assert isinstance(request, TaskCallbackRequest)
         assert request.bundle_version == expected_bv
 
+    @pytest.mark.parametrize(
+        ("dag_run_bv", "dag_version_bv", "expected_bv"),
+        [
+            pytest.param(None, "abc123-sha", None, id="disable_bundle_versioning"),
+            pytest.param("abc123-sha", "abc123-sha", "abc123-sha", id="versioning_enabled"),
+        ],
+    )
+    def test_external_kill_email_bundle_version_follows_dag_run(
+        self, dag_maker, session, dag_run_bv, dag_version_bv, expected_bv
+    ):
+        """
+        EmailRequest.bundle_version must mirror dag_run.bundle_version, not
+        dag_version.bundle_version -- the same invariant asserted for
+        TaskCallbackRequest above by test_external_kill_callback_bundle_version_follows_dag_run.
+        With disable_bundle_versioning=True the trigger path leaves dag_run.bundle_version=None
+        even though DagVersion was written with a SHA -- the failure/retry email must inherit
+        None so the DAG Processor renders it against the same on-disk code as the task, instead
+        of pinning to a version the run was never pinned to.
+        """
+        with dag_maker(dag_id=f"ext_kill_email_bv_{dag_run_bv or 'none'}", fileloc="/test_path1/"):
+            EmptyOperator(task_id="t1", email="test@example.com", email_on_failure=True)
+        dr = dag_maker.create_dagrun(state=DagRunState.RUNNING)
+
+        ti = dr.get_task_instance(task_id="t1", session=session)
+        dag_version = ti.dag_version
+        dag_version.bundle_version = dag_version_bv
+        dr.bundle_version = dag_run_bv
+        ti.state = State.QUEUED
+        session.merge(dag_version)
+        session.merge(dr)
+        session.merge(ti)
+        session.commit()
+
+        executor = MockExecutor(do_update=False)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(scheduler_job, executors=[executor])
+        executor.event_buffer[ti.key] = State.FAILED, None
+
+        self.job_runner._process_executor_events(executor=executor, session=session)
+
+        self.job_runner.executor.callback_sink.send.assert_called_once()
+        request = self.job_runner.executor.callback_sink.send.call_args[0][0]
+        assert isinstance(request, EmailRequest)
+        assert request.bundle_version == expected_bv
+
     def test_heartbeat_timeout_callback_bundle_version_follows_dag_run(self, dag_maker, session):
         """
         Same invariant as the external-kill path, exercised through


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

PR #66485 fixed scheduler-emitted `TaskCallbackRequest`s (external kill, heartbeat
timeout, stuck-in-queued) to source `bundle_version` from `dag_run.bundle_version`
instead of `DagVersion.bundle_version`, so that callbacks for Dags with
`disable_bundle_versioning=True` stay unpinned and run against the same on-disk
code the task did, instead of pinning to a version the run was never pinned to.

That fix touched three call sites but missed a fourth: the `EmailRequest` built a
few lines below the `TaskCallbackRequest` in `process_executor_events`'s
external-kill path. It still falls back to `DagVersion.bundle_version` whenever
`dag_version` is set, regardless of whether `dag_run.bundle_version` is `None`.

For a Dag with `disable_bundle_versioning=True` and `email_on_failure`/
`email_on_retry` configured, when a task is detected as externally killed, the
failure/retry email ends up pinned to a stale bundle version the run was never
pinned to — causing the Dag Processor to check out an unnecessary
`versions/<sha>/` working tree for that email callback (the exact class of
problem #66485 set out to fix, just through the one path it didn't touch).

This applies the same guard used at the other three call sites (and used by the
`_resolve_ti_callback_bundle_info` helper, whose own docstring says
`process_executor_events` "inlines the same resolution" — this brings it back in
sync), and adds a regression test mirroring the existing
`test_external_kill_callback_bundle_version_follows_dag_run` for the `EmailRequest`
path, since the existing `TestSchedulerCallbackBundleInfoDagVersionNullable` suite
verifies a reimplementation of the logic rather than the real per-callsite code,
which is how this one diverged unnoticed.

Verified locally: the new test fails against the pre-fix code
(`AssertionError: -'abc123-sha' +None`) and passes with the fix; the full
`bundle_version` / `process_executor_events` / heartbeat-timeout test surface in
`test_scheduler_job.py` passes with no regressions; `ruff check` and
`ruff format --check` are clean on both changed files.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

<!--
Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

Claude Code was used to investigate the root cause (via `git blame`/`git log` on the
original fix, and tracing `EmailRequest.bundle_version` through to
`BundleVersionLock`), implement the fix, write the regression test, and run/verify
the test suite. All findings and the diff were reviewed and understood before
submission.

---

* Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines).
* No related issue — this was found via source/history review rather than a bug report.
* Newsfragment (`{pr_number}.bugfix.rst`) will be added as a follow-up commit once this PR's number is known.
