### PR TITLE
Recover Athena queries after worker crashes

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/athena.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/athena.py
@@ -19,8 +19,10 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Final, cast
 from urllib.parse import urlparse
+
+from botocore.exceptions import ClientError
 
 from airflow.providers.amazon.aws.hooks.athena import AthenaHook
 from airflow.providers.amazon.aws.links.athena import AthenaQueryResultsLink
@@ -31,6 +33,7 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException, conf
 
 _DURABLE_UNSET = object()
+_NOT_FOUND_QUERY_STATE: Final[str] = "NOT_FOUND"
 
 
 def _warn_and_disable_durable_pre_3_3(durable: Any) -> bool:
@@ -41,6 +44,16 @@ def _warn_and_disable_durable_pre_3_3(durable: Any) -> bool:
             stacklevel=3,
         )
     return False
+
+
+def _is_query_not_found_error(*, error: ClientError, query_execution_id: str) -> bool:
+    error_details: dict[str, Any] = error.response.get("Error", {})
+    message: Any = error_details.get("Message")
+    return (
+        error_details.get("Code") == "InvalidRequestException"
+        and isinstance(message, str)
+        and message == f"QueryExecution {query_execution_id} was not found"
+    )
 
 
 try:
@@ -241,7 +254,12 @@ class AthenaOperator(ResumableJobMixin, AwsBaseOperator[AthenaHook]):
     def get_job_status(self, external_id: JsonValue, context: Context) -> str:
         query_execution_id = cast("str", external_id)
         self._set_query_execution_id(context=context, query_execution_id=query_execution_id)
-        query_status = self.hook.check_query_status(query_execution_id=query_execution_id)
+        try:
+            query_status = self.hook.check_query_status(query_execution_id=query_execution_id)
+        except ClientError as error:
+            if _is_query_not_found_error(error=error, query_execution_id=query_execution_id):
+                return _NOT_FOUND_QUERY_STATE
+            raise
         if query_status not in (*AthenaHook.INTERMEDIATE_STATES, *AthenaHook.TERMINAL_STATES):
             raise ValueError(f"Unexpected Athena query status: {query_status!r}")
         self._query_status = query_status

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/athena.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/athena.py
@@ -17,8 +17,9 @@
 # under the License.
 from __future__ import annotations
 
+import warnings
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlparse
 
 from airflow.providers.amazon.aws.hooks.athena import AthenaHook
@@ -29,13 +30,48 @@ from airflow.providers.amazon.aws.utils import validate_execute_complete_event
 from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException, conf
 
+_DURABLE_UNSET = object()
+
+
+def _warn_and_disable_durable_pre_3_3(durable: Any) -> bool:
+    if durable is not _DURABLE_UNSET:
+        warnings.warn(
+            "`durable` has no effect on Airflow versions below 3.3.",
+            UserWarning,
+            stacklevel=3,
+        )
+    return False
+
+
+try:
+    from airflow.sdk import ResumableJobMixin
+except ImportError:
+
+    class ResumableJobMixin:  # type: ignore[no-redef]
+        """Airflow <3.3 stub, task_state_store unavailable, always submits fresh."""
+
+        external_id_key: str = "athena_query_execution_id"
+
+        def __init__(self, *, durable: Any = _DURABLE_UNSET, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+            self.durable = _warn_and_disable_durable_pre_3_3(durable)
+
+        def execute_resumable(self, context: Context) -> Any:
+            operator = cast("AthenaOperator", self)
+            external_id = operator.submit_job(context)
+            operator.poll_until_complete(external_id, context)
+            return operator.get_job_result(external_id, context)
+
+
 if TYPE_CHECKING:
+    from pydantic import JsonValue
+
     from airflow.providers.common.compat.openlineage.facet import BaseFacet, Dataset, DatasetFacet
     from airflow.providers.openlineage.extractors.base import OperatorLineage
     from airflow.sdk import Context
 
 
-class AthenaOperator(AwsBaseOperator[AthenaHook]):
+class AthenaOperator(ResumableJobMixin, AwsBaseOperator[AthenaHook]):
     """
     An operator that submits a Trino/Presto query to Amazon Athena.
 
@@ -67,6 +103,11 @@ class AthenaOperator(AwsBaseOperator[AthenaHook]):
         To limit task execution time, use execution_timeout.
     :param log_query: Whether to log athena query and other execution params when it's executed.
         Defaults to *True*.
+    :param durable: When ``True`` (the default on Airflow 3.3+), the Athena query execution id
+        is persisted to task state before synchronous polling begins. A worker crash on retry
+        reconnects to the existing query instead of submitting a duplicate. Set to ``False`` to
+        always submit a fresh query. On earlier Airflow versions, this defaults to ``False`` and
+        an explicitly configured value is ignored with a warning.
     :param aws_conn_id: The Airflow connection used for AWS credentials.
         If this is ``None`` or empty then the default boto3 behaviour is used. If
         running Airflow in a distributed manner and aws_conn_id is None or
@@ -87,6 +128,7 @@ class AthenaOperator(AwsBaseOperator[AthenaHook]):
     template_ext: Sequence[str] = (".sql",)
     template_fields_renderers = {"query": "sql"}
     operator_extra_links = (AthenaQueryResultsLink(),)
+    external_id_key: str = "athena_query_execution_id"
 
     def __init__(
         self,
@@ -103,8 +145,11 @@ class AthenaOperator(AwsBaseOperator[AthenaHook]):
         log_query: bool = True,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
         catalog: str = "AwsDataCatalog",
+        durable: bool | None = None,
         **kwargs: Any,
     ) -> None:
+        if durable is not None:
+            kwargs["durable"] = durable
         super().__init__(**kwargs)
         self.query = query
         self.database = database
@@ -116,6 +161,8 @@ class AthenaOperator(AwsBaseOperator[AthenaHook]):
         self.sleep_time = sleep_time
         self.max_polling_attempts = max_polling_attempts or 999999
         self.query_execution_id: str | None = None
+        self._query_results_link_id: str | None = None
+        self._query_status: str | None = None
         self.log_query: bool = log_query
         self.deferrable = deferrable
         self.catalog: str = catalog
@@ -131,25 +178,13 @@ class AthenaOperator(AwsBaseOperator[AthenaHook]):
         self.query_execution_context["Catalog"] = self.catalog
         if self.output_location:
             self.result_configuration["OutputLocation"] = self.output_location
-        self.query_execution_id = self.hook.run_query(
-            self.query,
-            self.query_execution_context,
-            self.result_configuration,
-            self.client_request_token,
-            self.workgroup,
-        )
-        AthenaQueryResultsLink.persist(
-            context=context,
-            operator=self,
-            region_name=self.hook.conn_region_name,
-            aws_partition=self.hook.conn_partition,
-            query_execution_id=self.query_execution_id,
-        )
 
         if self.deferrable:
+            query_execution_id = self.submit_job(context)
+            self._set_query_execution_id(context=context, query_execution_id=query_execution_id)
             self.defer(
                 trigger=AthenaTrigger(
-                    query_execution_id=self.query_execution_id,
+                    query_execution_id=query_execution_id,
                     waiter_delay=self.sleep_time,
                     waiter_max_attempts=self.max_polling_attempts,
                     aws_conn_id=self.aws_conn_id,
@@ -159,26 +194,78 @@ class AthenaOperator(AwsBaseOperator[AthenaHook]):
                 ),
                 method_name="execute_complete",
             )
-        # implicit else:
-        query_status = self.hook.poll_query_status(
-            self.query_execution_id,
-            max_polling_attempts=self.max_polling_attempts,
-            sleep_time=self.sleep_time,
-        )
+            return query_execution_id
+
+        self.execute_resumable(context)
+        query_status = self._query_status
+        query_execution_id = cast("str", self.query_execution_id)
 
         if query_status in AthenaHook.FAILURE_STATES:
-            error_message = self.hook.get_state_change_reason(self.query_execution_id)
+            error_message = self.hook.get_state_change_reason(query_execution_id=query_execution_id)
             raise AirflowException(
                 f"Final state of Athena job is {query_status}, query_execution_id is "
-                f"{self.query_execution_id}. Error: {error_message}"
+                f"{query_execution_id}. Error: {error_message}"
             )
         if not query_status or query_status in AthenaHook.INTERMEDIATE_STATES:
             raise AirflowException(
                 f"Final state of Athena job is {query_status}. Max tries of poll status exceeded, "
-                f"query_execution_id is {self.query_execution_id}."
+                f"query_execution_id is {query_execution_id}."
             )
 
-        return self.query_execution_id
+        return query_execution_id
+
+    def _set_query_execution_id(self, *, context: Context, query_execution_id: str) -> None:
+        self.query_execution_id = query_execution_id
+        if self._query_results_link_id == query_execution_id:
+            return
+        AthenaQueryResultsLink.persist(
+            context=context,
+            operator=self,
+            region_name=self.hook.conn_region_name,
+            aws_partition=self.hook.conn_partition,
+            query_execution_id=query_execution_id,
+        )
+        self._query_results_link_id = query_execution_id
+
+    def submit_job(self, context: Context) -> str:
+        query_execution_id: str = self.hook.run_query(
+            query=self.query,
+            query_context=self.query_execution_context,
+            result_configuration=self.result_configuration,
+            client_request_token=self.client_request_token,
+            workgroup=self.workgroup,
+        )
+        self.query_execution_id = query_execution_id
+        return query_execution_id
+
+    def get_job_status(self, external_id: JsonValue, context: Context) -> str:
+        query_execution_id = cast("str", external_id)
+        self._set_query_execution_id(context=context, query_execution_id=query_execution_id)
+        query_status = self.hook.check_query_status(query_execution_id=query_execution_id)
+        if query_status not in (*AthenaHook.INTERMEDIATE_STATES, *AthenaHook.TERMINAL_STATES):
+            raise ValueError(f"Unexpected Athena query status: {query_status!r}")
+        self._query_status = query_status
+        return query_status
+
+    def is_job_active(self, status: str) -> bool:
+        return status in AthenaHook.INTERMEDIATE_STATES
+
+    def is_job_succeeded(self, status: str) -> bool:
+        return status in AthenaHook.SUCCESS_STATES
+
+    def poll_until_complete(self, external_id: JsonValue, context: Context) -> None:
+        query_execution_id = cast("str", external_id)
+        self._set_query_execution_id(context=context, query_execution_id=query_execution_id)
+        self._query_status = self.hook.poll_query_status(
+            query_execution_id=query_execution_id,
+            max_polling_attempts=self.max_polling_attempts,
+            sleep_time=self.sleep_time,
+        )
+
+    def get_job_result(self, external_id: JsonValue, context: Context) -> str:
+        query_execution_id = cast("str", external_id)
+        self._set_query_execution_id(context=context, query_execution_id=query_execution_id)
+        return query_execution_id
 
     def execute_complete(self, context: Context, event: dict[str, Any] | None = None) -> str:
         validated_event = validate_execute_complete_event(event)

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_athena.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_athena.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import os
+import warnings
 from unittest import mock
 
 import pytest
@@ -25,7 +26,12 @@ from moto import mock_aws
 
 from airflow.models import DAG, DagRun, TaskInstance
 from airflow.providers.amazon.aws.hooks.athena import AthenaHook
-from airflow.providers.amazon.aws.operators.athena import AthenaOperator
+from airflow.providers.amazon.aws.links.athena import AthenaQueryResultsLink
+from airflow.providers.amazon.aws.operators.athena import (
+    _DURABLE_UNSET,
+    AthenaOperator,
+    _warn_and_disable_durable_pre_3_3,
+)
 from airflow.providers.amazon.aws.triggers.athena import AthenaTrigger
 from airflow.providers.common.compat.openlineage.facet import (
     Dataset,
@@ -44,7 +50,7 @@ from airflow.utils.types import DagRunType
 from tests_common.test_utils.compat import timezone
 from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.taskinstance import create_task_instance, get_template_context
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_3_PLUS
 from unit.amazon.aws.utils.test_template_fields import validate_template_fields
 
 TEST_DAG_ID = "unit_tests"
@@ -131,11 +137,11 @@ class TestAthenaOperator:
         self.athena.catalog = "MyCatalog"
         self.athena.execute({})
         mock_run_query.assert_called_once_with(
-            MOCK_DATA["query"],
-            query_context_catalog,
-            result_configuration,
-            MOCK_DATA["client_request_token"],
-            MOCK_DATA["workgroup"],
+            query=MOCK_DATA["query"],
+            query_context=query_context_catalog,
+            result_configuration=result_configuration,
+            client_request_token=MOCK_DATA["client_request_token"],
+            workgroup=MOCK_DATA["workgroup"],
         )
         assert mock_check_query_status.call_count == 1
 
@@ -151,11 +157,11 @@ class TestAthenaOperator:
         )
         op.execute({})
         mock_run_query.assert_called_once_with(
-            MOCK_DATA["query"],
-            {"Catalog": MOCK_DATA["catalog"]},
-            result_configuration,
-            MOCK_DATA["client_request_token"],
-            MOCK_DATA["workgroup"],
+            query=MOCK_DATA["query"],
+            query_context={"Catalog": MOCK_DATA["catalog"]},
+            result_configuration=result_configuration,
+            client_request_token=MOCK_DATA["client_request_token"],
+            workgroup=MOCK_DATA["workgroup"],
         )
         assert mock_check_query_status.call_count == 1
 
@@ -165,11 +171,11 @@ class TestAthenaOperator:
     def test_hook_run_small_success_query(self, mock_conn, mock_run_query, mock_check_query_status):
         self.athena.execute({})
         mock_run_query.assert_called_once_with(
-            MOCK_DATA["query"],
-            query_context,
-            result_configuration,
-            MOCK_DATA["client_request_token"],
-            MOCK_DATA["workgroup"],
+            query=MOCK_DATA["query"],
+            query_context=query_context,
+            result_configuration=result_configuration,
+            client_request_token=MOCK_DATA["client_request_token"],
+            workgroup=MOCK_DATA["workgroup"],
         )
         assert mock_check_query_status.call_count == 1
 
@@ -192,11 +198,11 @@ class TestAthenaOperator:
     def test_hook_run_big_success_query(self, mock_conn, mock_run_query, mock_check_query_status):
         self.athena.execute({})
         mock_run_query.assert_called_once_with(
-            MOCK_DATA["query"],
-            query_context,
-            result_configuration,
-            MOCK_DATA["client_request_token"],
-            MOCK_DATA["workgroup"],
+            query=MOCK_DATA["query"],
+            query_context=query_context,
+            result_configuration=result_configuration,
+            client_request_token=MOCK_DATA["client_request_token"],
+            workgroup=MOCK_DATA["workgroup"],
         )
 
     @mock.patch.object(AthenaHook, "get_state_change_reason")
@@ -213,11 +219,11 @@ class TestAthenaOperator:
         with pytest.raises(AirflowException):
             self.athena.execute({})
         mock_run_query.assert_called_once_with(
-            MOCK_DATA["query"],
-            query_context,
-            result_configuration,
-            MOCK_DATA["client_request_token"],
-            MOCK_DATA["workgroup"],
+            query=MOCK_DATA["query"],
+            query_context=query_context,
+            result_configuration=result_configuration,
+            client_request_token=MOCK_DATA["client_request_token"],
+            workgroup=MOCK_DATA["workgroup"],
         )
         assert mock_get_state_change_reason.call_count == 1
 
@@ -228,11 +234,11 @@ class TestAthenaOperator:
         with pytest.raises(AirflowException):
             self.athena.execute({})
         mock_run_query.assert_called_once_with(
-            MOCK_DATA["query"],
-            query_context,
-            result_configuration,
-            MOCK_DATA["client_request_token"],
-            MOCK_DATA["workgroup"],
+            query=MOCK_DATA["query"],
+            query_context=query_context,
+            result_configuration=result_configuration,
+            client_request_token=MOCK_DATA["client_request_token"],
+            workgroup=MOCK_DATA["workgroup"],
         )
 
     @mock.patch.object(AthenaHook, "check_query_status", return_value="RUNNING")
@@ -242,11 +248,11 @@ class TestAthenaOperator:
         with pytest.raises(AirflowException):
             self.athena.execute({})
         mock_run_query.assert_called_once_with(
-            MOCK_DATA["query"],
-            query_context,
-            result_configuration,
-            MOCK_DATA["client_request_token"],
-            MOCK_DATA["workgroup"],
+            query=MOCK_DATA["query"],
+            query_context=query_context,
+            result_configuration=result_configuration,
+            client_request_token=MOCK_DATA["client_request_token"],
+            workgroup=MOCK_DATA["workgroup"],
         )
 
     @pytest.mark.db_test
@@ -288,6 +294,7 @@ class TestAthenaOperator:
         ti.dag_run = dag_run
         session.add(ti)
         session.commit()
+        self.athena.durable = False
         assert self.athena.execute(get_template_context(ti, self.athena)) == ATHENA_QUERY_ID
 
     @mock.patch.object(AthenaHook, "check_query_status", side_effect=("SUCCEEDED",))
@@ -298,11 +305,11 @@ class TestAthenaOperator:
 
         op.execute({})
         mock_run_query.assert_called_once_with(
-            MOCK_DATA["query"],
-            query_context,
-            {},  # Should be an empty dict since we do not provide output_location
-            MOCK_DATA["client_request_token"],
-            MOCK_DATA["workgroup"],
+            query=MOCK_DATA["query"],
+            query_context=query_context,
+            result_configuration={},  # Should be an empty dict since we do not provide output_location
+            client_request_token=MOCK_DATA["client_request_token"],
+            workgroup=MOCK_DATA["workgroup"],
         )
 
     @mock.patch.object(AthenaHook, "run_query", return_value=ATHENA_QUERY_ID)
@@ -464,3 +471,248 @@ class TestAthenaOperator:
 
     def test_template_fields(self):
         validate_template_fields(self.athena)
+
+
+@pytest.mark.skipif(
+    not AIRFLOW_V_3_3_PLUS, reason="task_state_store (durable execution) requires Airflow 3.3+"
+)
+class TestAthenaOperatorDurableExecution:
+    @staticmethod
+    def _context(task_state_store):
+        return {
+            "ti": mock.MagicMock(spec_set=["stats_tags"], stats_tags={}),
+            "task_state_store": task_state_store,
+        }
+
+    @staticmethod
+    def _make_operator(**kwargs):
+        return AthenaOperator(
+            task_id="test_athena_durable",
+            query=MOCK_DATA["query"],
+            database=MOCK_DATA["database"],
+            output_location=MOCK_DATA["outputLocation"],
+            client_request_token=MOCK_DATA["client_request_token"],
+            sleep_time=0,
+            max_polling_attempts=3,
+            aws_conn_id=None,
+            **kwargs,
+        )
+
+    @mock.patch.object(AthenaQueryResultsLink, "persist")
+    @mock.patch.object(AthenaHook, "poll_query_status", return_value="SUCCEEDED")
+    @mock.patch.object(AthenaHook, "run_query", return_value=ATHENA_QUERY_ID)
+    def test_fresh_submission_persists_before_polling(self, mock_run_query, mock_poll, mock_persist):
+        operator = self._make_operator()
+        task_state_store = mock.MagicMock(spec_set=["get", "set"])
+        task_state_store.get.return_value = None
+        persisted_before_poll = []
+        mock_poll.side_effect = lambda *args, **kwargs: (
+            persisted_before_poll.append(task_state_store.set.call_args.args) or "SUCCEEDED"
+        )
+
+        result = operator.execute(self._context(task_state_store))
+
+        assert result == ATHENA_QUERY_ID
+        task_state_store.set.assert_called_once_with("athena_query_execution_id", ATHENA_QUERY_ID)
+        assert persisted_before_poll == [("athena_query_execution_id", ATHENA_QUERY_ID)]
+        mock_run_query.assert_called_once()
+        mock_persist.assert_called_once()
+
+    @pytest.mark.parametrize("status", AthenaHook.INTERMEDIATE_STATES)
+    @mock.patch.object(AthenaQueryResultsLink, "persist")
+    @mock.patch.object(AthenaHook, "poll_query_status", return_value="SUCCEEDED")
+    @mock.patch.object(AthenaHook, "check_query_status")
+    @mock.patch.object(AthenaHook, "run_query")
+    def test_active_query_reconnects_without_resubmission(
+        self, mock_run_query, mock_check_status, mock_poll, mock_persist, status
+    ):
+        operator = self._make_operator()
+        mock_check_status.return_value = status
+        task_state_store = mock.MagicMock(spec_set=["get", "set"])
+        task_state_store.get.return_value = ATHENA_QUERY_ID
+
+        result = operator.execute(self._context(task_state_store))
+
+        assert result == ATHENA_QUERY_ID
+        assert operator.query_execution_id == ATHENA_QUERY_ID
+        mock_run_query.assert_not_called()
+        task_state_store.set.assert_not_called()
+        mock_poll.assert_called_once_with(
+            query_execution_id=ATHENA_QUERY_ID,
+            max_polling_attempts=3,
+            sleep_time=0,
+        )
+        mock_persist.assert_called_once_with(
+            context=mock.ANY,
+            operator=operator,
+            region_name=mock.ANY,
+            aws_partition=mock.ANY,
+            query_execution_id=ATHENA_QUERY_ID,
+        )
+
+    @mock.patch.object(AthenaQueryResultsLink, "persist")
+    @mock.patch.object(AthenaHook, "poll_query_status")
+    @mock.patch.object(AthenaHook, "check_query_status", return_value="SUCCEEDED")
+    @mock.patch.object(AthenaHook, "run_query")
+    def test_succeeded_query_recovers_without_polling_or_resubmission(
+        self, mock_run_query, mock_check_status, mock_poll, mock_persist
+    ):
+        operator = self._make_operator()
+        task_state_store = mock.MagicMock(spec_set=["get", "set"])
+        task_state_store.get.return_value = ATHENA_QUERY_ID
+
+        result = operator.execute(self._context(task_state_store))
+
+        assert result == ATHENA_QUERY_ID
+        assert operator.query_execution_id == ATHENA_QUERY_ID
+        mock_run_query.assert_not_called()
+        mock_poll.assert_not_called()
+        task_state_store.set.assert_not_called()
+        mock_persist.assert_called_once()
+
+    @pytest.mark.parametrize("status", AthenaHook.FAILURE_STATES)
+    @mock.patch.object(AthenaQueryResultsLink, "persist")
+    @mock.patch.object(AthenaHook, "poll_query_status", return_value="SUCCEEDED")
+    @mock.patch.object(AthenaHook, "check_query_status")
+    @mock.patch.object(AthenaHook, "run_query", return_value="new-query-id")
+    def test_terminal_query_resubmits_with_unchanged_client_token(
+        self, mock_run_query, mock_check_status, mock_poll, mock_persist, status
+    ):
+        operator = self._make_operator()
+        mock_check_status.return_value = status
+        task_state_store = mock.MagicMock(spec_set=["get", "set"])
+        task_state_store.get.return_value = ATHENA_QUERY_ID
+
+        result = operator.execute(self._context(task_state_store))
+
+        assert result == "new-query-id"
+        assert operator.query_execution_id == "new-query-id"
+        mock_run_query.assert_called_once_with(
+            query=MOCK_DATA["query"],
+            query_context=query_context,
+            result_configuration=result_configuration,
+            client_request_token=MOCK_DATA["client_request_token"],
+            workgroup=MOCK_DATA["workgroup"],
+        )
+        task_state_store.set.assert_called_once_with("athena_query_execution_id", "new-query-id")
+
+    @mock.patch.object(AthenaQueryResultsLink, "persist")
+    @mock.patch.object(AthenaHook, "poll_query_status", return_value="SUCCEEDED")
+    @mock.patch.object(AthenaHook, "run_query", return_value=ATHENA_QUERY_ID)
+    def test_durable_false_submits_without_reading_or_writing_store(
+        self, mock_run_query, mock_poll, mock_persist
+    ):
+        operator = self._make_operator(durable=False)
+        task_state_store = mock.MagicMock(spec_set=["get", "set"])
+
+        assert operator.execute(self._context(task_state_store)) == ATHENA_QUERY_ID
+
+        task_state_store.get.assert_not_called()
+        task_state_store.set.assert_not_called()
+        mock_run_query.assert_called_once()
+
+    @mock.patch.object(AthenaOperator, "defer")
+    @mock.patch.object(AthenaQueryResultsLink, "persist")
+    @mock.patch.object(AthenaHook, "run_query", return_value=ATHENA_QUERY_ID)
+    def test_deferrable_execution_does_not_use_task_state_store(
+        self, mock_run_query, mock_persist, mock_defer
+    ):
+        operator = self._make_operator(deferrable=True)
+        task_state_store = mock.MagicMock(spec_set=["get", "set"])
+
+        operator.execute(self._context(task_state_store))
+
+        mock_defer.assert_called_once()
+        task_state_store.get.assert_not_called()
+        task_state_store.set.assert_not_called()
+        mock_run_query.assert_called_once()
+
+    @mock.patch.object(AthenaQueryResultsLink, "persist")
+    @mock.patch.object(AthenaHook, "poll_query_status", side_effect=RuntimeError("worker stopped"))
+    @mock.patch.object(AthenaHook, "check_query_status", return_value="RUNNING")
+    @mock.patch.object(AthenaHook, "run_query")
+    @mock.patch.object(AthenaHook, "stop_query", return_value={"ResponseMetadata": {"HTTPStatusCode": 200}})
+    def test_on_kill_cancels_reconnected_query(
+        self, mock_stop_query, mock_run_query, mock_check_status, mock_poll, mock_persist
+    ):
+        operator = self._make_operator()
+        task_state_store = mock.MagicMock(spec_set=["get", "set"])
+        task_state_store.get.return_value = ATHENA_QUERY_ID
+
+        with pytest.raises(RuntimeError, match="worker stopped"):
+            operator.execute(self._context(task_state_store))
+
+        mock_poll.side_effect = None
+        mock_poll.return_value = "CANCELLED"
+        operator.on_kill()
+
+        mock_stop_query.assert_called_once_with(ATHENA_QUERY_ID)
+        mock_run_query.assert_not_called()
+
+    @mock.patch.object(AthenaQueryResultsLink, "persist")
+    @mock.patch.object(AthenaHook, "poll_query_status", return_value="SUCCEEDED")
+    @mock.patch.object(AthenaHook, "run_query", return_value=ATHENA_QUERY_ID)
+    def test_unset_client_request_token_remains_unset(self, mock_run_query, mock_poll, mock_persist):
+        operator = AthenaOperator(
+            task_id="test_athena_durable_without_token",
+            query=MOCK_DATA["query"],
+            database=MOCK_DATA["database"],
+            output_location=MOCK_DATA["outputLocation"],
+            sleep_time=0,
+            max_polling_attempts=3,
+            aws_conn_id=None,
+        )
+        task_state_store = mock.MagicMock(spec_set=["get", "set"])
+        task_state_store.get.return_value = None
+
+        assert operator.execute(self._context(task_state_store)) == ATHENA_QUERY_ID
+
+        mock_run_query.assert_called_once_with(
+            query=MOCK_DATA["query"],
+            query_context=query_context,
+            result_configuration=result_configuration,
+            client_request_token=None,
+            workgroup=MOCK_DATA["workgroup"],
+        )
+
+    @pytest.mark.parametrize("status", [None, "UNKNOWN"])
+    @mock.patch.object(AthenaQueryResultsLink, "persist")
+    @mock.patch.object(AthenaHook, "check_query_status")
+    @mock.patch.object(AthenaHook, "run_query")
+    def test_unknown_recovered_status_does_not_resubmit(
+        self, mock_run_query, mock_check_status, mock_persist, status
+    ):
+        operator = self._make_operator()
+        mock_check_status.return_value = status
+        task_state_store = mock.MagicMock(spec_set=["get", "set"])
+        task_state_store.get.return_value = ATHENA_QUERY_ID
+
+        with pytest.raises(ValueError, match="Unexpected Athena query status"):
+            operator.execute(self._context(task_state_store))
+
+        mock_run_query.assert_not_called()
+
+    def test_default_args_durable_reaches_operator(self):
+        with DAG(
+            dag_id="test_athena_durable_default_args",
+            schedule=None,
+            start_date=DEFAULT_DATE,
+            default_args={"durable": False},
+        ):
+            operator = self._make_operator()
+        assert operator.durable is False
+
+
+class TestWarnAndDisableDurableAirflowPre3_3:
+    def test_no_warning_when_unset(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = _warn_and_disable_durable_pre_3_3(_DURABLE_UNSET)
+        assert result is False
+        assert caught == []
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_warns_and_disables_when_explicitly_set(self, value):
+        with pytest.warns(UserWarning, match="durable.*no effect"):
+            result = _warn_and_disable_durable_pre_3_3(value)
+        assert result is False

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_athena.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_athena.py
@@ -22,6 +22,7 @@ import warnings
 from unittest import mock
 
 import pytest
+from botocore.exceptions import ClientError
 from moto import mock_aws
 
 from airflow.models import DAG, DagRun, TaskInstance
@@ -478,6 +479,16 @@ class TestAthenaOperator:
 )
 class TestAthenaOperatorDurableExecution:
     @staticmethod
+    def _invalid_request_error(message: str) -> ClientError:
+        return ClientError(
+            error_response={
+                "Error": {"Code": "InvalidRequestException", "Message": message},
+                "ResponseMetadata": {"HTTPStatusCode": 400},
+            },
+            operation_name="GetQueryExecution",
+        )
+
+    @staticmethod
     def _context(task_state_store):
         return {
             "ti": mock.MagicMock(spec_set=["stats_tags"], stats_tags={}),
@@ -595,6 +606,46 @@ class TestAthenaOperatorDurableExecution:
             workgroup=MOCK_DATA["workgroup"],
         )
         task_state_store.set.assert_called_once_with("athena_query_execution_id", "new-query-id")
+
+    @mock.patch.object(AthenaQueryResultsLink, "persist")
+    @mock.patch.object(AthenaHook, "poll_query_status", return_value="SUCCEEDED")
+    @mock.patch.object(AthenaHook, "check_query_status")
+    @mock.patch.object(AthenaHook, "run_query", return_value="new-query-id")
+    def test_missing_query_resubmits(self, mock_run_query, mock_check_status, mock_poll, mock_persist):
+        operator = self._make_operator()
+        mock_check_status.side_effect = self._invalid_request_error(
+            f"QueryExecution {ATHENA_QUERY_ID} was not found"
+        )
+        task_state_store = mock.MagicMock(spec_set=["get", "set"])
+        task_state_store.get.return_value = ATHENA_QUERY_ID
+
+        assert operator.execute(self._context(task_state_store)) == "new-query-id"
+
+        mock_run_query.assert_called_once()
+        task_state_store.set.assert_called_once_with("athena_query_execution_id", "new-query-id")
+
+    @mock.patch.object(AthenaQueryResultsLink, "persist")
+    @mock.patch.object(AthenaHook, "check_query_status")
+    @mock.patch.object(AthenaHook, "run_query")
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "QueryExecutionId is malformed",
+            "QueryExecution 0f8db785-a48f-42c2-84c5-d749b034234a was not found",
+        ],
+    )
+    def test_other_invalid_request_is_raised(self, mock_run_query, mock_check_status, mock_persist, message):
+        operator = self._make_operator()
+        error = self._invalid_request_error(message)
+        mock_check_status.side_effect = error
+        task_state_store = mock.MagicMock(spec_set=["get", "set"])
+        task_state_store.get.return_value = ATHENA_QUERY_ID
+
+        with pytest.raises(ClientError) as caught:
+            operator.execute(self._context(task_state_store))
+
+        assert caught.value is error
+        mock_run_query.assert_not_called()
 
     @mock.patch.object(AthenaQueryResultsLink, "persist")
     @mock.patch.object(AthenaHook, "poll_query_status", return_value="SUCCEEDED")


### PR DESCRIPTION
A synchronous Athena task submits another query when its worker exits after `StartQueryExecution` and Airflow retries it. The retry now resumes the stored query. A completed query returns without resubmission; failed, cancelled, or missing queries submit normally.

When Athena no longer recognizes the stored ID, it returns `InvalidRequestException: QueryExecution <id> was not found`. Only that response for the same query ID triggers replacement; other invalid requests still fail.

AIP-103 task state is used only for synchronous polling. The operator stores the query ID before polling, reconnects active queries, and restores the ID and results link. Deferrable tasks and `client_request_token` behavior do not change.

## Testing

`uv run --project providers/amazon pytest providers/amazon/tests/unit/amazon/aws/operators/test_athena.py -xq`

The live test drove the real operator `execute()` path and task state API against fresh SQLite with a local Athena hook stand-in.

```console
UPSTREAM=/tmp/airflow-athena-main
git worktree add --detach "$UPSTREAM" upstream/main
AIRFLOW_HOME="$PWD/.tmp-athena-e2e" \
LEGACY_ATHENA_OPERATOR_PATH="$UPSTREAM/providers/amazon/src/airflow/providers/amazon/aws/operators/athena.py" \
uv run --project providers/amazon pytest -p tests_common.pytest_plugin \
  dev/test_athena_resumability_e2e.py -xvs
git worktree remove "$UPSTREAM"
```

<details>
<summary>Raw logs</summary>

```text
TASK_STATE_AFTER_CRASH api=query-1 db=query-1
BEFORE stored=query-1 result=query-2 submitted=['query-2']
Reconnecting to existing job external_id=query-1 external_id_key=athena_query_execution_id status=RUNNING
AFTER stored=query-1 result=query-1 submitted=[] operator_id=query-1 link_id=query-1
PASSED
1 passed, 1 warning in 50.94s
```

</details>

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (GitHub Copilot CLI (GPT-5.6 Sol))

Generated-by: GitHub Copilot CLI (GPT-5.6 Sol) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
