### PR TITLE
Keep polling DataFusion pipeline state when the run is not visible yet

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/hooks/datafusion.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/datafusion.py
@@ -133,8 +133,11 @@ class DataFusionHook(GoogleBaseHook):
                     namespace=namespace,
                 )
                 current_state = workflow["status"]
-            except KeyError:
-                pass  # Because the pipeline may not be visible in system yet
+            except (HTTPError, KeyError):
+                # A 404 is raised as HTTPError by _check_response_status_and_data, and a
+                # missing "status" key raises KeyError. Both mean the run is not visible
+                # in the system yet, so keep polling instead of failing the task.
+                pass
             if current_state in success_states:
                 return
             if current_state in failure_states:

--- a/providers/google/tests/unit/google/cloud/hooks/test_datafusion.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_datafusion.py
@@ -589,6 +589,39 @@ class TestDataFusionHook:
         )
 
     @pytest.mark.parametrize(
+        "error",
+        [
+            pytest.param(HTTPError("Retrieving a pipeline state failed with code 404"), id="404"),
+            pytest.param(KeyError("status"), id="missing-status"),
+        ],
+    )
+    @mock.patch(HOOK_STR.format("time.sleep"))
+    @mock.patch(HOOK_STR.format("DataFusionHook.get_pipeline_workflow"))
+    def test_wait_for_pipeline_state_keeps_polling_until_pipeline_is_visible(
+        self, mock_get_pipeline_workflow, mock_sleep, error, hook
+    ):
+        """A run that is not visible in the system yet must not fail the task."""
+        mock_get_pipeline_workflow.side_effect = [error, {"status": "COMPLETED"}]
+
+        hook.wait_for_pipeline_state(
+            pipeline_name=PIPELINE_NAME, pipeline_id=PIPELINE_ID, instance_url=INSTANCE_URL
+        )
+
+        assert mock_get_pipeline_workflow.call_count == 2
+
+    @mock.patch(HOOK_STR.format("time.sleep"))
+    @mock.patch(HOOK_STR.format("DataFusionHook.get_pipeline_workflow"))
+    def test_wait_for_pipeline_state_raises_on_failure_state(
+        self, mock_get_pipeline_workflow, mock_sleep, hook
+    ):
+        mock_get_pipeline_workflow.return_value = {"status": "FAILED"}
+
+        with pytest.raises(ValueError, match=r"Pipeline shrubberyPipeline state FAILED is not one of"):
+            hook.wait_for_pipeline_state(
+                pipeline_name=PIPELINE_NAME, pipeline_id=PIPELINE_ID, instance_url=INSTANCE_URL
+            )
+
+    @pytest.mark.parametrize(
         ("pipeline_type", "expected_program_type"),
         [
             (DataFusionPipelineType.BATCH, "workflows"),


### PR DESCRIPTION
closes: #72385
## What's the problem

`CloudDataFusionStartPipelineOperator` starts a pipeline and then polls `DataFusionHook.wait_for_pipeline_state()` for the run's status. Right after the start call, CDAP hasn't registered the run yet and returns `404` for the first poll or two.

#60688 changed the exception handling, causing the 404 to no longer be caught:

| | Raised by `_check_response_status_and_data` | Caught by `wait_for_pipeline_state` |
|---|---|---|
| Before | `AirflowNotFoundException` | `AirflowException` |
| After | `HTTPError` | `KeyError` |

`HTTPError` isn't a `KeyError`, so the 404 escapes the polling loop and fails the task immediately.

## The fix

Changed the exception handling to:

```python
except (HTTPError, KeyError):
    pass

---

<sub>Disclosure: this PR was prepared with the assistance of Claude Code (the commit carries a `Co-Authored-By` trailer). The provider's datafusion unit tests were run before and after the change — the new 404 test fails on `main` and passes with the fix, and the rest of the file is unchanged — along with `ruff check` and `ruff format --check`. I have reviewed the change and take responsibility for it.</sub>