### PR TITLE
Retry prek hook installation in CI when toolchain downloads fail

### DIFF
--- a/.github/actions/install-prek/action.yml
+++ b/.github/actions/install-prek/action.yml
@@ -108,7 +108,23 @@ runs:
       if: steps.restore-prek-cache.outputs.stash-hit != 'true' || steps.restore-prek-tar.outputs.tar-restored != 'true'
     - name: Install prek hooks
       shell: bash
-      run: prek install-hooks
+      # prek downloads the toolchains its hooks need and does not retry, so a transient 5xx
+      # from a download host fails the job before it does any work.
+      run: |
+        max_attempts=4
+        for attempt in $(seq 1 "${max_attempts}"); do
+          if prek install-hooks; then
+            exit 0
+          fi
+          if [[ "${attempt}" -eq "${max_attempts}" ]]; then
+            break
+          fi
+          delay=$((attempt * 20))
+          echo "prek install-hooks failed (attempt ${attempt}/${max_attempts}), retrying in ${delay}s"
+          sleep "${delay}"
+        done
+        echo "prek install-hooks failed after ${max_attempts} attempts" >&2
+        exit 1
       working-directory: ${{ github.workspace }}
     - name: "Show prek log"
       shell: bash


### PR DESCRIPTION
## Summary

`prek install-hooks` downloads the toolchains required by its hooks, but prek does not retry failed downloads. As a result, a transient 5xx from a download host can fail the job before any work starts.

For example, two jobs in [[run 33525573182](https://github.com/apache/airflow/actions/runs/33525573182)] failed this way while the other 48 passed:

```text
error: Failed to install hook `go-mod-tidy`
  caused by: Failed to download file from https://go.dev/dl/go1.25.0.linux-amd64.tar.gz
  caused by: HTTP status server error (500 Internal Server Error) for url (https://go.dev/dl/go1.25.0.linux-amd64.tar.gz)
```

Only jobs that reach `prek install-hooks` before the prek cache tarball is created make an outbound request. Later jobs restore the toolchains from cache. This makes the failure appear randomly on otherwise unrelated PRs.

The cache restore step in this action already retries its own download, leaving hook installation as the last unguarded external dependency. Upgrading prek would not address this: the toolchain download path is byte-identical between the pinned 0.4.14 and current 0.5.1, and the Go installer still uses the `go.dev` URL directly.

This change:

* Retries `prek install-hooks` up to four times, with 20s, 40s, and 60s backoff.
* Fails the step after all attempts are exhausted, so a persistent outage still fails the job.

### Why retry all non-zero exits?

Prek reports different failure types with the same exit code (`2`). This was verified with:

* a download returning HTTP 500
* a malformed `.pre-commit-config.yaml`
* an unknown language
* a bad hook revision

The existing cache restore step can retry selectively because `gh run download` uses exit code `1` for retryable failures. Prek provides no equivalent signal.

Parsing stderr for messages such as `Failed to download file from` would be fragile because those strings are not a stable interface. A wording change could silently disable the retry and bring the flake back.

Retrying all failures has a bounded cost: a genuinely broken configuration adds at most two minutes to a job that would fail anyway. This is preferable to leaving transient download failures unprotected.

### Why 20s / 40s / 60s?

The backoff follows existing patterns in the repository:

* `download_k8s_schemas.py` uses increasing delays for retries.
* `run_integration_tests_with_retry.sh` uses a 60s delay for transient registry/network failures.

The observed outage lasted about 49 seconds. The third attempt therefore already starts after that window, while the fourth attempt provides additional margin for a longer outage.

## Tests

Reproduced the failure against a stand-in `go.dev` using the prek version pinned by this repo. The proxy returned HTTP 500 for the pinned Go tarball and real bytes on success, so prek's checksum verification remained genuine.

Verified:

* **Two 500s, then recovery:** the step fails without the retry; with the retry, the third attempt installs Go 1.25.0 and runs the hook.
* **Persistent 500:** the step still fails after four attempts.
* **Interrupted download:** the partial tarball remains only in prek's scratch directory; nothing is written under `tools/`, so the retry safely re-downloads the toolchain.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
