### PR TITLE
Prevent duplicate OpenAI batches on task retry

### DIFF
--- a/providers/openai/src/airflow/providers/openai/operators/openai.py
+++ b/providers/openai/src/airflow/providers/openai/operators/openai.py
@@ -17,16 +17,62 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Sequence
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from airflow.providers.common.compat.sdk import BaseOperator, conf
 from airflow.providers.openai.exceptions import OpenAIBatchJobException
-from airflow.providers.openai.hooks.openai import OpenAIHook, validate_execute_complete_event
+from airflow.providers.openai.hooks.openai import BatchStatus, OpenAIHook, validate_execute_complete_event
 from airflow.providers.openai.triggers.openai import OpenAIBatchTrigger
 
+_DURABLE_UNSET: object = object()
+
+
+def _warn_and_disable_durable_pre_3_3(durable: Any) -> bool:
+    """Disable unsupported durable mode and warn when explicitly requested."""
+    if durable is not _DURABLE_UNSET:
+        warnings.warn(
+            "`durable` has no effect on Airflow versions below 3.3.",
+            UserWarning,
+            stacklevel=3,
+        )
+    return False
+
+
+# ResumableJobMixin requires Airflow 3.3; this provider still supports Airflow 2.11.
+try:
+    from airflow.sdk import ResumableJobMixin
+except ImportError:
+
+    class ResumableJobMixin:  # type: ignore[no-redef]
+        """Airflow <3.3 stub that always submits a fresh job."""
+
+        external_id_key: str = "openai_batch_id"
+
+        def __init__(self, *, durable: Any = _DURABLE_UNSET, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+            self.durable = _warn_and_disable_durable_pre_3_3(durable)
+
+        def execute_resumable(self, context: Any) -> Any:
+            external_id: Any = self.submit_job(context=context)
+            self.poll_until_complete(external_id=external_id, context=context)
+            return self.get_job_result(external_id=external_id, context=context)
+
+        def submit_job(self, context: Any) -> Any:
+            raise NotImplementedError
+
+        def poll_until_complete(self, external_id: Any, context: Any) -> None:
+            raise NotImplementedError
+
+        def get_job_result(self, external_id: Any, context: Any) -> Any:
+            raise NotImplementedError
+
+
 if TYPE_CHECKING:
+    from pydantic import JsonValue
+
     from airflow.providers.common.compat.sdk import Context
 
 
@@ -134,7 +180,7 @@ class OpenAIResponseOperator(BaseOperator):
         return response.output_text
 
 
-class OpenAITriggerBatchOperator(BaseOperator):
+class OpenAITriggerBatchOperator(ResumableJobMixin, BaseOperator):
     """
     Operator that triggers an OpenAI Batch API endpoint and waits for the batch to complete.
 
@@ -148,6 +194,9 @@ class OpenAITriggerBatchOperator(BaseOperator):
         Only used when ``deferrable`` is False. Defaults to 24 hour, which is the SLA for OpenAI Batch API.
     :param wait_for_completion: Optional. Whether to wait for the batch to complete. If set to False, the operator
         will return immediately after triggering the batch. Defaults to True.
+    :param durable: When True (the default) and waiting synchronously, persist the OpenAI batch ID before
+        polling so a worker crash reconnects to the existing batch on retry. Requires Airflow 3.3+; this
+        option has no effect on earlier versions.
 
     .. seealso::
         For more information on how to use this operator, please take a look at the guide:
@@ -155,6 +204,7 @@ class OpenAITriggerBatchOperator(BaseOperator):
     """
 
     template_fields: Sequence[str] = ("file_id",)
+    external_id_key: str = "openai_batch_id"
 
     def __init__(
         self,
@@ -165,8 +215,11 @@ class OpenAITriggerBatchOperator(BaseOperator):
         wait_seconds: float = 3,
         timeout: float = 24 * 60 * 60,
         wait_for_completion: bool = True,
+        durable: bool | None = None,
         **kwargs: Any,
-    ):
+    ) -> None:
+        if durable is not None:
+            kwargs["durable"] = durable
         super().__init__(**kwargs)
         self.conn_id = conn_id
         self.file_id = file_id
@@ -183,23 +236,50 @@ class OpenAITriggerBatchOperator(BaseOperator):
         return OpenAIHook(conn_id=self.conn_id)
 
     def execute(self, context: Context) -> str | None:
+        if self.wait_for_completion and not self.deferrable:
+            self.execute_resumable(context)
+            return self.batch_id
+
+        batch_id = self.submit_job(context)
+        if self.wait_for_completion:
+            self.defer(
+                timeout=self.execution_timeout,
+                trigger=OpenAIBatchTrigger(
+                    conn_id=self.conn_id,
+                    batch_id=batch_id,
+                    poll_interval=60,
+                    timeout=self.timeout,
+                ),
+                method_name="execute_complete",
+            )
+        return batch_id
+
+    def submit_job(self, context: Context) -> str:
         batch = self.hook.create_batch(file_id=self.file_id, endpoint=self.endpoint)
         self.batch_id = batch.id
-        if self.wait_for_completion:
-            if self.deferrable:
-                self.defer(
-                    timeout=self.execution_timeout,
-                    trigger=OpenAIBatchTrigger(
-                        conn_id=self.conn_id,
-                        batch_id=self.batch_id,
-                        poll_interval=60,
-                        timeout=self.timeout,
-                    ),
-                    method_name="execute_complete",
-                )
-            else:
-                self.log.info("Waiting for batch %s to complete", self.batch_id)
-                self.hook.wait_for_batch(self.batch_id, wait_seconds=self.wait_seconds, timeout=self.timeout)
+        return self.batch_id
+
+    def get_job_status(self, external_id: JsonValue, context: Context) -> str:
+        self.batch_id = cast("str", external_id)
+        return self.hook.get_batch(batch_id=self.batch_id).status
+
+    def is_job_active(self, status: str) -> bool:
+        return BatchStatus.is_in_progress(status)
+
+    def is_job_succeeded(self, status: str) -> bool:
+        return status == BatchStatus.COMPLETED
+
+    def poll_until_complete(self, external_id: JsonValue, context: Context) -> None:
+        self.batch_id = cast("str", external_id)
+        self.log.info("Waiting for batch %s to complete", self.batch_id)
+        self.hook.wait_for_batch(
+            batch_id=self.batch_id,
+            wait_seconds=self.wait_seconds,
+            timeout=self.timeout,
+        )
+
+    def get_job_result(self, external_id: JsonValue, context: Context) -> str:
+        self.batch_id = cast("str", external_id)
         return self.batch_id
 
     def execute_complete(self, context: Context, event: Any = None) -> str:
@@ -220,4 +300,4 @@ class OpenAITriggerBatchOperator(BaseOperator):
         """Cancel the batch if task is cancelled."""
         if self.batch_id:
             self.log.info("on_kill: cancel the OpenAI Batch %s", self.batch_id)
-            self.hook.cancel_batch(self.batch_id)
+            self.hook.cancel_batch(batch_id=self.batch_id)

--- a/providers/openai/src/airflow/providers/openai/operators/openai.py
+++ b/providers/openai/src/airflow/providers/openai/operators/openai.py
@@ -22,12 +22,15 @@ from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Literal, cast
 
+from openai import NotFoundError
+
 from airflow.providers.common.compat.sdk import BaseOperator, conf
 from airflow.providers.openai.exceptions import OpenAIBatchJobException
 from airflow.providers.openai.hooks.openai import BatchStatus, OpenAIHook, validate_execute_complete_event
 from airflow.providers.openai.triggers.openai import OpenAIBatchTrigger
 
 _DURABLE_UNSET: object = object()
+_MISSING_BATCH_STATUS: str = "missing"
 
 
 def _warn_and_disable_durable_pre_3_3(durable: Any) -> bool:
@@ -261,7 +264,10 @@ class OpenAITriggerBatchOperator(ResumableJobMixin, BaseOperator):
 
     def get_job_status(self, external_id: JsonValue, context: Context) -> str:
         self.batch_id = cast("str", external_id)
-        return self.hook.get_batch(batch_id=self.batch_id).status
+        try:
+            return self.hook.get_batch(batch_id=self.batch_id).status
+        except NotFoundError:
+            return _MISSING_BATCH_STATUS
 
     def is_job_active(self, status: str) -> bool:
         return BatchStatus.is_in_progress(status)

--- a/providers/openai/tests/unit/openai/operators/test_openai.py
+++ b/providers/openai/tests/unit/openai/operators/test_openai.py
@@ -23,6 +23,7 @@ from types import ModuleType
 from typing import Any
 from unittest.mock import Mock
 
+import httpx
 import pytest
 from openai.types.batch import Batch
 from openai.types.responses import Response
@@ -271,6 +272,38 @@ class TestOpenAITriggerBatchOperatorResumable:
             wait_seconds=operator.wait_seconds,
             timeout=operator.timeout,
         )
+
+    def test_retry_submits_fresh_when_persisted_batch_is_missing(self) -> None:
+        operator = self._operator()
+        operator.hook = hook = self._hook()
+        store = FakeTaskStateStore({"openai_batch_id": BATCH_ID})
+        request = httpx.Request(method="GET", url=f"https://api.openai.com/v1/batches/{BATCH_ID}")
+        hook.get_batch.side_effect = openai.NotFoundError(
+            "Batch not found",
+            response=httpx.Response(status_code=404, request=request),
+            body={"error": {"message": "Batch not found"}},
+        )
+
+        result = operator.execute(self._context(store))
+
+        assert result == NEW_BATCH_ID
+        assert store.values["openai_batch_id"] == NEW_BATCH_ID
+        hook.create_batch.assert_called_once_with(file_id=FILE_ID, endpoint=BATCH_ENDPOINT)
+
+    def test_retry_propagates_other_api_errors(self) -> None:
+        operator = self._operator()
+        operator.hook = hook = self._hook()
+        store = FakeTaskStateStore({"openai_batch_id": BATCH_ID})
+        error = openai.APIConnectionError(
+            request=httpx.Request(method="GET", url=f"https://api.openai.com/v1/batches/{BATCH_ID}")
+        )
+        hook.get_batch.side_effect = error
+
+        with pytest.raises(openai.APIConnectionError) as exc_info:
+            operator.execute(self._context(store))
+
+        assert exc_info.value is error
+        hook.create_batch.assert_not_called()
 
     def test_durable_false_submits_fresh_without_touching_store(self):
         operator = self._operator(durable=False)

--- a/providers/openai/tests/unit/openai/operators/test_openai.py
+++ b/providers/openai/tests/unit/openai/operators/test_openai.py
@@ -20,7 +20,7 @@ import importlib
 import sys
 import warnings
 from types import ModuleType
-from typing import Any
+from typing import Any, Literal, cast
 from unittest.mock import Mock
 
 import httpx
@@ -47,7 +47,7 @@ CONN_ID = "test_conn_id"
 BATCH_ID = "batch_id"
 NEW_BATCH_ID = "new_batch_id"
 FILE_ID = "file_id"
-BATCH_ENDPOINT = "/v1/chat/completions"
+BATCH_ENDPOINT: Literal["/v1/chat/completions"] = "/v1/chat/completions"
 
 
 @pytest.fixture
@@ -196,8 +196,8 @@ class TestOpenAITriggerBatchOperatorResumable:
         hook.get_batch.return_value = Mock(spec=Batch, status=status)
         return hook
 
-    def _context(self, store: FakeTaskStateStore) -> dict[str, Any]:
-        return {"task_state_store": store, "ti": Mock(stats_tags={})}
+    def _context(self, store: FakeTaskStateStore) -> Context:
+        return cast("Context", {"task_state_store": store, "ti": Mock(stats_tags={})})
 
     def test_first_run_persists_batch_id_before_waiting(self):
         operator = self._operator()

--- a/providers/openai/tests/unit/openai/operators/test_openai.py
+++ b/providers/openai/tests/unit/openai/operators/test_openai.py
@@ -16,6 +16,11 @@
 # under the License.
 from __future__ import annotations
 
+import importlib
+import sys
+import warnings
+from types import ModuleType
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
@@ -24,7 +29,8 @@ from openai.types.responses import Response
 
 from airflow.providers.common.compat.sdk import Context, TaskDeferred
 from airflow.providers.openai.exceptions import OpenAIBatchJobException, OpenAITriggerEventError
-from airflow.providers.openai.hooks.openai import OpenAIHook
+from airflow.providers.openai.hooks.openai import BatchStatus, OpenAIHook
+from airflow.providers.openai.operators import openai as openai_operators
 from airflow.providers.openai.operators.openai import (
     OpenAIEmbeddingOperator,
     OpenAIResponseOperator,
@@ -32,10 +38,13 @@ from airflow.providers.openai.operators.openai import (
 )
 from airflow.providers.openai.triggers.openai import OpenAIBatchTrigger
 
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_3_PLUS
+
 openai = pytest.importorskip("openai")
 TASK_ID = "TaskId"
 CONN_ID = "test_conn_id"
 BATCH_ID = "batch_id"
+NEW_BATCH_ID = "new_batch_id"
 FILE_ID = "file_id"
 BATCH_ENDPOINT = "/v1/chat/completions"
 
@@ -148,6 +157,227 @@ def test_openai_trigger_batch_operator_with_deferred(mock_batch, wait_for_comple
     else:
         batch_id = operator.execute(context)
         assert batch_id == BATCH_ID
+
+
+class FakeTaskStateStore:
+    def __init__(self, stored: dict[str, Any] | None = None) -> None:
+        self.values: dict[str, Any] = dict(stored or {})
+        self.get_keys: list[str] = []
+        self.set_items: list[tuple[str, Any]] = []
+
+    def get(self, key: str) -> Any:
+        self.get_keys.append(key)
+        return self.values.get(key)
+
+    def set(self, key: str, value: Any) -> None:
+        self.set_items.append((key, value))
+        self.values[key] = value
+
+
+@pytest.mark.skipif(
+    not AIRFLOW_V_3_3_PLUS,
+    reason="ResumableJobMixin requires task_state_store, available in Airflow 3.3+",
+)
+class TestOpenAITriggerBatchOperatorResumable:
+    def _operator(self, **kwargs: Any) -> OpenAITriggerBatchOperator:
+        return OpenAITriggerBatchOperator(
+            task_id=TASK_ID,
+            conn_id=CONN_ID,
+            file_id=FILE_ID,
+            endpoint=BATCH_ENDPOINT,
+            deferrable=False,
+            **kwargs,
+        )
+
+    def _hook(self, *, status: str = BatchStatus.IN_PROGRESS) -> Mock:
+        hook = Mock(spec=OpenAIHook)
+        hook.create_batch.return_value = Mock(spec=Batch, id=NEW_BATCH_ID)
+        hook.get_batch.return_value = Mock(spec=Batch, status=status)
+        return hook
+
+    def _context(self, store: FakeTaskStateStore) -> dict[str, Any]:
+        return {"task_state_store": store, "ti": Mock(stats_tags={})}
+
+    def test_first_run_persists_batch_id_before_waiting(self):
+        operator = self._operator()
+        operator.hook = hook = self._hook()
+        store = FakeTaskStateStore()
+        persisted_before_wait: list[Any] = []
+        hook.wait_for_batch.side_effect = lambda *_, **__: persisted_before_wait.append(
+            store.values.get("openai_batch_id")
+        )
+
+        result = operator.execute(self._context(store))
+
+        assert result == NEW_BATCH_ID
+        assert persisted_before_wait == [NEW_BATCH_ID]
+        hook.create_batch.assert_called_once_with(file_id=FILE_ID, endpoint=BATCH_ENDPOINT)
+
+    @pytest.mark.parametrize(
+        "status",
+        [BatchStatus.VALIDATING, BatchStatus.IN_PROGRESS, BatchStatus.FINALIZING],
+    )
+    def test_retry_reconnects_active_batch_and_restores_on_kill(self, status):
+        operator = self._operator()
+        operator.hook = hook = self._hook(status=status)
+        store = FakeTaskStateStore({"openai_batch_id": BATCH_ID})
+        batch_id_before_lookup: list[str | None] = []
+        hook.get_batch.side_effect = lambda **_: (
+            batch_id_before_lookup.append(operator.batch_id) or Mock(spec=Batch, status=status)
+        )
+
+        result = operator.execute(self._context(store))
+        operator.on_kill()
+
+        assert result == BATCH_ID
+        assert batch_id_before_lookup == [BATCH_ID]
+        assert operator.batch_id == BATCH_ID
+        hook.create_batch.assert_not_called()
+        hook.wait_for_batch.assert_called_once_with(
+            batch_id=BATCH_ID,
+            wait_seconds=operator.wait_seconds,
+            timeout=operator.timeout,
+        )
+        hook.cancel_batch.assert_called_once_with(batch_id=BATCH_ID)
+
+    def test_retry_returns_completed_batch_without_waiting(self):
+        operator = self._operator()
+        operator.hook = hook = self._hook(status=BatchStatus.COMPLETED)
+        store = FakeTaskStateStore({"openai_batch_id": BATCH_ID})
+
+        result = operator.execute(self._context(store))
+
+        assert result == BATCH_ID
+        assert operator.batch_id == BATCH_ID
+        hook.create_batch.assert_not_called()
+        hook.wait_for_batch.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "status",
+        [BatchStatus.FAILED, BatchStatus.EXPIRED, BatchStatus.CANCELLING, BatchStatus.CANCELLED],
+    )
+    def test_retry_submits_fresh_after_terminal_batch(self, status):
+        operator = self._operator()
+        operator.hook = hook = self._hook(status=status)
+        store = FakeTaskStateStore({"openai_batch_id": BATCH_ID})
+
+        result = operator.execute(self._context(store))
+
+        assert result == NEW_BATCH_ID
+        assert store.values["openai_batch_id"] == NEW_BATCH_ID
+        hook.create_batch.assert_called_once_with(file_id=FILE_ID, endpoint=BATCH_ENDPOINT)
+        hook.wait_for_batch.assert_called_once_with(
+            batch_id=NEW_BATCH_ID,
+            wait_seconds=operator.wait_seconds,
+            timeout=operator.timeout,
+        )
+
+    def test_durable_false_submits_fresh_without_touching_store(self):
+        operator = self._operator(durable=False)
+        operator.hook = hook = self._hook()
+        store = FakeTaskStateStore({"openai_batch_id": BATCH_ID})
+
+        result = operator.execute(self._context(store))
+
+        assert result == NEW_BATCH_ID
+        assert store.get_keys == []
+        assert store.set_items == []
+        hook.create_batch.assert_called_once_with(file_id=FILE_ID, endpoint=BATCH_ENDPOINT)
+
+    def test_default_args_durable_reaches_operator(self):
+        operator = OpenAITriggerBatchOperator(
+            task_id=TASK_ID,
+            conn_id=CONN_ID,
+            file_id=FILE_ID,
+            endpoint=BATCH_ENDPOINT,
+            default_args={"durable": False},
+        )
+
+        assert operator.durable is False
+
+
+@pytest.mark.parametrize("deferrable", [False, True])
+def test_fire_and_forget_does_not_use_task_state_store(deferrable):
+    operator = OpenAITriggerBatchOperator(
+        task_id=TASK_ID,
+        conn_id=CONN_ID,
+        file_id=FILE_ID,
+        endpoint=BATCH_ENDPOINT,
+        deferrable=deferrable,
+        wait_for_completion=False,
+    )
+    operator.hook = hook = Mock(spec=OpenAIHook)
+    hook.create_batch.return_value = Mock(spec=Batch, id=NEW_BATCH_ID)
+    store = FakeTaskStateStore({"openai_batch_id": BATCH_ID})
+
+    result = operator.execute({"task_state_store": store})
+
+    assert result == NEW_BATCH_ID
+    assert store.get_keys == []
+    assert store.set_items == []
+    hook.wait_for_batch.assert_not_called()
+
+
+def test_deferrable_wait_does_not_use_task_state_store():
+    operator = OpenAITriggerBatchOperator(
+        task_id=TASK_ID,
+        conn_id=CONN_ID,
+        file_id=FILE_ID,
+        endpoint=BATCH_ENDPOINT,
+        deferrable=True,
+    )
+    operator.hook = hook = Mock(spec=OpenAIHook)
+    hook.create_batch.return_value = Mock(spec=Batch, id=NEW_BATCH_ID)
+    store = FakeTaskStateStore({"openai_batch_id": BATCH_ID})
+
+    with pytest.raises(TaskDeferred):
+        operator.execute({"task_state_store": store})
+
+    assert store.get_keys == []
+    assert store.set_items == []
+
+
+class TestWarnAndDisableDurableAirflowPre3_3:
+    def test_no_warning_when_unset(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = openai_operators._warn_and_disable_durable_pre_3_3(openai_operators._DURABLE_UNSET)
+        assert result is False
+        assert caught == []
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_warns_and_disables_when_explicitly_set(self, value):
+        with pytest.warns(UserWarning, match="durable.*no effect"):
+            result = openai_operators._warn_and_disable_durable_pre_3_3(value)
+        assert result is False
+
+    def test_operator_submits_without_resumable_mixin(self, monkeypatch, mock_batch):
+        try:
+            with monkeypatch.context() as patch:
+                patch.setitem(sys.modules, "airflow.sdk", ModuleType("airflow.sdk"))
+                compatibility_module = importlib.reload(openai_operators)
+                with pytest.warns(UserWarning, match="durable.*no effect"):
+                    operator = compatibility_module.OpenAITriggerBatchOperator(
+                        task_id=TASK_ID,
+                        conn_id=CONN_ID,
+                        file_id=FILE_ID,
+                        endpoint=BATCH_ENDPOINT,
+                        durable=True,
+                    )
+                operator.hook = hook = Mock(spec=OpenAIHook)
+                hook.create_batch.return_value = mock_batch
+
+                result = operator.execute(Context())
+        finally:
+            importlib.reload(openai_operators)
+
+        assert result == BATCH_ID
+        hook.create_batch.assert_called_once_with(file_id=FILE_ID, endpoint=BATCH_ENDPOINT)
+        hook.wait_for_batch.assert_called_once_with(
+            batch_id=BATCH_ID,
+            wait_seconds=operator.wait_seconds,
+            timeout=operator.timeout,
+        )
 
 
 class TestOpenAITriggerBatchOperatorExecuteComplete:


### PR DESCRIPTION
A synchronous OpenAI Batch task can keep running after its worker exits. A retry then submits another batch because its ID existed only in memory.

Synchronous waits now persist the ID through `ResumableJobMixin`. Retries reconnect active or completed batches and resubmit after failed, expired, or cancelled states, or when the saved batch no longer exists. Deferrable and fire-and-forget paths are unchanged. Airflow versions before 3.3 keep legacy behavior and warn on explicit `durable`.

## Testing

<details>
<summary>Red regression and task-state retry proof</summary>

```console
$ uv run --project providers/openai pytest providers/openai/tests/unit/openai/operators/test_openai.py -xvs
E   AssertionError: assert equals failed
E     -[None]
E     +['new_batch_id']
1 failed, 9 passed

$ E2E_MODE=legacy uv run --project providers/openai python dev/openai_e2e_dags/openai_resumable_e2e.py
RuntimeError: simulated worker loss after batch submission
mode=legacy state=success submissions=2 waits=2 stored_batch_id=None

$ E2E_MODE=current uv run --project providers/openai python dev/openai_e2e_dags/openai_resumable_e2e.py
RuntimeError: simulated worker loss after batch submission
Reconnecting to existing job external_id=batch-1 external_id_key=openai_batch_id status=in_progress
mode=current state=success submissions=1 waits=2 stored_batch_id=batch-1

$ uv run --project providers/openai pytest providers/openai/tests/unit/openai/operators/test_openai.py::TestOpenAITriggerBatchOperatorResumable::test_retry_submits_fresh_when_persisted_batch_is_missing -xvs --skip-db-tests
E   openai.NotFoundError: Batch not found
1 failed

$ uv run --project providers/openai pytest providers/openai/tests/unit/openai/operators/test_openai.py::TestOpenAITriggerBatchOperatorResumable::test_retry_submits_fresh_when_persisted_batch_is_missing providers/openai/tests/unit/openai/operators/test_openai.py::TestOpenAITriggerBatchOperatorResumable::test_retry_propagates_other_api_errors -xvs --skip-db-tests
2 passed

$ uv run --project providers/openai pytest providers/openai/tests/unit/openai --skip-db-tests -q
133 passed, 1 warning in 20.52s
```

</details>

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (GitHub Copilot CLI, GPT-5.6 Sol)

Generated-by: GitHub Copilot CLI (GPT-5.6 Sol) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
