### PR TITLE
Fix mark-failed KeyError for removed-task TIs (#72338)

### DIFF
--- a/airflow-core/src/airflow/api/common/mark_tasks.py
+++ b/airflow-core/src/airflow/api/common/mark_tasks.py
@@ -285,6 +285,7 @@ def _set_dag_run_terminal_state(
             select(TaskInstance).filter(
                 TaskInstance.dag_id == dag.dag_id,
                 TaskInstance.run_id == run_id,
+                TaskInstance.task_id.in_(task_ids),
                 or_(
                     TaskInstance.state.is_(None),
                     and_(

--- a/airflow-core/tests/unit/api/common/test_mark_tasks.py
+++ b/airflow-core/tests/unit/api/common/test_mark_tasks.py
@@ -39,6 +39,25 @@ if TYPE_CHECKING:
 pytestmark = [pytest.mark.db_test, pytest.mark.need_serialized_dag]
 
 
+def test_set_dag_run_state_to_failed_ignores_removed_task_tis(dag_maker: DagMaker[SerializedDAG]):
+    with dag_maker("TEST_DAG_REMOVED_TASK"):
+        EmptyOperator(task_id="pending")
+        EmptyOperator(task_id="removed_task")
+    dr = dag_maker.create_dagrun()
+    dag_maker.session.flush()
+
+    with dag_maker("TEST_DAG_REMOVED_TASK") as dag_without_removed:
+        EmptyOperator(task_id="pending")
+
+    result: tuple[list[TaskInstance], list[TaskInstance]] = set_dag_run_state_to_failed(
+        dag=dag_without_removed, run_id=dr.run_id, commit=True, session=dag_maker.session
+    )
+    updated_tis, _ = result
+    assert len(updated_tis) == 1
+    assert updated_tis[0].task_id == "pending"
+    assert updated_tis[0].state == TaskInstanceState.SKIPPED
+
+
 def test_set_dag_run_state_to_failed(dag_maker: DagMaker[SerializedDAG]):
     with dag_maker("TEST_DAG_1") as dag:
         with EmptyOperator(task_id="teardown").as_teardown():


### PR DESCRIPTION
## Summary
Marking a DAG run failed could raise `KeyError` when the run still had task instance rows for tasks removed in a later DAG version. The `pending_tis` query did not filter to the current DAG's task ids, unlike the `running_tis` query, so lookups into `dag.task_dict` failed on orphaned rows. This change filters pending task instances the same way running ones are filtered.

## Changes
- **`airflow-core/src/airflow/api/common/mark_tasks.py`** -- add `TaskInstance.task_id.in_(task_ids)` to the pending task instance query in `_set_dag_run_terminal_state`.
- **`airflow-core/tests/unit/api/common/test_mark_tasks.py`** -- add regression test for mark-failed with a leftover TI for a removed task.

## Test plan
- [x] `ruff check` and `ruff format --check` on changed files
- [x] `pytest airflow-core/tests/unit/api/common/test_mark_tasks.py::test_set_dag_run_state_to_failed_ignores_removed_task_tis` (2 passed with existing test)
- [x] Current GitHub CI passes (ruff, mypy, pytest)

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (OpenAI Codex)

Generated-by: OpenAI Codex following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

Fixes #72338