### PR TITLE
Reconnect AWS Batch jobs after worker crashes

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/batch_client.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/batch_client.py
@@ -38,10 +38,14 @@ import botocore.exceptions
 import botocore.waiter
 
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
-from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.common.compat.sdk import AirflowException, AirflowNotFoundException
 
 if TYPE_CHECKING:
     from airflow.providers.amazon.aws.utils.task_log_fetcher import AwsTaskLogFetcher
+
+
+class BatchJobNotFoundException(AirflowNotFoundException):
+    """Raised when AWS Batch no longer returns a requested job."""
 
 
 @runtime_checkable
@@ -398,6 +402,7 @@ class BatchClientHook(AwsBaseHook):
 
         :raises: AirflowException
         """
+        last_response_not_found = False
         for retries in range(self.status_retries):
             if retries:
                 pause = self.exponential_delay(retries)
@@ -413,18 +418,27 @@ class BatchClientHook(AwsBaseHook):
             try:
                 response = self.get_conn().describe_jobs(jobs=[job_id])
                 return self.parse_job_description(job_id, response)
+            except BatchJobNotFoundException as err:
+                last_response_not_found = True
+                self.log.warning(err)
             except AirflowException as err:
+                last_response_not_found = False
                 self.log.warning(err)
             except botocore.exceptions.ClientError as err:
                 # Allow it to retry in case of exceeded quota limit of requests to AWS API
                 if err.response.get("Error", {}).get("Code") != "TooManyRequestsException":
                     raise
+                last_response_not_found = False
                 self.log.warning(
                     "Ignored TooManyRequestsException error, original message: %r. "
                     "Please consider to setup retries mode in boto3, "
                     "check Amazon Provider AWS Connection documentation for more details.",
                     str(err),
                 )
+        if last_response_not_found:
+            raise BatchJobNotFoundException(
+                f"AWS Batch job ({job_id}) was not found after status_retries ({self.status_retries})"
+            )
         raise AirflowException(
             f"AWS Batch job ({job_id}) description error: exceeded status_retries ({self.status_retries})"
         )
@@ -443,6 +457,8 @@ class BatchClientHook(AwsBaseHook):
         :raises: AirflowException
         """
         jobs = response.get("jobs", [])
+        if not jobs:
+            raise BatchJobNotFoundException(f"AWS Batch job ({job_id}) was not found")
         matching_jobs = [job for job in jobs if job.get("jobId") == job_id]
         if len(matching_jobs) != 1:
             raise AirflowException(f"AWS Batch job ({job_id}) description error: response: {response}")

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/batch.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/batch.py
@@ -31,7 +31,7 @@ from collections.abc import Sequence
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Final, cast
 
-from airflow.providers.amazon.aws.hooks.batch_client import BatchClientHook
+from airflow.providers.amazon.aws.hooks.batch_client import BatchClientHook, BatchJobNotFoundException
 from airflow.providers.amazon.aws.links.batch import (
     BatchJobDefinitionLink,
     BatchJobDetailsLink,
@@ -73,6 +73,15 @@ except ImportError:
         def __init__(self, *, durable: Any = _DURABLE_UNSET, **kwargs: Any) -> None:
             super().__init__(**kwargs)
             self.durable = _warn_and_disable_durable_pre_3_3(durable)
+
+        def submit_job(self, context: Context) -> str:
+            raise NotImplementedError
+
+        def poll_until_complete(self, external_id: JsonValue, context: Context) -> None:
+            raise NotImplementedError
+
+        def get_job_result(self, external_id: JsonValue, context: Context) -> str:
+            raise NotImplementedError
 
         def execute_resumable(self, context: Context) -> str:
             external_id: str = self.submit_job(context=context)
@@ -418,7 +427,12 @@ class BatchOperator(ResumableJobMixin, AwsBaseOperator[BatchClientHook]):
             aws_partition=self.hook.conn_partition,
             job_id=self.job_id,
         )
-        job_description: dict[str, Any] = self._persist_links(context=context)
+        try:
+            job_description: dict[str, Any] = self.hook.get_job_description(job_id=self.job_id)
+        except BatchJobNotFoundException:
+            self._restored_job_succeeded = False
+            return "NOT_FOUND"
+        self._persist_links(context=context, job_description=job_description)
         status = job_description.get("status")
         if not isinstance(status, str):
             raise ValueError(f"AWS Batch job {self.job_id} has no status")

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/batch.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/batch.py
@@ -26,9 +26,10 @@ AWS Batch services.
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Sequence
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final, cast
 
 from airflow.providers.amazon.aws.hooks.batch_client import BatchClientHook
 from airflow.providers.amazon.aws.links.batch import (
@@ -47,11 +48,45 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.amazon.aws.utils.task_log_fetcher import AwsTaskLogFetcher
 from airflow.providers.common.compat.sdk import AirflowException, conf
 
+_DURABLE_UNSET: Final[object] = object()
+
+
+def _warn_and_disable_durable_pre_3_3(durable: Any) -> bool:
+    if durable is not _DURABLE_UNSET:
+        warnings.warn(
+            "`durable` has no effect on Airflow versions below 3.3.",
+            UserWarning,
+            stacklevel=3,
+        )
+    return False
+
+
+try:
+    from airflow.sdk import ResumableJobMixin
+except ImportError:
+
+    class ResumableJobMixin:  # type: ignore[no-redef]
+        """Airflow <3.3 compatibility stub."""
+
+        external_id_key: str = "batch_job_id"
+
+        def __init__(self, *, durable: Any = _DURABLE_UNSET, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+            self.durable = _warn_and_disable_durable_pre_3_3(durable)
+
+        def execute_resumable(self, context: Context) -> str:
+            external_id: str = self.submit_job(context=context)
+            self.poll_until_complete(external_id=external_id, context=context)
+            return self.get_job_result(external_id=external_id, context=context)
+
+
 if TYPE_CHECKING:
+    from pydantic import JsonValue
+
     from airflow.sdk import Context
 
 
-class BatchOperator(AwsBaseOperator[BatchClientHook]):
+class BatchOperator(ResumableJobMixin, AwsBaseOperator[BatchClientHook]):
     """
     Execute a job on AWS Batch.
 
@@ -98,6 +133,8 @@ class BatchOperator(AwsBaseOperator[BatchClientHook]):
     :param awslogs_fetch_interval: The interval with which cloudwatch logs are to be fetched, 30 sec.
     :param poll_interval: (Deferrable mode only) Time in seconds to wait between polling.
     :param submit_job_timeout: Execution timeout in seconds for submitted batch job.
+    :param durable: When ``True`` (the default), synchronous execution reconnects to the stored Batch
+        job after a worker crash. Set to ``False`` to always submit a new job. Requires Airflow 3.3+.
 
     .. note::
         Any custom waiters must return a waiter for these calls:
@@ -109,6 +146,7 @@ class BatchOperator(AwsBaseOperator[BatchClientHook]):
     """
 
     aws_hook_class = BatchClientHook
+    external_id_key: str = "batch_job_id"
 
     ui_color = "#c3dae0"
     arn: str | None = None
@@ -172,8 +210,11 @@ class BatchOperator(AwsBaseOperator[BatchClientHook]):
         awslogs_enabled: bool = False,
         awslogs_fetch_interval: timedelta = timedelta(seconds=30),
         submit_job_timeout: int | None = None,
-        **kwargs,
+        durable: bool | None = None,
+        **kwargs: Any,
     ) -> None:
+        if durable is not None:
+            kwargs["durable"] = durable
         super().__init__(**kwargs)
         self.job_id = job_id
         self.job_name = job_name
@@ -197,6 +238,7 @@ class BatchOperator(AwsBaseOperator[BatchClientHook]):
         self.awslogs_enabled = awslogs_enabled
         self.awslogs_fetch_interval = awslogs_fetch_interval
         self.submit_job_timeout = submit_job_timeout
+        self._restored_job_succeeded: bool = False
 
         # params for hook
         self.max_retries = max_retries
@@ -217,7 +259,11 @@ class BatchOperator(AwsBaseOperator[BatchClientHook]):
         :raises ValueError: if job_id is not found
         :raises AirflowException: if job submission fails or job ends in failure state
         """
-        self.submit_job(context)
+        if not self.deferrable and self.wait_for_completion:
+            self.execute_resumable(context=context)
+            return self.job_id
+
+        self.submit_job(context=context)
 
         if self.deferrable:
             if not self.job_id:
@@ -299,7 +345,7 @@ class BatchOperator(AwsBaseOperator[BatchClientHook]):
         response = self.hook.client.terminate_job(jobId=self.job_id, reason="Task killed by the user")
         self.log.info("AWS Batch job (%s) terminated: %s", self.job_id, response)
 
-    def submit_job(self, context: Context):
+    def submit_job(self, context: Context) -> str:
         """
         Submit an AWS Batch job.
 
@@ -352,6 +398,7 @@ class BatchOperator(AwsBaseOperator[BatchClientHook]):
             raise AirflowException(e)
 
         self.job_id = response["jobId"]
+        self._restored_job_succeeded = False
         self.log.info("AWS Batch job (%s) started: %s", self.job_id, response)
         BatchJobDetailsLink.persist(
             context=context,
@@ -360,6 +407,40 @@ class BatchOperator(AwsBaseOperator[BatchClientHook]):
             aws_partition=self.hook.conn_partition,
             job_id=self.job_id,
         )
+        return self.job_id
+
+    def get_job_status(self, external_id: JsonValue, context: Context) -> str:
+        self.job_id = cast("str", external_id)
+        BatchJobDetailsLink.persist(
+            context=context,
+            operator=self,
+            region_name=self.hook.conn_region_name,
+            aws_partition=self.hook.conn_partition,
+            job_id=self.job_id,
+        )
+        job_description: dict[str, Any] = self._persist_links(context=context)
+        status = job_description.get("status")
+        if not isinstance(status, str):
+            raise ValueError(f"AWS Batch job {self.job_id} has no status")
+        self._restored_job_succeeded = self.is_job_succeeded(status)
+        return status
+
+    def is_job_active(self, status: str) -> bool:
+        return status in BatchClientHook.INTERMEDIATE_STATES
+
+    def is_job_succeeded(self, status: str) -> bool:
+        return status == BatchClientHook.SUCCESS_STATE
+
+    def poll_until_complete(self, external_id: JsonValue, context: Context) -> None:
+        self.job_id = cast("str", external_id)
+        self.monitor_job(context=context)
+
+    def get_job_result(self, external_id: JsonValue, context: Context) -> str:
+        self.job_id = cast("str", external_id)
+        if self._restored_job_succeeded:
+            self._persist_cloudwatch_link(context=context)
+            self.hook.check_job_success(job_id=self.job_id)
+        return self.job_id
 
     def _persist_links(
         self,

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_batch_client.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_batch_client.py
@@ -24,7 +24,7 @@ from unittest import mock
 import botocore.exceptions
 import pytest
 
-from airflow.providers.amazon.aws.hooks.batch_client import BatchClientHook
+from airflow.providers.amazon.aws.hooks.batch_client import BatchClientHook, BatchJobNotFoundException
 from airflow.providers.amazon.aws.utils.task_log_fetcher import AwsTaskLogFetcher
 from airflow.providers.common.compat.sdk import AirflowException
 
@@ -246,11 +246,19 @@ class TestBatchClient:
     def test_check_job_success_raises_without_jobs(self, caplog):
         self.client_mock.describe_jobs.return_value = {"jobs": []}
         with caplog.at_level(level=logging.WARNING):
-            with pytest.raises(AirflowException):
+            with pytest.raises(BatchJobNotFoundException):
                 self.batch_client.check_job_success(JOB_ID)
             self.client_mock.describe_jobs.assert_has_calls([mock.call(jobs=[JOB_ID])] * 3)
-            msg = f"AWS Batch job ({JOB_ID}) description error"
+            msg = f"AWS Batch job ({JOB_ID}) was not found"
             assert msg in caplog.messages[0]
+
+    def test_get_job_description_raises_not_found_after_retries(self):
+        self.client_mock.describe_jobs.return_value = {"jobs": []}
+
+        with pytest.raises(BatchJobNotFoundException):
+            self.batch_client.get_job_description(JOB_ID)
+
+        self.client_mock.describe_jobs.assert_has_calls([mock.call(jobs=[JOB_ID])] * self.STATUS_RETRIES)
 
     def test_terminate_job(self):
         self.client_mock.terminate_job.return_value = {}

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_batch.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_batch.py
@@ -18,16 +18,18 @@
 from __future__ import annotations
 
 import warnings
+from collections.abc import Iterator
 from datetime import datetime
 from typing import Any
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import botocore.client
+import botocore.exceptions
 import pytest
 
 from airflow.models.dag import DAG
-from airflow.providers.amazon.aws.hooks.batch_client import BatchClientHook
+from airflow.providers.amazon.aws.hooks.batch_client import BatchClientHook, BatchJobNotFoundException
 from airflow.providers.amazon.aws.hooks.batch_waiters import BatchWaitersHook
 from airflow.providers.amazon.aws.operators.batch import (
     _DURABLE_UNSET,
@@ -41,7 +43,7 @@ from airflow.providers.amazon.aws.triggers.batch import (
     BatchCreateComputeEnvironmentTrigger,
     BatchJobTrigger,
 )
-from airflow.providers.common.compat.sdk import AirflowException, TaskDeferred
+from airflow.providers.common.compat.sdk import AirflowException, Context, TaskDeferred
 
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_3_PLUS
 from unit.amazon.aws.utils.test_template_fields import validate_template_fields
@@ -597,37 +599,42 @@ class TestBatchOperator:
         hook.get_job_all_awslogs_info.return_value = []
         return hook
 
+    @pytest.fixture
+    def batch_hook(self) -> Iterator[MagicMock]:
+        hook = self._make_hook()
+        with mock.patch.object(BatchOperator, "hook", new_callable=mock.PropertyMock, return_value=hook):
+            yield hook
+
     @staticmethod
-    def _context(task_store: Any | None = None) -> dict[str, Any]:
-        context: dict[str, Any] = {"ti": MagicMock(spec_set=["stats_tags", "xcom_push"], stats_tags={})}
+    def _context(task_store: Any | None = None, task_instance: MagicMock | None = None) -> Context:
+        if task_instance is None:
+            task_instance = MagicMock(spec_set=["stats_tags", "xcom_push"], stats_tags={})
+        context: Context = {"ti": task_instance}
         if task_store is not None:
             context["task_state_store"] = task_store
         return context
 
     @requires_resumable_job_mixin
-    def test_fresh_submit_persists_job_id_before_polling(self):
+    def test_fresh_submit_persists_job_id_before_polling(self, batch_hook: MagicMock):
         operator = self._make_operator()
-        operator.hook = self._make_hook()
         task_store = FakeTaskStateStore()
         persisted_before_poll: list[str | None] = []
-        operator.monitor_job = mock.create_autospec(
-            operator.monitor_job,
-            side_effect=lambda context: persisted_before_poll.append(task_store.get("batch_job_id")),
-        )
-
-        result = operator.execute(self._context(task_store))
+        with mock.patch.object(operator, "monitor_job", autospec=True) as monitor_job:
+            monitor_job.side_effect = lambda context: persisted_before_poll.append(
+                task_store.get("batch_job_id")
+            )
+            result = operator.execute(self._context(task_store))
 
         assert result == JOB_ID
         assert task_store.get("batch_job_id") == JOB_ID
         assert persisted_before_poll == [JOB_ID]
-        operator.hook.client.submit_job.assert_called_once()
+        batch_hook.client.submit_job.assert_called_once()
 
     @requires_resumable_job_mixin
     @pytest.mark.parametrize("status", BatchClientHook.INTERMEDIATE_STATES)
-    def test_reconnects_to_active_job_without_resubmitting(self, status: str):
+    def test_reconnects_to_active_job_without_resubmitting(self, status: str, batch_hook: MagicMock):
         operator = self._make_operator()
-        operator.hook = self._make_hook()
-        operator.hook.get_job_description.return_value = {
+        batch_hook.get_job_description.return_value = {
             "jobId": JOB_ID,
             "status": status,
             "jobDefinition": "definition-arn",
@@ -639,61 +646,89 @@ class TestBatchOperator:
 
         assert result == JOB_ID
         assert operator.job_id == JOB_ID
-        operator.hook.client.submit_job.assert_not_called()
-        operator.hook.wait_for_job.assert_called_once_with(JOB_ID)
-        operator.hook.check_job_success.assert_called_once_with(JOB_ID)
+        batch_hook.client.submit_job.assert_not_called()
+        batch_hook.wait_for_job.assert_called_once_with(JOB_ID)
+        batch_hook.check_job_success.assert_called_once_with(JOB_ID)
 
     @requires_resumable_job_mixin
-    def test_recovers_succeeded_job_without_resubmitting_or_polling(self):
+    def test_recovers_succeeded_job_without_resubmitting_or_polling(self, batch_hook: MagicMock):
         operator = self._make_operator()
-        operator.hook = self._make_hook()
-        operator.hook.get_job_description.return_value = {
+        batch_hook.get_job_description.return_value = {
             "jobId": JOB_ID,
             "status": "SUCCEEDED",
             "jobDefinition": "definition-arn",
             "jobQueue": "queue-arn",
         }
-        operator.monitor_job = mock.create_autospec(operator.monitor_job)
         task_store = FakeTaskStateStore({"batch_job_id": JOB_ID})
 
-        result = operator.execute(self._context(task_store))
+        with mock.patch.object(operator, "monitor_job", autospec=True) as monitor_job:
+            result = operator.execute(self._context(task_store))
+            monitor_job.assert_not_called()
 
         assert result == JOB_ID
-        operator.hook.client.submit_job.assert_not_called()
-        operator.monitor_job.assert_not_called()
-        operator.hook.check_job_success.assert_called_once_with(job_id=JOB_ID)
-        operator.hook.get_job_all_awslogs_info.assert_called_once_with(JOB_ID)
+        batch_hook.client.submit_job.assert_not_called()
+        batch_hook.check_job_success.assert_called_once_with(job_id=JOB_ID)
+        batch_hook.get_job_all_awslogs_info.assert_called_once_with(JOB_ID)
 
     @requires_resumable_job_mixin
-    def test_resubmits_after_stored_job_failed(self):
+    def test_resubmits_after_stored_job_failed(self, batch_hook: MagicMock):
         operator = self._make_operator()
-        operator.hook = self._make_hook(job_id="new-job-id")
-        operator.hook.get_job_description.return_value = {
+        batch_hook.client.submit_job.return_value = {"jobName": JOB_NAME, "jobId": "new-job-id"}
+        batch_hook.get_job_description.return_value = {
             "jobId": JOB_ID,
             "status": "FAILED",
             "jobDefinition": "definition-arn",
             "jobQueue": "queue-arn",
         }
-        operator.monitor_job = mock.create_autospec(operator.monitor_job)
         task_store = FakeTaskStateStore({"batch_job_id": JOB_ID})
 
-        result = operator.execute(self._context(task_store))
+        with mock.patch.object(operator, "monitor_job", autospec=True) as monitor_job:
+            result = operator.execute(self._context(task_store))
+            monitor_job.assert_called_once()
 
         assert result == "new-job-id"
         assert task_store.get("batch_job_id") == "new-job-id"
-        operator.hook.client.submit_job.assert_called_once()
-        operator.monitor_job.assert_called_once()
+        batch_hook.client.submit_job.assert_called_once()
 
     @requires_resumable_job_mixin
-    def test_restores_job_id_and_xcom_link_before_status_lookup(self):
+    def test_resubmits_when_stored_job_not_found(self, batch_hook: MagicMock):
         operator = self._make_operator()
-        operator.hook = self._make_hook()
+        batch_hook.client.submit_job.return_value = {"jobName": JOB_NAME, "jobId": "new-job-id"}
+        batch_hook.get_job_description.side_effect = BatchJobNotFoundException("job aged out")
         task_store = FakeTaskStateStore({"batch_job_id": JOB_ID})
-        context = self._context(task_store)
+
+        with mock.patch.object(operator, "monitor_job", autospec=True) as monitor_job:
+            result = operator.execute(self._context(task_store))
+            monitor_job.assert_called_once()
+
+        assert result == "new-job-id"
+        assert task_store.get("batch_job_id") == "new-job-id"
+        batch_hook.client.submit_job.assert_called_once()
+
+    @requires_resumable_job_mixin
+    def test_stored_job_status_propagates_client_error(self, batch_hook: MagicMock):
+        operator = self._make_operator()
+        batch_hook.get_job_description.side_effect = botocore.exceptions.ClientError(
+            error_response={"Error": {"Code": "InvalidClientTokenId", "Message": "invalid credentials"}},
+            operation_name="DescribeJobs",
+        )
+        task_store = FakeTaskStateStore({"batch_job_id": JOB_ID})
+
+        with pytest.raises(botocore.exceptions.ClientError):
+            operator.execute(self._context(task_store))
+
+        batch_hook.client.submit_job.assert_not_called()
+
+    @requires_resumable_job_mixin
+    def test_restores_job_id_and_xcom_link_before_status_lookup(self, batch_hook: MagicMock):
+        operator = self._make_operator()
+        task_store = FakeTaskStateStore({"batch_job_id": JOB_ID})
+        task_instance = MagicMock(spec_set=["stats_tags", "xcom_push"], stats_tags={})
+        context = self._context(task_store, task_instance=task_instance)
 
         def get_job_description(job_id: str) -> dict[str, str]:
             assert operator.job_id == JOB_ID
-            context["ti"].xcom_push.assert_any_call(
+            task_instance.xcom_push.assert_any_call(
                 key="batch_job_details",
                 value={
                     "region_name": AWS_REGION,
@@ -709,56 +744,52 @@ class TestBatchOperator:
                 "jobQueue": "queue-arn",
             }
 
-        operator.hook.get_job_description.side_effect = get_job_description
-        operator.monitor_job = mock.create_autospec(operator.monitor_job)
+        batch_hook.get_job_description.side_effect = get_job_description
 
-        operator.execute(context)
+        with mock.patch.object(operator, "monitor_job", autospec=True):
+            operator.execute(context)
 
-        operator.hook.client.terminate_job.assert_called_once_with(
+        batch_hook.client.terminate_job.assert_called_once_with(
             jobId=JOB_ID, reason="Task killed by the user"
         )
 
     @requires_resumable_job_mixin
-    def test_active_reconnect_preserves_custom_waiter_log_fetching(self):
+    def test_active_reconnect_preserves_custom_waiter_log_fetching(self, batch_hook: MagicMock):
         operator = self._make_operator(awslogs_enabled=True)
-        operator.hook = self._make_hook()
-        operator.hook.get_job_description.return_value = {
+        batch_hook.get_job_description.return_value = {
             "jobId": JOB_ID,
             "status": "RUNNING",
             "jobDefinition": "definition-arn",
             "jobQueue": "queue-arn",
         }
         operator.waiters = mock.create_autospec(BatchWaitersHook, instance=True)
-        operator._get_batch_log_fetcher = mock.create_autospec(operator._get_batch_log_fetcher)
         task_store = FakeTaskStateStore({"batch_job_id": JOB_ID})
 
-        result = operator.execute(self._context(task_store))
+        with mock.patch.object(operator, "_get_batch_log_fetcher", autospec=True) as log_fetcher:
+            result = operator.execute(self._context(task_store))
 
         assert result == JOB_ID
-        operator.waiters.wait_for_job.assert_called_once_with(
-            JOB_ID, get_batch_log_fetcher=operator._get_batch_log_fetcher
-        )
-        operator.hook.wait_for_job.assert_not_called()
-        operator.hook.check_job_success.assert_called_once_with(JOB_ID)
+        operator.waiters.wait_for_job.assert_called_once_with(JOB_ID, get_batch_log_fetcher=log_fetcher)
+        batch_hook.wait_for_job.assert_not_called()
+        batch_hook.check_job_success.assert_called_once_with(JOB_ID)
 
     @requires_resumable_job_mixin
-    def test_durable_false_submits_fresh_without_accessing_store(self):
+    def test_durable_false_submits_fresh_without_accessing_store(self, batch_hook: MagicMock):
         operator = self._make_operator(durable=False)
-        operator.hook = self._make_hook(job_id="new-job-id")
-        operator.monitor_job = mock.create_autospec(operator.monitor_job)
+        batch_hook.client.submit_job.return_value = {"jobName": JOB_NAME, "jobId": "new-job-id"}
         task_store = MagicMock(spec_set=["get", "set"])
 
-        result = operator.execute(self._context(task_store))
+        with mock.patch.object(operator, "monitor_job", autospec=True):
+            result = operator.execute(self._context(task_store))
 
         assert result == "new-job-id"
         task_store.get.assert_not_called()
         task_store.set.assert_not_called()
 
     @requires_resumable_job_mixin
-    def test_deferrable_mode_does_not_access_store(self):
+    def test_deferrable_mode_does_not_access_store(self, batch_hook: MagicMock):
         operator = self._make_operator(deferrable=True)
-        operator.hook = self._make_hook()
-        operator.hook.get_job_description.return_value = {
+        batch_hook.get_job_description.return_value = {
             "jobId": JOB_ID,
             "status": "SUBMITTED",
             "jobDefinition": "definition-arn",
@@ -771,12 +802,12 @@ class TestBatchOperator:
 
         task_store.get.assert_not_called()
         task_store.set.assert_not_called()
-        operator.hook.client.submit_job.assert_called_once()
+        batch_hook.client.submit_job.assert_called_once()
 
     @requires_resumable_job_mixin
-    def test_wait_for_completion_false_does_not_access_store(self):
+    def test_wait_for_completion_false_does_not_access_store(self, batch_hook: MagicMock):
         operator = self._make_operator(wait_for_completion=False)
-        operator.hook = self._make_hook(job_id="new-job-id")
+        batch_hook.client.submit_job.return_value = {"jobName": JOB_NAME, "jobId": "new-job-id"}
         task_store = MagicMock(spec_set=["get", "set"])
 
         result = operator.execute(self._context(task_store))
@@ -784,7 +815,7 @@ class TestBatchOperator:
         assert result == "new-job-id"
         task_store.get.assert_not_called()
         task_store.set.assert_not_called()
-        operator.hook.client.submit_job.assert_called_once()
+        batch_hook.client.submit_job.assert_called_once()
 
     @requires_resumable_job_mixin
     def test_status_helpers_classify_batch_states(self):

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_batch.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_batch.py
@@ -17,14 +17,24 @@
 # under the License.
 from __future__ import annotations
 
+import warnings
+from datetime import datetime
+from typing import Any
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import botocore.client
 import pytest
 
+from airflow.models.dag import DAG
 from airflow.providers.amazon.aws.hooks.batch_client import BatchClientHook
-from airflow.providers.amazon.aws.operators.batch import BatchCreateComputeEnvironmentOperator, BatchOperator
+from airflow.providers.amazon.aws.hooks.batch_waiters import BatchWaitersHook
+from airflow.providers.amazon.aws.operators.batch import (
+    _DURABLE_UNSET,
+    BatchCreateComputeEnvironmentOperator,
+    BatchOperator,
+    _warn_and_disable_durable_pre_3_3,
+)
 
 # Use dummy AWS credentials
 from airflow.providers.amazon.aws.triggers.batch import (
@@ -33,6 +43,7 @@ from airflow.providers.amazon.aws.triggers.batch import (
 )
 from airflow.providers.common.compat.sdk import AirflowException, TaskDeferred
 
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_3_PLUS
 from unit.amazon.aws.utils.test_template_fields import validate_template_fields
 
 AWS_REGION = "eu-west-1"
@@ -46,6 +57,21 @@ RESPONSE_WITHOUT_FAILURES = {
     "jobName": JOB_NAME,
     "jobId": JOB_ID,
 }
+requires_resumable_job_mixin = pytest.mark.skipif(
+    not AIRFLOW_V_3_3_PLUS,
+    reason="ResumableJobMixin reconnect requires task_state_store, available in Airflow 3.3+",
+)
+
+
+class FakeTaskStateStore:
+    def __init__(self, stored: dict[str, str] | None = None) -> None:
+        self._store: dict[str, str] = dict(stored or {})
+
+    def get(self, key: str) -> str | None:
+        return self._store.get(key)
+
+    def set(self, key: str, value: str) -> None:
+        self._store[key] = value
 
 
 class TestBatchOperator:
@@ -90,7 +116,7 @@ class TestBatchOperator:
         assert self.batch.job_id is None
         self.batch.job_id = JOB_ID
 
-        self.mock_context = mock.MagicMock()
+        self.mock_context = {"ti": MagicMock(spec_set=["stats_tags", "xcom_push"], stats_tags={})}
 
     def test_init(self):
         assert self.batch.job_id == JOB_ID
@@ -549,6 +575,228 @@ class TestBatchOperator:
         wait_mock.assert_called_once()
         assert len(wait_mock.call_args) == 2
 
+    @staticmethod
+    def _make_operator(**kwargs: Any) -> BatchOperator:
+        return BatchOperator(
+            task_id="batch_resumable",
+            job_name=JOB_NAME,
+            job_queue="queue",
+            job_definition="hello-world",
+            **kwargs,
+        )
+
+    @staticmethod
+    def _make_hook(job_id: str = JOB_ID) -> MagicMock:
+        hook = mock.create_autospec(BatchClientHook, instance=True)
+        hook.client.submit_job.return_value = {"jobName": JOB_NAME, "jobId": job_id}
+        hook.conn_region_name = AWS_REGION
+        hook.conn_partition = "aws"
+        hook.SUCCESS_STATE = BatchClientHook.SUCCESS_STATE
+        hook.FAILURE_STATE = BatchClientHook.FAILURE_STATE
+        hook.INTERMEDIATE_STATES = BatchClientHook.INTERMEDIATE_STATES
+        hook.get_job_all_awslogs_info.return_value = []
+        return hook
+
+    @staticmethod
+    def _context(task_store: Any | None = None) -> dict[str, Any]:
+        context: dict[str, Any] = {"ti": MagicMock(spec_set=["stats_tags", "xcom_push"], stats_tags={})}
+        if task_store is not None:
+            context["task_state_store"] = task_store
+        return context
+
+    @requires_resumable_job_mixin
+    def test_fresh_submit_persists_job_id_before_polling(self):
+        operator = self._make_operator()
+        operator.hook = self._make_hook()
+        task_store = FakeTaskStateStore()
+        persisted_before_poll: list[str | None] = []
+        operator.monitor_job = mock.create_autospec(
+            operator.monitor_job,
+            side_effect=lambda context: persisted_before_poll.append(task_store.get("batch_job_id")),
+        )
+
+        result = operator.execute(self._context(task_store))
+
+        assert result == JOB_ID
+        assert task_store.get("batch_job_id") == JOB_ID
+        assert persisted_before_poll == [JOB_ID]
+        operator.hook.client.submit_job.assert_called_once()
+
+    @requires_resumable_job_mixin
+    @pytest.mark.parametrize("status", BatchClientHook.INTERMEDIATE_STATES)
+    def test_reconnects_to_active_job_without_resubmitting(self, status: str):
+        operator = self._make_operator()
+        operator.hook = self._make_hook()
+        operator.hook.get_job_description.return_value = {
+            "jobId": JOB_ID,
+            "status": status,
+            "jobDefinition": "definition-arn",
+            "jobQueue": "queue-arn",
+        }
+        task_store = FakeTaskStateStore({"batch_job_id": JOB_ID})
+
+        result = operator.execute(self._context(task_store))
+
+        assert result == JOB_ID
+        assert operator.job_id == JOB_ID
+        operator.hook.client.submit_job.assert_not_called()
+        operator.hook.wait_for_job.assert_called_once_with(JOB_ID)
+        operator.hook.check_job_success.assert_called_once_with(JOB_ID)
+
+    @requires_resumable_job_mixin
+    def test_recovers_succeeded_job_without_resubmitting_or_polling(self):
+        operator = self._make_operator()
+        operator.hook = self._make_hook()
+        operator.hook.get_job_description.return_value = {
+            "jobId": JOB_ID,
+            "status": "SUCCEEDED",
+            "jobDefinition": "definition-arn",
+            "jobQueue": "queue-arn",
+        }
+        operator.monitor_job = mock.create_autospec(operator.monitor_job)
+        task_store = FakeTaskStateStore({"batch_job_id": JOB_ID})
+
+        result = operator.execute(self._context(task_store))
+
+        assert result == JOB_ID
+        operator.hook.client.submit_job.assert_not_called()
+        operator.monitor_job.assert_not_called()
+        operator.hook.check_job_success.assert_called_once_with(job_id=JOB_ID)
+        operator.hook.get_job_all_awslogs_info.assert_called_once_with(JOB_ID)
+
+    @requires_resumable_job_mixin
+    def test_resubmits_after_stored_job_failed(self):
+        operator = self._make_operator()
+        operator.hook = self._make_hook(job_id="new-job-id")
+        operator.hook.get_job_description.return_value = {
+            "jobId": JOB_ID,
+            "status": "FAILED",
+            "jobDefinition": "definition-arn",
+            "jobQueue": "queue-arn",
+        }
+        operator.monitor_job = mock.create_autospec(operator.monitor_job)
+        task_store = FakeTaskStateStore({"batch_job_id": JOB_ID})
+
+        result = operator.execute(self._context(task_store))
+
+        assert result == "new-job-id"
+        assert task_store.get("batch_job_id") == "new-job-id"
+        operator.hook.client.submit_job.assert_called_once()
+        operator.monitor_job.assert_called_once()
+
+    @requires_resumable_job_mixin
+    def test_restores_job_id_and_xcom_link_before_status_lookup(self):
+        operator = self._make_operator()
+        operator.hook = self._make_hook()
+        task_store = FakeTaskStateStore({"batch_job_id": JOB_ID})
+        context = self._context(task_store)
+
+        def get_job_description(job_id: str) -> dict[str, str]:
+            assert operator.job_id == JOB_ID
+            context["ti"].xcom_push.assert_any_call(
+                key="batch_job_details",
+                value={
+                    "region_name": AWS_REGION,
+                    "aws_domain": "aws.amazon.com",
+                    "job_id": JOB_ID,
+                },
+            )
+            operator.on_kill()
+            return {
+                "jobId": job_id,
+                "status": "RUNNING",
+                "jobDefinition": "definition-arn",
+                "jobQueue": "queue-arn",
+            }
+
+        operator.hook.get_job_description.side_effect = get_job_description
+        operator.monitor_job = mock.create_autospec(operator.monitor_job)
+
+        operator.execute(context)
+
+        operator.hook.client.terminate_job.assert_called_once_with(
+            jobId=JOB_ID, reason="Task killed by the user"
+        )
+
+    @requires_resumable_job_mixin
+    def test_active_reconnect_preserves_custom_waiter_log_fetching(self):
+        operator = self._make_operator(awslogs_enabled=True)
+        operator.hook = self._make_hook()
+        operator.hook.get_job_description.return_value = {
+            "jobId": JOB_ID,
+            "status": "RUNNING",
+            "jobDefinition": "definition-arn",
+            "jobQueue": "queue-arn",
+        }
+        operator.waiters = mock.create_autospec(BatchWaitersHook, instance=True)
+        operator._get_batch_log_fetcher = mock.create_autospec(operator._get_batch_log_fetcher)
+        task_store = FakeTaskStateStore({"batch_job_id": JOB_ID})
+
+        result = operator.execute(self._context(task_store))
+
+        assert result == JOB_ID
+        operator.waiters.wait_for_job.assert_called_once_with(
+            JOB_ID, get_batch_log_fetcher=operator._get_batch_log_fetcher
+        )
+        operator.hook.wait_for_job.assert_not_called()
+        operator.hook.check_job_success.assert_called_once_with(JOB_ID)
+
+    @requires_resumable_job_mixin
+    def test_durable_false_submits_fresh_without_accessing_store(self):
+        operator = self._make_operator(durable=False)
+        operator.hook = self._make_hook(job_id="new-job-id")
+        operator.monitor_job = mock.create_autospec(operator.monitor_job)
+        task_store = MagicMock(spec_set=["get", "set"])
+
+        result = operator.execute(self._context(task_store))
+
+        assert result == "new-job-id"
+        task_store.get.assert_not_called()
+        task_store.set.assert_not_called()
+
+    @requires_resumable_job_mixin
+    def test_deferrable_mode_does_not_access_store(self):
+        operator = self._make_operator(deferrable=True)
+        operator.hook = self._make_hook()
+        operator.hook.get_job_description.return_value = {
+            "jobId": JOB_ID,
+            "status": "SUBMITTED",
+            "jobDefinition": "definition-arn",
+            "jobQueue": "queue-arn",
+        }
+        task_store = MagicMock(spec_set=["get", "set"])
+
+        with pytest.raises(TaskDeferred):
+            operator.execute(self._context(task_store))
+
+        task_store.get.assert_not_called()
+        task_store.set.assert_not_called()
+        operator.hook.client.submit_job.assert_called_once()
+
+    @requires_resumable_job_mixin
+    def test_wait_for_completion_false_does_not_access_store(self):
+        operator = self._make_operator(wait_for_completion=False)
+        operator.hook = self._make_hook(job_id="new-job-id")
+        task_store = MagicMock(spec_set=["get", "set"])
+
+        result = operator.execute(self._context(task_store))
+
+        assert result == "new-job-id"
+        task_store.get.assert_not_called()
+        task_store.set.assert_not_called()
+        operator.hook.client.submit_job.assert_called_once()
+
+    @requires_resumable_job_mixin
+    def test_status_helpers_classify_batch_states(self):
+        operator = self._make_operator()
+
+        for status in BatchClientHook.INTERMEDIATE_STATES:
+            assert operator.is_job_active(status) is True
+        assert operator.is_job_active(BatchClientHook.SUCCESS_STATE) is False
+        assert operator.is_job_active(BatchClientHook.FAILURE_STATE) is False
+        assert operator.is_job_succeeded(BatchClientHook.SUCCESS_STATE) is True
+        assert operator.is_job_succeeded(BatchClientHook.FAILURE_STATE) is False
+
     @patch.object(BatchOperator, "log", new_callable=MagicMock)
     @patch("airflow.providers.amazon.aws.operators.batch.validate_execute_complete_event")
     @patch.object(BatchClientHook, "check_job_success")
@@ -722,6 +970,35 @@ class TestBatchOperator:
 
             # Verify CloudWatch links were still persisted despite failure
             mock_get_job_all_awslogs_info.assert_called_once_with("12345")
+
+    @requires_resumable_job_mixin
+    def test_default_args_durable_reaches_operator(self):
+        with DAG(
+            dag_id="test_batch_durable_default_args",
+            schedule=None,
+            start_date=datetime(2024, 1, 1),
+            default_args={"durable": False},
+        ):
+            operator = self._make_operator()
+
+        assert operator.durable is False
+
+
+class TestWarnAndDisableDurableAirflowPre3_3:
+    def test_no_warning_when_unset(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = _warn_and_disable_durable_pre_3_3(_DURABLE_UNSET)
+
+        assert result is False
+        assert caught == []
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_warns_and_disables_when_explicitly_set(self, value: bool):
+        with pytest.warns(UserWarning, match="durable.*no effect"):
+            result = _warn_and_disable_durable_pre_3_3(value)
+
+        assert result is False
 
 
 class TestBatchCreateComputeEnvironmentOperator:


### PR DESCRIPTION
Synchronous `BatchOperator` tasks always submit a new AWS Batch job when a worker retry starts. If the first worker dies after submission, the retry can run the same workload twice.

This change uses AIP-103 task state to persist the Batch job ID before polling. A retry reconnects to active jobs, finalizes successful jobs without resubmitting, and submits a new job after a terminal failure. If AWS no longer returns the stored job, the retry submits a replacement after the existing status retries are exhausted. Other AWS API errors still propagate. Deferrable tasks and `wait_for_completion=False` keep their existing submission paths.

## Testing

<details>
<summary>Crash/retry proof with task state</summary>

The temporary proof script loaded the operator from `upstream/main` and the updated operator, then ran each twice with the real `TaskStateStoreAccessor`, local supervisor communication, and local AWS hook/waiter stand-ins.

```console
$ AIRFLOW_HOME="$PWD/.build/airflow-batch-tests" uv run --project providers/amazon python dev/batch_resumability_live.py
2026-09-02T04:09:47.893031Z [warning  ] BatchOperator.execute cannot be called outside of the Task Runner! [airflow.task.operators.batch_before.BatchOperator] loc=operator.py:439
2026-09-02T04:09:47.895223Z [info     ] Running AWS Batch job - job definition: proof:1 - on queue proof [airflow.task.operators.batch_before.BatchOperator] loc=batch_operator_before.py:308
2026-09-02T04:09:47.895396Z [info     ] AWS Batch job (before-job-1) started: {'jobId': 'before-job-1'} [airflow.task.operators.batch_before.BatchOperator] loc=batch_operator_before.py:355
2026-09-02T04:09:47.895503Z [info     ] AWS Batch job (before-job-1) Job Definition ARN: 'arn:aws:batch:us-east-1:123456789012:job-definition/proof:1', Job Queue ARN: 'arn:aws:batch:us-east-1:123456789012:job-queue/proof' [airflow.task.operators.batch_before.BatchOperator] loc=batch_operator_before.py:385
2026-09-02T04:09:47.896036Z [warning  ] BatchOperator.execute cannot be called outside of the Task Runner! [airflow.task.operators.batch_before.BatchOperator] loc=operator.py:439
2026-09-02T04:09:47.896102Z [info     ] Running AWS Batch job - job definition: proof:1 - on queue proof [airflow.task.operators.batch_before.BatchOperator] loc=batch_operator_before.py:308
2026-09-02T04:09:47.896258Z [info     ] AWS Batch job (before-job-2) started: {'jobId': 'before-job-2'} [airflow.task.operators.batch_before.BatchOperator] loc=batch_operator_before.py:355
2026-09-02T04:09:47.896389Z [info     ] AWS Batch job (before-job-2) Job Definition ARN: 'arn:aws:batch:us-east-1:123456789012:job-definition/proof:1', Job Queue ARN: 'arn:aws:batch:us-east-1:123456789012:job-queue/proof' [airflow.task.operators.batch_before.BatchOperator] loc=batch_operator_before.py:385
2026-09-02T04:09:47.896517Z [info     ] AWS Batch job (before-job-2) succeeded [airflow.task.operators.batch_before.BatchOperator] loc=batch_operator_before.py:477
before: submissions=['before-job-1', 'before-job-2'] stored_job_id=None retry_result='before-job-2'
2026-09-02T04:09:47.897154Z [warning  ] BatchOperator.execute cannot be called outside of the Task Runner! [airflow.task.operators.airflow.providers.amazon.aws.operators.batch.BatchOperator] loc=operator.py:439
2026-09-02T04:09:47.948536Z [info     ] Running AWS Batch job - job definition: proof:1 - on queue proof [airflow.task.operators.airflow.providers.amazon.aws.operators.batch.BatchOperator] loc=batch.py:354
2026-09-02T04:09:47.948675Z [info     ] AWS Batch job (after-job-1) started: {'jobId': 'after-job-1'} [airflow.task.operators.airflow.providers.amazon.aws.operators.batch.BatchOperator] loc=batch.py:402
2026-09-02T04:09:47.972051Z [info     ] AWS Batch job (after-job-1) Job Definition ARN: 'arn:aws:batch:us-east-1:123456789012:job-definition/proof:1', Job Queue ARN: 'arn:aws:batch:us-east-1:123456789012:job-queue/proof' [airflow.task.operators.airflow.providers.amazon.aws.operators.batch.BatchOperator] loc=batch.py:466
2026-09-02T04:09:47.976298Z [warning  ] BatchOperator.execute cannot be called outside of the Task Runner! [airflow.task.operators.airflow.providers.amazon.aws.operators.batch.BatchOperator] loc=operator.py:439
2026-09-02T04:09:47.976632Z [info     ] AWS Batch job (after-job-1) Job Definition ARN: 'arn:aws:batch:us-east-1:123456789012:job-definition/proof:1', Job Queue ARN: 'arn:aws:batch:us-east-1:123456789012:job-queue/proof' [airflow.task.operators.airflow.providers.amazon.aws.operators.batch.BatchOperator] loc=batch.py:466
2026-09-02T04:09:47.976871Z [info     ] Reconnecting to existing job   [airflow.task.operators.airflow.providers.amazon.aws.operators.batch.BatchOperator] external_id=after-job-1 external_id_key=batch_job_id loc=resumablejobmixin.py:161 status=RUNNING
2026-09-02T04:09:47.976966Z [info     ] AWS Batch job (after-job-1) Job Definition ARN: 'arn:aws:batch:us-east-1:123456789012:job-definition/proof:1', Job Queue ARN: 'arn:aws:batch:us-east-1:123456789012:job-queue/proof' [airflow.task.operators.airflow.providers.amazon.aws.operators.batch.BatchOperator] loc=batch.py:466
2026-09-02T04:09:47.977017Z [info     ] AWS Batch job (after-job-1) succeeded [airflow.task.operators.airflow.providers.amazon.aws.operators.batch.BatchOperator] loc=batch.py:558
after: submissions=['after-job-1'] stored_job_id='after-job-1' retry_result='after-job-1'
```

</details>

<details>
<summary>Aged-out job regression</summary>

```console
$ AIRFLOW_HOME="$PWD/.build/airflow-batch-tests" uv run --project providers/amazon pytest providers/amazon/tests/unit/amazon/aws/hooks/test_batch_client.py::TestBatchClient::test_get_job_description_raises_not_found_after_retries providers/amazon/tests/unit/amazon/aws/operators/test_batch.py::TestBatchOperator::test_resubmits_when_stored_job_not_found providers/amazon/tests/unit/amazon/aws/operators/test_batch.py::TestBatchOperator::test_stored_job_status_propagates_client_error -xvs

# Before
AirflowException: AWS Batch job (...) description error:
exceeded status_retries (3)
1 failed, 1 warning

# After
Prior job in terminal state, resubmitting fresh
external_id=... status=NOT_FOUND
AWS Batch job (new-job-id) started
3 passed, 1 warning
```

</details>

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (GitHub Copilot CLI, GPT-5.6 Sol)

Generated-by: GitHub Copilot CLI (GPT-5.6 Sol) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
