### PR TITLE
Reconnect Cloud Batch jobs on task retry

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/cloud_batch.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/cloud_batch.py
@@ -18,9 +18,11 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from contextlib import suppress
+from typing import TYPE_CHECKING, Any
 
-from google.cloud.batch_v1 import Job, Task
+from google.api_core.exceptions import NotFound
+from google.cloud.batch_v1 import Job, JobStatus, Task
 
 from airflow.providers.common.compat.sdk import AirflowException, conf
 from airflow.providers.google.cloud.hooks.cloud_batch import CloudBatchHook
@@ -54,24 +56,28 @@ class CloudBatchSubmitJobOperator(GoogleCloudBaseOperator):
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
     :param deferrable: Run operator in the deferrable mode
+    :param durable: Persist the submitted job name so synchronous retries reconnect to the same job.
+        Requires Airflow 3.3+; on earlier versions, retries submit a new job.
 
     """
 
     template_fields = ("project_id", "region", "gcp_conn_id", "impersonation_chain", "job_name", "job")
     template_fields_renderers = {"job": "json"}
+    external_id_key: str = "cloud_batch_job_name"
 
     def __init__(
         self,
         project_id: str,
         region: str,
         job_name: str,
-        job: dict | Job,
+        job: dict[str, Any] | Job,
         polling_period_seconds: float = 10,
         timeout_seconds: float | None = None,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
-        **kwargs,
+        durable: bool = True,
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.project_id = project_id
@@ -83,6 +89,7 @@ class CloudBatchSubmitJobOperator(GoogleCloudBaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
         self.deferrable = deferrable
+        self.durable: bool = durable
         self.polling_period_seconds = polling_period_seconds
 
     def prepare_template(self) -> None:
@@ -91,20 +98,18 @@ class CloudBatchSubmitJobOperator(GoogleCloudBaseOperator):
         if isinstance(self.job, Job):
             self.job = Job.to_dict(self.job)
 
-    def execute(self, context: Context):
-        hook: CloudBatchHook = CloudBatchHook(self.gcp_conn_id, self.impersonation_chain)
-        job = hook.submit_batch_job(
-            job_name=self.job_name, job=self.job, region=self.region, project_id=self.project_id
+    def execute(self, context: Context) -> dict[str, Any]:
+        hook = CloudBatchHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
         )
 
         if not self.deferrable:
-            completed_job = hook.wait_for_job(
-                job_name=job.name,
-                polling_period_seconds=self.polling_period_seconds,
-                timeout=self.timeout_seconds,
-            )
+            return self._execute_sync(context=context, hook=hook)
 
-            return Job.to_dict(completed_job)
+        job = hook.submit_batch_job(
+            job_name=self.job_name, job=self.job, region=self.region, project_id=self.project_id
+        )
 
         self.defer(
             trigger=CloudBatchJobFinishedTrigger(
@@ -119,10 +124,55 @@ class CloudBatchSubmitJobOperator(GoogleCloudBaseOperator):
             method_name="execute_complete",
         )
 
-    def execute_complete(self, context: Context, event: dict):
+    def _execute_sync(self, *, context: Context, hook: CloudBatchHook) -> dict[str, Any]:
+        task_state_store = context.get("task_state_store") if self.durable else None
+        job: Job | None = None
+
+        if task_state_store is not None and (stored_job_name := task_state_store.get(self.external_id_key)):
+            if not isinstance(stored_job_name, str):
+                raise ValueError(f"Stored Cloud Batch job name is not a string: {stored_job_name!r}")
+            with suppress(NotFound):
+                job = hook.get_job(job_name=stored_job_name)
+
+        if job is None:
+            job = hook.submit_batch_job(
+                job_name=self.job_name,
+                job=self.job,
+                region=self.region,
+                project_id=self.project_id,
+            )
+            if task_state_store is not None:
+                task_state_store.set(key=self.external_id_key, value=job.name)
+        else:
+            self._raise_for_terminal_job(job)
+            if job.status.state == JobStatus.State.SUCCEEDED:
+                return Job.to_dict(job)
+
+        completed_job = hook.wait_for_job(
+            job_name=job.name,
+            polling_period_seconds=self.polling_period_seconds,
+            timeout=self.timeout_seconds,
+        )
+        return Job.to_dict(completed_job)
+
+    @staticmethod
+    def _raise_for_terminal_job(job: Job) -> None:
+        if job.status.state == JobStatus.State.FAILED:
+            raise RuntimeError(f"Batch job with name {job.name} has failed its execution.")
+        if job.status.state == JobStatus.State.DELETION_IN_PROGRESS:
+            raise RuntimeError(f"Batch job with name {job.name} is being deleted.")
+        if job.status.state == JobStatus.State.CANCELLATION_IN_PROGRESS:
+            raise RuntimeError(f"Batch job with name {job.name} is being cancelled.")
+        if job.status.state == JobStatus.State.CANCELLED:
+            raise RuntimeError(f"Batch job with name {job.name} was cancelled.")
+
+    def execute_complete(self, context: Context, event: dict[str, Any]) -> dict[str, Any]:
         job_status = event["status"]
         if job_status == "success":
-            hook: CloudBatchHook = CloudBatchHook(self.gcp_conn_id, self.impersonation_chain)
+            hook = CloudBatchHook(
+                gcp_conn_id=self.gcp_conn_id,
+                impersonation_chain=self.impersonation_chain,
+            )
             job = hook.get_job(job_name=event["job_name"])
             return Job.to_dict(job)
         raise AirflowException(f"Unexpected error in the operation: {event['message']}")

--- a/providers/google/src/airflow/providers/google/cloud/operators/cloud_batch.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/cloud_batch.py
@@ -128,7 +128,9 @@ class CloudBatchSubmitJobOperator(GoogleCloudBaseOperator):
         task_state_store = context.get("task_state_store") if self.durable else None
         job: Job | None = None
 
-        if task_state_store is not None and (stored_job_name := task_state_store.get(self.external_id_key)):
+        if task_state_store is not None and (
+            stored_job_name := task_state_store.get(key=self.external_id_key)
+        ):
             if not isinstance(stored_job_name, str):
                 raise ValueError(f"Stored Cloud Batch job name is not a string: {stored_job_name!r}")
             with suppress(NotFound):
@@ -144,7 +146,7 @@ class CloudBatchSubmitJobOperator(GoogleCloudBaseOperator):
             if task_state_store is not None:
                 task_state_store.set(key=self.external_id_key, value=job.name)
         else:
-            self._raise_for_terminal_job(job)
+            self._raise_for_terminal_job(job=job)
             if job.status.state == JobStatus.State.SUCCEEDED:
                 return Job.to_dict(job)
 

--- a/providers/google/src/airflow/providers/google/cloud/operators/cloud_batch.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/cloud_batch.py
@@ -34,6 +34,11 @@ if TYPE_CHECKING:
 
     from airflow.providers.common.compat.sdk import Context
 
+# Older google-cloud-batch clients preserve these newer wire values as ints.
+# https://github.com/googleapis/googleapis/blob/02fc2b28bc702c8bb45735631ea0ad66893067fb/google/cloud/batch/v1/job.proto#L199-L205
+_CANCELLATION_IN_PROGRESS_STATE: int = 7
+_CANCELLED_STATE: int = 8
+
 
 class CloudBatchSubmitJobOperator(GoogleCloudBaseOperator):
     """
@@ -159,13 +164,14 @@ class CloudBatchSubmitJobOperator(GoogleCloudBaseOperator):
 
     @staticmethod
     def _raise_for_terminal_job(job: Job) -> None:
-        if job.status.state == JobStatus.State.FAILED:
+        job_state: int = int(job.status.state)
+        if job_state == JobStatus.State.FAILED:
             raise RuntimeError(f"Batch job with name {job.name} has failed its execution.")
-        if job.status.state == JobStatus.State.DELETION_IN_PROGRESS:
+        if job_state == JobStatus.State.DELETION_IN_PROGRESS:
             raise RuntimeError(f"Batch job with name {job.name} is being deleted.")
-        if job.status.state == JobStatus.State.CANCELLATION_IN_PROGRESS:
+        if job_state == _CANCELLATION_IN_PROGRESS_STATE:
             raise RuntimeError(f"Batch job with name {job.name} is being cancelled.")
-        if job.status.state == JobStatus.State.CANCELLED:
+        if job_state == _CANCELLED_STATE:
             raise RuntimeError(f"Batch job with name {job.name} was cancelled.")
 
     def execute_complete(self, context: Context, event: dict[str, Any]) -> dict[str, Any]:

--- a/providers/google/tests/unit/google/cloud/operators/test_cloud_batch.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_cloud_batch.py
@@ -272,20 +272,20 @@ class TestCloudBatchSubmitJobOperator:
         assert result["name"] == FULL_JOB_NAME
         mock_hook.return_value.submit_batch_job.assert_called_once()
 
-    @mock.patch(CLOUD_BATCH_HOOK_PATH)
-    def test_execute_deferrable(self, mock, task_state_store):
+    @mock.patch(CLOUD_BATCH_HOOK_PATH, autospec=True)
+    def test_execute_deferrable(self, mock_hook, task_state_store):
         store, _, supervisor_comms = task_state_store
         store.set(key="cloud_batch_job_name", value=FULL_JOB_NAME)
         supervisor_comms.reset_mock()
-        mock.return_value.submit_batch_job.return_value = JOB
+        mock_hook.return_value.submit_batch_job.return_value = JOB
         operator = CloudBatchSubmitJobOperator(**OPERATOR_ARGS, deferrable=True)
 
         with pytest.raises(expected_exception=TaskDeferred):
             operator.execute(context=_context(store))
 
-        mock.return_value.submit_batch_job.assert_called_once()
-        mock.return_value.get_job.assert_not_called()
-        mock.return_value.wait_for_job.assert_not_called()
+        mock_hook.return_value.submit_batch_job.assert_called_once()
+        mock_hook.return_value.get_job.assert_not_called()
+        mock_hook.return_value.wait_for_job.assert_not_called()
         assert not supervisor_comms.send.called
 
     @mock.patch(CLOUD_BATCH_HOOK_PATH)

--- a/providers/google/tests/unit/google/cloud/operators/test_cloud_batch.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_cloud_batch.py
@@ -68,7 +68,7 @@ OPERATOR_ARGS: dict[str, Any] = {
 }
 
 
-def _job_with_state(state: batch_v1.JobStatus.State) -> batch_v1.Job:
+def _job_with_state(state: batch_v1.JobStatus.State | int) -> batch_v1.Job:
     return batch_v1.Job(name=FULL_JOB_NAME, status=batch_v1.JobStatus(state=state))
 
 
@@ -191,8 +191,8 @@ class TestCloudBatchSubmitJobOperator:
         [
             (batch_v1.JobStatus.State.FAILED, "has failed its execution"),
             (batch_v1.JobStatus.State.DELETION_IN_PROGRESS, "is being deleted"),
-            (batch_v1.JobStatus.State.CANCELLATION_IN_PROGRESS, "is being cancelled"),
-            (batch_v1.JobStatus.State.CANCELLED, "was cancelled"),
+            (7, "is being cancelled"),
+            (8, "was cancelled"),
         ],
     )
     @mock.patch(CLOUD_BATCH_HOOK_PATH, autospec=True)

--- a/providers/google/tests/unit/google/cloud/operators/test_cloud_batch.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_cloud_batch.py
@@ -35,18 +35,21 @@ from airflow.providers.google.cloud.operators.cloud_batch import (
     CloudBatchListTasksOperator,
     CloudBatchSubmitJobOperator,
 )
-from airflow.sdk.execution_time.comms import (
-    ErrorResponse,
-    ErrorType,
-    GetTaskStateStore,
-    OKResponse,
-    SetTaskStateStore,
-    TaskStateStoreResult,
-)
-from airflow.sdk.execution_time.context import TaskStateStoreAccessor
-from airflow.sdk.state import TaskScope
 
 from tests_common.test_utils.compat import DagSerialization
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_3_PLUS
+
+if AIRFLOW_V_3_3_PLUS:
+    from airflow.sdk.execution_time.comms import (
+        ErrorResponse,
+        ErrorType,
+        GetTaskStateStore,
+        OKResponse,
+        SetTaskStateStore,
+        TaskStateStoreResult,
+    )
+    from airflow.sdk.execution_time.context import TaskStateStoreAccessor
+    from airflow.sdk.state import TaskScope
 
 CLOUD_BATCH_HOOK_PATH = "airflow.providers.google.cloud.operators.cloud_batch.CloudBatchHook"
 TASK_ID = "test"
@@ -71,6 +74,9 @@ def _job_with_state(state: batch_v1.JobStatus.State) -> batch_v1.Job:
 
 @pytest.fixture
 def task_state_store() -> Iterator[tuple[TaskStateStoreAccessor, dict[str, Any], mock.Mock]]:
+    if not AIRFLOW_V_3_3_PLUS:
+        pytest.skip("Task state store recovery requires Airflow 3.3+")
+
     stored: dict[str, Any] = {}
     supervisor_comms = mock.Mock(spec=["send"])
 

--- a/providers/google/tests/unit/google/cloud/operators/test_cloud_batch.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_cloud_batch.py
@@ -18,10 +18,14 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 from datetime import datetime
+from typing import Any
 from unittest import mock
+from uuid import UUID
 
 import pytest
+from google.api_core.exceptions import AlreadyExists, NotFound
 from google.cloud import batch_v1
 
 from airflow.providers.common.compat.sdk import AirflowException, TaskDeferred
@@ -31,6 +35,16 @@ from airflow.providers.google.cloud.operators.cloud_batch import (
     CloudBatchListTasksOperator,
     CloudBatchSubmitJobOperator,
 )
+from airflow.sdk.execution_time.comms import (
+    ErrorResponse,
+    ErrorType,
+    GetTaskStateStore,
+    OKResponse,
+    SetTaskStateStore,
+    TaskStateStoreResult,
+)
+from airflow.sdk.execution_time.context import TaskStateStoreAccessor
+from airflow.sdk.state import TaskScope
 
 from tests_common.test_utils.compat import DagSerialization
 
@@ -41,6 +55,46 @@ REGION = "us-central1"
 JOB_NAME = "test"
 JOB = batch_v1.Job()
 JOB.name = JOB_NAME
+FULL_JOB_NAME = f"projects/{PROJECT_ID}/locations/{REGION}/jobs/{JOB_NAME}"
+OPERATOR_ARGS: dict[str, Any] = {
+    "task_id": TASK_ID,
+    "project_id": PROJECT_ID,
+    "region": REGION,
+    "job_name": JOB_NAME,
+    "job": JOB,
+}
+
+
+def _job_with_state(state: batch_v1.JobStatus.State) -> batch_v1.Job:
+    return batch_v1.Job(name=FULL_JOB_NAME, status=batch_v1.JobStatus(state=state))
+
+
+@pytest.fixture
+def task_state_store() -> Iterator[tuple[TaskStateStoreAccessor, dict[str, Any], mock.Mock]]:
+    stored: dict[str, Any] = {}
+    supervisor_comms = mock.Mock(spec=["send"])
+
+    def send(message: object) -> object:
+        if isinstance(message, GetTaskStateStore):
+            if message.key in stored:
+                return TaskStateStoreResult(value=stored[message.key])
+            return ErrorResponse(error=ErrorType.TASK_STORE_NOT_FOUND, detail={"key": message.key})
+        if isinstance(message, SetTaskStateStore):
+            stored[message.key] = message.value
+            return OKResponse(ok=True)
+        raise AssertionError(f"Unexpected task state store message: {message!r}")
+
+    supervisor_comms.send.side_effect = send
+    state_store = TaskStateStoreAccessor(
+        ti_id=UUID("01900000-0000-0000-0000-000000000001"),
+        scope=TaskScope(dag_id="dag", run_id="run", task_id=TASK_ID),
+    )
+    with mock.patch("airflow.sdk.execution_time.task_runner.SUPERVISOR_COMMS", supervisor_comms, create=True):
+        yield state_store, stored, supervisor_comms
+
+
+def _context(task_state_store: TaskStateStoreAccessor) -> dict[str, Any]:
+    return {"task_state_store": task_state_store}
 
 
 class TestCloudBatchSubmitJobOperator:
@@ -48,10 +102,14 @@ class TestCloudBatchSubmitJobOperator:
     def test_execute(self, mock):
         mock.return_value.wait_for_job.return_value = JOB
         operator = CloudBatchSubmitJobOperator(
-            task_id=TASK_ID, project_id=PROJECT_ID, region=REGION, job_name=JOB_NAME, job=JOB
+            task_id=TASK_ID,
+            project_id=PROJECT_ID,
+            region=REGION,
+            job_name=JOB_NAME,
+            job=JOB,
         )
 
-        completed_job = operator.execute(context=mock.MagicMock())
+        completed_job = operator.execute(context={})
 
         assert completed_job["name"] == JOB_NAME
 
@@ -60,14 +118,169 @@ class TestCloudBatchSubmitJobOperator:
         )
         mock.return_value.wait_for_job.assert_called()
 
-    @mock.patch(CLOUD_BATCH_HOOK_PATH)
-    def test_execute_deferrable(self, mock):
-        operator = CloudBatchSubmitJobOperator(
-            task_id=TASK_ID, project_id=PROJECT_ID, region=REGION, job_name=JOB_NAME, job=JOB, deferrable=True
+    @mock.patch(CLOUD_BATCH_HOOK_PATH, autospec=True)
+    def test_fresh_run_persists_exact_job_name_before_waiting(self, mock_hook, task_state_store):
+        store, stored, _ = task_state_store
+        submitted_job = _job_with_state(batch_v1.JobStatus.State.RUNNING)
+        completed_job = _job_with_state(batch_v1.JobStatus.State.SUCCEEDED)
+        mock_hook.return_value.submit_batch_job.return_value = submitted_job
+
+        def wait_for_job(**_: Any) -> batch_v1.Job:
+            assert stored["cloud_batch_job_name"] == FULL_JOB_NAME
+            return completed_job
+
+        mock_hook.return_value.wait_for_job.side_effect = wait_for_job
+        operator = CloudBatchSubmitJobOperator(**OPERATOR_ARGS)
+
+        result = operator.execute(context=_context(store))
+
+        assert result["name"] == FULL_JOB_NAME
+        mock_hook.return_value.submit_batch_job.assert_called_once_with(
+            job_name=JOB_NAME, job=JOB, region=REGION, project_id=PROJECT_ID
+        )
+        mock_hook.return_value.wait_for_job.assert_called_once_with(
+            job_name=FULL_JOB_NAME,
+            polling_period_seconds=10,
+            timeout=None,
         )
 
+    @mock.patch(CLOUD_BATCH_HOOK_PATH, autospec=True)
+    def test_retry_reconnects_to_running_job(self, mock_hook, task_state_store):
+        store, _, supervisor_comms = task_state_store
+        store.set(key="cloud_batch_job_name", value=FULL_JOB_NAME)
+        supervisor_comms.reset_mock()
+        mock_hook.return_value.submit_batch_job.side_effect = AlreadyExists(
+            f"Job {FULL_JOB_NAME} already exists"
+        )
+        mock_hook.return_value.get_job.return_value = _job_with_state(batch_v1.JobStatus.State.RUNNING)
+        mock_hook.return_value.wait_for_job.return_value = _job_with_state(batch_v1.JobStatus.State.SUCCEEDED)
+        operator = CloudBatchSubmitJobOperator(**OPERATOR_ARGS)
+
+        result = operator.execute(context=_context(store))
+
+        assert result["name"] == FULL_JOB_NAME
+        mock_hook.return_value.submit_batch_job.assert_not_called()
+        mock_hook.return_value.get_job.assert_called_once_with(job_name=FULL_JOB_NAME)
+        mock_hook.return_value.wait_for_job.assert_called_once_with(
+            job_name=FULL_JOB_NAME,
+            polling_period_seconds=10,
+            timeout=None,
+        )
+
+    @mock.patch(CLOUD_BATCH_HOOK_PATH, autospec=True)
+    def test_retry_restores_succeeded_job(self, mock_hook, task_state_store):
+        store, _, _ = task_state_store
+        store.set(key="cloud_batch_job_name", value=FULL_JOB_NAME)
+        mock_hook.return_value.get_job.return_value = _job_with_state(batch_v1.JobStatus.State.SUCCEEDED)
+        operator = CloudBatchSubmitJobOperator(**OPERATOR_ARGS)
+
+        result = operator.execute(context=_context(store))
+
+        assert result["name"] == FULL_JOB_NAME
+        mock_hook.return_value.submit_batch_job.assert_not_called()
+        mock_hook.return_value.wait_for_job.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("state", "message"),
+        [
+            (batch_v1.JobStatus.State.FAILED, "has failed its execution"),
+            (batch_v1.JobStatus.State.DELETION_IN_PROGRESS, "is being deleted"),
+            (batch_v1.JobStatus.State.CANCELLATION_IN_PROGRESS, "is being cancelled"),
+            (batch_v1.JobStatus.State.CANCELLED, "was cancelled"),
+        ],
+    )
+    @mock.patch(CLOUD_BATCH_HOOK_PATH, autospec=True)
+    def test_retry_does_not_replace_terminal_job(self, mock_hook, state, message, task_state_store):
+        store, _, _ = task_state_store
+        store.set(key="cloud_batch_job_name", value=FULL_JOB_NAME)
+        mock_hook.return_value.get_job.return_value = _job_with_state(state)
+        operator = CloudBatchSubmitJobOperator(**OPERATOR_ARGS)
+
+        with pytest.raises(RuntimeError, match=message):
+            operator.execute(context=_context(store))
+
+        mock_hook.return_value.submit_batch_job.assert_not_called()
+        mock_hook.return_value.wait_for_job.assert_not_called()
+
+    @mock.patch(CLOUD_BATCH_HOOK_PATH, autospec=True)
+    def test_retry_replaces_missing_job(self, mock_hook, task_state_store):
+        store, stored, _ = task_state_store
+        store.set(key="cloud_batch_job_name", value=FULL_JOB_NAME)
+        mock_hook.return_value.get_job.side_effect = NotFound("job was deleted")
+        mock_hook.return_value.submit_batch_job.return_value = _job_with_state(
+            batch_v1.JobStatus.State.RUNNING
+        )
+        mock_hook.return_value.wait_for_job.return_value = _job_with_state(batch_v1.JobStatus.State.SUCCEEDED)
+        operator = CloudBatchSubmitJobOperator(**OPERATOR_ARGS)
+
+        result = operator.execute(context=_context(store))
+
+        assert result["name"] == FULL_JOB_NAME
+        assert stored["cloud_batch_job_name"] == FULL_JOB_NAME
+        mock_hook.return_value.get_job.assert_called_once_with(job_name=FULL_JOB_NAME)
+        mock_hook.return_value.submit_batch_job.assert_called_once_with(
+            job_name=JOB_NAME, job=JOB, region=REGION, project_id=PROJECT_ID
+        )
+
+    @mock.patch(CLOUD_BATCH_HOOK_PATH, autospec=True)
+    def test_retry_rejects_non_string_job_name(self, mock_hook, task_state_store):
+        store, _, _ = task_state_store
+        store.set(key="cloud_batch_job_name", value=42)
+        operator = CloudBatchSubmitJobOperator(**OPERATOR_ARGS)
+
+        with pytest.raises(ValueError, match="Stored Cloud Batch job name is not a string: 42"):
+            operator.execute(context=_context(store))
+
+        mock_hook.return_value.submit_batch_job.assert_not_called()
+
+    @mock.patch(CLOUD_BATCH_HOOK_PATH, autospec=True)
+    def test_durable_false_submits_fresh(self, mock_hook, task_state_store):
+        store, _, supervisor_comms = task_state_store
+        store.set(key="cloud_batch_job_name", value=FULL_JOB_NAME)
+        supervisor_comms.reset_mock()
+        mock_hook.return_value.submit_batch_job.return_value = _job_with_state(
+            batch_v1.JobStatus.State.RUNNING
+        )
+        mock_hook.return_value.wait_for_job.return_value = _job_with_state(batch_v1.JobStatus.State.SUCCEEDED)
+        operator = CloudBatchSubmitJobOperator(**OPERATOR_ARGS, durable=False)
+
+        result = operator.execute(context=_context(store))
+
+        assert result["name"] == FULL_JOB_NAME
+        mock_hook.return_value.submit_batch_job.assert_called_once()
+        mock_hook.return_value.get_job.assert_not_called()
+        assert not any(
+            isinstance(call.args[0], GetTaskStateStore) for call in supervisor_comms.send.call_args_list
+        )
+
+    @mock.patch(CLOUD_BATCH_HOOK_PATH, autospec=True)
+    def test_missing_task_state_store_submits_fresh(self, mock_hook):
+        mock_hook.return_value.submit_batch_job.return_value = _job_with_state(
+            batch_v1.JobStatus.State.RUNNING
+        )
+        mock_hook.return_value.wait_for_job.return_value = _job_with_state(batch_v1.JobStatus.State.SUCCEEDED)
+        operator = CloudBatchSubmitJobOperator(**OPERATOR_ARGS)
+
+        result = operator.execute(context={})
+
+        assert result["name"] == FULL_JOB_NAME
+        mock_hook.return_value.submit_batch_job.assert_called_once()
+
+    @mock.patch(CLOUD_BATCH_HOOK_PATH)
+    def test_execute_deferrable(self, mock, task_state_store):
+        store, _, supervisor_comms = task_state_store
+        store.set(key="cloud_batch_job_name", value=FULL_JOB_NAME)
+        supervisor_comms.reset_mock()
+        mock.return_value.submit_batch_job.return_value = JOB
+        operator = CloudBatchSubmitJobOperator(**OPERATOR_ARGS, deferrable=True)
+
         with pytest.raises(expected_exception=TaskDeferred):
-            operator.execute(context=mock.MagicMock())
+            operator.execute(context=_context(store))
+
+        mock.return_value.submit_batch_job.assert_called_once()
+        mock.return_value.get_job.assert_not_called()
+        mock.return_value.wait_for_job.assert_not_called()
+        assert not supervisor_comms.send.called
 
     @mock.patch(CLOUD_BATCH_HOOK_PATH)
     def test_execute_complete(self, mock):


### PR DESCRIPTION
A synchronous Cloud Batch task uses a caller-stable job ID. If its worker exits after submission, retry resubmits the same ID and fails with `409 ... already exists`, even if the first job is active or succeeded.

On Airflow 3.3+, the operator saves the canonical name before waiting. Retry fetches only that task-owned job: wait if active, restore success, resubmit after `NotFound`, or reject other terminal states. Fresh and deferrable execution, `durable=False`, and older Airflow behavior do not change.

## Testing

The regression test drives the real task state accessor and `execute()` with a local hook stand-in.

<details>
<summary>Raw retry proof</summary>

```console
$ AIRFLOW_HOME=.build/cloud-batch-proof-home uv run --project providers/google pytest providers/google/tests/unit/google/cloud/operators/test_cloud_batch.py::TestCloudBatchSubmitJobOperator::test_retry_reconnects_to_running_job -xvs

# upstream/main
E   google.api_core.exceptions.AlreadyExists: 409 Job projects/testproject/locations/us-central1/jobs/test already exists
=================== 1 failed, 1 warning in 113.59s (0:01:53) ===================

# this branch
PASSED
=================== 1 passed, 1 warning in 92.69s (0:01:32) ====================
```

</details>

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (GitHub Copilot CLI, GPT-5.6 Sol)

Generated-by: GitHub Copilot CLI (GPT-5.6 Sol) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
