### PR TITLE
Recover Dataproc jobs after worker crashes

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/dataproc.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/dataproc.py
@@ -65,12 +65,54 @@ from airflow.providers.google.cloud.utils.dataproc import DataprocOperationType
 from airflow.providers.google.common.hooks.base_google import PROVIDE_PROJECT_ID
 from airflow.triggers.base import StartTriggerArgs
 
+_DURABLE_UNSET = object()
+
+
+def _warn_and_disable_durable_pre_3_3(durable: Any) -> bool:
+    if durable is not _DURABLE_UNSET:
+        warnings.warn(
+            "`durable` has no effect on Airflow versions below 3.3.",
+            UserWarning,
+            stacklevel=3,
+        )
+    return False
+
+
+try:
+    from airflow.sdk import ResumableJobMixin
+except ImportError:
+
+    class ResumableJobMixin:  # type: ignore[no-redef]
+        """Airflow <3.3 compatibility stub without durable recovery."""
+
+        external_id_key: str = "dataproc_job_id"
+
+        def __init__(self, *, durable: Any = _DURABLE_UNSET, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+            self.durable = _warn_and_disable_durable_pre_3_3(durable)
+
+        def execute_resumable(self, context: Any) -> Any:
+            external_id = self.submit_job(context)
+            self.poll_until_complete(external_id, context)
+            return self.get_job_result(external_id, context)
+
+        def submit_job(self, context: Any) -> Any:
+            raise NotImplementedError
+
+        def poll_until_complete(self, external_id: Any, context: Any) -> None:
+            raise NotImplementedError
+
+        def get_job_result(self, external_id: Any, context: Any) -> Any:
+            raise NotImplementedError
+
+
 if TYPE_CHECKING:
     from google.api_core import operation
     from google.api_core.retry_async import AsyncRetry
     from google.protobuf.duration_pb2 import Duration
     from google.protobuf.field_mask_pb2 import FieldMask
     from google.type.interval_pb2 import Interval
+    from pydantic import JsonValue
 
     from airflow.providers.common.compat.sdk import Context
 
@@ -1893,7 +1935,7 @@ class DataprocInstantiateInlineWorkflowTemplateOperator(GoogleCloudBaseOperator)
             )
 
 
-class DataprocSubmitJobOperator(GoogleCloudBaseOperator):
+class DataprocSubmitJobOperator(ResumableJobMixin, GoogleCloudBaseOperator):
     """
     Submit a job to a cluster.
 
@@ -1928,6 +1970,10 @@ class DataprocSubmitJobOperator(GoogleCloudBaseOperator):
     :param deferrable: Run operator in the deferrable mode
     :param polling_interval_seconds: time in seconds between polling for job completion.
         The value is considered only when running in deferrable mode. Must be greater than 0.
+    :param durable: When ``True`` (the default), the submitted Dataproc job ID is persisted to task
+        state before polling begins. A worker crash and retry reconnects to the existing job instead
+        of submitting another one. Set to ``False`` to always submit fresh on retry. Synchronous
+        mode only. Requires Airflow 3.3+; no-op on earlier versions.
     :param cancel_on_kill: Flag which indicates whether cancel the hook's job or not, when on_kill is called
     :param wait_timeout: How many seconds wait for job to be ready. Used only if ``asynchronous`` is False
     :param start_from_trigger: If True and deferrable is True, the operator will start directly
@@ -1945,6 +1991,7 @@ class DataprocSubmitJobOperator(GoogleCloudBaseOperator):
     template_fields_renderers = {"job": "json"}
 
     operator_extra_links = (DataprocJobLink(),)
+    external_id_key = "dataproc_job_id"
 
     start_trigger_args = StartTriggerArgs(
         trigger_cls="airflow.providers.google.cloud.triggers.dataproc.DataprocSubmitJobDirectTrigger",
@@ -1979,8 +2026,11 @@ class DataprocSubmitJobOperator(GoogleCloudBaseOperator):
         openlineage_inject_transport_info: bool = conf.getboolean(
             "openlineage", "spark_inject_transport_info", fallback=False
         ),
-        **kwargs,
+        durable: bool | None = None,
+        **kwargs: Any,
     ) -> None:
+        if durable is not None:
+            kwargs["durable"] = durable
         super().__init__(**kwargs)
         if deferrable and polling_interval_seconds <= 0:
             raise ValueError("Invalid value for polling_interval_seconds. Expected value greater than 0")
@@ -2022,37 +2072,19 @@ class DataprocSubmitJobOperator(GoogleCloudBaseOperator):
                 timeout=None,
             )
 
-    def execute(self, context: Context):
-        self.log.info("Submitting job")
-        self.hook = DataprocHook(gcp_conn_id=self.gcp_conn_id, impersonation_chain=self.impersonation_chain)
+    def execute(self, context: Context) -> str | None:
+        hook = self._get_hook()
         if self.openlineage_inject_parent_job_info or self.openlineage_inject_transport_info:
             self.log.info("Automatic injection of OpenLineage information into Spark properties is enabled.")
             self._inject_openlineage_properties_into_dataproc_job(context)
 
-        job_object = self.hook.submit_job(
-            project_id=self.project_id,
-            region=self.region,
-            job=self.job,
-            request_id=self.request_id,
-            retry=self.retry,
-            timeout=self.timeout,
-            metadata=self.metadata,
-        )
-        new_job_id: str = job_object.reference.job_id
-        self.log.info("Job %s submitted successfully.", new_job_id)
-        # Save data required by extra links no matter what the job status will be
-        project_id = self.project_id or self.hook.project_id
-        if project_id:
-            DataprocJobLink.persist(
-                context=context,
-                job_id=new_job_id,
-                region=self.region,
-                project_id=project_id,
-            )
+        if not self.deferrable and not self.asynchronous:
+            self.execute_resumable(context)
+            return self.job_id
 
-        self.job_id = new_job_id
+        self.job_id = self.submit_job(context)
         if self.deferrable:
-            job = self.hook.get_job(project_id=self.project_id, region=self.region, job_id=self.job_id)
+            job = hook.get_job(project_id=self.project_id, region=self.region, job_id=self.job_id)
             state = job.status.state
             if state == JobStatus.State.DONE:
                 return self.job_id
@@ -2072,13 +2104,88 @@ class DataprocSubmitJobOperator(GoogleCloudBaseOperator):
                 ),
                 method_name="execute_complete",
             )
-        elif not self.asynchronous:
-            self.log.info("Waiting for job %s to complete", new_job_id)
-            self.hook.wait_for_job(
-                job_id=new_job_id, region=self.region, project_id=self.project_id, timeout=self.wait_timeout
-            )
-            self.log.info("Job %s completed successfully.", new_job_id)
         return self.job_id
+
+    def submit_job(self, context: Context) -> str:
+        self.log.info("Submitting job")
+        hook = self._get_hook()
+        job_object = hook.submit_job(
+            project_id=self.project_id,
+            region=self.region,
+            job=self.job,
+            request_id=self.request_id,
+            retry=self.retry,
+            timeout=self.timeout,
+            metadata=self.metadata,
+        )
+        new_job_id: str = job_object.reference.job_id
+        self.log.info("Job %s submitted successfully.", new_job_id)
+        self.job_id = new_job_id
+        self._persist_job_link(context=context, job_id=new_job_id)
+        return new_job_id
+
+    def get_job_status(self, external_id: JsonValue, context: Context) -> str:
+        job_id = str(external_id)
+        self.job_id = job_id
+        hook = self._get_hook()
+        try:
+            job = hook.get_job(
+                job_id=job_id,
+                project_id=self.project_id,
+                region=self.region,
+                retry=self.retry,
+                timeout=self.timeout,
+                metadata=self.metadata,
+            )
+        except NotFound:
+            return "not_found"
+        self._persist_job_link(context=context, job_id=job_id)
+        return JobStatus.State(job.status.state).name
+
+    def is_job_active(self, status: str) -> bool:
+        return status not in (
+            JobStatus.State(JobStatus.State.DONE).name,
+            JobStatus.State(JobStatus.State.ERROR).name,
+            JobStatus.State(JobStatus.State.CANCELLED).name,
+            "not_found",
+        )
+
+    def is_job_succeeded(self, status: str) -> bool:
+        return status == JobStatus.State(JobStatus.State.DONE).name
+
+    def poll_until_complete(self, external_id: JsonValue, context: Context) -> None:
+        job_id = str(external_id)
+        self.job_id = job_id
+        self.log.info("Waiting for job %s to complete", job_id)
+        self._get_hook().wait_for_job(
+            job_id=job_id,
+            region=self.region,
+            project_id=self.project_id,
+            timeout=self.wait_timeout,
+        )
+        self.log.info("Job %s completed successfully.", job_id)
+
+    def get_job_result(self, external_id: JsonValue, context: Context) -> None:
+        self.job_id = str(external_id)
+        return None
+
+    def _get_hook(self) -> DataprocHook:
+        if self.hook is None:
+            self.hook = DataprocHook(
+                gcp_conn_id=self.gcp_conn_id,
+                impersonation_chain=self.impersonation_chain,
+            )
+        return self.hook
+
+    def _persist_job_link(self, *, context: Context, job_id: str) -> None:
+        project_id = self.project_id or self._get_hook().project_id
+        if project_id:
+            DataprocJobLink.persist(
+                context=context,
+                job_id=job_id,
+                region=self.region,
+                project_id=project_id,
+            )
 
     def execute_complete(self, context, event=None) -> None:
         """

--- a/providers/google/tests/unit/google/cloud/operators/test_dataproc.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_dataproc.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import datetime as dt
 import inspect
+import warnings
 from copy import deepcopy
 from unittest import mock
 from unittest.mock import ANY, MagicMock, Mock, call
@@ -44,6 +45,7 @@ from airflow.providers.google.cloud.links.dataproc import (
     DATAPROC_JOB_LINK_DEPRECATED,
 )
 from airflow.providers.google.cloud.operators.dataproc import (
+    _DURABLE_UNSET,
     ClusterGenerator,
     DataprocCreateBatchOperator,
     DataprocCreateClusterOperator,
@@ -61,6 +63,7 @@ from airflow.providers.google.cloud.operators.dataproc import (
     DataprocUpdateClusterOperator,
     InstanceFlexibilityPolicy,
     InstanceSelection,
+    _warn_and_disable_durable_pre_3_3,
 )
 from airflow.providers.google.cloud.triggers.dataproc import (
     DataprocBatchTrigger,
@@ -73,7 +76,7 @@ from airflow.providers.google.common.consts import GOOGLE_DEFAULT_DEFERRABLE_MET
 
 from tests_common.test_utils.compat import DagSerialization, timezone
 from tests_common.test_utils.db import clear_db_runs, clear_db_xcom
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_3_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
     from airflow.sdk.execution_time.comms import XComResult
@@ -2490,6 +2493,7 @@ class TestDataprocSubmitJobOperator(DataprocJobTestBase):
             polling_interval_seconds=15,
             cancel_on_kill=False,
             request_id=REQUEST_ID,
+            durable=False,
         )
         assert op.start_from_trigger is True
         assert (
@@ -2507,6 +2511,7 @@ class TestDataprocSubmitJobOperator(DataprocJobTestBase):
             "request_id": REQUEST_ID,
         }
         assert op.start_trigger_args.next_method == "execute_complete"
+        assert op.durable is False
 
     def test_start_from_trigger_without_deferrable_does_not_set_args(self):
         op = DataprocSubmitJobOperator(
@@ -2520,6 +2525,226 @@ class TestDataprocSubmitJobOperator(DataprocJobTestBase):
         )
         assert op.start_from_trigger is True
         assert op.start_trigger_args.trigger_kwargs == {}
+
+
+@pytest.mark.skipif(
+    not AIRFLOW_V_3_3_PLUS, reason="task_state_store (durable execution) requires Airflow 3.3+"
+)
+class TestDataprocSubmitJobOperatorDurable:
+    @staticmethod
+    def _make_operator(**kwargs):
+        return DataprocSubmitJobOperator(
+            task_id=TASK_ID,
+            project_id=GCP_PROJECT,
+            region=GCP_REGION,
+            job={},
+            request_id=REQUEST_ID,
+            retry=RETRY,
+            timeout=TIMEOUT,
+            metadata=METADATA,
+            **kwargs,
+        )
+
+    @staticmethod
+    def _context(task_store):
+        task_instance = MagicMock(spec_set=["stats_tags", "xcom_push"])
+        task_instance.stats_tags = {}
+        return {"ti": task_instance, "task_state_store": task_store}
+
+    @mock.patch(DATAPROC_PATH.format("DataprocHook"))
+    def test_persists_job_id_on_fresh_submit(self, mock_hook):
+        mock_hook.return_value.project_id = GCP_PROJECT
+        mock_hook.return_value.submit_job.return_value.reference.job_id = TEST_JOB_ID
+        task_store = MagicMock(spec_set=["get", "set"])
+        task_store.get.return_value = None
+        op = self._make_operator()
+
+        result = op.execute(context=self._context(task_store))
+
+        task_store.set.assert_called_once_with("dataproc_job_id", TEST_JOB_ID)
+        mock_hook.return_value.submit_job.assert_called_once_with(
+            project_id=GCP_PROJECT,
+            region=GCP_REGION,
+            job={},
+            request_id=REQUEST_ID,
+            retry=RETRY,
+            timeout=TIMEOUT,
+            metadata=METADATA,
+        )
+        assert result == TEST_JOB_ID
+
+    @mock.patch(DATAPROC_PATH.format("DataprocHook"))
+    def test_reconnects_to_active_job_and_restores_runtime_state(self, mock_hook):
+        mock_hook.return_value.project_id = GCP_PROJECT
+        mock_hook.return_value.get_job.return_value = dataproc.Job(
+            reference={"job_id": TEST_JOB_ID},
+            status={"state": JobStatus.State.RUNNING},
+        )
+        task_store = MagicMock(spec_set=["get", "set"])
+        task_store.get.return_value = TEST_JOB_ID
+        context = self._context(task_store)
+        op = self._make_operator()
+
+        result = op.execute(context=context)
+
+        mock_hook.return_value.submit_job.assert_not_called()
+        mock_hook.return_value.wait_for_job.assert_called_once_with(
+            job_id=TEST_JOB_ID,
+            region=GCP_REGION,
+            project_id=GCP_PROJECT,
+            timeout=None,
+        )
+        context["ti"].xcom_push.assert_called_once_with(
+            key="dataproc_job",
+            value={"job_id": TEST_JOB_ID, "region": GCP_REGION, "project_id": GCP_PROJECT},
+        )
+        assert op.job_id == TEST_JOB_ID
+        assert result == TEST_JOB_ID
+        op.on_kill()
+        mock_hook.return_value.cancel_job.assert_called_once_with(
+            job_id=TEST_JOB_ID,
+            project_id=GCP_PROJECT,
+            region=GCP_REGION,
+        )
+
+    @mock.patch(DATAPROC_PATH.format("DataprocHook"))
+    def test_recovers_completed_job_without_waiting_or_resubmitting(self, mock_hook):
+        mock_hook.return_value.project_id = GCP_PROJECT
+        mock_hook.return_value.get_job.return_value = dataproc.Job(
+            reference={"job_id": TEST_JOB_ID},
+            status={"state": JobStatus.State.DONE},
+        )
+        task_store = MagicMock(spec_set=["get", "set"])
+        task_store.get.return_value = TEST_JOB_ID
+        op = self._make_operator()
+
+        result = op.execute(context=self._context(task_store))
+
+        mock_hook.return_value.submit_job.assert_not_called()
+        mock_hook.return_value.wait_for_job.assert_not_called()
+        assert op.job_id == TEST_JOB_ID
+        assert result == TEST_JOB_ID
+
+    @pytest.mark.parametrize("state", [JobStatus.State.ERROR, JobStatus.State.CANCELLED])
+    @mock.patch(DATAPROC_PATH.format("DataprocHook"))
+    def test_resubmits_after_terminal_failure(self, mock_hook, state):
+        mock_hook.return_value.project_id = GCP_PROJECT
+        mock_hook.return_value.get_job.return_value = dataproc.Job(
+            reference={"job_id": "failed-job"},
+            status={"state": state},
+        )
+        mock_hook.return_value.submit_job.return_value.reference.job_id = TEST_JOB_ID
+        task_store = MagicMock(spec_set=["get", "set"])
+        task_store.get.return_value = "failed-job"
+        op = self._make_operator()
+
+        result = op.execute(context=self._context(task_store))
+
+        task_store.set.assert_called_once_with("dataproc_job_id", TEST_JOB_ID)
+        mock_hook.return_value.submit_job.assert_called_once_with(
+            project_id=GCP_PROJECT,
+            region=GCP_REGION,
+            job={},
+            request_id=REQUEST_ID,
+            retry=RETRY,
+            timeout=TIMEOUT,
+            metadata=METADATA,
+        )
+        assert result == TEST_JOB_ID
+
+    @mock.patch(DATAPROC_PATH.format("DataprocHook"))
+    def test_resubmits_when_stored_job_is_not_found(self, mock_hook):
+        mock_hook.return_value.project_id = GCP_PROJECT
+        mock_hook.return_value.get_job.side_effect = NotFound("gone")
+        mock_hook.return_value.submit_job.return_value.reference.job_id = TEST_JOB_ID
+        task_store = MagicMock(spec_set=["get", "set"])
+        task_store.get.return_value = "missing-job"
+        op = self._make_operator()
+
+        result = op.execute(context=self._context(task_store))
+
+        task_store.set.assert_called_once_with("dataproc_job_id", TEST_JOB_ID)
+        assert result == TEST_JOB_ID
+
+    @mock.patch(DATAPROC_PATH.format("DataprocHook"))
+    def test_durable_false_does_not_use_task_state(self, mock_hook):
+        mock_hook.return_value.project_id = GCP_PROJECT
+        mock_hook.return_value.submit_job.return_value.reference.job_id = TEST_JOB_ID
+        task_store = MagicMock(spec_set=["get", "set"])
+        op = self._make_operator(durable=False)
+
+        result = op.execute(context=self._context(task_store))
+
+        task_store.get.assert_not_called()
+        task_store.set.assert_not_called()
+        assert result == TEST_JOB_ID
+
+    @mock.patch(DATAPROC_PATH.format("DataprocHook"))
+    def test_asynchronous_mode_does_not_use_task_state(self, mock_hook):
+        mock_hook.return_value.project_id = GCP_PROJECT
+        mock_hook.return_value.submit_job.return_value.reference.job_id = TEST_JOB_ID
+        task_store = MagicMock(spec_set=["get", "set"])
+        op = self._make_operator(asynchronous=True)
+
+        result = op.execute(context=self._context(task_store))
+
+        task_store.get.assert_not_called()
+        task_store.set.assert_not_called()
+        mock_hook.return_value.wait_for_job.assert_not_called()
+        assert result == TEST_JOB_ID
+
+    @mock.patch(DATAPROC_PATH.format("DataprocHook"))
+    def test_deferrable_mode_does_not_use_task_state(self, mock_hook):
+        mock_hook.return_value.project_id = GCP_PROJECT
+        mock_hook.return_value.submit_job.return_value.reference.job_id = TEST_JOB_ID
+        task_store = MagicMock(spec_set=["get", "set"])
+        op = self._make_operator(deferrable=True)
+
+        with pytest.raises(TaskDeferred):
+            op.execute(context=self._context(task_store))
+
+        task_store.get.assert_not_called()
+        task_store.set.assert_not_called()
+
+    @mock.patch(DATAPROC_PATH.format("DataprocHook"))
+    def test_openlineage_injection_runs_before_completed_job_recovery(self, mock_hook):
+        mock_hook.return_value.project_id = GCP_PROJECT
+        mock_hook.return_value.get_job.return_value = dataproc.Job(
+            reference={"job_id": TEST_JOB_ID},
+            status={"state": JobStatus.State.DONE},
+        )
+        task_store = MagicMock(spec_set=["get", "set"])
+        task_store.get.return_value = TEST_JOB_ID
+        context = self._context(task_store)
+        op = self._make_operator(openlineage_inject_parent_job_info=True)
+
+        with mock.patch.object(
+            op,
+            "_inject_openlineage_properties_into_dataproc_job",
+            autospec=True,
+        ) as mock_inject:
+            op.execute(context=context)
+
+        mock_inject.assert_called_once_with(context)
+        mock_hook.return_value.submit_job.assert_not_called()
+
+    def test_default_args_durable_reaches_operator(self):
+        op = self._make_operator(default_args={"durable": False})
+
+        assert op.durable is False
+
+
+class TestDataprocSubmitJobOperatorPre33Compatibility:
+    def test_unset_durable_is_disabled_without_warning(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+
+            assert _warn_and_disable_durable_pre_3_3(_DURABLE_UNSET) is False
+
+    @pytest.mark.parametrize("durable", [True, False])
+    def test_explicit_durable_is_disabled_with_warning(self, durable):
+        with pytest.warns(UserWarning, match="has no effect"):
+            assert _warn_and_disable_durable_pre_3_3(durable) is False
 
 
 @pytest.mark.db_test


### PR DESCRIPTION
A synchronous Dataproc job can outlive its worker, but a task retry currently submits a second job instead of reconnecting. After this change, the retry restores the API-returned job ID from task state and resumes waiting for the same job.

`DataprocSubmitJobOperator` uses the AIP-103 resumable-job contract only on its synchronous wait path. Active jobs reconnect, completed jobs return without another submission, and terminal or missing jobs submit fresh. Recovery restores the operator job ID and extra link state used by cancellation. Asynchronous, deferrable, direct-to-trigger, OpenLineage, and pre-Airflow 3.3 behavior stay unchanged.

An explicit `request_id` is still passed unchanged. Dataproc may therefore return the prior terminal job when a retry resubmits with the same idempotency key.

## Testing

```console
$ PATH="$PWD/.venv/bin:$PATH" AIRFLOW_HOME="$PWD/.build/airflow-home-dataproc-final" uv run --project providers/google pytest providers/google/tests/unit/google/cloud/operators/test_dataproc.py -q
125 passed, 1 warning in 97.29s
```

A scratch harness executed two operator instances against a local Dataproc hook and the real `TaskStateStoreAccessor` path:

<details><summary>Commands and raw crash/retry output</summary>

```console
$ AIRFLOW_HOME="$PWD/.build/airflow-home-baseline-approved" PYTHONPATH="$PWD/.build/dataproc-baseline/airflow-core/src:$PWD/.build/dataproc-baseline/task-sdk/src:$PWD/.build/dataproc-baseline/providers/google/src" PATH="$PWD/.venv/bin:$PATH" uv run --project providers/google python dev/dataproc_resumability_e2e.py --label baseline | tee .build/dataproc-proof-baseline-approved.log
{
  "first_attempt_error": "WorkerCrash: simulated worker crash while waiting for Dataproc job",
  "label": "baseline",
  "link_job_ids": [
    "dataproc-job-1",
    "dataproc-job-2"
  ],
  "recovered_without_resubmission": false,
  "second_operator_job_id": "dataproc-job-2",
  "second_result": "dataproc-job-2",
  "status_reads": [],
  "stored_state_after_crash": {},
  "submissions": [
    "dataproc-job-1",
    "dataproc-job-2"
  ],
  "waited_job_ids": [
    "dataproc-job-1",
    "dataproc-job-2"
  ]
}
$ AIRFLOW_HOME="$PWD/.build/airflow-home-patched-approved" PYTHONPATH="$PWD/airflow-core/src:$PWD/task-sdk/src:$PWD/providers/google/src" PATH="$PWD/.venv/bin:$PATH" uv run --project providers/google python dev/dataproc_resumability_e2e.py --label patched | tee .build/dataproc-proof-patched-approved.log
{
  "first_attempt_error": "WorkerCrash: simulated worker crash while waiting for Dataproc job",
  "label": "patched",
  "link_job_ids": [
    "dataproc-job-1",
    "dataproc-job-1"
  ],
  "recovered_without_resubmission": true,
  "second_operator_job_id": "dataproc-job-1",
  "second_result": "dataproc-job-1",
  "status_reads": [
    "dataproc-job-1"
  ],
  "stored_state_after_crash": {
    "dataproc_job_id": "dataproc-job-1"
  },
  "submissions": [
    "dataproc-job-1"
  ],
  "waited_job_ids": [
    "dataproc-job-1",
    "dataproc-job-1"
  ]
}
```

</details>

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes - GitHub Copilot CLI (GPT-5.6 Sol)

Generated-by: GitHub Copilot CLI (GPT-5.6 Sol) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---
