### PR TITLE
Fix HttpOperator deferrable pagination returning only the last page instead of all page

### DIFF
--- a/providers/http/src/airflow/providers/http/operators/http.py
+++ b/providers/http/src/airflow/providers/http/operators/http.py
@@ -317,31 +317,33 @@ class HttpOperator(BaseOperator):
         """
         if event["status"] == "success":
             response = HttpResponseSerializer.deserialize(event["response"])
-
-            self.paginate_async(context=context, response=response, previous_responses=paginated_responses)
-            return self.process_response(context=context, response=response)
+            return self.paginate_async(
+                context=context, response=response, previous_responses=paginated_responses
+            )
         raise AirflowException(f"Unexpected error in the operation: {event['message']}")
 
     def paginate_async(
         self, context: Context, response: Response, previous_responses: None | list[Response] = None
     ):
-        if self.pagination_function:
-            all_responses = previous_responses or []
-            all_responses.append(response)
+        if not self.pagination_function:
+            return self.process_response(context=context, response=response)
 
-            next_page_params = self.pagination_function(response)
-            if not next_page_params:
-                return self.process_response(context=context, response=all_responses)
-            self.defer(
-                trigger=HttpTrigger(
-                    http_conn_id=self.http_conn_id,
-                    auth_type=serialize_auth_type(self._resolve_auth_type()),
-                    method=self.method,
-                    **self._merge_next_page_parameters(next_page_params),
-                ),
-                method_name="execute_complete",
-                kwargs={"paginated_responses": all_responses},
-            )
+        all_responses = previous_responses or []
+        all_responses.append(response)
+
+        next_page_params = self.pagination_function(response)
+        if not next_page_params:
+            return self.process_response(context=context, response=all_responses)
+        self.defer(
+            trigger=HttpTrigger(
+                http_conn_id=self.http_conn_id,
+                auth_type=serialize_auth_type(self._resolve_auth_type()),
+                method=self.method,
+                **self._merge_next_page_parameters(next_page_params),
+            ),
+            method_name="execute_complete",
+            kwargs={"paginated_responses": all_responses},
+        )
 
     def _merge_next_page_parameters(self, next_page_params: dict) -> dict:
         """

--- a/providers/http/tests/unit/http/operators/test_http.py
+++ b/providers/http/tests/unit/http/operators/test_http.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import base64
-import contextlib
 import json
 import logging
 import pickle
@@ -412,9 +411,11 @@ class TestHttpOperator:
         returns a dictionary that override previous' call parameters.
         """
 
+        values = iter([5, 10])
+
         def make_response_object() -> Response:
             response = Response()
-            response._content = b'{"value": 5}'
+            response._content = json.dumps({"value": next(values)}).encode()
             return response
 
         def create_resume_response_parameters() -> dict:
@@ -443,15 +444,81 @@ class TestHttpOperator:
             deferrable=True,
         )
 
-        # Do two calls: On the first one, the pagination_function creates a new
-        # deferrable trigger. On the second one, the pagination_function returns
-        # None, which ends the execution of the Operator
-        with contextlib.suppress(TaskDeferred):
+        with pytest.raises(TaskDeferred) as exc_info:
             operator.execute_complete(**create_resume_response_parameters())
-            result = operator.execute_complete(
-                **create_resume_response_parameters(), paginated_responses=[make_response_object()]
+
+        paginated_responses = exc_info.value.kwargs["paginated_responses"]
+        assert [r.text for r in paginated_responses] == ['{"value": 5}']
+
+        result = operator.execute_complete(
+            **create_resume_response_parameters(), paginated_responses=paginated_responses
+        )
+        assert result == ['{"value": 5}', '{"value": 10}']
+
+    def test_async_pagination_with_response_filter(self, requests_mock):
+        """The response_filter must receive every accumulated page on the final resume."""
+        values = iter([1, 2, 3])
+
+        def make_response_object() -> Response:
+            response = Response()
+            response._content = json.dumps({"value": next(values)}).encode()
+            return response
+
+        def create_resume_response_parameters() -> dict:
+            return dict(
+                context={},
+                event={
+                    "status": "success",
+                    "response": HttpResponseSerializer.serialize(make_response_object()),
+                },
             )
-            assert result == ['{"value": 5}', '{"value": 5}']
+
+        remaining_pages = {"count": 2}
+
+        def pagination_function(response: Response) -> dict | None:
+            if remaining_pages["count"] > 0:
+                remaining_pages["count"] -= 1
+                return dict(endpoint="/")
+            return None
+
+        operator = HttpOperator(
+            task_id="test_HTTP_op",
+            pagination_function=pagination_function,
+            deferrable=True,
+            response_filter=lambda resp: [entry.json()["value"] for entry in resp],
+        )
+
+        with pytest.raises(TaskDeferred) as exc_info:
+            operator.execute_complete(**create_resume_response_parameters())
+        paginated_responses = exc_info.value.kwargs["paginated_responses"]
+
+        with pytest.raises(TaskDeferred) as exc_info:
+            operator.execute_complete(
+                **create_resume_response_parameters(), paginated_responses=paginated_responses
+            )
+        paginated_responses = exc_info.value.kwargs["paginated_responses"]
+
+        result = operator.execute_complete(
+            **create_resume_response_parameters(), paginated_responses=paginated_responses
+        )
+        assert result == [1, 2, 3]
+
+    def test_async_execute_complete_without_pagination_returns_single_response(self, requests_mock):
+        """Without a pagination_function, the resume call must return the lone response as before."""
+        operator = HttpOperator(
+            task_id="test_HTTP_op",
+            deferrable=True,
+        )
+        response = Response()
+        response._content = b'{"value": 1}'
+        result = operator.execute_complete(
+            context={},
+            event={
+                "status": "success",
+                "response": HttpResponseSerializer.serialize(response),
+            },
+        )
+        assert result == '{"value": 1}'
 
     @patch.object(HttpHook, "run_with_advanced_retry")
     def test_retry_args(self, mock_run_with_advanced_retry, requests_mock):


### PR DESCRIPTION
### Sumarry

In `execute_complete()`, the return value of `paginate_async()` was discarded, and the code called `process_response()` a second time with just the current page's `response`. `paginate_async()` already calls `process_response()` itself with the full accumulated `all_responses` list once pagination ends, so its result was thrown away and immediately overwritten with a single-page result.

The practical effect: in synchronous mode, `HttpOperator` with a `pagination_function` returns a list of every page's response. In deferrable mode, it silently returned only the last page. Any Dag that switched a paginated `HttpOperator` to `deferrable=True` would quietly lose all pages but the last one, with no error raised.

The existing regression test, `test_async_pagination`, could not catch this because both `execute_complete()` calls were wrapped in a single `contextlib.suppress(TaskDeferred)` block. The first call raises `TaskDeferred` (correctly, to request the next page), which is suppressed — but that also exits the `with` block immediately, so the second `execute_complete()` call and its `assert result == [...]` never executed. The test always reported as passing regardless of what the code actually returned.

### Changes

- `paginate_async()` now owns the full response-building/return logic (including the non-paginated case, which previously lived in `execute_complete()`), and `execute_complete()` simply returns its result.
- Rewrote `test_async_pagination` to use `pytest.raises(TaskDeferred)` around each deferring call individually, and assert on the final, non-raising resume call's result — so the test actually exercises the code path instead of skipping it.
- Added `test_async_pagination_with_response_filter` to cover a `response_filter` receiving the full accumulated page list across three pages (two deferrals, one final page).
- Added `test_async_execute_complete_without_pagination_returns_single_response` to lock in the unpaginated resume behavior, which is unchanged but now goes through the refactored `paginate_async()`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)