### PR TITLE
Reconnect Data Fusion pipelines after task retries

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/datafusion.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/datafusion.py
@@ -19,14 +19,21 @@
 from __future__ import annotations
 
 import time
+import warnings
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any
+from functools import cached_property
+from typing import TYPE_CHECKING, Any, cast
 
 from google.api_core.retry import exponential_sleep_generator
 from googleapiclient.errors import HttpError
 
 from airflow.providers.common.compat.sdk import AirflowException, conf
-from airflow.providers.google.cloud.hooks.datafusion import SUCCESS_STATES, DataFusionHook, PipelineStates
+from airflow.providers.google.cloud.hooks.datafusion import (
+    FAILURE_STATES,
+    SUCCESS_STATES,
+    DataFusionHook,
+    PipelineStates,
+)
 from airflow.providers.google.cloud.links.datafusion import (
     DataFusionInstanceLink,
     DataFusionPipelineLink,
@@ -38,7 +45,42 @@ from airflow.providers.google.cloud.utils.datafusion import DataFusionPipelineTy
 from airflow.providers.google.cloud.utils.helpers import resource_path_to_dict
 from airflow.providers.google.common.hooks.base_google import PROVIDE_PROJECT_ID
 
+_DURABLE_UNSET = object()
+
+
+def _warn_and_disable_durable_pre_3_3(durable: Any) -> bool:
+    """Disable durable execution below Airflow 3.3 and warn when explicitly set."""
+    if durable is not _DURABLE_UNSET:
+        warnings.warn(
+            "`durable` has no effect on Airflow versions below 3.3.",
+            UserWarning,
+            stacklevel=3,
+        )
+    return False
+
+
+try:
+    from airflow.sdk import ResumableJobMixin
+except ImportError:
+
+    class ResumableJobMixin:  # type: ignore[no-redef]
+        """Airflow <3.3 stub that always submits a fresh job."""
+
+        external_id_key: str = "datafusion_pipeline_run_id"
+
+        def __init__(self, *, durable: Any = _DURABLE_UNSET, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+            self.durable = _warn_and_disable_durable_pre_3_3(durable)
+
+        def execute_resumable(self, context: Context) -> Any:
+            external_id = self.submit_job(context=context)  # type: ignore[attr-defined]
+            self.poll_until_complete(external_id=external_id, context=context)  # type: ignore[attr-defined]
+            return self.get_job_result(external_id=external_id, context=context)  # type: ignore[attr-defined]
+
+
 if TYPE_CHECKING:
+    from pydantic import JsonValue
+
     from airflow.providers.common.compat.sdk import Context
     from airflow.providers.openlineage.extractors import OperatorLineage
 
@@ -694,7 +736,7 @@ class CloudDataFusionListPipelinesOperator(GoogleCloudBaseOperator):
         return pipelines
 
 
-class CloudDataFusionStartPipelineOperator(GoogleCloudBaseOperator):
+class CloudDataFusionStartPipelineOperator(ResumableJobMixin, GoogleCloudBaseOperator):
     """
     Starts a Cloud Data Fusion pipeline. Works for both batch and stream pipelines.
 
@@ -732,6 +774,9 @@ class CloudDataFusionStartPipelineOperator(GoogleCloudBaseOperator):
         sleep() method, deferrable mode checks for the state using asynchronous calls. It is not possible to
         use both asynchronous and deferrable parameters at the same time.
     :param poll_interval: Polling period in seconds to check for the status. Used only in deferrable mode.
+    :param durable: When ``True`` (the default) and waiting synchronously, persist the pipeline run ID
+        before polling so a worker retry reconnects to that run. Set to ``False`` to submit a new run
+        on retry. Requires Airflow 3.3+; no-op on earlier versions.
     """
 
     template_fields: Sequence[str] = (
@@ -741,6 +786,7 @@ class CloudDataFusionStartPipelineOperator(GoogleCloudBaseOperator):
         "impersonation_chain",
     )
     operator_extra_links = (DataFusionPipelineLink(),)
+    external_id_key = "datafusion_pipeline_run_id"
 
     def __init__(
         self,
@@ -757,11 +803,14 @@ class CloudDataFusionStartPipelineOperator(GoogleCloudBaseOperator):
         api_version: str = "v1beta1",
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
-        asynchronous=False,
+        asynchronous: bool = False,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
-        poll_interval=3.0,
-        **kwargs,
+        poll_interval: float = 3.0,
+        durable: bool | None = None,
+        **kwargs: Any,
     ) -> None:
+        if durable is not None:
+            kwargs["durable"] = durable
         super().__init__(**kwargs)
         self.pipeline_name = pipeline_name
         self.pipeline_type = pipeline_type
@@ -778,33 +827,81 @@ class CloudDataFusionStartPipelineOperator(GoogleCloudBaseOperator):
         self.deferrable = deferrable
         self.poll_interval = poll_interval
         self.pipeline_id: str | None = None
+        self._api_url: str | None = None
 
         if success_states:
             self.success_states = success_states
         else:
             self.success_states = [*SUCCESS_STATES, PipelineStates.RUNNING]
 
-    def execute(self, context: Context) -> str:
-        hook = DataFusionHook(
+    @cached_property
+    def hook(self) -> DataFusionHook:
+        return DataFusionHook(
             gcp_conn_id=self.gcp_conn_id,
             api_version=self.api_version,
             impersonation_chain=self.impersonation_chain,
         )
+
+    @property
+    def _resolved_api_url(self) -> str:
+        if self._api_url is None:
+            raise RuntimeError("Data Fusion API endpoint is not initialized")
+        return self._api_url
+
+    def submit_job(self, context: Context) -> str:
         self.log.info("Starting Data Fusion pipeline: %s", self.pipeline_name)
-        instance = hook.get_instance(
-            instance_name=self.instance_name,
-            location=self.location,
-            project_id=self.project_id,
-        )
-        api_url = instance["apiEndpoint"]
-        self.pipeline_id = hook.start_pipeline(
+        self.pipeline_id = self.hook.start_pipeline(
             pipeline_name=self.pipeline_name,
             pipeline_type=self.pipeline_type,
-            instance_url=api_url,
+            instance_url=self._resolved_api_url,
             namespace=self.namespace,
             runtime_args=self.runtime_args,
         )
         self.log.info("Pipeline %s submitted successfully.", self.pipeline_id)
+        return self.pipeline_id
+
+    def get_job_status(self, external_id: JsonValue, context: Context) -> str:
+        self.pipeline_id = cast("str", external_id)
+        workflow = self.hook.get_pipeline_workflow(
+            pipeline_name=self.pipeline_name,
+            pipeline_type=self.pipeline_type,
+            namespace=self.namespace,
+            instance_url=self._resolved_api_url,
+            pipeline_id=self.pipeline_id,
+        )
+        return workflow["status"]
+
+    def is_job_active(self, status: str) -> bool:
+        return status not in SUCCESS_STATES and status not in FAILURE_STATES
+
+    def is_job_succeeded(self, status: str) -> bool:
+        return status in SUCCESS_STATES
+
+    def poll_until_complete(self, external_id: JsonValue, context: Context) -> None:
+        self.pipeline_id = cast("str", external_id)
+        self.log.info("Waiting when pipeline %s will be in one of the success states", self.pipeline_id)
+        self.hook.wait_for_pipeline_state(
+            success_states=self.success_states,
+            pipeline_id=self.pipeline_id,
+            pipeline_name=self.pipeline_name,
+            pipeline_type=self.pipeline_type,
+            namespace=self.namespace,
+            instance_url=self._resolved_api_url,
+            timeout=self.pipeline_timeout,
+        )
+        self.log.info("Pipeline %s discovered success state.", self.pipeline_id)
+
+    def get_job_result(self, external_id: JsonValue, context: Context) -> str:
+        self.pipeline_id = cast("str", external_id)
+        return self.pipeline_id
+
+    def execute(self, context: Context) -> str:
+        instance = self.hook.get_instance(
+            instance_name=self.instance_name,
+            location=self.location,
+            project_id=self.project_id,
+        )
+        self._api_url = instance["apiEndpoint"]
 
         DataFusionPipelineLink.persist(
             context=context,
@@ -813,6 +910,11 @@ class CloudDataFusionStartPipelineOperator(GoogleCloudBaseOperator):
             namespace=self.namespace,
         )
 
+        if not self.asynchronous and not self.deferrable:
+            self.execute_resumable(context=context)
+            return cast("str", self.pipeline_id)
+
+        self.submit_job(context=context)
         if self.deferrable:
             if self.asynchronous:
                 raise AirflowException(
@@ -821,35 +923,29 @@ class CloudDataFusionStartPipelineOperator(GoogleCloudBaseOperator):
             self.defer(
                 trigger=DataFusionStartPipelineTrigger(
                     success_states=self.success_states,
-                    instance_url=api_url,
+                    instance_url=self._resolved_api_url,
                     namespace=self.namespace,
                     pipeline_name=self.pipeline_name,
                     pipeline_type=self.pipeline_type.value,
-                    pipeline_id=self.pipeline_id,
+                    pipeline_id=cast("str", self.pipeline_id),
                     poll_interval=self.poll_interval,
                     gcp_conn_id=self.gcp_conn_id,
                     impersonation_chain=self.impersonation_chain,
                 ),
                 method_name="execute_complete",
             )
-        else:
-            if not self.asynchronous:
-                # when NOT using asynchronous mode it will just wait for pipeline to finish and print message
-                self.log.info(
-                    "Waiting when pipeline %s will be in one of the success states", self.pipeline_id
-                )
-                hook.wait_for_pipeline_state(
-                    success_states=self.success_states,
-                    pipeline_id=self.pipeline_id,
-                    pipeline_name=self.pipeline_name,
-                    pipeline_type=self.pipeline_type,
-                    namespace=self.namespace,
-                    instance_url=api_url,
-                    timeout=self.pipeline_timeout,
-                )
-                self.log.info("Pipeline %s discovered success state.", self.pipeline_id)
-            #  otherwise, return pipeline_id so that sensor can use it later to check the pipeline state
-        return self.pipeline_id
+        return cast("str", self.pipeline_id)
+
+    def on_kill(self) -> None:
+        if self.pipeline_id is None or self._api_url is None:
+            return
+        self.hook.stop_pipeline(
+            instance_url=self._api_url,
+            pipeline_name=self.pipeline_name,
+            namespace=self.namespace,
+            pipeline_type=self.pipeline_type,
+            run_id=self.pipeline_id,
+        )
 
     def execute_complete(self, context: Context, event: dict[str, Any]):
         """

--- a/providers/google/tests/unit/google/cloud/operators/test_datafusion.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_datafusion.py
@@ -43,8 +43,13 @@ from airflow.providers.google.cloud.operators.datafusion import (
 from airflow.providers.google.cloud.triggers.datafusion import DataFusionStartPipelineTrigger
 from airflow.providers.google.cloud.utils.datafusion import DataFusionPipelineType
 
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_3_PLUS
+
 HOOK_STR = "airflow.providers.google.cloud.operators.datafusion.DataFusionHook"
 RESOURCE_PATH_TO_DICT_STR = "airflow.providers.google.cloud.operators.datafusion.resource_path_to_dict"
+REQUIRES_TASK_STATE_STORE = pytest.mark.skipif(
+    not AIRFLOW_V_3_3_PLUS, reason="task_state_store (durable execution) requires Airflow 3.3+"
+)
 
 TASK_ID = "test_task"
 LOCATION = "test-location"
@@ -306,6 +311,7 @@ class TestCloudDataFusionStartPipelineOperator:
             timeout=300,
         )
 
+    @REQUIRES_TASK_STATE_STORE
     @mock.patch(HOOK_STR)
     def test_first_run_persists_pipeline_id_before_polling(self, mock_hook):
         hook = self.configure_hook(mock_hook)
@@ -335,6 +341,7 @@ class TestCloudDataFusionStartPipelineOperator:
             "UNKNOWN",
         ],
     )
+    @REQUIRES_TASK_STATE_STORE
     @mock.patch(HOOK_STR)
     def test_retry_reconnects_active_pipeline(self, mock_hook, status):
         hook = self.configure_hook(mock_hook)
@@ -366,6 +373,7 @@ class TestCloudDataFusionStartPipelineOperator:
             timeout=300,
         )
 
+    @REQUIRES_TASK_STATE_STORE
     @mock.patch("airflow.providers.google.cloud.operators.datafusion.DataFusionPipelineLink.persist")
     @mock.patch(HOOK_STR)
     def test_retry_recovers_completed_pipeline(self, mock_hook, mock_persist):
@@ -405,6 +413,7 @@ class TestCloudDataFusionStartPipelineOperator:
         "status",
         [PipelineStates.FAILED, PipelineStates.KILLED, PipelineStates.REJECTED],
     )
+    @REQUIRES_TASK_STATE_STORE
     @mock.patch(HOOK_STR)
     def test_retry_resubmits_after_terminal_pipeline(self, mock_hook, status):
         hook = self.configure_hook(mock_hook, pipeline_id="new_pipeline_id")
@@ -435,6 +444,7 @@ class TestCloudDataFusionStartPipelineOperator:
             timeout=300,
         )
 
+    @REQUIRES_TASK_STATE_STORE
     @mock.patch(HOOK_STR)
     def test_retry_lookup_error_does_not_submit_another_pipeline(self, mock_hook):
         hook = self.configure_hook(mock_hook)
@@ -488,6 +498,7 @@ class TestCloudDataFusionStartPipelineOperator:
         hook.get_pipeline_workflow.assert_not_called()
         hook.wait_for_pipeline_state.assert_not_called()
 
+    @REQUIRES_TASK_STATE_STORE
     @mock.patch(HOOK_STR)
     def test_streaming_retry_reconnects_running_pipeline(self, mock_hook):
         hook = self.configure_hook(mock_hook)
@@ -517,6 +528,7 @@ class TestCloudDataFusionStartPipelineOperator:
             timeout=300,
         )
 
+    @REQUIRES_TASK_STATE_STORE
     @mock.patch(HOOK_STR)
     def test_on_kill_stops_only_recovered_pipeline_run(self, mock_hook):
         hook = self.configure_hook(mock_hook)

--- a/providers/google/tests/unit/google/cloud/operators/test_datafusion.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_datafusion.py
@@ -16,6 +16,8 @@
 # under the License.
 from __future__ import annotations
 
+import warnings
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -25,6 +27,7 @@ from airflow.providers.common.compat.sdk import AirflowException, TaskDeferred
 from airflow.providers.google.cloud.hooks.datafusion import SUCCESS_STATES, PipelineStates
 from airflow.providers.google.cloud.openlineage.facets import DataFusionRunFacet
 from airflow.providers.google.cloud.operators.datafusion import (
+    _DURABLE_UNSET,
     CloudDataFusionCreateInstanceOperator,
     CloudDataFusionCreatePipelineOperator,
     CloudDataFusionDeleteInstanceOperator,
@@ -35,6 +38,7 @@ from airflow.providers.google.cloud.operators.datafusion import (
     CloudDataFusionStartPipelineOperator,
     CloudDataFusionStopPipelineOperator,
     CloudDataFusionUpdateInstanceOperator,
+    _warn_and_disable_durable_pre_3_3,
 )
 from airflow.providers.google.cloud.triggers.datafusion import DataFusionStartPipelineTrigger
 from airflow.providers.google.cloud.utils.datafusion import DataFusionPipelineType
@@ -51,8 +55,20 @@ PIPELINE_NAME = "shrubberyPipeline"
 PIPELINE = {"test": "pipeline"}
 PIPELINE_ID = "test_pipeline_id"
 INSTANCE_URL = "http://datafusion.instance.com"
+SERVICE_URL = "http://datafusion.service.com"
 NAMESPACE = "TEST_NAMESPACE"
 RUNTIME_ARGS = {"arg1": "a", "arg2": "b"}
+
+
+class FakeTaskStateStore:
+    def __init__(self, stored: dict[str, str] | None = None) -> None:
+        self.values = stored or {}
+
+    def get(self, key: str) -> str | None:
+        return self.values.get(key)
+
+    def set(self, key: str, value: str) -> None:
+        self.values[key] = value
 
 
 class TestCloudDataFusionUpdateInstanceOperator:
@@ -217,6 +233,37 @@ class TestCloudDataFusionDeletePipelineOperator:
 
 
 class TestCloudDataFusionStartPipelineOperator:
+    @staticmethod
+    def make_operator(**kwargs: Any) -> CloudDataFusionStartPipelineOperator:
+        op = CloudDataFusionStartPipelineOperator(
+            task_id=TASK_ID,
+            pipeline_name=PIPELINE_NAME,
+            instance_name=INSTANCE_NAME,
+            namespace=NAMESPACE,
+            location=LOCATION,
+            project_id=PROJECT_ID,
+            runtime_args=RUNTIME_ARGS,
+            **kwargs,
+        )
+        op.dag = mock.MagicMock(spec=DAG, task_dict={}, dag_id="test")
+        return op
+
+    @staticmethod
+    def make_context(task_state_store: FakeTaskStateStore) -> dict[str, Any]:
+        task_instance = mock.MagicMock()
+        task_instance.stats_tags = {}
+        return {"task_state_store": task_state_store, "ti": task_instance}
+
+    @staticmethod
+    def configure_hook(mock_hook: mock.MagicMock, pipeline_id: str = PIPELINE_ID) -> mock.MagicMock:
+        hook = mock_hook.return_value
+        hook.get_instance.return_value = {
+            "apiEndpoint": INSTANCE_URL,
+            "serviceEndpoint": SERVICE_URL,
+        }
+        hook.start_pipeline.return_value = pipeline_id
+        return hook
+
     @mock.patch(HOOK_STR)
     def test_execute_check_hook_call_should_execute_successfully(self, mock_hook):
         mock_hook.return_value.get_instance.return_value = {
@@ -236,7 +283,7 @@ class TestCloudDataFusionStartPipelineOperator:
         )
         op.dag = mock.MagicMock(spec=DAG, task_dict={}, dag_id="test")
 
-        op.execute(context=mock.MagicMock())
+        op.execute(context=self.make_context(FakeTaskStateStore()))
         mock_hook.return_value.get_instance.assert_called_once_with(
             instance_name=INSTANCE_NAME, location=LOCATION, project_id=PROJECT_ID
         )
@@ -258,6 +305,242 @@ class TestCloudDataFusionStartPipelineOperator:
             instance_url=INSTANCE_URL,
             timeout=300,
         )
+
+    @mock.patch(HOOK_STR)
+    def test_first_run_persists_pipeline_id_before_polling(self, mock_hook):
+        hook = self.configure_hook(mock_hook)
+        task_state_store = FakeTaskStateStore()
+        context = self.make_context(task_state_store)
+        persisted_at_poll: list[str | None] = []
+
+        def record_persisted_id(**kwargs: Any) -> None:
+            persisted_at_poll.append(task_state_store.get("datafusion_pipeline_run_id"))
+
+        hook.wait_for_pipeline_state.side_effect = record_persisted_id
+
+        result = self.make_operator().execute(context=context)
+
+        assert result == PIPELINE_ID
+        assert persisted_at_poll == [PIPELINE_ID]
+        assert task_state_store.values == {"datafusion_pipeline_run_id": PIPELINE_ID}
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            PipelineStates.PENDING,
+            PipelineStates.STARTING,
+            PipelineStates.RUNNING,
+            PipelineStates.SUSPENDED,
+            PipelineStates.RESUMING,
+            "UNKNOWN",
+        ],
+    )
+    @mock.patch(HOOK_STR)
+    def test_retry_reconnects_active_pipeline(self, mock_hook, status):
+        hook = self.configure_hook(mock_hook)
+        hook.get_pipeline_workflow.return_value = {"status": status}
+        context = self.make_context(
+            FakeTaskStateStore({"datafusion_pipeline_run_id": "existing_pipeline_id"})
+        )
+        op = self.make_operator()
+
+        result = op.execute(context=context)
+
+        assert result == "existing_pipeline_id"
+        assert op.pipeline_id == "existing_pipeline_id"
+        hook.start_pipeline.assert_not_called()
+        hook.get_pipeline_workflow.assert_called_once_with(
+            pipeline_name=PIPELINE_NAME,
+            pipeline_type=DataFusionPipelineType.BATCH,
+            namespace=NAMESPACE,
+            instance_url=INSTANCE_URL,
+            pipeline_id="existing_pipeline_id",
+        )
+        hook.wait_for_pipeline_state.assert_called_once_with(
+            success_states=[*SUCCESS_STATES, PipelineStates.RUNNING],
+            pipeline_id="existing_pipeline_id",
+            pipeline_name=PIPELINE_NAME,
+            pipeline_type=DataFusionPipelineType.BATCH,
+            namespace=NAMESPACE,
+            instance_url=INSTANCE_URL,
+            timeout=300,
+        )
+
+    @mock.patch("airflow.providers.google.cloud.operators.datafusion.DataFusionPipelineLink.persist")
+    @mock.patch(HOOK_STR)
+    def test_retry_recovers_completed_pipeline(self, mock_hook, mock_persist):
+        hook = self.configure_hook(mock_hook)
+        hook.get_pipeline_workflow.return_value = {"status": PipelineStates.COMPLETED}
+        context = self.make_context(
+            FakeTaskStateStore({"datafusion_pipeline_run_id": "completed_pipeline_id"})
+        )
+        op = self.make_operator()
+
+        result = op.execute(context=context)
+
+        assert result == "completed_pipeline_id"
+        assert op.pipeline_id == "completed_pipeline_id"
+        hook.start_pipeline.assert_not_called()
+        hook.wait_for_pipeline_state.assert_not_called()
+        hook.get_instance.assert_called_once_with(
+            instance_name=INSTANCE_NAME,
+            location=LOCATION,
+            project_id=PROJECT_ID,
+        )
+        hook.get_pipeline_workflow.assert_called_once_with(
+            pipeline_name=PIPELINE_NAME,
+            pipeline_type=DataFusionPipelineType.BATCH,
+            namespace=NAMESPACE,
+            instance_url=INSTANCE_URL,
+            pipeline_id="completed_pipeline_id",
+        )
+        mock_persist.assert_called_once_with(
+            context=context,
+            uri=SERVICE_URL,
+            namespace=NAMESPACE,
+            pipeline_name=PIPELINE_NAME,
+        )
+
+    @pytest.mark.parametrize(
+        "status",
+        [PipelineStates.FAILED, PipelineStates.KILLED, PipelineStates.REJECTED],
+    )
+    @mock.patch(HOOK_STR)
+    def test_retry_resubmits_after_terminal_pipeline(self, mock_hook, status):
+        hook = self.configure_hook(mock_hook, pipeline_id="new_pipeline_id")
+        hook.get_pipeline_workflow.return_value = {"status": status}
+        task_state_store = FakeTaskStateStore({"datafusion_pipeline_run_id": "failed_pipeline_id"})
+        context = self.make_context(task_state_store)
+        op = self.make_operator()
+
+        result = op.execute(context=context)
+
+        assert result == "new_pipeline_id"
+        assert op.pipeline_id == "new_pipeline_id"
+        assert task_state_store.values == {"datafusion_pipeline_run_id": "new_pipeline_id"}
+        hook.start_pipeline.assert_called_once_with(
+            instance_url=INSTANCE_URL,
+            pipeline_name=PIPELINE_NAME,
+            namespace=NAMESPACE,
+            runtime_args=RUNTIME_ARGS,
+            pipeline_type=DataFusionPipelineType.BATCH,
+        )
+        hook.wait_for_pipeline_state.assert_called_once_with(
+            success_states=[*SUCCESS_STATES, PipelineStates.RUNNING],
+            pipeline_id="new_pipeline_id",
+            pipeline_name=PIPELINE_NAME,
+            pipeline_type=DataFusionPipelineType.BATCH,
+            namespace=NAMESPACE,
+            instance_url=INSTANCE_URL,
+            timeout=300,
+        )
+
+    @mock.patch(HOOK_STR)
+    def test_retry_lookup_error_does_not_submit_another_pipeline(self, mock_hook):
+        hook = self.configure_hook(mock_hook)
+        hook.get_pipeline_workflow.side_effect = RuntimeError("stored run is not visible")
+        context = self.make_context(
+            FakeTaskStateStore({"datafusion_pipeline_run_id": "existing_pipeline_id"})
+        )
+
+        with pytest.raises(RuntimeError, match="stored run is not visible"):
+            self.make_operator().execute(context=context)
+
+        hook.start_pipeline.assert_not_called()
+
+    @mock.patch(HOOK_STR)
+    def test_durable_false_submits_without_task_state_store(self, mock_hook):
+        hook = self.configure_hook(mock_hook, pipeline_id="new_pipeline_id")
+        task_state_store = FakeTaskStateStore({"datafusion_pipeline_run_id": "existing_pipeline_id"})
+        context = self.make_context(task_state_store)
+
+        result = self.make_operator(durable=False).execute(context=context)
+
+        assert result == "new_pipeline_id"
+        assert task_state_store.values == {"datafusion_pipeline_run_id": "existing_pipeline_id"}
+        hook.get_pipeline_workflow.assert_not_called()
+        hook.start_pipeline.assert_called_once()
+
+    @mock.patch(HOOK_STR)
+    def test_asynchronous_execution_does_not_use_recovery(self, mock_hook):
+        hook = self.configure_hook(mock_hook, pipeline_id="new_pipeline_id")
+        task_state_store = FakeTaskStateStore({"datafusion_pipeline_run_id": "existing_pipeline_id"})
+        context = self.make_context(task_state_store)
+
+        result = self.make_operator(asynchronous=True).execute(context=context)
+
+        assert result == "new_pipeline_id"
+        assert task_state_store.values == {"datafusion_pipeline_run_id": "existing_pipeline_id"}
+        hook.get_pipeline_workflow.assert_not_called()
+        hook.wait_for_pipeline_state.assert_not_called()
+
+    @mock.patch(HOOK_STR)
+    def test_deferrable_execution_does_not_use_recovery(self, mock_hook):
+        hook = self.configure_hook(mock_hook, pipeline_id="new_pipeline_id")
+        task_state_store = FakeTaskStateStore({"datafusion_pipeline_run_id": "existing_pipeline_id"})
+        context = self.make_context(task_state_store)
+
+        with pytest.raises(TaskDeferred) as exc:
+            self.make_operator(deferrable=True).execute(context=context)
+
+        assert exc.value.trigger.pipeline_id == "new_pipeline_id"
+        assert task_state_store.values == {"datafusion_pipeline_run_id": "existing_pipeline_id"}
+        hook.get_pipeline_workflow.assert_not_called()
+        hook.wait_for_pipeline_state.assert_not_called()
+
+    @mock.patch(HOOK_STR)
+    def test_streaming_retry_reconnects_running_pipeline(self, mock_hook):
+        hook = self.configure_hook(mock_hook)
+        hook.get_pipeline_workflow.return_value = {"status": PipelineStates.RUNNING}
+        context = self.make_context(
+            FakeTaskStateStore({"datafusion_pipeline_run_id": "existing_pipeline_id"})
+        )
+
+        result = self.make_operator(pipeline_type=DataFusionPipelineType.STREAM).execute(context=context)
+
+        assert result == "existing_pipeline_id"
+        hook.start_pipeline.assert_not_called()
+        hook.get_pipeline_workflow.assert_called_once_with(
+            pipeline_name=PIPELINE_NAME,
+            pipeline_type=DataFusionPipelineType.STREAM,
+            namespace=NAMESPACE,
+            instance_url=INSTANCE_URL,
+            pipeline_id="existing_pipeline_id",
+        )
+        hook.wait_for_pipeline_state.assert_called_once_with(
+            success_states=[*SUCCESS_STATES, PipelineStates.RUNNING],
+            pipeline_id="existing_pipeline_id",
+            pipeline_name=PIPELINE_NAME,
+            pipeline_type=DataFusionPipelineType.STREAM,
+            namespace=NAMESPACE,
+            instance_url=INSTANCE_URL,
+            timeout=300,
+        )
+
+    @mock.patch(HOOK_STR)
+    def test_on_kill_stops_only_recovered_pipeline_run(self, mock_hook):
+        hook = self.configure_hook(mock_hook)
+        hook.get_pipeline_workflow.return_value = {"status": PipelineStates.RUNNING}
+        context = self.make_context(
+            FakeTaskStateStore({"datafusion_pipeline_run_id": "existing_pipeline_id"})
+        )
+        op = self.make_operator()
+        hook.wait_for_pipeline_state.side_effect = lambda **kwargs: op.on_kill()
+
+        op.execute(context=context)
+
+        hook.stop_pipeline.assert_called_once_with(
+            instance_url=INSTANCE_URL,
+            pipeline_name=PIPELINE_NAME,
+            namespace=NAMESPACE,
+            pipeline_type=DataFusionPipelineType.BATCH,
+            run_id="existing_pipeline_id",
+        )
+
+    def test_default_args_durable_reaches_operator(self):
+        op = self.make_operator(default_args={"durable": False})
+
+        assert op.durable is False
 
     @mock.patch(HOOK_STR)
     def test_execute_check_hook_call_asynch_param_should_execute_successfully(self, mock_hook):
@@ -471,6 +754,23 @@ class TestCloudDataFusionStartPipelineOperatorAsync:
         assert facet.runtimeArgs == expected_runtime_args
 
         assert results.job_facets == {}
+
+
+class TestWarnAndDisableDurableAirflowPre3_3:
+    def test_no_warning_when_unset(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = _warn_and_disable_durable_pre_3_3(_DURABLE_UNSET)
+
+        assert result is False
+        assert caught == []
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_warns_and_disables_when_explicitly_set(self, value):
+        with pytest.warns(UserWarning, match="durable.*no effect"):
+            result = _warn_and_disable_durable_pre_3_3(value)
+
+        assert result is False
 
 
 class TestCloudDataFusionStopPipelineOperator:

--- a/providers/google/tests/unit/google/cloud/operators/test_datafusion.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_datafusion.py
@@ -145,6 +145,7 @@ class TestCloudDataFusionCreateInstanceOperator:
 
 
 class TestCloudDataFusionDeleteInstanceOperator:
+    @mock.patch("airflow.providers.google.cloud.links.base.AIRFLOW_V_3_0_PLUS", False)
     @mock.patch(HOOK_STR)
     def test_execute_check_hook_call_should_execute_successfully(self, mock_hook):
         op = CloudDataFusionDeleteInstanceOperator(
@@ -254,10 +255,18 @@ class TestCloudDataFusionStartPipelineOperator:
         return op
 
     @staticmethod
-    def make_context(task_state_store: FakeTaskStateStore) -> dict[str, Any]:
+    def make_context(
+        task_state_store: FakeTaskStateStore,
+        *,
+        task: CloudDataFusionStartPipelineOperator | None = None,
+    ) -> dict[str, Any]:
         task_instance = mock.MagicMock()
         task_instance.stats_tags = {}
-        return {"task_state_store": task_state_store, "ti": task_instance}
+        return {
+            "task": task if task is not None else mock.MagicMock(extra_links_params={}),
+            "task_state_store": task_state_store,
+            "ti": task_instance,
+        }
 
     @staticmethod
     def configure_hook(mock_hook: mock.MagicMock, pipeline_id: str = PIPELINE_ID) -> mock.MagicMock:
@@ -288,7 +297,8 @@ class TestCloudDataFusionStartPipelineOperator:
         )
         op.dag = mock.MagicMock(spec=DAG, task_dict={}, dag_id="test")
 
-        op.execute(context=self.make_context(FakeTaskStateStore()))
+        context = self.make_context(FakeTaskStateStore(), task=op)
+        op.execute(context=context)
         mock_hook.return_value.get_instance.assert_called_once_with(
             instance_name=INSTANCE_NAME, location=LOCATION, project_id=PROJECT_ID
         )
@@ -309,6 +319,14 @@ class TestCloudDataFusionStartPipelineOperator:
             namespace=NAMESPACE,
             instance_url=INSTANCE_URL,
             timeout=300,
+        )
+        context["ti"].xcom_push.assert_called_once_with(
+            key="pipeline_conf",
+            value={
+                "namespace": NAMESPACE,
+                "pipeline_name": PIPELINE_NAME,
+                "uri": INSTANCE_URL,
+            },
         )
 
     @REQUIRES_TASK_STATE_STORE


### PR DESCRIPTION
## Why

If a worker exits after starting a synchronous Data Fusion pipeline, the retry starts another run while the first one keeps running.

The retry now reconnects with the stored `runId`. Completed runs return without another submission. Failed, killed, or rejected runs start fresh.

## What

The synchronous polling path uses AIP-103's `ResumableJobMixin`. It stores the exact `runId` before polling and restores that run with `get_pipeline_workflow`. Lookup errors stop the task rather than risk a duplicate.

Asynchronous and deferrable execution keep their existing submission behavior. Airflow versions before 3.3 also keep the non-durable path.

## Tests

<details>
<summary>Task-state red/green proof</summary>

```console
$ AIRFLOW_HOME=/tmp/airflow-datafusion-e2e-base .venv/bin/uv run --project providers/google python dev/datafusion_resumability_e2e.py --git-ref upstream/main --expect-recovery
retry_result=run-002 completed_result=run-003 submissions=3 polls=3
store_events=
recovery=FAIL

$ AIRFLOW_HOME=/tmp/airflow-datafusion-e2e-current .venv/bin/uv run --project providers/google python dev/datafusion_resumability_e2e.py --expect-recovery
retry_result=run-001 completed_result=run-001 submissions=1 polls=2
store_events=GET datafusion_pipeline_run_id=None | SET datafusion_pipeline_run_id=run-001 | GET datafusion_pipeline_run_id=run-001 | GET datafusion_pipeline_run_id=run-001
recovery=PASS

red_status=1 green_status=0
```
</details>

## Risk

Only synchronous polling uses recovery. Unknown nonterminal states reconnect, and exact-run lookup failures propagate.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes, GitHub Copilot CLI (GPT-5.6 Sol)

Generated-by: GitHub Copilot CLI (GPT-5.6 Sol) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
