### PR TITLE
Use Airflow-specific warning for deprecated VariableInterval.resolve and remove mock

### DIFF
--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -1548,14 +1548,11 @@ class TestDagRun:
 
     @mock.patch.object(Deadline, "prune_deadlines")
     def test_dagrun_deadline_variable_interval_missing_variable_fails(self, _, session, deadline_test_dag):
-        mock_err = mock.Mock()
-        mock_err.error.value = "MISSING_DEADLINE"
-        mock_err.detail = "missing deadline"
 
         with mock.patch.object(
             Variable,
             "get",
-            side_effect=KeyError(mock_err),
+            side_effect=KeyError,
         ):
             future_date = datetime.datetime.now() + datetime.timedelta(days=365)
 

--- a/task-sdk/src/airflow/sdk/definitions/deadline.py
+++ b/task-sdk/src/airflow/sdk/definitions/deadline.py
@@ -27,7 +27,7 @@ import attrs
 
 from airflow.sdk.definitions.callback import AsyncCallback, Callback, SyncCallback
 from airflow.sdk.definitions.variable import Variable
-from airflow.sdk.exceptions import AirflowRuntimeError
+from airflow.sdk.exceptions import AirflowRuntimeError, RemovedInAirflow4Warning
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -442,7 +442,7 @@ class VariableInterval:
         warnings.warn(
             "VariableInterval.resolve() is deprecated and will be removed in a future release. "
             "Deadline interval resolution is handled internally during deadline evaluation.",
-            DeprecationWarning,
+            RemovedInAirflow4Warning,
             stacklevel=2,
         )
 


### PR DESCRIPTION
**Description**

This is a follow-up to PR #71802.

It updates the deprecation warning emitted by `VariableInterval.resolve()` to use `RemovedInAirflow4Warning` and simplifies the related deadline test by raising `KeyError` directly instead of using a mock exception.