### PR TITLE
Keep HttpEventTrigger asset watchers polling after a failed request

### DIFF
--- a/providers/http/docs/triggers.rst
+++ b/providers/http/docs/triggers.rst
@@ -34,6 +34,8 @@ How It Works
 1. Sends requests to an API every ``poll_interval`` seconds (default 60).
 2. Uses the callable at ``response_check_path`` to evaluate the API response.
 3. If the callable returns ``True``, a ``TriggerEvent`` is emitted. This will trigger DAGs using this ``AssetWatcher`` for scheduling.
+4. If the request fails or the callable raises, the error is logged with its traceback and the trigger polls again after ``poll_interval`` seconds.
+5. After ``max_consecutive_failures`` consecutive failed polls (default 10) the trigger reports the error instead of absorbing it, so a persistently broken watcher surfaces in the triggerer log; the triggerer then restarts it.
 
 .. note::
    This trigger requires **Airflow >= 3.0** due to dependencies on ``AssetWatcher`` and event-driven scheduling infrastructure.
@@ -146,6 +148,9 @@ Parameters
 
 ``poll_interval``
     How often, in seconds, the trigger should send a request to the API
+
+``max_consecutive_failures``
+    How many consecutive failed polls the trigger absorbs before reporting the error to the triggerer. A successful poll resets the count.
 
 
 Important Notes

--- a/providers/http/docs/triggers.rst
+++ b/providers/http/docs/triggers.rst
@@ -150,7 +150,10 @@ Parameters
     How often, in seconds, the trigger should send a request to the API
 
 ``max_consecutive_failures``
-    How many consecutive polling failures are tolerated. The effective time before the trigger fails is approximately ``max_consecutive_failures`` × ``poll_interval``. Any poll that completes resets the count, including one where ``response_check`` returns ``False``.
+    Maximum number of consecutive polling failures before the trigger raises.
+    The effective failure tolerance is approximately
+    ``max_consecutive_failures`` × ``poll_interval``.
+    Any poll that completes resets the count, including one where ``response_check`` returns ``False``.
 
 
 Important Notes

--- a/providers/http/docs/triggers.rst
+++ b/providers/http/docs/triggers.rst
@@ -34,8 +34,8 @@ How It Works
 1. Sends requests to an API every ``poll_interval`` seconds (default 60).
 2. Uses the callable at ``response_check_path`` to evaluate the API response.
 3. If the callable returns ``True``, a ``TriggerEvent`` is emitted. This will trigger DAGs using this ``AssetWatcher`` for scheduling.
-4. If the request fails or the callable raises, the error is logged with its traceback and the trigger polls again after ``poll_interval`` seconds.
-5. After ``max_consecutive_failures`` consecutive failed polls (default 10) the trigger reports the error instead of absorbing it, so a persistently broken watcher surfaces in the triggerer log; the triggerer then restarts it.
+4. If the request fails or the callable raises, the error is logged and the trigger polls again after ``poll_interval`` seconds.
+5. After ``max_consecutive_failures`` consecutive failed polls (default 10) the trigger stops absorbing the error and raises, so the failure and its traceback reach the trigger log. The triggerer then restarts the watcher.
 
 .. note::
    This trigger requires **Airflow >= 3.0** due to dependencies on ``AssetWatcher`` and event-driven scheduling infrastructure.
@@ -150,7 +150,7 @@ Parameters
     How often, in seconds, the trigger should send a request to the API
 
 ``max_consecutive_failures``
-    How many consecutive failed polls the trigger absorbs before reporting the error to the triggerer. A successful poll resets the count.
+    How many consecutive polling failures are tolerated. The effective time before the trigger fails is approximately ``max_consecutive_failures`` × ``poll_interval``. Any poll that completes resets the count, including one where ``response_check`` returns ``False``.
 
 
 Important Notes

--- a/providers/http/src/airflow/providers/http/triggers/http.py
+++ b/providers/http/src/airflow/providers/http/triggers/http.py
@@ -298,6 +298,8 @@ class HttpEventTrigger(HttpTrigger, BaseEventTrigger):
     :param data: Payload to be uploaded or request parameters.
     :param extra_options: Additional kwargs to pass when creating a request.
     :parama poll_interval: How often, in seconds, the trigger should send a request to the API.
+    :param max_consecutive_failures: How many consecutive failed polls the trigger tolerates
+        before giving up and reporting the error instead of retrying.
     """
 
     def __init__(
@@ -311,10 +313,14 @@ class HttpEventTrigger(HttpTrigger, BaseEventTrigger):
         data: dict[str, Any] | str | None = None,
         extra_options: dict[str, Any] | None = None,
         poll_interval: float = 60.0,
+        max_consecutive_failures: int = 10,
     ):
         super().__init__(http_conn_id, auth_type, method, endpoint, headers, data, extra_options)
         self.response_check_path = response_check_path
         self.poll_interval = poll_interval
+        if max_consecutive_failures < 1:
+            raise ValueError("max_consecutive_failures must be greater or equal to 1")
+        self.max_consecutive_failures = max_consecutive_failures
 
     def serialize(self) -> tuple[str, dict[str, Any]]:
         """Serialize HttpEventTrigger arguments and classpath."""
@@ -330,26 +336,46 @@ class HttpEventTrigger(HttpTrigger, BaseEventTrigger):
                 "extra_options": self.extra_options,
                 "response_check_path": self.response_check_path,
                 "poll_interval": self.poll_interval,
+                "max_consecutive_failures": self.max_consecutive_failures,
             },
         )
 
     async def run(self) -> AsyncIterator[TriggerEvent]:
         """Make a series of asynchronous http calls via a http hook until the response passes the response check."""
         hook = super()._get_async_hook()
-        try:
-            while True:
+        failures = 0
+        while True:
+            try:
                 response = await super()._get_response(hook)
-                if await self._run_response_check(response):
-                    break
-                await asyncio.sleep(self.poll_interval)
-            yield TriggerEvent(
-                {
-                    "status": "success",
-                    "response": HttpResponseSerializer.serialize(response),
-                }
-            )
-        except Exception as e:
-            self.log.error("status: error, message: %s", str(e))
+                check_passed = await self._run_response_check(response)
+                event = (
+                    TriggerEvent(
+                        {
+                            "status": "success",
+                            "response": HttpResponseSerializer.serialize(response),
+                        }
+                    )
+                    if check_passed
+                    else None
+                )
+            except Exception:
+                failures += 1
+                if failures >= self.max_consecutive_failures:
+                    # Stop absorbing: the triggerer records the traceback and restarts the
+                    # watcher, and anything deferred on this trigger fails instead of hanging.
+                    raise
+                self.log.exception(
+                    "Poll failed (%s/%s), retrying in %s seconds",
+                    failures,
+                    self.max_consecutive_failures,
+                    self.poll_interval,
+                )
+            else:
+                failures = 0
+                if event is not None:
+                    yield event
+                    return
+            await asyncio.sleep(self.poll_interval)
 
     async def _import_from_response_check_path(self):
         """Import the response check callable from the path provided by the user."""

--- a/providers/http/src/airflow/providers/http/triggers/http.py
+++ b/providers/http/src/airflow/providers/http/triggers/http.py
@@ -298,8 +298,8 @@ class HttpEventTrigger(HttpTrigger, BaseEventTrigger):
     :param data: Payload to be uploaded or request parameters.
     :param extra_options: Additional kwargs to pass when creating a request.
     :parama poll_interval: How often, in seconds, the trigger should send a request to the API.
-    :param max_consecutive_failures: How many consecutive failed polls the trigger tolerates
-        before giving up and reporting the error instead of retrying.
+    :param max_consecutive_failures: How many consecutive polling failures are tolerated. The
+        effective time before the trigger fails is roughly this times ``poll_interval``.
     """
 
     def __init__(
@@ -358,19 +358,22 @@ class HttpEventTrigger(HttpTrigger, BaseEventTrigger):
                     if check_passed
                     else None
                 )
-            except Exception:
+            except Exception as exc:
                 failures += 1
                 if failures >= self.max_consecutive_failures:
-                    # Stop absorbing: the triggerer records the traceback and restarts the
-                    # watcher, and anything deferred on this trigger fails instead of hanging.
+                    # The triggerer logs the traceback into this trigger's log and restarts the
+                    # watcher; anything deferred on this trigger fails instead of hanging.
                     raise
-                self.log.exception(
-                    "Poll failed (%s/%s), retrying in %s seconds",
+                self.log.warning(
+                    "Poll failed (%s/%s): %r, retrying in %s seconds",
                     failures,
                     self.max_consecutive_failures,
+                    exc,
                     self.poll_interval,
                 )
             else:
+                # "Not yet" clears the count too, or a healthy watcher would escalate after
+                # max_consecutive_failures ordinary polls.
                 failures = 0
                 if event is not None:
                     yield event

--- a/providers/http/src/airflow/providers/http/triggers/http.py
+++ b/providers/http/src/airflow/providers/http/triggers/http.py
@@ -298,8 +298,8 @@ class HttpEventTrigger(HttpTrigger, BaseEventTrigger):
     :param data: Payload to be uploaded or request parameters.
     :param extra_options: Additional kwargs to pass when creating a request.
     :parama poll_interval: How often, in seconds, the trigger should send a request to the API.
-    :param max_consecutive_failures: How many consecutive polling failures are tolerated. The
-        effective time before the trigger fails is roughly this times ``poll_interval``.
+    :param max_consecutive_failures: Maximum number of consecutive polling failures before the
+        trigger raises. The effective failure tolerance is roughly this times ``poll_interval``.
     """
 
     def __init__(

--- a/providers/http/src/airflow/providers/http/triggers/http.py
+++ b/providers/http/src/airflow/providers/http/triggers/http.py
@@ -297,7 +297,7 @@ class HttpEventTrigger(HttpTrigger, BaseEventTrigger):
     :param headers: Additional headers to be passed through as a dict.
     :param data: Payload to be uploaded or request parameters.
     :param extra_options: Additional kwargs to pass when creating a request.
-    :parama poll_interval: How often, in seconds, the trigger should send a request to the API.
+    :param poll_interval: How often, in seconds, the trigger should send a request to the API.
     :param max_consecutive_failures: Maximum number of consecutive polling failures before the
         trigger raises. The effective failure tolerance is roughly this times ``poll_interval``.
     """

--- a/providers/http/tests/unit/http/triggers/test_http.py
+++ b/providers/http/tests/unit/http/triggers/test_http.py
@@ -268,7 +268,7 @@ class TestHttpEventTrigger:
         self, mock_hook, mock_sleep, failing_call, event_trigger, client_response, monkeypatch
     ):
         """
-        Tests the HttpEventTrigger reports the failure with its traceback and fires on a later poll.
+        Tests the HttpEventTrigger reports the failure and fires on a later poll.
         """
         error = HttpErrorException("503:Service Unavailable")
         if failing_call == "request":
@@ -292,7 +292,8 @@ class TestHttpEventTrigger:
         )
         assert mock_hook.return_value.run.call_count == 2
         mock_sleep.assert_awaited_once_with(TEST_POLL_INTERVAL)
-        assert mock_logger.exception.call_count == 1
+        assert mock_logger.warning.call_count == 1
+        assert mock_logger.exception.call_count == 0
 
     @staticmethod
     def build_trigger_with_failure_cap(max_consecutive_failures: int) -> HttpEventTrigger:
@@ -306,27 +307,37 @@ class TestHttpEventTrigger:
     @pytest.mark.asyncio
     @mock.patch(HTTP_PATH.format("asyncio.sleep"), autospec=True)
     @mock.patch(HTTP_PATH.format("HttpAsyncHook"))
-    async def test_trigger_gives_up_after_max_consecutive_failures(self, mock_hook, mock_sleep):
+    async def test_trigger_gives_up_after_max_consecutive_failures(self, mock_hook, mock_sleep, monkeypatch):
         trigger = self.build_trigger_with_failure_cap(3)
         mock_hook.return_value.run.side_effect = HttpErrorException("503:Service Unavailable")
+        mock_logger = mock.Mock()
+        monkeypatch.setattr(type(trigger), "log", mock_logger)
 
         with pytest.raises(HttpErrorException):
             await trigger.run().asend(None)
 
         assert mock_hook.return_value.run.call_count == 3
-        assert mock_sleep.await_count == 2
+        assert mock_sleep.await_args_list == [mock.call(TEST_POLL_INTERVAL)] * 2
+        assert mock_logger.warning.call_count == 2
+        assert mock_logger.exception.call_count == 0
 
     @pytest.mark.asyncio
     @mock.patch(HTTP_PATH.format("asyncio.sleep"), autospec=True)
     @mock.patch(HTTP_PATH.format("HttpAsyncHook"))
-    async def test_trigger_resets_failure_count_after_a_successful_poll(
+    async def test_trigger_resets_failure_count_after_a_completed_poll(
         self, mock_hook, mock_sleep, client_response
     ):
-        trigger = self.build_trigger_with_failure_cap(2)
+        """
+        Two failures, a poll whose ``response_check`` returns False, then two more failures:
+        the count must go back to zero rather than merely drop, or the cap of 3 would trip.
+        """
+        trigger = self.build_trigger_with_failure_cap(3)
         error = HttpErrorException("503:Service Unavailable")
         mock_hook.return_value.run.side_effect = [
             error,
+            error,
             self._mock_run_result(client_response),
+            error,
             error,
             self._mock_run_result(client_response),
         ]
@@ -335,7 +346,8 @@ class TestHttpEventTrigger:
         event = await trigger.run().asend(None)
 
         assert event.payload["status"] == "success"
-        assert mock_hook.return_value.run.call_count == 4
+        assert mock_hook.return_value.run.call_count == 6
+        assert mock_sleep.await_args_list == [mock.call(TEST_POLL_INTERVAL)] * 5
 
     def test_max_consecutive_failures_must_be_positive(self):
         with pytest.raises(ValueError, match="max_consecutive_failures"):

--- a/providers/http/tests/unit/http/triggers/test_http.py
+++ b/providers/http/tests/unit/http/triggers/test_http.py
@@ -29,6 +29,7 @@ from requests.structures import CaseInsensitiveDict
 from yarl import URL
 
 from airflow.models import Connection
+from airflow.providers.http.exceptions import HttpErrorException
 from airflow.providers.http.triggers.http import (
     HttpEventTrigger,
     HttpResponseSerializer,
@@ -235,6 +236,7 @@ class TestHttpEventTrigger:
             "extra_options": TEST_EXTRA_OPTIONS,
             "response_check_path": TEST_RESPONSE_CHECK_PATH,
             "poll_interval": TEST_POLL_INTERVAL,
+            "max_consecutive_failures": 10,
         }
 
     @pytest.mark.asyncio
@@ -259,22 +261,85 @@ class TestHttpEventTrigger:
         assert event_trigger._run_response_check.call_count == 2
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("failing_call", ["request", "response_check"])
+    @mock.patch(HTTP_PATH.format("asyncio.sleep"), autospec=True)
     @mock.patch(HTTP_PATH.format("HttpAsyncHook"))
-    async def test_trigger_on_exception_logs_error_and_never_yields(
-        self, mock_hook, event_trigger, monkeypatch
+    async def test_trigger_keeps_polling_after_an_exception(
+        self, mock_hook, mock_sleep, failing_call, event_trigger, client_response, monkeypatch
     ):
         """
-        Tests the HttpEventTrigger logs the appropriate message and does not yield a TriggerEvent when an exception is raised.
+        Tests the HttpEventTrigger reports the failure with its traceback and fires on a later poll.
         """
-        mock_hook.return_value.run.side_effect = Exception("Test exception")
+        error = HttpErrorException("503:Service Unavailable")
+        if failing_call == "request":
+            mock_hook.return_value.run.side_effect = [error, self._mock_run_result(client_response)]
+            event_trigger._run_response_check = mock.AsyncMock(return_value=True)
+        else:
+            mock_hook.return_value.run.return_value = self._mock_run_result(client_response)
+            event_trigger._run_response_check = mock.AsyncMock(side_effect=[error, True])
         mock_logger = mock.Mock()
         monkeypatch.setattr(type(event_trigger), "log", mock_logger)
+        response = await HttpEventTrigger._convert_response(client_response)
 
         generator = event_trigger.run()
-        with pytest.raises(StopAsyncIteration):
-            await generator.asend(None)
+        actual = await generator.asend(None)
 
-        mock_logger.error.assert_called_once_with("status: error, message: %s", "Test exception")
+        assert actual == TriggerEvent(
+            {
+                "status": "success",
+                "response": HttpResponseSerializer.serialize(response),
+            }
+        )
+        assert mock_hook.return_value.run.call_count == 2
+        mock_sleep.assert_awaited_once_with(TEST_POLL_INTERVAL)
+        assert mock_logger.exception.call_count == 1
+
+    @staticmethod
+    def build_trigger_with_failure_cap(max_consecutive_failures: int) -> HttpEventTrigger:
+        return HttpEventTrigger(
+            endpoint=TEST_ENDPOINT,
+            response_check_path=TEST_RESPONSE_CHECK_PATH,
+            poll_interval=TEST_POLL_INTERVAL,
+            max_consecutive_failures=max_consecutive_failures,
+        )
+
+    @pytest.mark.asyncio
+    @mock.patch(HTTP_PATH.format("asyncio.sleep"), autospec=True)
+    @mock.patch(HTTP_PATH.format("HttpAsyncHook"))
+    async def test_trigger_gives_up_after_max_consecutive_failures(self, mock_hook, mock_sleep):
+        trigger = self.build_trigger_with_failure_cap(3)
+        mock_hook.return_value.run.side_effect = HttpErrorException("503:Service Unavailable")
+
+        with pytest.raises(HttpErrorException):
+            await trigger.run().asend(None)
+
+        assert mock_hook.return_value.run.call_count == 3
+        assert mock_sleep.await_count == 2
+
+    @pytest.mark.asyncio
+    @mock.patch(HTTP_PATH.format("asyncio.sleep"), autospec=True)
+    @mock.patch(HTTP_PATH.format("HttpAsyncHook"))
+    async def test_trigger_resets_failure_count_after_a_successful_poll(
+        self, mock_hook, mock_sleep, client_response
+    ):
+        trigger = self.build_trigger_with_failure_cap(2)
+        error = HttpErrorException("503:Service Unavailable")
+        mock_hook.return_value.run.side_effect = [
+            error,
+            self._mock_run_result(client_response),
+            error,
+            self._mock_run_result(client_response),
+        ]
+        trigger._run_response_check = mock.AsyncMock(side_effect=[False, True])
+
+        event = await trigger.run().asend(None)
+
+        assert event.payload["status"] == "success"
+        assert mock_hook.return_value.run.call_count == 4
+
+    def test_max_consecutive_failures_must_be_positive(self):
+        with pytest.raises(ValueError, match="max_consecutive_failures"):
+            self.build_trigger_with_failure_cap(0)
 
     @pytest.mark.asyncio
     async def test_convert_response(self, client_response):
@@ -293,14 +358,21 @@ class TestHttpEventTrigger:
 
     @pytest.mark.db_test
     @pytest.mark.asyncio
+    @mock.patch(HTTP_PATH.format("asyncio.sleep"), autospec=True)
     @mock.patch("aiohttp.client.ClientSession.post")
-    async def test_trigger_on_post_with_data(self, mock_http_post, event_trigger):
+    async def test_trigger_on_post_with_data(
+        self, mock_http_post, mock_sleep, event_trigger, client_response
+    ):
         """
         Test that HttpEventTrigger posts the correct payload when a request is made.
         """
+        mock_http_post.return_value = self._mock_run_result(client_response)
+        event_trigger._run_response_check = mock.AsyncMock(return_value=True)
+
         generator = event_trigger.run()
-        with pytest.raises(StopAsyncIteration):
-            await generator.asend(None)
+        await generator.asend(None)
+
+        mock_sleep.assert_not_awaited()
         mock_http_post.assert_called_once()
         _, kwargs = mock_http_post.call_args
         assert kwargs["data"] == TEST_DATA

--- a/providers/http/tests/unit/http/triggers/test_http.py
+++ b/providers/http/tests/unit/http/triggers/test_http.py
@@ -293,7 +293,6 @@ class TestHttpEventTrigger:
         assert mock_hook.return_value.run.call_count == 2
         mock_sleep.assert_awaited_once_with(TEST_POLL_INTERVAL)
         assert mock_logger.warning.call_count == 1
-        assert mock_logger.exception.call_count == 0
 
     @staticmethod
     def build_trigger_with_failure_cap(max_consecutive_failures: int) -> HttpEventTrigger:
@@ -319,7 +318,6 @@ class TestHttpEventTrigger:
         assert mock_hook.return_value.run.call_count == 3
         assert mock_sleep.await_args_list == [mock.call(TEST_POLL_INTERVAL)] * 2
         assert mock_logger.warning.call_count == 2
-        assert mock_logger.exception.call_count == 0
 
     @pytest.mark.asyncio
     @mock.patch(HTTP_PATH.format("asyncio.sleep"), autospec=True)


### PR DESCRIPTION
## Summary

`HttpEventTrigger` wrapped its whole poll loop in one `except Exception` that logged `str(e)` and returned, so the first error of any kind ended the generator. The watcher stopped firing even when the next poll would have succeeded, and since the only sleep sat on the success path the triggerer recreated it on every ~1s loop — polling the endpoint at roughly 1 req/s with `poll_interval` ignored entirely.

- Keep polling after a failed poll, paced by `poll_interval`
- Give up after `max_consecutive_failures` consecutive failures and raise
- Log a warning per failed poll rather than a full traceback

Dependents already failed before this change — a trigger that exits without yielding lands in `failed_triggers` whether it returned or raised — so what raising adds is the traceback that `submit_failure` used to record as `None`.

The default of 10 is picked against the default `poll_interval` of 60 seconds: roughly ten minutes of continuous failure before escalating. Effective tolerance is that product rather than the count, which the parameter documentation now states.

## Before / after

Both versions of `run()` driven through the same scenarios with `asyncio.sleep` stubbed:

| Scenario | Before | After |
| --- | --- | --- |
| Transient 503, next poll would succeed | never fires (1 poll) | fires (2 polls, 1 backoff) |
| Endpoint down indefinitely | exits after 1 poll, recreated every ~1s | raises after 10 polls, one `poll_interval` apart |
| `response_check` raises | exits after 1 poll | raises after 10 polls |
| Cancelled during backoff | never reaches a backoff | `CancelledError` propagates |

## Tests

`test_trigger_on_post_with_data` relied on the swallowed exception to end the generator, so it now drives one successful poll instead.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
