### PR TITLE
Pin pnpm version for FAB and Edge3 UI so bumps keep security overrides

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/plugins/www/package.json
+++ b/providers/edge3/src/airflow/providers/edge3/plugins/www/package.json
@@ -85,6 +85,7 @@
     "vite-plugin-dts": "^5.0.3",
     "vitest": "^4.1.10"
   },
+  "packageManager": "pnpm@10.28.1",
   "pnpm": {
     "minimumReleaseAge": 5760,
     "onlyBuiltDependencies": [

--- a/providers/fab/src/airflow/providers/fab/www/package.json
+++ b/providers/fab/src/airflow/providers/fab/www/package.json
@@ -65,6 +65,7 @@
     "jquery-ui": "^1.14.2",
     "moment-timezone": "^0.6.3"
   },
+  "packageManager": "pnpm@10.28.1",
   "pnpm": {
     "minimumReleaseAge": 5760,
     "onlyBuiltDependencies": [],


### PR DESCRIPTION
These were the only two pnpm directories in the repo without a `packageManager` field. Without it, Dependabot resolves them with pnpm 11, which no longer reads `pnpm.overrides` from `package.json`. It therefore regenerates `pnpm-lock.yaml` with the `overrides:` block missing entirely, silently dropping the pinned security patches for transitive dependencies and breaking frozen installs for the pnpm 10 that the asset-compilation hooks use.

The version matches the one already used everywhere else in the repo.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
