### PR TITLE
Reconnect Airbyte sync jobs after task retries

### DIFF
--- a/providers/airbyte/docs/operators/airbyte.rst
+++ b/providers/airbyte/docs/operators/airbyte.rst
@@ -29,6 +29,11 @@ trigger an existing ConnectionId sync job in Airbyte.
   You must be aware of the source (database, API, etc) you are updating/sync and
   the method applied to perform the operation in Airbyte.
 
+On Airflow 3.3 and later, synchronous non-deferrable tasks persist the Airbyte job id before
+polling. If the worker exits, a retry reconnects to an active job, returns the stored job id
+after a successful job, or starts a new job after the earlier job fails or is cancelled. Set
+``durable=False`` to disable this behavior. Earlier Airflow versions always start a new job on retry.
+
 
 Using the Operator
 ^^^^^^^^^^^^^^^^^^

--- a/providers/airbyte/src/airflow/providers/airbyte/operators/airbyte.py
+++ b/providers/airbyte/src/airflow/providers/airbyte/operators/airbyte.py
@@ -19,8 +19,10 @@ from __future__ import annotations
 
 import datetime
 import time
+import warnings
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any
+from functools import cached_property
+from typing import TYPE_CHECKING, Any, cast
 
 from airbyte_api.models import JobStatusEnum
 
@@ -28,11 +30,45 @@ from airflow.providers.airbyte.hooks.airbyte import AirbyteHook
 from airflow.providers.airbyte.triggers.airbyte import AirbyteSyncTrigger
 from airflow.providers.common.compat.sdk import AirflowException, BaseOperator, conf
 
+_DURABLE_UNSET: object = object()
+
+
+def _warn_and_disable_durable_pre_3_3(durable: object) -> bool:
+    if durable is not _DURABLE_UNSET:
+        warnings.warn(
+            "`durable` has no effect on Airflow versions below 3.3.",
+            UserWarning,
+            stacklevel=3,
+        )
+    return False
+
+
+try:
+    from airflow.sdk import ResumableJobMixin
+except ImportError:
+
+    class ResumableJobMixin:  # type: ignore[no-redef]
+        """Submit a fresh job on Airflow versions before 3.3."""
+
+        external_id_key: str = "airbyte_job_id"
+
+        def __init__(self, *, durable: Any = _DURABLE_UNSET, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+            self.durable = _warn_and_disable_durable_pre_3_3(durable)
+
+        def execute_resumable(self, context: Context) -> Any:
+            external_id = self.submit_job(context=context)
+            self.poll_until_complete(external_id=external_id, context=context)
+            return self.get_job_result(external_id=external_id, context=context)
+
+
 if TYPE_CHECKING:
+    from pydantic import JsonValue
+
     from airflow.providers.common.compat.sdk import Context
 
 
-class AirbyteTriggerSyncOperator(BaseOperator):
+class AirbyteTriggerSyncOperator(ResumableJobMixin, BaseOperator):
     """
     Submits a job to an Airbyte server to run a integration process between your source and destination.
 
@@ -57,10 +93,15 @@ class AirbyteTriggerSyncOperator(BaseOperator):
     :param execution_timeout: Maximum time allowed for the task to run. If exceeded, the Airbyte
         Job will be cancelled and the task will fail. When both ``execution_timeout`` and
         ``timeout`` are set, the earlier deadline takes precedence.
+    :param durable: When True (the default), synchronous non-deferrable execution persists the
+        Airbyte job id before polling. A retry reconnects to an active job, returns a succeeded
+        job, or submits a new job after terminal failure. Requires Airflow 3.3+ and has no effect
+        on earlier versions.
     """
 
     template_fields: Sequence[str] = ("connection_id",)
     ui_color = "#6C51FD"
+    external_id_key: str = "airbyte_job_id"
 
     def __init__(
         self,
@@ -71,8 +112,11 @@ class AirbyteTriggerSyncOperator(BaseOperator):
         api_version: str = "v1",
         wait_seconds: float = 3,
         timeout: float = 3600,
-        **kwargs,
+        durable: bool | None = None,
+        **kwargs: Any,
     ) -> None:
+        if durable is not None:
+            kwargs["durable"] = durable
         super().__init__(**kwargs)
         self.airbyte_conn_id = airbyte_conn_id
         self.connection_id = connection_id
@@ -82,15 +126,22 @@ class AirbyteTriggerSyncOperator(BaseOperator):
         self.asynchronous = asynchronous
         self.deferrable = deferrable
 
-    def execute(self, context: Context) -> None:
+    @cached_property
+    def hook(self) -> AirbyteHook:
+        return AirbyteHook(airbyte_conn_id=self.airbyte_conn_id, api_version=self.api_version)
+
+    def execute(self, context: Context) -> int | None:
         """Create Airbyte Job and wait to finish."""
-        hook = AirbyteHook(airbyte_conn_id=self.airbyte_conn_id, api_version=self.api_version)
-        job_object = hook.submit_sync_connection(connection_id=self.connection_id)
-        self.job_id = job_object.job_id
-        state = job_object.status
         trigger_poll_interval = 60
 
         now = time.time()
+
+        if not self.asynchronous and not self.deferrable:
+            self.execute_resumable(context=context)
+            return self.job_id
+
+        job_object = self._submit_sync_connection()
+        state = job_object.status
 
         # Derive absolute deadlines for deferrable execution.
         # execution_timeout is a hard task-level limit (cancels the job),
@@ -110,39 +161,65 @@ class AirbyteTriggerSyncOperator(BaseOperator):
             poll_buffer = 2 * trigger_poll_interval
             defer_timeout = datetime.timedelta(seconds=self.execution_timeout.total_seconds() + poll_buffer)
 
-        self.log.info("Job %s was submitted to Airbyte Server", self.job_id)
-
         if self.asynchronous:
             self.log.info("Async Task returning job_id %s", self.job_id)
             return self.job_id
 
-        if not self.deferrable:
-            self.log.debug("Running in non-deferrable mode...")
-            hook.wait_for_job(job_id=self.job_id, wait_seconds=self.wait_seconds, timeout=self.timeout)
+        self.log.debug("Running in deferrable mode in job state %s...", state)
+        if state in (JobStatusEnum.RUNNING, JobStatusEnum.PENDING, JobStatusEnum.INCOMPLETE):
+            self.defer(
+                timeout=defer_timeout,
+                trigger=AirbyteSyncTrigger(
+                    conn_id=self.airbyte_conn_id,
+                    job_id=self.job_id,
+                    end_time=end_time,
+                    execution_deadline=execution_deadline,
+                    poll_interval=trigger_poll_interval,
+                ),
+                method_name="execute_complete",
+            )
+        elif state == JobStatusEnum.SUCCEEDED:
+            self.log.info("Job %s completed successfully", self.job_id)
+            return None
+        elif state == JobStatusEnum.FAILED:
+            raise AirflowException(f"Job failed:\n{self.job_id}")
+        elif state == JobStatusEnum.CANCELLED:
+            raise AirflowException(f"Job was cancelled:\n{self.job_id}")
         else:
-            self.log.debug("Running in deferrable mode in job state %s...", state)
-            if state in (JobStatusEnum.RUNNING, JobStatusEnum.PENDING, JobStatusEnum.INCOMPLETE):
-                self.defer(
-                    timeout=defer_timeout,
-                    trigger=AirbyteSyncTrigger(
-                        conn_id=self.airbyte_conn_id,
-                        job_id=self.job_id,
-                        end_time=end_time,
-                        execution_deadline=execution_deadline,
-                        poll_interval=trigger_poll_interval,
-                    ),
-                    method_name="execute_complete",
-                )
-            elif state == JobStatusEnum.SUCCEEDED:
-                self.log.info("Job %s completed successfully", self.job_id)
-                return
-            elif state == JobStatusEnum.FAILED:
-                raise AirflowException(f"Job failed:\n{self.job_id}")
-            elif state == JobStatusEnum.CANCELLED:
-                raise AirflowException(f"Job was cancelled:\n{self.job_id}")
-            else:
-                raise AirflowException(f"Encountered unexpected state `{state}` for job_id `{self.job_id}")
+            raise AirflowException(f"Encountered unexpected state `{state}` for job_id `{self.job_id}")
 
+        return None
+
+    def _submit_sync_connection(self) -> Any:
+        job_object = self.hook.submit_sync_connection(connection_id=self.connection_id)
+        self.job_id = job_object.job_id
+        self.log.info("Job %s was submitted to Airbyte Server", self.job_id)
+        return job_object
+
+    def submit_job(self, context: Context) -> JsonValue:
+        self._submit_sync_connection()
+        return self.job_id
+
+    def get_job_status(self, external_id: JsonValue, context: Context) -> str:
+        self.job_id = cast("int", external_id)
+        return self.hook.get_job_status(job_id=self.job_id)
+
+    def is_job_active(self, status: str) -> bool:
+        return status in (JobStatusEnum.RUNNING, JobStatusEnum.PENDING, JobStatusEnum.INCOMPLETE)
+
+    def is_job_succeeded(self, status: str) -> bool:
+        return status == JobStatusEnum.SUCCEEDED
+
+    def poll_until_complete(self, external_id: JsonValue, context: Context) -> None:
+        self.job_id = cast("int", external_id)
+        self.hook.wait_for_job(
+            job_id=self.job_id,
+            wait_seconds=self.wait_seconds,
+            timeout=self.timeout,
+        )
+
+    def get_job_result(self, external_id: JsonValue, context: Context) -> int:
+        self.job_id = cast("int", external_id)
         return self.job_id
 
     def execute_complete(self, context: Context, event: Any = None) -> None:
@@ -182,18 +259,17 @@ class AirbyteTriggerSyncOperator(BaseOperator):
         self.log.info("%s completed successfully.", self.task_id)
         return None
 
-    def on_kill(self):
+    def on_kill(self) -> None:
         """Cancel the job if task is cancelled."""
-        hook = AirbyteHook(airbyte_conn_id=self.airbyte_conn_id, api_version=self.api_version)
         self.log.debug(
             "Job status for job_id %s prior to canceling is: %s",
             self.job_id,
-            hook.get_job_status(self.job_id),
+            self.hook.get_job_status(job_id=self.job_id),
         )
         if self.job_id:
             self.log.info("on_kill: cancel the airbyte Job %s", self.job_id)
             try:
-                hook.cancel_job(self.job_id)
+                self.hook.cancel_job(job_id=self.job_id)
             except Exception:
                 self.log.warning(
                     "Failed to cancel Airbyte job %s during on_kill",

--- a/providers/airbyte/src/airflow/providers/airbyte/operators/airbyte.py
+++ b/providers/airbyte/src/airflow/providers/airbyte/operators/airbyte.py
@@ -57,15 +57,25 @@ except ImportError:
             self.durable = _warn_and_disable_durable_pre_3_3(durable)
 
         def execute_resumable(self, context: Context) -> Any:
-            external_id = self.submit_job(context=context)
-            self.poll_until_complete(external_id=external_id, context=context)
-            return self.get_job_result(external_id=external_id, context=context)
+            resumable_job = cast("_ResumableJob", self)
+            external_id = resumable_job.submit_job(context=context)
+            resumable_job.poll_until_complete(external_id=external_id, context=context)
+            return resumable_job.get_job_result(external_id=external_id, context=context)
 
 
 if TYPE_CHECKING:
+    from typing import Protocol
+
     from pydantic import JsonValue
 
     from airflow.providers.common.compat.sdk import Context
+
+    class _ResumableJob(Protocol):
+        def submit_job(self, context: Context) -> JsonValue: ...
+
+        def poll_until_complete(self, external_id: JsonValue, context: Context) -> None: ...
+
+        def get_job_result(self, external_id: JsonValue, context: Context) -> Any: ...
 
 
 class AirbyteTriggerSyncOperator(ResumableJobMixin, BaseOperator):

--- a/providers/airbyte/src/airflow/providers/airbyte/operators/airbyte.py
+++ b/providers/airbyte/src/airflow/providers/airbyte/operators/airbyte.py
@@ -134,14 +134,13 @@ class AirbyteTriggerSyncOperator(ResumableJobMixin, BaseOperator):
         """Create Airbyte Job and wait to finish."""
         trigger_poll_interval = 60
 
-        now = time.time()
-
         if not self.asynchronous and not self.deferrable:
             self.execute_resumable(context=context)
             return self.job_id
 
         job_object = self._submit_sync_connection()
         state = job_object.status
+        now = time.time()
 
         # Derive absolute deadlines for deferrable execution.
         # execution_timeout is a hard task-level limit (cancels the job),

--- a/providers/airbyte/tests/unit/airbyte/operators/test_airbyte.py
+++ b/providers/airbyte/tests/unit/airbyte/operators/test_airbyte.py
@@ -17,15 +17,20 @@
 # under the License.
 from __future__ import annotations
 
+import warnings
 from datetime import timedelta
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
 from airbyte_api.models import JobCreateRequest, JobResponse, JobStatusEnum, JobTypeEnum
 
 from airflow.models import Connection
+from airflow.providers.airbyte.operators import airbyte as airbyte_module
 from airflow.providers.airbyte.operators.airbyte import AirbyteTriggerSyncOperator
 from airflow.providers.common.compat.sdk import AirflowException
+
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_3_PLUS
 
 
 class TestAirbyteTriggerSyncOp:
@@ -234,8 +239,8 @@ class TestAirbyteTriggerSyncOp:
         op.job_id = self.job_id
         op.on_kill()
 
-        mock_cancel_job.assert_called_once_with(self.job_id)
-        mock_get_job_status.assert_called_once_with(self.job_id)
+        mock_cancel_job.assert_called_once_with(job_id=self.job_id)
+        mock_get_job_status.assert_called_once_with(job_id=self.job_id)
 
     @mock.patch("airflow.providers.airbyte.hooks.airbyte.AirbyteHook.get_job_status")
     @mock.patch("airflow.providers.airbyte.hooks.airbyte.AirbyteHook.cancel_job")
@@ -256,7 +261,7 @@ class TestAirbyteTriggerSyncOp:
         op.job_id = self.job_id
         op.on_kill()
 
-        mock_get_job_status.assert_called_once_with(self.job_id)
+        mock_get_job_status.assert_called_once_with(job_id=self.job_id)
 
     @mock.patch("airflow.providers.airbyte.operators.airbyte.AirbyteHook.cancel_job")
     def test_execute_complete_timeout_cancels_job(self, mock_cancel_job, create_connection_without_db):
@@ -318,3 +323,185 @@ class TestAirbyteTriggerSyncOp:
             op.execute_complete(context={}, event=timeout_event)
 
         mock_cancel_job.assert_called_once_with(job_id=self.job_id)
+
+
+class FakeTaskStateStore:
+    def __init__(self, stored: dict[str, int] | None = None) -> None:
+        self._store = dict(stored or {})
+
+    def get(self, key: str) -> int | None:
+        return self._store.get(key)
+
+    def set(self, key: str, value: int) -> None:
+        self._store[key] = value
+
+
+@pytest.mark.skipif(
+    not AIRFLOW_V_3_3_PLUS,
+    reason="ResumableJobMixin requires task_state_store, available in Airflow 3.3+",
+)
+class TestAirbyteTriggerSyncOperatorResumable:
+    connection_id = "test_airbyte_connection"
+    submitted_job_id = 42
+    stored_job_id = 7
+
+    def _make_operator(self, **kwargs) -> AirbyteTriggerSyncOperator:
+        return AirbyteTriggerSyncOperator(
+            task_id="airbyte_resumable",
+            connection_id=self.connection_id,
+            wait_seconds=0,
+            timeout=360,
+            **kwargs,
+        )
+
+    @pytest.fixture
+    def hook(self):
+        with mock.patch.object(airbyte_module, "AirbyteHook", autospec=True) as hook_class:
+            hook = hook_class.return_value
+            hook.submit_sync_connection.return_value = SimpleNamespace(
+                job_id=self.submitted_job_id,
+                status=JobStatusEnum.RUNNING,
+            )
+            yield hook
+
+    def test_first_run_persists_job_id_before_polling(self, hook):
+        operator = self._make_operator()
+        task_store = FakeTaskStateStore()
+
+        def assert_job_id_persisted(*, job_id: int, wait_seconds: float, timeout: float) -> None:
+            assert job_id == self.submitted_job_id
+            assert wait_seconds == operator.wait_seconds
+            assert timeout == operator.timeout
+            assert task_store.get("airbyte_job_id") == self.submitted_job_id
+
+        hook.wait_for_job.side_effect = assert_job_id_persisted
+
+        result = operator.execute(context={"task_state_store": task_store})
+
+        assert result == self.submitted_job_id
+        assert operator.job_id == self.submitted_job_id
+
+    @pytest.mark.parametrize(
+        "status", [JobStatusEnum.RUNNING, JobStatusEnum.PENDING, JobStatusEnum.INCOMPLETE]
+    )
+    def test_retry_reconnects_to_active_job(self, hook, status):
+        operator = self._make_operator()
+        task_store = FakeTaskStateStore({"airbyte_job_id": self.stored_job_id})
+        hook.get_job_status.return_value = status
+
+        result = operator.execute(context={"task_state_store": task_store})
+
+        hook.submit_sync_connection.assert_not_called()
+        hook.wait_for_job.assert_called_once_with(
+            job_id=self.stored_job_id,
+            wait_seconds=operator.wait_seconds,
+            timeout=operator.timeout,
+        )
+        assert result == self.stored_job_id
+        assert operator.job_id == self.stored_job_id
+
+    def test_retry_recovers_succeeded_job(self, hook):
+        operator = self._make_operator()
+        task_store = FakeTaskStateStore({"airbyte_job_id": self.stored_job_id})
+        hook.get_job_status.return_value = JobStatusEnum.SUCCEEDED
+
+        result = operator.execute(context={"task_state_store": task_store})
+
+        hook.submit_sync_connection.assert_not_called()
+        hook.wait_for_job.assert_not_called()
+        assert result == self.stored_job_id
+        assert operator.job_id == self.stored_job_id
+
+    @pytest.mark.parametrize("status", [JobStatusEnum.FAILED, JobStatusEnum.CANCELLED])
+    def test_retry_submits_fresh_after_terminal_job(self, hook, status):
+        operator = self._make_operator()
+        task_store = FakeTaskStateStore({"airbyte_job_id": self.stored_job_id})
+        hook.get_job_status.return_value = status
+
+        result = operator.execute(context={"task_state_store": task_store})
+
+        hook.submit_sync_connection.assert_called_once_with(connection_id=self.connection_id)
+        hook.wait_for_job.assert_called_once_with(
+            job_id=self.submitted_job_id,
+            wait_seconds=operator.wait_seconds,
+            timeout=operator.timeout,
+        )
+        assert task_store.get("airbyte_job_id") == self.submitted_job_id
+        assert result == self.submitted_job_id
+
+    def test_durable_false_submits_fresh(self, hook):
+        operator = self._make_operator(durable=False)
+        task_store = FakeTaskStateStore({"airbyte_job_id": self.stored_job_id})
+
+        result = operator.execute(context={"task_state_store": task_store})
+
+        hook.get_job_status.assert_not_called()
+        hook.submit_sync_connection.assert_called_once_with(connection_id=self.connection_id)
+        assert task_store.get("airbyte_job_id") == self.stored_job_id
+        assert result == self.submitted_job_id
+
+    def test_asynchronous_mode_does_not_use_recovery(self, hook):
+        operator = self._make_operator(asynchronous=True)
+        task_store = mock.Mock(spec=["get", "set"])
+        task_store.get.return_value = self.stored_job_id
+
+        result = operator.execute(context={"task_state_store": task_store})
+
+        task_store.get.assert_not_called()
+        task_store.set.assert_not_called()
+        hook.get_job_status.assert_not_called()
+        hook.wait_for_job.assert_not_called()
+        assert operator.durable is True
+        assert result == self.submitted_job_id
+
+    @mock.patch.object(AirbyteTriggerSyncOperator, "defer", autospec=True)
+    def test_deferrable_mode_does_not_use_recovery(self, mock_defer, hook):
+        operator = self._make_operator(deferrable=True)
+        task_store = mock.Mock(spec=["get", "set"])
+        task_store.get.return_value = self.stored_job_id
+
+        operator.execute(context={"task_state_store": task_store})
+
+        task_store.get.assert_not_called()
+        task_store.set.assert_not_called()
+        hook.get_job_status.assert_not_called()
+        hook.submit_sync_connection.assert_called_once_with(connection_id=self.connection_id)
+        mock_defer.assert_called_once()
+        assert operator.durable is True
+
+    def test_default_args_durable_reaches_operator(self):
+        operator = AirbyteTriggerSyncOperator(
+            task_id="airbyte_default_args",
+            connection_id=self.connection_id,
+            default_args={"durable": False},
+        )
+
+        assert operator.durable is False
+
+    def test_on_kill_cancels_reconnected_job(self, hook):
+        operator = self._make_operator()
+        task_store = FakeTaskStateStore({"airbyte_job_id": self.stored_job_id})
+        hook.get_job_status.return_value = JobStatusEnum.RUNNING
+
+        operator.execute(context={"task_state_store": task_store})
+        operator.on_kill()
+
+        assert operator.job_id == self.stored_job_id
+        hook.cancel_job.assert_called_once_with(job_id=self.stored_job_id)
+
+
+class TestWarnAndDisableDurableAirflowPre3_3:
+    def test_no_warning_when_unset(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = airbyte_module._warn_and_disable_durable_pre_3_3(airbyte_module._DURABLE_UNSET)
+
+        assert result is False
+        assert caught == []
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_warns_and_disables_when_explicitly_set(self, value):
+        with pytest.warns(UserWarning, match="durable.*no effect"):
+            result = airbyte_module._warn_and_disable_durable_pre_3_3(value)
+
+        assert result is False

--- a/providers/airbyte/tests/unit/airbyte/operators/test_airbyte.py
+++ b/providers/airbyte/tests/unit/airbyte/operators/test_airbyte.py
@@ -78,8 +78,7 @@ class TestAirbyteTriggerSyncOp:
             job_id=self.job_id, wait_seconds=self.wait_seconds, timeout=self.timeout
         )
 
-        # Ensure that wall-clock time is used during operator execution flow.
-        mock_time.time.assert_called()
+        mock_time.time.assert_not_called()
         mock_time.monotonic.assert_not_called()
 
     @mock.patch("airflow.providers.airbyte.operators.airbyte.time")
@@ -131,6 +130,59 @@ class TestAirbyteTriggerSyncOp:
             job_id=self.job_id,
             end_time=1000.0 + self.timeout,
             execution_deadline=None,
+            poll_interval=60,
+        )
+
+    @mock.patch("airflow.providers.airbyte.operators.airbyte.time")
+    @mock.patch("airflow.providers.airbyte.operators.airbyte.AirbyteTriggerSyncOperator.defer")
+    @mock.patch("airflow.providers.airbyte.operators.airbyte.AirbyteSyncTrigger")
+    @mock.patch("airbyte_api.jobs.Jobs.create_job")
+    def test_execute_deferrable_deadlines_exclude_submission_time(
+        self,
+        mock_create_job,
+        mock_airbyte_trigger,
+        mock_defer,
+        mock_time,
+        create_connection_without_db,
+    ) -> None:
+        conn = Connection(conn_id=self.airbyte_conn_id, conn_type="airbyte", host="airbyte.com")
+        create_connection_without_db(conn)
+        mock_time.time.side_effect = [1000.0, 1060.0]
+
+        mock_response = SimpleNamespace(
+            job_response=JobResponse(
+                connection_id="connection-mock",
+                job_id=1,
+                start_time="today",
+                job_type=JobTypeEnum.SYNC,
+                status=JobStatusEnum.RUNNING,
+            )
+        )
+
+        def submit_after_latency(*, request: JobCreateRequest) -> SimpleNamespace:
+            assert request == JobCreateRequest(connection_id=self.connection_id, job_type=JobTypeEnum.SYNC)
+            mock_time.time()
+            return mock_response
+
+        mock_create_job.side_effect = submit_after_latency
+
+        op = AirbyteTriggerSyncOperator(
+            task_id="test_airbyte_op",
+            airbyte_conn_id=self.airbyte_conn_id,
+            connection_id=self.connection_id,
+            timeout=self.timeout,
+            deferrable=True,
+            execution_timeout=timedelta(seconds=60),
+        )
+
+        op.execute({})
+
+        mock_defer.assert_called_once()
+        mock_airbyte_trigger.assert_called_once_with(
+            conn_id=self.airbyte_conn_id,
+            job_id=self.job_id,
+            end_time=1060.0 + self.timeout,
+            execution_deadline=1120.0,
             poll_interval=60,
         )
 


### PR DESCRIPTION
A synchronous Airbyte task can crash after Airbyte accepts a sync, then start a duplicate sync when Airflow retries it. With this change, retries resume active Airbyte jobs and recover completed jobs. A new job is created only when no durable state exists or the previous job failed or was cancelled.

The operator uses AIP-103 `ResumableJobMixin` only for the synchronous, non-deferrable wait path. Recovery restores `job_id` before polling or returning so task results, the Airbyte job link, and `on_kill()` keep pointing at the recovered job. Asynchronous and deferrable execution are unchanged. Airflow versions before 3.3 retain the existing submit behavior.

## Testing

| Scenario | Result |
| --- | --- |
| Provider behavior matrix | Sync recovery, async/deferrable isolation, `on_kill()`, and pre-3.3 compatibility covered |
| Active job stored before retry | Reconnected to job 77 without submitting |
| Current `upstream/main` with the same stored job | Submitted duplicate job 101 |
| Slow deferrable submission | Trigger deadlines start after submission |
| Airflow 2.11 compatibility probe | Existing submit behavior preserved |

<details>
<summary>Commands and raw logs</summary>

```console
$ AIRFLOW_HOME=/tmp/airbyte-tests .venv/bin/uv run --project providers/airbyte pytest providers/airbyte/tests/unit/airbyte -q
collected 65 items
...
======================== 65 passed, 1 warning in 28.24s ========================
```

The recovery probe calls the real operator `execute()` path with a task-state store containing `airbyte_job_id=77`. A local stand-in `AirbyteHook` reports that job as running and records submissions, status checks, and waits.

```console
$ REPRO_VARIANT=upstream/main \
  AIRBYTE_PROVIDER_SOURCE_ROOT=$UPSTREAM_MAIN/providers/airbyte/src \
  .venv/bin/uv run --project providers/airbyte python airbyte_resumable_repro.py
{'variant': 'upstream/main', 'stored_before': 77, 'task_state_get_calls': [], 'task_state_set_calls': [], 'submit_count': 1, 'status_calls': [], 'wait_calls': [101], 'result': 101, 'operator_job_id': 101}
Traceback (most recent call last):
  File "airbyte_resumable_repro.py", line 90, in <module>
    raise RuntimeError("operator did not reconnect to the stored active job")
RuntimeError: operator did not reconnect to the stored active job

$ REPRO_VARIANT="PR branch" \
  AIRBYTE_PROVIDER_SOURCE_ROOT=$PWD/providers/airbyte/src \
  .venv/bin/uv run --project providers/airbyte python airbyte_resumable_repro.py
2026-09-02T05:01:37.864774Z [info     ] Reconnecting to existing job   [airflow.task.operators.airflow.providers.airbyte.operators.airbyte.AirbyteTriggerSyncOperator] external_id=77 external_id_key=airbyte_job_id loc=resumablejobmixin.py:161 status=running
{'variant': 'PR branch', 'stored_before': 77, 'task_state_get_calls': ['airbyte_job_id'], 'task_state_set_calls': [], 'submit_count': 0, 'status_calls': [77], 'wait_calls': [77], 'result': 77, 'operator_job_id': 77}
```

</details>

<details>
<summary>Stand-in hook reproducer</summary>

Save this as `airbyte_resumable_repro.py` before running the commands above.

```python
from __future__ import annotations

import os
import sys
from importlib import import_module, invalidate_caches
from pathlib import Path
from types import SimpleNamespace
from typing import Any

from airbyte_api.models import JobStatusEnum

import airflow.providers

if source_root := os.environ.get("AIRBYTE_PROVIDER_SOURCE_ROOT"):
    airflow.providers.__path__.insert(0, str(Path(source_root) / "airflow" / "providers"))
    for module_name in tuple(sys.modules):
        if module_name == "airflow.providers.airbyte" or module_name.startswith(
            "airflow.providers.airbyte."
        ):
            del sys.modules[module_name]
    invalidate_caches()

airbyte_module = import_module("airflow.providers.airbyte.operators.airbyte")


class TaskStateStore:
    def __init__(self) -> None:
        self.values: dict[str, int] = {"airbyte_job_id": 77}
        self.get_calls: list[str] = []
        self.set_calls: list[tuple[str, int]] = []

    def get(self, key: str) -> int | None:
        self.get_calls.append(key)
        return self.values.get(key)

    def set(self, key: str, value: int) -> None:
        self.set_calls.append((key, value))
        self.values[key] = value


class StandInAirbyteHook:
    def __init__(self) -> None:
        self.submit_count = 0
        self.status_calls: list[int] = []
        self.wait_calls: list[int] = []

    def submit_sync_connection(self, *, connection_id: str) -> Any:
        self.submit_count += 1
        return SimpleNamespace(job_id=101, status=JobStatusEnum.RUNNING)

    def get_job_status(self, *, job_id: int) -> str:
        self.status_calls.append(job_id)
        return JobStatusEnum.RUNNING

    def wait_for_job(self, *, job_id: int, wait_seconds: float, timeout: float) -> None:
        self.wait_calls.append(job_id)


task_store = TaskStateStore()
hook = StandInAirbyteHook()
airbyte_module.AirbyteHook = lambda **kwargs: hook
operator = airbyte_module.AirbyteTriggerSyncOperator(
    task_id="airbyte_live_recovery",
    connection_id="connection-uuid",
    deferrable=False,
    asynchronous=False,
    wait_seconds=0,
)
result = operator.execute(context={"task_state_store": task_store})
print(
    {
        "variant": os.environ["REPRO_VARIANT"],
        "stored_before": 77,
        "task_state_get_calls": task_store.get_calls,
        "task_state_set_calls": task_store.set_calls,
        "submit_count": hook.submit_count,
        "status_calls": hook.status_calls,
        "wait_calls": hook.wait_calls,
        "result": result,
        "operator_job_id": operator.job_id,
    }
)

if (
    hook.submit_count != 0
    or hook.status_calls != [77]
    or hook.wait_calls != [77]
    or result != 77
    or operator.job_id != 77
):
    raise RuntimeError("operator did not reconnect to the stored active job")
```

</details>

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (GitHub Copilot CLI, GPT-5.6 Sol)

Generated-by: GitHub Copilot CLI (GPT-5.6 Sol) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
