### PR TITLE
Prevent duplicate Anthropic batches on task retry

### DIFF
--- a/providers/anthropic/docs/operators/anthropic.rst
+++ b/providers/anthropic/docs/operators/anthropic.rst
@@ -69,7 +69,8 @@ Parameters
 .. note::
 
     On Airflow 3.3+, synchronous waits persist the batch ID before polling. A retry reconnects
-    to an active batch or recovers its successful result. Deferrable tasks,
+    to an in-progress batch or recovers a completed batch when its result policy succeeds.
+    Canceled, missing, or policy-failed batches are replaced. Deferrable tasks,
     ``wait_for_completion=False``, and older Airflow versions still submit a new batch on retry.
 
 Example

--- a/providers/anthropic/docs/operators/anthropic.rst
+++ b/providers/anthropic/docs/operators/anthropic.rst
@@ -63,12 +63,14 @@ Parameters
 * ``wait_for_completion`` — if ``False``, return the batch ID immediately after submission.
 * ``fail_on_partial_error`` — if ``True``, fail the task when any request errored or expired.
   Defaults to ``False`` (succeed and log a warning so successful results are not discarded).
+* ``durable`` reconnects synchronous retries to the existing batch instead of submitting a
+  duplicate. This defaults to ``True`` and requires Airflow 3.3+.
 
-.. warning::
+.. note::
 
-    A task retry re-submits a **new** batch. Prefer ``retries=0`` on this task. The submitted
-    ``batch_id`` is pushed to XCom under key ``batch_id`` immediately after submission, so a
-    crashed run never loses track of an in-flight batch.
+    On Airflow 3.3+, synchronous waits persist the batch ID before polling. A retry reconnects
+    to an active batch or recovers its successful result. Deferrable tasks,
+    ``wait_for_completion=False``, and older Airflow versions still submit a new batch on retry.
 
 Example
 """""""
@@ -87,8 +89,8 @@ AnthropicBatchSensor
 :class:`~airflow.providers.anthropic.sensors.batch.AnthropicBatchSensor` waits for an
 already-submitted batch (by ``batch_id``) to reach a terminal status. Pair it with
 ``AnthropicBatchOperator(wait_for_completion=False)`` for a fire-and-forget submit followed
-by a re-entrant await — because the sensor only polls an existing batch, retrying it never
-re-submits, which sidesteps the "retry creates a new batch" hazard of a waiting submit task.
+by a re-entrant await. The sensor only polls an existing batch, so retrying it never
+re-submits.
 
 It applies the same terminal-status policy as the operator (skip on full cancellation,
 ``fail_on_partial_error`` to fail on errored/expired requests) and supports ``deferrable``

--- a/providers/anthropic/docs/quickstart.rst
+++ b/providers/anthropic/docs/quickstart.rst
@@ -55,7 +55,7 @@ Or add it through the Airflow UI (``Admin > Connections``) or the CLI (``airflow
 
 ``AnthropicBatchOperator`` submits a Message Batch — a list of
 ``messages.create`` requests — and waits for it to reach a terminal status.
-A task retry resubmits a **new** batch, so set ``retries=0``:
+On Airflow 3.3+, a synchronous task retry reconnects to its existing batch:
 
 
 .. exampleinclude:: /../../anthropic/src/airflow/providers/anthropic/example_dags/example_batch.py

--- a/providers/anthropic/src/airflow/providers/anthropic/example_dags/example_batch.py
+++ b/providers/anthropic/src/airflow/providers/anthropic/example_dags/example_batch.py
@@ -49,7 +49,6 @@ def quickstart_batch():
             },
         ],
         wait_for_completion=True,
-        retries=0,
     )
 
 

--- a/providers/anthropic/src/airflow/providers/anthropic/operators/batch.py
+++ b/providers/anthropic/src/airflow/providers/anthropic/operators/batch.py
@@ -64,10 +64,19 @@ except ImportError:
             super().__init__(**kwargs)
             self.durable = _warn_and_disable_durable_pre_3_3(durable)
 
+        def submit_job(self, context: Context) -> JsonValue:
+            raise NotImplementedError
+
+        def poll_until_complete(self, external_id: JsonValue, context: Context) -> None:
+            raise NotImplementedError
+
+        def get_job_result(self, external_id: JsonValue, context: Context) -> Any:
+            raise NotImplementedError
+
         def execute_resumable(self, context: Context) -> Any:
-            external_id = self.submit_job(context)
-            self.poll_until_complete(external_id, context)
-            return self.get_job_result(external_id, context)
+            external_id: JsonValue = self.submit_job(context=context)
+            self.poll_until_complete(external_id=external_id, context=context)
+            return self.get_job_result(external_id=external_id, context=context)
 
 
 if TYPE_CHECKING:

--- a/providers/anthropic/src/airflow/providers/anthropic/operators/batch.py
+++ b/providers/anthropic/src/airflow/providers/anthropic/operators/batch.py
@@ -101,7 +101,8 @@ class AnthropicBatchOperator(ResumableJobMixin, BaseOperator):
     to XCom. Results are retained for 29 days after the batch is created.
 
     Synchronous waits on Airflow 3.3+ persist the batch ID before polling. A task retry
-    reconnects to active work and recovers successful work without submitting another batch.
+    reconnects to in-progress work or recovers a completed batch when its result policy succeeds.
+    Canceled, missing, or policy-failed work is replaced.
 
     .. seealso::
         For more information, take a look at the guide:
@@ -214,7 +215,7 @@ class AnthropicBatchOperator(ResumableJobMixin, BaseOperator):
         return self._get_batch_resume_status(batch)
 
     def is_job_active(self, status: str) -> bool:
-        return status in (BatchStatus.IN_PROGRESS, BatchStatus.CANCELING)
+        return status == BatchStatus.IN_PROGRESS
 
     def is_job_succeeded(self, status: str) -> bool:
         return status == _BATCH_RESUME_SUCCEEDED
@@ -248,8 +249,7 @@ class AnthropicBatchOperator(ResumableJobMixin, BaseOperator):
         if batch.processing_status != BatchStatus.ENDED:
             return batch.processing_status
         counts = batch.request_counts
-        total = counts.canceled + counts.errored + counts.expired + counts.succeeded
-        if total and counts.canceled == total:
+        if counts.canceled:
             return _BATCH_RESUME_FAILED
         if self.fail_on_partial_error and (counts.errored or counts.expired):
             return _BATCH_RESUME_FAILED

--- a/providers/anthropic/src/airflow/providers/anthropic/operators/batch.py
+++ b/providers/anthropic/src/airflow/providers/anthropic/operators/batch.py
@@ -17,25 +17,67 @@
 from __future__ import annotations
 
 import time
+import warnings
 from collections.abc import Sequence
 from datetime import timedelta
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
+from anthropic import NotFoundError
+
 from airflow.providers.anthropic.exceptions import AnthropicBatchJobError, AnthropicBatchTimeout
 from airflow.providers.anthropic.hooks.anthropic import (
     AnthropicHook,
+    BatchStatus,
     evaluate_batch_counts,
     validate_execute_complete_event,
 )
 from airflow.providers.anthropic.triggers.batch import AnthropicBatchTrigger
 from airflow.providers.common.compat.sdk import BaseOperator, conf
 
+_DURABLE_UNSET = object()
+_BATCH_RESUME_SUCCEEDED = "succeeded"
+_BATCH_RESUME_FAILED = "failed"
+_BATCH_RESUME_NOT_FOUND = "not_found"
+
+
+def _warn_and_disable_durable_pre_3_3(durable: Any) -> bool:
+    if durable is not _DURABLE_UNSET:
+        warnings.warn(
+            "`durable` has no effect on Airflow versions below 3.3.",
+            UserWarning,
+            stacklevel=3,
+        )
+    return False
+
+
+try:
+    from airflow.sdk import ResumableJobMixin
+except ImportError:
+
+    class ResumableJobMixin:  # type: ignore[no-redef]
+        """Airflow <3.3 stub, task_state_store unavailable, always submits fresh."""
+
+        external_id_key: str = "anthropic_batch_id"
+
+        def __init__(self, *, durable: Any = _DURABLE_UNSET, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+            self.durable = _warn_and_disable_durable_pre_3_3(durable)
+
+        def execute_resumable(self, context: Context) -> Any:
+            external_id = self.submit_job(context)
+            self.poll_until_complete(external_id, context)
+            return self.get_job_result(external_id, context)
+
+
 if TYPE_CHECKING:
+    from anthropic.types.messages import MessageBatch
+    from pydantic import JsonValue
+
     from airflow.providers.common.compat.sdk import Context
 
 
-class AnthropicBatchOperator(BaseOperator):
+class AnthropicBatchOperator(ResumableJobMixin, BaseOperator):
     """
     Submit an Anthropic Message Batch and wait for it to complete.
 
@@ -49,10 +91,8 @@ class AnthropicBatchOperator(BaseOperator):
     and persist them to object storage; results can be very large and must not be pushed
     to XCom. Results are retained for 29 days after the batch is created.
 
-    .. note::
-        A retry re-submits a brand-new batch. Prefer ``retries=0`` on this task (the
-        submitted ``batch_id`` is pushed to XCom under key ``batch_id`` immediately, so
-        a crashed run never loses track of an in-flight batch).
+    Synchronous waits on Airflow 3.3+ persist the batch ID before polling. A task retry
+    reconnects to active work and recovers successful work without submitting another batch.
 
     .. seealso::
         For more information, take a look at the guide:
@@ -77,9 +117,13 @@ class AnthropicBatchOperator(BaseOperator):
     :param fail_on_partial_error: If ``True``, fail the task when any request errored or
         expired. Defaults to ``False`` (succeed and log a warning so the successful
         results are not discarded).
+    :param durable: Reconnect synchronous task retries to a previously submitted batch.
+        Requires Airflow 3.3+ and defaults to ``True``. This has no effect on deferrable
+        or ``wait_for_completion=False`` execution.
     """
 
     template_fields: Sequence[str] = ("requests", "model")
+    external_id_key: str = "anthropic_batch_id"
 
     def __init__(
         self,
@@ -91,8 +135,11 @@ class AnthropicBatchOperator(BaseOperator):
         timeout: float = 24 * 60 * 60,
         wait_for_completion: bool = True,
         fail_on_partial_error: bool = False,
+        durable: bool | None = None,
         **kwargs: Any,
     ) -> None:
+        if durable is not None:
+            kwargs["durable"] = durable
         super().__init__(**kwargs)
         self.requests = requests
         self.model = model
@@ -103,6 +150,7 @@ class AnthropicBatchOperator(BaseOperator):
         self.wait_for_completion = wait_for_completion
         self.fail_on_partial_error = fail_on_partial_error
         self.batch_id: str | None = None
+        self._recovered_batch: MessageBatch | None = None
 
     @cached_property
     def hook(self) -> AnthropicHook:
@@ -112,14 +160,15 @@ class AnthropicBatchOperator(BaseOperator):
     def execute(self, context: Context) -> str | None:
         if not self.requests:
             raise ValueError("AnthropicBatchOperator requires at least one request; got an empty list.")
-        batch = self.hook.create_batch(self.requests, model=self.model)
-        self.batch_id = batch.id
-        # Push immediately so a crash between submit and completion never loses the batch.
-        context["ti"].xcom_push(key="batch_id", value=batch.id)
-        self.log.info("Submitted Anthropic Message Batch %s (%d requests)", batch.id, len(self.requests))
+
+        if self.wait_for_completion and not self.deferrable:
+            self.execute_resumable(context)
+            return self.batch_id
+
+        batch_id = self.submit_job(context)
 
         if not self.wait_for_completion:
-            return self.batch_id
+            return batch_id
 
         if self.deferrable:
             self.defer(
@@ -130,27 +179,84 @@ class AnthropicBatchOperator(BaseOperator):
                 timeout=self.execution_timeout or timedelta(seconds=self.timeout + self.poll_interval + 60),
                 trigger=AnthropicBatchTrigger(
                     conn_id=self.conn_id,
-                    batch_id=self.batch_id,
+                    batch_id=batch_id,
                     poll_interval=self.poll_interval,
                     end_time=time.time() + self.timeout,
                 ),
                 method_name="execute_complete",
             )
 
-        self.log.info("Waiting for batch %s to complete", self.batch_id)
+        return batch_id
+
+    def submit_job(self, context: Context) -> str:
+        batch = self.hook.create_batch(requests=self.requests, model=self.model)
+        self._set_batch_id(context=context, batch_id=batch.id)
+        self.log.info("Submitted Anthropic Message Batch %s (%d requests)", batch.id, len(self.requests))
+        return batch.id
+
+    def get_job_status(self, external_id: JsonValue, context: Context) -> str:
+        batch_id = self._require_batch_id(external_id)
+        try:
+            batch = self.hook.get_batch(batch_id)
+        except NotFoundError:
+            self.log.info("Stored Anthropic Message Batch %s no longer exists", batch_id)
+            return _BATCH_RESUME_NOT_FOUND
+        self._recovered_batch = batch
+        return self._get_batch_resume_status(batch)
+
+    def is_job_active(self, status: str) -> bool:
+        return status in (BatchStatus.IN_PROGRESS, BatchStatus.CANCELING)
+
+    def is_job_succeeded(self, status: str) -> bool:
+        return status == _BATCH_RESUME_SUCCEEDED
+
+    def poll_until_complete(self, external_id: JsonValue, context: Context) -> None:
+        batch_id = self._require_batch_id(external_id)
+        self._set_batch_id(context=context, batch_id=batch_id)
+        self.log.info("Waiting for batch %s to complete", batch_id)
         try:
             batch = self.hook.wait_for_batch(
-                self.batch_id, wait_seconds=self.poll_interval, timeout=self.timeout
+                batch_id=batch_id,
+                wait_seconds=self.poll_interval,
+                timeout=self.timeout,
             )
         except Exception:
-            # Any failure after submission (timeout, SDK 5xx, auth expiry) leaves the batch
-            # running and billing; cancel it best-effort before the task fails.
-            self.log.warning("Batch %s failed while waiting; requesting cancellation.", self.batch_id)
+            self.log.warning("Batch %s failed while waiting; requesting cancellation.", batch_id)
             self._cancel_batch_quietly()
             raise
         counts = batch.request_counts
         self._apply_policy(counts.canceled, counts.errored, counts.expired, counts.succeeded)
-        return self.batch_id
+
+    def get_job_result(self, external_id: JsonValue, context: Context) -> str:
+        batch_id = self._require_batch_id(external_id)
+        self._set_batch_id(context=context, batch_id=batch_id)
+        if self._recovered_batch is not None and self._recovered_batch.id == batch_id:
+            counts = self._recovered_batch.request_counts
+            self._apply_policy(counts.canceled, counts.errored, counts.expired, counts.succeeded)
+        return batch_id
+
+    def _get_batch_resume_status(self, batch: MessageBatch) -> str:
+        if batch.processing_status != BatchStatus.ENDED:
+            return batch.processing_status
+        counts = batch.request_counts
+        total = counts.canceled + counts.errored + counts.expired + counts.succeeded
+        if total and counts.canceled == total:
+            return _BATCH_RESUME_FAILED
+        if self.fail_on_partial_error and (counts.errored or counts.expired):
+            return _BATCH_RESUME_FAILED
+        return _BATCH_RESUME_SUCCEEDED
+
+    @staticmethod
+    def _require_batch_id(external_id: JsonValue) -> str:
+        if not isinstance(external_id, str):
+            raise TypeError(f"Expected Anthropic batch ID to be a string, got {type(external_id).__name__}.")
+        return external_id
+
+    def _set_batch_id(self, *, context: Context, batch_id: str) -> None:
+        if self.batch_id == batch_id:
+            return
+        self.batch_id = batch_id
+        context["ti"].xcom_push(key="batch_id", value=batch_id)
 
     def execute_complete(self, context: Context, event: Any = None) -> str:
         """

--- a/providers/anthropic/tests/unit/anthropic/operators/test_batch.py
+++ b/providers/anthropic/tests/unit/anthropic/operators/test_batch.py
@@ -29,7 +29,7 @@ from airflow.providers.anthropic.exceptions import (
     AnthropicBatchTimeout,
     AnthropicTriggerEventError,
 )
-from airflow.providers.anthropic.hooks.anthropic import AnthropicHook
+from airflow.providers.anthropic.hooks.anthropic import AnthropicHook, BatchStatus
 from airflow.providers.anthropic.operators import batch as batch_module
 from airflow.providers.anthropic.operators.batch import AnthropicBatchOperator
 from airflow.providers.anthropic.triggers.batch import AnthropicBatchTrigger
@@ -315,19 +315,34 @@ class TestAnthropicBatchOperatorExecute:
         reason="ResumableJobMixin reconnect requires task_state_store, available in Airflow 3.3+",
     )
     @mock.patch.object(AnthropicBatchOperator, "hook", new_callable=mock.PropertyMock)
-    def test_worker_crash_preserves_remote_batch(self, mock_hook_prop):
+    def test_retry_reconnects_to_first_submission(self, mock_hook_prop):
         hook = mock.MagicMock(spec=AnthropicHook)
         hook.create_batch.return_value = _batch(batch_id="batch_1")
-        hook.wait_for_batch.side_effect = WorkerCrash()
+        hook.get_batch.return_value = _batch(
+            batch_id="batch_1",
+            processing_status=BatchStatus.IN_PROGRESS,
+            processing=1,
+        )
+        hook.wait_for_batch.side_effect = [WorkerCrash(), _batch(batch_id="batch_1", succeeded=1)]
         mock_hook_prop.return_value = hook
         task_store = FakeTaskStateStore()
 
         op = AnthropicBatchOperator(task_id="t", requests=REQUESTS, deferrable=False)
+        first_context = _context(task_store)
         with pytest.raises(WorkerCrash):
-            op.execute(_context(task_store))
+            op.execute(first_context)
 
-        assert task_store.get("anthropic_batch_id") == "batch_1"
+        retry_op = AnthropicBatchOperator(task_id="t", requests=REQUESTS, deferrable=False)
+        retry_context = _context(task_store)
+        assert retry_op.execute(retry_context) == "batch_1"
+
+        hook.create_batch.assert_called_once_with(requests=REQUESTS, model=None)
+        hook.get_batch.assert_called_once_with("batch_1")
+        assert hook.wait_for_batch.call_count == 2
         hook.cancel_batch.assert_not_called()
+        assert task_store.get("anthropic_batch_id") == "batch_1"
+        first_context["ti"].xcom_push.assert_called_once_with(key="batch_id", value="batch_1")
+        retry_context["ti"].xcom_push.assert_called_once_with(key="batch_id", value="batch_1")
 
     @mock.patch.object(AnthropicBatchOperator, "hook", new_callable=mock.PropertyMock)
     def test_deferrable_defers_with_trigger(self, mock_hook_prop):

--- a/providers/anthropic/tests/unit/anthropic/operators/test_batch.py
+++ b/providers/anthropic/tests/unit/anthropic/operators/test_batch.py
@@ -147,13 +147,12 @@ class TestAnthropicBatchOperatorExecute:
         not AIRFLOW_V_3_3_PLUS,
         reason="ResumableJobMixin reconnect requires task_state_store, available in Airflow 3.3+",
     )
-    @pytest.mark.parametrize("processing_status", ["in_progress", "canceling"])
     @mock.patch.object(AnthropicBatchOperator, "hook", new_callable=mock.PropertyMock)
-    def test_sync_retry_reconnects_to_active_batch(self, mock_hook_prop, processing_status):
+    def test_sync_retry_reconnects_to_active_batch(self, mock_hook_prop):
         hook = mock.MagicMock(spec=AnthropicHook)
         hook.get_batch.return_value = _batch(
             batch_id="batch_existing",
-            processing_status=processing_status,
+            processing_status=BatchStatus.IN_PROGRESS,
             processing=1,
         )
         hook.wait_for_batch.return_value = _batch(batch_id="batch_existing", succeeded=1)
@@ -200,10 +199,24 @@ class TestAnthropicBatchOperatorExecute:
             pytest.param(_batch(batch_id="batch_failed", errored=1), True, id="failed"),
             pytest.param(_batch(batch_id="batch_expired", expired=1), True, id="expired"),
             pytest.param(_batch(batch_id="batch_canceled", canceled=1), False, id="canceled"),
+            pytest.param(
+                _batch(batch_id="batch_partially_canceled", canceled=1, succeeded=1),
+                False,
+                id="partially-canceled",
+            ),
+            pytest.param(
+                _batch(
+                    batch_id="batch_canceling",
+                    processing_status=BatchStatus.CANCELING,
+                    processing=1,
+                ),
+                False,
+                id="canceling",
+            ),
         ],
     )
     @mock.patch.object(AnthropicBatchOperator, "hook", new_callable=mock.PropertyMock)
-    def test_sync_retry_resubmits_terminal_batch(
+    def test_sync_retry_replaces_non_resumable_batch(
         self,
         mock_hook_prop,
         stored_batch,
@@ -343,6 +356,46 @@ class TestAnthropicBatchOperatorExecute:
         assert task_store.get("anthropic_batch_id") == "batch_1"
         first_context["ti"].xcom_push.assert_called_once_with(key="batch_id", value="batch_1")
         retry_context["ti"].xcom_push.assert_called_once_with(key="batch_id", value="batch_1")
+
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_3_PLUS,
+        reason="ResumableJobMixin reconnect requires task_state_store, available in Airflow 3.3+",
+    )
+    @mock.patch.object(AnthropicBatchOperator, "hook", new_callable=mock.PropertyMock)
+    def test_retry_replaces_batch_canceled_by_previous_attempt(self, mock_hook_prop):
+        hook = mock.MagicMock(spec=AnthropicHook)
+        hook.create_batch.side_effect = [
+            _batch(batch_id="batch_1"),
+            _batch(batch_id="batch_2"),
+        ]
+        hook.get_batch.return_value = _batch(
+            batch_id="batch_1",
+            processing_status=BatchStatus.CANCELING,
+            processing=1,
+        )
+        waited_batch_ids: list[str] = []
+
+        def wait_for_batch(*, batch_id: str, wait_seconds: float, timeout: float) -> mock.MagicMock:
+            waited_batch_ids.append(batch_id)
+            if len(waited_batch_ids) == 1:
+                raise AnthropicBatchTimeout("too slow")
+            return _batch(batch_id=batch_id, succeeded=1)
+
+        hook.wait_for_batch.side_effect = wait_for_batch
+        mock_hook_prop.return_value = hook
+        task_store = FakeTaskStateStore()
+
+        first_op = AnthropicBatchOperator(task_id="t", requests=REQUESTS, deferrable=False)
+        with pytest.raises(AnthropicBatchTimeout, match="too slow"):
+            first_op.execute(_context(task_store))
+
+        retry_op = AnthropicBatchOperator(task_id="t", requests=REQUESTS, deferrable=False)
+        assert retry_op.execute(_context(task_store)) == "batch_2"
+
+        assert hook.create_batch.call_count == 2
+        hook.cancel_batch.assert_called_once_with("batch_1")
+        assert waited_batch_ids == ["batch_1", "batch_2"]
+        assert task_store.get("anthropic_batch_id") == "batch_2"
 
     @mock.patch.object(AnthropicBatchOperator, "hook", new_callable=mock.PropertyMock)
     def test_deferrable_defers_with_trigger(self, mock_hook_prop):

--- a/providers/anthropic/tests/unit/anthropic/operators/test_batch.py
+++ b/providers/anthropic/tests/unit/anthropic/operators/test_batch.py
@@ -16,9 +16,12 @@
 # under the License.
 from __future__ import annotations
 
+import warnings
+from typing import Any
 from unittest import mock
 
 import pytest
+from anthropic import NotFoundError
 
 from airflow.exceptions import TaskDeferred
 from airflow.providers.anthropic.exceptions import (
@@ -27,16 +30,40 @@ from airflow.providers.anthropic.exceptions import (
     AnthropicTriggerEventError,
 )
 from airflow.providers.anthropic.hooks.anthropic import AnthropicHook
+from airflow.providers.anthropic.operators import batch as batch_module
 from airflow.providers.anthropic.operators.batch import AnthropicBatchOperator
 from airflow.providers.anthropic.triggers.batch import AnthropicBatchTrigger
 from airflow.providers.common.compat.sdk import AirflowSkipException
+
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_3_PLUS
 
 pytest.importorskip("anthropic")
 
 REQUESTS = [{"custom_id": "a", "params": {"model": "claude-opus-4-8", "max_tokens": 8, "messages": []}}]
 
 
-def _counts(succeeded=0, errored=0, canceled=0, expired=0, processing=0):
+class FakeTaskStateStore:
+    def __init__(self, stored: dict[str, Any] | None = None) -> None:
+        self._store: dict[str, Any] = dict(stored or {})
+
+    def get(self, key: str) -> Any:
+        return self._store.get(key)
+
+    def set(self, key: str, value: Any) -> None:
+        self._store[key] = value
+
+
+class WorkerCrash(BaseException):
+    pass
+
+
+def _counts(
+    succeeded: int = 0,
+    errored: int = 0,
+    canceled: int = 0,
+    expired: int = 0,
+    processing: int = 0,
+) -> mock.MagicMock:
     counts = mock.MagicMock()
     counts.succeeded = succeeded
     counts.errored = errored
@@ -46,8 +73,36 @@ def _counts(succeeded=0, errored=0, canceled=0, expired=0, processing=0):
     return counts
 
 
-def _context():
-    return {"ti": mock.MagicMock()}
+def _batch(
+    *,
+    batch_id: str = "batch_1",
+    processing_status: str = "ended",
+    succeeded: int = 0,
+    errored: int = 0,
+    canceled: int = 0,
+    expired: int = 0,
+    processing: int = 0,
+) -> mock.MagicMock:
+    batch = mock.MagicMock()
+    batch.id = batch_id
+    batch.processing_status = processing_status
+    batch.request_counts = _counts(
+        succeeded=succeeded,
+        errored=errored,
+        canceled=canceled,
+        expired=expired,
+        processing=processing,
+    )
+    return batch
+
+
+def _context(task_state_store: Any = None) -> dict[str, Any]:
+    ti = mock.MagicMock()
+    ti.stats_tags = {}
+    context = {"ti": ti}
+    if task_state_store is not None:
+        context["task_state_store"] = task_state_store
+    return context
 
 
 class TestAnthropicBatchOperatorExecute:
@@ -66,6 +121,214 @@ class TestAnthropicBatchOperatorExecute:
         hook.wait_for_batch.assert_called_once()
         context["ti"].xcom_push.assert_called_once_with(key="batch_id", value="batch_1")
 
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_3_PLUS,
+        reason="ResumableJobMixin reconnect requires task_state_store, available in Airflow 3.3+",
+    )
+    @mock.patch.object(AnthropicBatchOperator, "hook", new_callable=mock.PropertyMock)
+    def test_sync_persists_batch_id_before_polling(self, mock_hook_prop):
+        hook = mock.MagicMock(spec=AnthropicHook)
+        hook.create_batch.return_value = _batch(batch_id="batch_1")
+        task_store = FakeTaskStateStore()
+        persisted_before_poll = []
+
+        def wait_for_batch(*, batch_id: str, wait_seconds: float, timeout: float) -> mock.MagicMock:
+            persisted_before_poll.append(task_store.get("anthropic_batch_id"))
+            return _batch(batch_id=batch_id, succeeded=1)
+
+        hook.wait_for_batch.side_effect = wait_for_batch
+        mock_hook_prop.return_value = hook
+
+        op = AnthropicBatchOperator(task_id="t", requests=REQUESTS, deferrable=False)
+        assert op.execute(_context(task_store)) == "batch_1"
+        assert persisted_before_poll == ["batch_1"]
+
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_3_PLUS,
+        reason="ResumableJobMixin reconnect requires task_state_store, available in Airflow 3.3+",
+    )
+    @pytest.mark.parametrize("processing_status", ["in_progress", "canceling"])
+    @mock.patch.object(AnthropicBatchOperator, "hook", new_callable=mock.PropertyMock)
+    def test_sync_retry_reconnects_to_active_batch(self, mock_hook_prop, processing_status):
+        hook = mock.MagicMock(spec=AnthropicHook)
+        hook.get_batch.return_value = _batch(
+            batch_id="batch_existing",
+            processing_status=processing_status,
+            processing=1,
+        )
+        hook.wait_for_batch.return_value = _batch(batch_id="batch_existing", succeeded=1)
+        mock_hook_prop.return_value = hook
+        task_store = FakeTaskStateStore({"anthropic_batch_id": "batch_existing"})
+        context = _context(task_store)
+
+        op = AnthropicBatchOperator(task_id="t", requests=REQUESTS, deferrable=False)
+        assert op.execute(context) == "batch_existing"
+
+        hook.create_batch.assert_not_called()
+        hook.wait_for_batch.assert_called_once_with(
+            batch_id="batch_existing",
+            wait_seconds=op.poll_interval,
+            timeout=op.timeout,
+        )
+        context["ti"].xcom_push.assert_called_once_with(key="batch_id", value="batch_existing")
+
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_3_PLUS,
+        reason="ResumableJobMixin reconnect requires task_state_store, available in Airflow 3.3+",
+    )
+    @mock.patch.object(AnthropicBatchOperator, "hook", new_callable=mock.PropertyMock)
+    def test_sync_retry_recovers_successful_batch(self, mock_hook_prop):
+        hook = mock.MagicMock(spec=AnthropicHook)
+        hook.get_batch.return_value = _batch(batch_id="batch_existing", succeeded=1)
+        mock_hook_prop.return_value = hook
+        context = _context(FakeTaskStateStore({"anthropic_batch_id": "batch_existing"}))
+
+        op = AnthropicBatchOperator(task_id="t", requests=REQUESTS, deferrable=False)
+        assert op.execute(context) == "batch_existing"
+
+        hook.create_batch.assert_not_called()
+        hook.wait_for_batch.assert_not_called()
+        context["ti"].xcom_push.assert_called_once_with(key="batch_id", value="batch_existing")
+
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_3_PLUS,
+        reason="ResumableJobMixin reconnect requires task_state_store, available in Airflow 3.3+",
+    )
+    @pytest.mark.parametrize(
+        ("stored_batch", "fail_on_partial_error"),
+        [
+            pytest.param(_batch(batch_id="batch_failed", errored=1), True, id="failed"),
+            pytest.param(_batch(batch_id="batch_expired", expired=1), True, id="expired"),
+            pytest.param(_batch(batch_id="batch_canceled", canceled=1), False, id="canceled"),
+        ],
+    )
+    @mock.patch.object(AnthropicBatchOperator, "hook", new_callable=mock.PropertyMock)
+    def test_sync_retry_resubmits_terminal_batch(
+        self,
+        mock_hook_prop,
+        stored_batch,
+        fail_on_partial_error,
+    ):
+        hook = mock.MagicMock(spec=AnthropicHook)
+        hook.get_batch.return_value = stored_batch
+        hook.create_batch.return_value = _batch(batch_id="batch_new")
+        hook.wait_for_batch.return_value = _batch(batch_id="batch_new", succeeded=1)
+        mock_hook_prop.return_value = hook
+        task_store = FakeTaskStateStore({"anthropic_batch_id": stored_batch.id})
+
+        op = AnthropicBatchOperator(
+            task_id="t",
+            requests=REQUESTS,
+            deferrable=False,
+            fail_on_partial_error=fail_on_partial_error,
+        )
+        assert op.execute(_context(task_store)) == "batch_new"
+
+        hook.create_batch.assert_called_once_with(requests=REQUESTS, model=None)
+        assert task_store.get("anthropic_batch_id") == "batch_new"
+
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_3_PLUS,
+        reason="ResumableJobMixin reconnect requires task_state_store, available in Airflow 3.3+",
+    )
+    @mock.patch.object(AnthropicBatchOperator, "hook", new_callable=mock.PropertyMock)
+    def test_sync_retry_resubmits_missing_batch(self, mock_hook_prop):
+        response = mock.MagicMock()
+        response.status_code = 404
+        hook = mock.MagicMock(spec=AnthropicHook)
+        hook.get_batch.side_effect = NotFoundError("missing", response=response, body=None)
+        hook.create_batch.return_value = _batch(batch_id="batch_new")
+        hook.wait_for_batch.return_value = _batch(batch_id="batch_new", succeeded=1)
+        mock_hook_prop.return_value = hook
+        task_store = FakeTaskStateStore({"anthropic_batch_id": "batch_missing"})
+
+        op = AnthropicBatchOperator(task_id="t", requests=REQUESTS, deferrable=False)
+        assert op.execute(_context(task_store)) == "batch_new"
+
+        hook.create_batch.assert_called_once_with(requests=REQUESTS, model=None)
+        assert task_store.get("anthropic_batch_id") == "batch_new"
+
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_3_PLUS,
+        reason="ResumableJobMixin reconnect requires task_state_store, available in Airflow 3.3+",
+    )
+    @mock.patch.object(AnthropicBatchOperator, "hook", new_callable=mock.PropertyMock)
+    def test_sync_retry_rejects_non_string_batch_id(self, mock_hook_prop):
+        hook = mock.MagicMock(spec=AnthropicHook)
+        mock_hook_prop.return_value = hook
+
+        op = AnthropicBatchOperator(task_id="t", requests=REQUESTS, deferrable=False)
+        with pytest.raises(TypeError, match="Expected Anthropic batch ID to be a string"):
+            op.execute(_context(FakeTaskStateStore({"anthropic_batch_id": 42})))
+
+        hook.get_batch.assert_not_called()
+        hook.create_batch.assert_not_called()
+
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_3_PLUS,
+        reason="ResumableJobMixin reconnect requires task_state_store, available in Airflow 3.3+",
+    )
+    @mock.patch.object(AnthropicBatchOperator, "hook", new_callable=mock.PropertyMock)
+    def test_sync_retry_recovers_partial_error_when_non_strict(self, mock_hook_prop):
+        hook = mock.MagicMock(spec=AnthropicHook)
+        hook.get_batch.return_value = _batch(batch_id="batch_existing", succeeded=9, errored=1)
+        mock_hook_prop.return_value = hook
+        context = _context(FakeTaskStateStore({"anthropic_batch_id": "batch_existing"}))
+
+        op = AnthropicBatchOperator(
+            task_id="t",
+            requests=REQUESTS,
+            deferrable=False,
+            fail_on_partial_error=False,
+        )
+        assert op.execute(context) == "batch_existing"
+
+        hook.create_batch.assert_not_called()
+        hook.wait_for_batch.assert_not_called()
+        context["ti"].xcom_push.assert_called_once_with(key="batch_id", value="batch_existing")
+
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_3_PLUS,
+        reason="ResumableJobMixin reconnect requires task_state_store, available in Airflow 3.3+",
+    )
+    @mock.patch.object(AnthropicBatchOperator, "hook", new_callable=mock.PropertyMock)
+    def test_durable_false_submits_fresh(self, mock_hook_prop):
+        hook = mock.MagicMock(spec=AnthropicHook)
+        hook.create_batch.return_value = _batch(batch_id="batch_new")
+        hook.wait_for_batch.return_value = _batch(batch_id="batch_new", succeeded=1)
+        mock_hook_prop.return_value = hook
+        task_store = mock.MagicMock(spec_set=["get", "set"])
+
+        op = AnthropicBatchOperator(
+            task_id="t",
+            requests=REQUESTS,
+            deferrable=False,
+            durable=False,
+        )
+        assert op.execute(_context(task_store)) == "batch_new"
+
+        task_store.get.assert_not_called()
+        task_store.set.assert_not_called()
+
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_3_PLUS,
+        reason="ResumableJobMixin reconnect requires task_state_store, available in Airflow 3.3+",
+    )
+    @mock.patch.object(AnthropicBatchOperator, "hook", new_callable=mock.PropertyMock)
+    def test_worker_crash_preserves_remote_batch(self, mock_hook_prop):
+        hook = mock.MagicMock(spec=AnthropicHook)
+        hook.create_batch.return_value = _batch(batch_id="batch_1")
+        hook.wait_for_batch.side_effect = WorkerCrash()
+        mock_hook_prop.return_value = hook
+        task_store = FakeTaskStateStore()
+
+        op = AnthropicBatchOperator(task_id="t", requests=REQUESTS, deferrable=False)
+        with pytest.raises(WorkerCrash):
+            op.execute(_context(task_store))
+
+        assert task_store.get("anthropic_batch_id") == "batch_1"
+        hook.cancel_batch.assert_not_called()
+
     @mock.patch.object(AnthropicBatchOperator, "hook", new_callable=mock.PropertyMock)
     def test_deferrable_defers_with_trigger(self, mock_hook_prop):
         hook = mock.MagicMock(spec=AnthropicHook)
@@ -73,12 +336,15 @@ class TestAnthropicBatchOperatorExecute:
         mock_hook_prop.return_value = hook
 
         op = AnthropicBatchOperator(task_id="t", requests=REQUESTS, deferrable=True)
+        task_store = mock.MagicMock(spec_set=["get", "set"])
         with pytest.raises(TaskDeferred) as exc:
-            op.execute(_context())
+            op.execute(_context(task_store))
         assert isinstance(exc.value.trigger, AnthropicBatchTrigger)
         assert exc.value.trigger.batch_id == "batch_1"
         assert exc.value.method_name == "execute_complete"
         hook.wait_for_batch.assert_not_called()
+        task_store.get.assert_not_called()
+        task_store.set.assert_not_called()
 
     @mock.patch.object(AnthropicBatchOperator, "hook", new_callable=mock.PropertyMock)
     def test_no_wait_returns_immediately(self, mock_hook_prop):
@@ -87,8 +353,11 @@ class TestAnthropicBatchOperatorExecute:
         mock_hook_prop.return_value = hook
 
         op = AnthropicBatchOperator(task_id="t", requests=REQUESTS, wait_for_completion=False)
-        assert op.execute(_context()) == "batch_1"
+        task_store = mock.MagicMock(spec_set=["get", "set"])
+        assert op.execute(_context(task_store)) == "batch_1"
         hook.wait_for_batch.assert_not_called()
+        task_store.get.assert_not_called()
+        task_store.set.assert_not_called()
 
     @mock.patch.object(AnthropicBatchOperator, "hook", new_callable=mock.PropertyMock)
     def test_sync_applies_policy_skip_on_full_cancel(self, mock_hook_prop):
@@ -150,7 +419,7 @@ class TestAnthropicBatchOperatorExecute:
             task_id="t", requests=REQUESTS, model="claude-haiku-4-5", wait_for_completion=False
         )
         op.execute(_context())
-        hook.create_batch.assert_called_once_with(REQUESTS, model="claude-haiku-4-5")
+        hook.create_batch.assert_called_once_with(requests=REQUESTS, model="claude-haiku-4-5")
 
     @mock.patch.object(AnthropicBatchOperator, "hook", new_callable=mock.PropertyMock)
     def test_empty_requests_raises_before_any_api_call(self, mock_hook_prop):
@@ -161,6 +430,14 @@ class TestAnthropicBatchOperatorExecute:
         with pytest.raises(ValueError, match="at least one request"):
             op.execute(_context())
         hook.create_batch.assert_not_called()
+
+    def test_default_args_durable_reaches_operator(self):
+        op = AnthropicBatchOperator(
+            task_id="t",
+            requests=REQUESTS,
+            default_args={"durable": False},
+        )
+        assert op.durable is False
 
 
 class TestExecuteComplete:
@@ -234,3 +511,18 @@ class TestOnKill:
         op = AnthropicBatchOperator(task_id="t", requests=REQUESTS)
         op.on_kill()
         hook.cancel_batch.assert_not_called()
+
+
+class TestWarnAndDisableDurableAirflowPre3_3:
+    def test_no_warning_when_unset(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = batch_module._warn_and_disable_durable_pre_3_3(batch_module._DURABLE_UNSET)
+        assert result is False
+        assert caught == []
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_warns_and_disables_when_explicitly_set(self, value):
+        with pytest.warns(UserWarning, match="durable.*no effect"):
+            result = batch_module._warn_and_disable_durable_pre_3_3(value)
+        assert result is False


### PR DESCRIPTION
Synchronous `AnthropicBatchOperator` retries can submit a second billable Message Batch after a worker exits while polling. The batch ID is available through XCom, but Airflow clears XCom before the retry, so the next attempt cannot reconnect.

On Airflow 3.3+, synchronous waits now persist the batch ID through `ResumableJobMixin`. A retry reconnects to an `in_progress` batch or returns a completed successful batch without another submission. It submits fresh work when the stored batch is missing, failed, expired, canceling, or contains canceled requests. Deferrable execution and `wait_for_completion=False` retain their current behavior.

## Testing

The regression drives two attempts through the real operator with a local task-state backing and mocked Anthropic API. On `upstream/main`, the retry submits twice. This branch reconnects to the first batch.

| Source | Result |
| --- | --- |
| `upstream/main` with this PR's regression test | Failed: `create_batch` called twice |
| This PR | Passed: one submission across both attempts |

<details>
<summary>Raw retry regression</summary>

```text
$ breeze run pytest providers/anthropic/tests/unit/anthropic/operators/test_batch.py::TestAnthropicBatchOperatorExecute::test_retry_reconnects_to_first_submission -q
providers/anthropic/tests/unit/anthropic/operators/test_batch.py::TestAnthropicBatchOperatorExecute::test_retry_reconnects_to_first_submission FAILED
E   AssertionError: Expected 'create_batch' to be called once. Called 2 times.
E   Calls: [call([{'custom_id': 'a', 'params': {'model': 'claude-opus-4-8', 'max_tokens': 8, 'messages': []}}], model=None),
E    call([{'custom_id': 'a', 'params': {'model': 'claude-opus-4-8', 'max_tokens': 8, 'messages': []}}], model=None)].
======================== 1 failed, 1 warning in 18.19s =========================

$ breeze run pytest providers/anthropic/tests/unit/anthropic/operators/test_batch.py::TestAnthropicBatchOperatorExecute::test_retry_reconnects_to_first_submission -q
providers/anthropic/tests/unit/anthropic/operators/test_batch.py::TestAnthropicBatchOperatorExecute::test_retry_reconnects_to_first_submission PASSED
======================== 1 passed, 1 warning in 17.93s =========================
```

</details>

<details>
<summary>Provider suites</summary>

```text
$ breeze run pytest providers/anthropic/tests/unit/anthropic/operators/test_batch.py -xs
37 passed, 1 warning in 16.70s

$ breeze run pytest providers/anthropic/tests -xs
222 passed, 1 warning in 18.63s

$ breeze testing providers-tests --test-type "Providers[anthropic,common.compat]"
419 passed, 3 skipped, 1 warning in 24.41s
```

</details>

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes - GitHub Copilot CLI (GPT-5.6 Sol)

Generated-by: GitHub Copilot CLI (GPT-5.6 Sol) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)