### PR TITLE
Log blocking run/task IDs when a DAG hits max_active_runs

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -4271,7 +4271,67 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             )
             active_non_backfill_runs = runs_dict.get(dag_model.dag_id, 0)
 
-        dag_model.exceeds_max_non_backfill = active_non_backfill_runs >= (dag_model.max_active_runs or 0)
+        was_exceeding = dag_model.exceeds_max_non_backfill
+        now_exceeding = active_non_backfill_runs >= (dag_model.max_active_runs or 0)
+        dag_model.exceeds_max_non_backfill = now_exceeding
+
+        # Only log (and query for the blocking runs/tasks) the moment a DAG newly reaches its
+        # max_active_runs limit, so this adds no database load during normal, healthy scheduling
+        # loops where the DAG is not stuck.
+        if now_exceeding and not was_exceeding:
+            self._log_blocking_runs_and_tasks(
+                dag_model=dag_model,
+                active_non_backfill_runs=active_non_backfill_runs,
+                session=session,
+            )
+
+    def _log_blocking_runs_and_tasks(
+        self,
+        *,
+        dag_model: DagModel,
+        active_non_backfill_runs: int,
+        session: Session,
+    ) -> None:
+        """
+        Log the run_ids and task_ids currently occupying a DAG's max_active_runs slots.
+
+        This gives platform administrators enough context to identify why a DAG is stuck
+        without leaving the scheduler logs. Only called when a DAG newly reaches (or exceeds)
+        its max_active_runs limit; see ``_set_exceeds_max_active_runs``.
+
+        :meta private:
+        """
+        blocking_run_ids = session.scalars(
+            select(DagRun.run_id)
+            .where(
+                DagRun.dag_id == dag_model.dag_id,
+                DagRun.state.in_((DagRunState.RUNNING, DagRunState.QUEUED)),
+                DagRun.run_type != DagRunType.BACKFILL_JOB,
+            )
+            .order_by(DagRun.run_id)
+        ).all()
+
+        blocking_tasks: list[str] = []
+        if blocking_run_ids:
+            active_tis = session.execute(
+                select(TaskInstance.run_id, TaskInstance.task_id, TaskInstance.state)
+                .where(
+                    TaskInstance.dag_id == dag_model.dag_id,
+                    TaskInstance.run_id.in_(blocking_run_ids),
+                    TaskInstance.state.in_(EXECUTION_STATES),
+                )
+                .order_by(TaskInstance.run_id, TaskInstance.task_id)
+            ).all()
+            blocking_tasks = [f"{task_id} in {run_id} ({state})" for run_id, task_id, state in active_tis]
+
+        self.log.info(
+            "DAG is at (or above) max_active_runs, not creating any more runs",
+            dag_id=dag_model.dag_id,
+            active_runs=active_non_backfill_runs,
+            max_active_runs=dag_model.max_active_runs,
+            blocking_run_ids=list(blocking_run_ids) or "none",
+            blocking_tasks=blocking_tasks or "none",
+        )
 
 
 # Backcompat for older versions of task sdk import SchedulerDagBag from here

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -11636,6 +11636,66 @@ def test_create_dag_runs_partitioned_timetable_proceeds_when_partition_key_set(s
     mock_get_dag.assert_called_once()
 
 
+@pytest.mark.db_test
+def test_set_exceeds_max_active_runs_logs_blocking_runs_and_tasks(dag_maker, session):
+    """
+    When a Dag newly reaches its max_active_runs limit, the scheduler should log which
+    run_ids and task_ids are occupying the active slots so operators can diagnose a stuck
+    Dag from the scheduler logs alone (see #72387).
+    """
+    with dag_maker(dag_id="test_set_exceeds_max_active_runs_logging", max_active_runs=1, session=session):
+        EmptyOperator(task_id="sleep_task")
+
+    dag_run = dag_maker.create_dagrun(state=DagRunState.RUNNING)
+    ti = dag_run.get_task_instance(task_id="sleep_task", session=session)
+    ti.state = TaskInstanceState.RUNNING
+    session.merge(ti)
+    session.flush()
+
+    runner = SchedulerJobRunner(job=Job(job_type=SchedulerJobRunner.job_type))
+    runner._log = mock.MagicMock()
+
+    runner._set_exceeds_max_active_runs(dag_model=dag_maker.dag_model, session=session)
+
+    assert dag_maker.dag_model.exceeds_max_non_backfill is True
+    runner._log.info.assert_called_once_with(
+        "DAG is at (or above) max_active_runs, not creating any more runs",
+        dag_id="test_set_exceeds_max_active_runs_logging",
+        active_runs=1,
+        max_active_runs=1,
+        blocking_run_ids=[dag_run.run_id],
+        blocking_tasks=[f"sleep_task in {dag_run.run_id} (running)"],
+    )
+
+    # Calling it again while still over the limit must not re-query or re-log: this is
+    # what keeps the check free of overhead during normal, healthy scheduling loops.
+    runner._set_exceeds_max_active_runs(dag_model=dag_maker.dag_model, session=session)
+    runner._log.info.assert_called_once()
+
+
+@pytest.mark.db_test
+def test_set_exceeds_max_active_runs_no_active_tasks(dag_maker, session):
+    """A blocking run with no active task instances yet should still log with an empty task list."""
+    with dag_maker(dag_id="test_set_exceeds_max_active_runs_no_tasks", max_active_runs=1, session=session):
+        EmptyOperator(task_id="sleep_task")
+
+    dag_run = dag_maker.create_dagrun(state=DagRunState.QUEUED)
+
+    runner = SchedulerJobRunner(job=Job(job_type=SchedulerJobRunner.job_type))
+    runner._log = mock.MagicMock()
+
+    runner._set_exceeds_max_active_runs(dag_model=dag_maker.dag_model, session=session)
+
+    runner._log.info.assert_called_once_with(
+        "DAG is at (or above) max_active_runs, not creating any more runs",
+        dag_id="test_set_exceeds_max_active_runs_no_tasks",
+        active_runs=1,
+        max_active_runs=1,
+        blocking_run_ids=[dag_run.run_id],
+        blocking_tasks="none",
+    )
+
+
 @pytest.mark.need_serialized_dag
 @pytest.mark.usefixtures("clear_asset_partition_rows")
 def test_partitioned_dag_run_with_customized_mapper(


### PR DESCRIPTION
Closes #72387

Currently, when a DAG reaches its max_active_runs limit, the scheduler
sets DagModel.exceeds_max_non_backfill without logging anything, so
operators have no way to tell which DagRun/TaskInstance is occupying
the active slots from the scheduler logs alone.

This adds a targeted, one-time log in
SchedulerJobRunner._set_exceeds_max_active_runs: the moment a DAG
newly reaches (or exceeds) max_active_runs, it queries the blocking
run_ids and the task_ids/states holding them, and logs that context.
The query only runs on the False->True transition, so there is no
added database load during normal, healthy scheduling loops, and no
repeated log spam while the DAG stays stuck.

Adds two unit tests covering the log content and the no-repeat-log
behavior on a subsequent call.