### PR TITLE
Prevent duplicate ECS submissions on task retry

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/ecs.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/ecs.py
@@ -18,16 +18,17 @@
 from __future__ import annotations
 
 import re
+import warnings
 from collections.abc import Container, Sequence
 from datetime import timedelta
 from functools import cached_property
 from time import sleep
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from botocore.exceptions import WaiterError
 
 from airflow.providers.amazon.aws.exceptions import EcsOperatorError, EcsTaskFailToStart
-from airflow.providers.amazon.aws.hooks.ecs import EcsClusterStates, EcsHook
+from airflow.providers.amazon.aws.hooks.ecs import EcsClusterStates, EcsHook, EcsTaskStates
 from airflow.providers.amazon.aws.hooks.logs import AwsLogsHook
 from airflow.providers.amazon.aws.operators.base_aws import AwsBaseOperator
 from airflow.providers.amazon.aws.triggers.ecs import (
@@ -42,10 +43,43 @@ from airflow.providers.amazon.aws.utils.task_log_fetcher import AwsTaskLogFetche
 from airflow.providers.common.compat.sdk import AirflowException, AirflowSkipException, conf
 from airflow.utils.helpers import prune_dict
 
+_DURABLE_UNSET = object()
+_TASK_NOT_FOUND = "NOT_FOUND"
+
+
+def _warn_and_disable_durable_pre_3_3(durable: Any) -> bool:
+    if durable is not _DURABLE_UNSET:
+        warnings.warn(
+            "`durable` has no effect on Airflow versions below 3.3.",
+            UserWarning,
+            stacklevel=3,
+        )
+    return False
+
+
+try:
+    from airflow.sdk import ResumableJobMixin
+except ImportError:
+
+    class ResumableJobMixin:  # type: ignore[no-redef]
+        """Submit jobs without task-state recovery on Airflow versions below 3.3."""
+
+        external_id_key: str = "ecs_task_arn"
+
+        def __init__(self, *, durable: Any = _DURABLE_UNSET, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+            self.durable = _warn_and_disable_durable_pre_3_3(durable)
+
+        def execute_resumable(self: Any, context: Context) -> Any:
+            external_id = self.submit_job(context)
+            self.poll_until_complete(external_id, context)
+            return self.get_job_result(external_id, context)
+
+
 if TYPE_CHECKING:
     import boto3
+    from pydantic import JsonValue
 
-    from airflow.models import TaskInstance
     from airflow.sdk import Context
 
 
@@ -329,7 +363,7 @@ class EcsRegisterTaskDefinitionOperator(EcsBaseOperator):
         return task_definition_arn
 
 
-class EcsRunTaskOperator(EcsBaseOperator):
+class EcsRunTaskOperator(ResumableJobMixin, EcsBaseOperator):
     """
     Execute a task on AWS ECS (Elastic Container Service).
 
@@ -401,9 +435,12 @@ class EcsRunTaskOperator(EcsBaseOperator):
         Additionally, if logs are fetched, the last log message will be pushed to XCom with the key 'return_value'. (default: False)
     :param stop_task_on_failure: If True, attempt to stop the ECS task if the Airflow task fails
         after the ECS task has started. (default: True)
+    :param durable: If True, reconnect to the ECS task from task state on retry instead of
+        starting a duplicate. Defaults to True on Airflow 3.3+ and is ignored on earlier versions.
     """
 
     ui_color = "#f0ede4"
+    external_id_key = "ecs_task_arn"
     template_fields: Sequence[str] = (
         "task_definition",
         "cluster",
@@ -466,8 +503,11 @@ class EcsRunTaskOperator(EcsBaseOperator):
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
         skip_on_exit_code: int | Container[int] | None = None,
         stop_task_on_failure: bool = True,
-        **kwargs,
-    ):
+        durable: bool | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if durable is not None:
+            kwargs["durable"] = durable
         super().__init__(**kwargs)
 
         self.task_definition = task_definition
@@ -494,6 +534,9 @@ class EcsRunTaskOperator(EcsBaseOperator):
         self.arn: str | None = None
         self.container_name: str | None = container_name
         self._started_by: str | None = None
+        self._stored_task_active = False
+        self._stored_task_succeeded = False
+        self._task_started_by_this_run = False
 
         self.retry_args = quota_retry
         self.task_log_fetcher: AwsTaskLogFetcher | None = None
@@ -516,7 +559,7 @@ class EcsRunTaskOperator(EcsBaseOperator):
             return None
         return task_arn.split("/")[-1]
 
-    def execute(self, context):
+    def execute(self, context: Context) -> str | None:
         if self._aws_logs_enabled() and not self.wait_for_completion:
             self.log.warning(
                 "Trying to get logs without waiting for the task to complete is undefined behavior."
@@ -527,29 +570,22 @@ class EcsRunTaskOperator(EcsBaseOperator):
         )
         self.log.info("EcsOperator overrides: %s", self.overrides)
 
-        task_started_by_this_run = False
+        self._task_started_by_this_run = False
 
         try:
             if self.reattach:
                 # Generate deterministic UUID which refers to unique TaskInstanceKey
-                ti: TaskInstance = context["ti"]
+                ti = context["ti"]
                 self._started_by = generate_uuid(*map(str, [ti.dag_id, ti.task_id, ti.run_id, ti.map_index]))
                 self.log.info("Try to find run with startedBy=%r", self._started_by)
-                self._try_reattach_task(started_by=self._started_by)
-
-            if not self.arn:
-                # start the task except if we reattached to an existing one just before.
-                self._start_task()
-                task_started_by_this_run = True
-
-            if self.do_xcom_push:
-                context["ti"].xcom_push(key="ecs_task_arn", value=self.arn)
 
             if self.deferrable:
+                task_arn = self.submit_job(context)
+                self._resolve_container_name()
                 self.defer(
                     trigger=TaskDoneTrigger(
                         cluster=self.cluster,
-                        task_arn=self.arn,
+                        task_arn=task_arn,
                         waiter_delay=self.waiter_delay,
                         waiter_max_attempts=self.waiter_max_attempts,
                         aws_conn_id=self.aws_conn_id,
@@ -565,32 +601,9 @@ class EcsRunTaskOperator(EcsBaseOperator):
                     # 60 seconds is added to allow the trigger to exit gracefully (i.e. yield TriggerEvent)
                     timeout=timedelta(seconds=self.waiter_max_attempts * self.waiter_delay + 60),
                 )
-                # self.defer raises a special exception, so execution stops here in this case.
-
-            if not self.wait_for_completion:
-                return
-
-            if self._aws_logs_enabled():
-                self.log.info("Starting ECS Task Log Fetcher")
-                self.task_log_fetcher = self._get_task_log_fetcher()
-                self.task_log_fetcher.start()
-
-                try:
-                    self._wait_for_task_ended()
-                finally:
-                    self.task_log_fetcher.stop()
-                self.task_log_fetcher.join()
-            else:
-                self._wait_for_task_ended()
-
-            self._after_execution()
-
-            if self.do_xcom_push and self.task_log_fetcher:
-                return self.task_log_fetcher.get_last_log_message()
-            return None
+            return self.execute_resumable(context)
         except WaiterError:
-            # Best-effort cleanup when post-initiation steps fail (e.g. IAM/permission errors).
-            if task_started_by_this_run and self.arn:
+            if self._task_started_by_this_run and self.arn:
                 self.log.warning(
                     "Execution failed after ECS task %s was started by this task instance.", self.arn
                 )
@@ -611,6 +624,90 @@ class EcsRunTaskOperator(EcsBaseOperator):
                         )
             raise
 
+    def execute_resumable(self, context: Context) -> str | None:
+        self._stored_task_active = False
+        self._stored_task_succeeded = False
+        result: str | None = super().execute_resumable(context)
+        if self._stored_task_active and self.arn:
+            return self.get_job_result(self.arn, context)
+        return result
+
+    def submit_job(self, context: Context) -> str:
+        self.arn = None
+        if self.reattach:
+            self._try_reattach_task(started_by=self._started_by)
+        if self.arn is None:
+            self.arn = self._start_task()
+            self._task_started_by_this_run = True
+        if self.do_xcom_push:
+            context["ti"].xcom_push(key=self.external_id_key, value=self.arn)
+        return self.arn
+
+    def get_job_status(self, external_id: JsonValue, context: Context) -> str:
+        task_arn = cast("str", external_id)
+        self.arn = task_arn
+        self._stored_task_active = False
+        self._stored_task_succeeded = False
+        if self.do_xcom_push:
+            context["ti"].xcom_push(key=self.external_id_key, value=task_arn)
+        response = self.client.describe_tasks(cluster=self.cluster, tasks=[task_arn])
+        tasks = response.get("tasks", [])
+        if not tasks:
+            return _TASK_NOT_FOUND
+
+        task = tasks[0]
+        if not self.container_name:
+            containers = task.get("containers", [])
+            if containers:
+                self.container_name = containers[0].get("name")
+
+        status = cast("str", task.get("lastStatus") or _TASK_NOT_FOUND)
+        self._stored_task_active = self.is_job_active(status)
+        if status == EcsTaskStates.STOPPED:
+            try:
+                self._check_success_task_response(response)
+            except AirflowSkipException:
+                raise
+            except (AirflowException, EcsTaskFailToStart):
+                pass
+            else:
+                self._stored_task_succeeded = True
+        return status
+
+    def is_job_active(self, status: str) -> bool:
+        return status not in (EcsTaskStates.STOPPED, _TASK_NOT_FOUND)
+
+    def is_job_succeeded(self, status: str) -> bool:
+        return status == EcsTaskStates.STOPPED and self._stored_task_succeeded
+
+    def poll_until_complete(self, external_id: JsonValue, context: Context) -> None:
+        self.arn = cast("str", external_id)
+        self._resolve_container_name()
+        if not self.wait_for_completion:
+            return
+
+        if self._aws_logs_enabled():
+            self.log.info("Starting ECS Task Log Fetcher")
+            self.task_log_fetcher = self._get_task_log_fetcher()
+            self.task_log_fetcher.start()
+            try:
+                self._wait_for_task_ended()
+            finally:
+                self.task_log_fetcher.stop()
+            self.task_log_fetcher.join()
+        else:
+            self._wait_for_task_ended()
+        self._after_execution()
+
+    def get_job_result(self, external_id: JsonValue, context: Context) -> str | None:
+        if not self.do_xcom_push:
+            return None
+        if self.task_log_fetcher:
+            return self.task_log_fetcher.get_last_log_message()
+        if self._stored_task_succeeded and self._aws_logs_enabled():
+            return self._get_last_log_message()
+        return None
+
     def execute_complete(self, context: Context, event: dict[str, Any] | None = None) -> str | None:
         validated_event = validate_execute_complete_event(event)
 
@@ -620,24 +717,27 @@ class EcsRunTaskOperator(EcsBaseOperator):
         self.cluster = validated_event["cluster"]
         self._after_execution()
         if self._aws_logs_enabled():
-            # same behavior as non-deferrable mode, return last line of logs of the task.
-            logs_client = AwsLogsHook(
-                aws_conn_id=self.aws_conn_id, region_name=self.resolve_awslogs_region()
-            ).conn
-            one_log = logs_client.get_log_events(
-                logGroupName=self.awslogs_group,
-                logStreamName=self._get_logs_stream_name(),
-                startFromHead=False,
-                limit=1,
-            )
-            if len(one_log["events"]) > 0:
-                return one_log["events"][0]["message"]
+            return self._get_last_log_message()
         return None
 
-    def _after_execution(self):
+    def _get_last_log_message(self) -> str | None:
+        logs_client = AwsLogsHook(
+            aws_conn_id=self.aws_conn_id, region_name=self.resolve_awslogs_region()
+        ).conn
+        one_log = logs_client.get_log_events(
+            logGroupName=self.awslogs_group,
+            logStreamName=self._get_logs_stream_name(),
+            startFromHead=False,
+            limit=1,
+        )
+        if one_log["events"]:
+            return one_log["events"][0]["message"]
+        return None
+
+    def _after_execution(self) -> None:
         self._check_success_task()
 
-    def _start_task(self):
+    def _start_task(self) -> str:
         run_opts = {
             "cluster": self.cluster,
             "taskDefinition": self.task_definition,
@@ -675,7 +775,9 @@ class EcsRunTaskOperator(EcsBaseOperator):
 
         self.arn = response["tasks"][0]["taskArn"]
         self.log.info("ECS task ID is: %s", self._get_ecs_task_id(self.arn))
+        return self.arn
 
+    def _resolve_container_name(self) -> None:
         if not self.container_name and (self.awslogs_group and self.awslogs_stream_prefix):
             backoff_schedule = [10, 30]
             for delay in backoff_schedule:
@@ -690,7 +792,7 @@ class EcsRunTaskOperator(EcsBaseOperator):
             if not self.container_name:
                 self.log.info("Could not find container name, required for the log stream after 2 tries")
 
-    def _try_reattach_task(self, started_by: str):
+    def _try_reattach_task(self, *, started_by: str | None) -> None:
         if not started_by:
             raise AirflowException("`started_by` should not be empty or None")
         list_tasks_resp = self.client.list_tasks(
@@ -759,7 +861,9 @@ class EcsRunTaskOperator(EcsBaseOperator):
 
         response = self.client.describe_tasks(cluster=self.cluster, tasks=[self.arn])
         self.log.info("ECS Task stopped, check status: %s", response)
+        self._check_success_task_response(response)
 
+    def _check_success_task_response(self, response: dict[str, Any]) -> None:
         if len(response.get("failures", [])) > 0:
             raise AirflowException(response)
 

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_ecs.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_ecs.py
@@ -17,7 +17,10 @@
 # under the License.
 from __future__ import annotations
 
+import warnings
 from copy import deepcopy
+from datetime import datetime
+from typing import Any
 from unittest import mock
 from unittest.mock import MagicMock, PropertyMock
 
@@ -25,15 +28,18 @@ import boto3
 import pytest
 from botocore.exceptions import ClientError, WaiterError
 
+from airflow.models.dag import DAG
 from airflow.providers.amazon.aws.exceptions import EcsOperatorError, EcsTaskFailToStart
 from airflow.providers.amazon.aws.hooks.ecs import EcsClusterStates, EcsHook
 from airflow.providers.amazon.aws.operators.ecs import (
+    _DURABLE_UNSET,
     EcsBaseOperator,
     EcsCreateClusterOperator,
     EcsDeleteClusterOperator,
     EcsDeregisterTaskDefinitionOperator,
     EcsRegisterTaskDefinitionOperator,
     EcsRunTaskOperator,
+    _warn_and_disable_durable_pre_3_3,
 )
 from airflow.providers.amazon.aws.triggers.ecs import TaskDoneTrigger
 from airflow.providers.amazon.aws.utils.task_log_fetcher import AwsTaskLogFetcher
@@ -94,6 +100,81 @@ RESPONSE_WITHOUT_NAME = {
         }
     ],
 }
+
+
+class FakeTaskStateStore:
+    def __init__(self, stored: dict[str, str] | None = None) -> None:
+        self._store = dict(stored or {})
+
+    def get(self, key: str) -> str | None:
+        return self._store.get(key)
+
+    def set(self, key: str, value: str) -> None:
+        self._store[key] = value
+
+
+class FakeTaskInstance:
+    def __init__(self) -> None:
+        self.stats_tags: dict[str, str] = {}
+        self.xcom_values: dict[str, str] = {}
+
+    def xcom_push(self, *, key: str, value: str) -> None:
+        self.xcom_values[key] = value
+
+
+class SuccessfulEcsTaskClient:
+    def __init__(self, task_arn: str) -> None:
+        self.task_arn = task_arn
+        self.run_task_calls = 0
+        self.describe_tasks_calls: list[dict[str, Any]] = []
+        self.stop_task_calls: list[dict[str, Any]] = []
+        self.waiter = mock.MagicMock(spec_set=["wait"])
+
+    def describe_tasks(self, **kwargs: Any) -> dict[str, Any]:
+        self.describe_tasks_calls.append(kwargs)
+        return {
+            "failures": [],
+            "tasks": [
+                {
+                    "containers": [{"name": CONTAINER_NAME, "lastStatus": "STOPPED", "exitCode": 0}],
+                    "lastStatus": "STOPPED",
+                    "taskArn": self.task_arn,
+                }
+            ],
+        }
+
+    def get_waiter(self, name: str) -> MagicMock:
+        return self.waiter
+
+    def run_task(self, **kwargs: Any) -> dict[str, Any]:
+        self.run_task_calls += 1
+        return RESPONSE_WITHOUT_FAILURES
+
+    def stop_task(self, **kwargs: Any) -> dict[str, Any]:
+        self.stop_task_calls.append(kwargs)
+        return {}
+
+
+class RunningThenSuccessfulEcsTaskClient(SuccessfulEcsTaskClient):
+    def __init__(self, task_arn: str) -> None:
+        super().__init__(task_arn)
+        self.describe_task_calls = 0
+
+    def describe_tasks(self, **kwargs: Any) -> dict[str, Any]:
+        self.describe_task_calls += 1
+        if self.describe_task_calls == 1:
+            self.describe_tasks_calls.append(kwargs)
+            return {
+                "failures": [],
+                "tasks": [
+                    {
+                        "containers": [{"name": CONTAINER_NAME, "lastStatus": "RUNNING"}],
+                        "lastStatus": "RUNNING",
+                        "taskArn": self.task_arn,
+                    }
+                ],
+            }
+        return super().describe_tasks(**kwargs)
 
 
 WAITERS_TEST_CASES = [
@@ -181,6 +262,7 @@ class TestEcsRunTaskOperator(EcsBaseTestCase):
         assert self.ecs.cluster == "c"
         assert self.ecs.overrides == {}
         assert self.ecs.awslogs_region is None
+        assert self.ecs.durable is True
 
     def test_get_task_log_fetcher_uses_region_name_when_awslogs_region_not_set(self):
         self.set_up_operator(
@@ -411,6 +493,193 @@ class TestEcsRunTaskOperator(EcsBaseTestCase):
         wait_mock.assert_called_once_with()
         check_mock.assert_called_once_with()
         assert self.ecs.arn == f"arn:aws:ecs:us-east-1:012345678910:task/{TASK_ID}"
+
+    def test_retry_after_remote_success_does_not_submit_duplicate(self, monkeypatch):
+        task_arn = f"arn:aws:ecs:us-east-1:012345678910:task/{TASK_ID}"
+        client = SuccessfulEcsTaskClient(task_arn)
+        monkeypatch.setattr(EcsHook, "conn", client)
+        store = FakeTaskStateStore({"ecs_task_arn": task_arn})
+        ti = FakeTaskInstance()
+
+        self.ecs.execute({"ti": ti, "task_state_store": store})
+
+        assert client.run_task_calls == 0
+        assert client.describe_tasks_calls == [{"cluster": "c", "tasks": [task_arn]}]
+        assert self.ecs.arn == task_arn
+
+    @mock.patch.object(
+        EcsRunTaskOperator,
+        "_get_last_log_message",
+        autospec=True,
+        return_value="last log",
+    )
+    def test_retry_after_remote_success_returns_last_log(self, last_log_mock, monkeypatch):
+        task_arn = f"arn:aws:ecs:us-east-1:012345678910:task/{TASK_ID}"
+        client = SuccessfulEcsTaskClient(task_arn)
+        monkeypatch.setattr(EcsHook, "conn", client)
+        store = FakeTaskStateStore({"ecs_task_arn": task_arn})
+        ti = FakeTaskInstance()
+        self.set_up_operator(
+            awslogs_group="awslogs-group",
+            awslogs_stream_prefix="prefix",
+            do_xcom_push=True,
+        )
+
+        result = self.ecs.execute({"ti": ti, "task_state_store": store})
+
+        assert result == "last log"
+        assert client.run_task_calls == 0
+        assert ti.xcom_values == {"ecs_task_arn": task_arn}
+        last_log_mock.assert_called_once_with(self.ecs)
+
+    @mock.patch.object(EcsRunTaskOperator, "_get_task_log_fetcher", autospec=True)
+    def test_retry_reattaches_to_active_task_and_returns_last_log(self, log_fetcher_mock, monkeypatch):
+        task_arn = f"arn:aws:ecs:us-east-1:012345678910:task/{TASK_ID}"
+        client = RunningThenSuccessfulEcsTaskClient(task_arn)
+        monkeypatch.setattr(EcsHook, "conn", client)
+        store = FakeTaskStateStore({"ecs_task_arn": task_arn})
+        ti = FakeTaskInstance()
+        log_fetcher_mock.return_value.get_last_log_message.return_value = "last log"
+        self.set_up_operator(
+            awslogs_group="awslogs-group",
+            awslogs_stream_prefix="prefix",
+            do_xcom_push=True,
+        )
+
+        result = self.ecs.execute({"ti": ti, "task_state_store": store})
+
+        assert result == "last log"
+        assert client.run_task_calls == 0
+        assert client.describe_tasks_calls[0] == {"cluster": "c", "tasks": [task_arn]}
+        client.waiter.wait.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "stored_response",
+        [
+            pytest.param({"failures": [], "tasks": []}, id="not-found"),
+            pytest.param(
+                {
+                    "failures": [],
+                    "tasks": [
+                        {
+                            "containers": [{"name": CONTAINER_NAME, "lastStatus": "STOPPED", "exitCode": 1}],
+                            "lastStatus": "STOPPED",
+                        }
+                    ],
+                },
+                id="failed",
+            ),
+            pytest.param(
+                {
+                    "failures": [],
+                    "tasks": [
+                        {
+                            "containers": [],
+                            "lastStatus": "STOPPED",
+                            "stopCode": "TaskFailedToStart",
+                        }
+                    ],
+                },
+                id="failed-to-start",
+            ),
+        ],
+    )
+    @mock.patch.object(EcsBaseOperator, "client")
+    def test_retry_resubmits_terminal_task(self, client_mock, stored_response):
+        old_task_arn = "arn:aws:ecs:us-east-1:012345678910:task/old"
+        new_task_arn = f"arn:aws:ecs:us-east-1:012345678910:task/{TASK_ID}"
+        successful_response = SuccessfulEcsTaskClient(new_task_arn).describe_tasks()
+        client_mock.describe_tasks.side_effect = [stored_response, successful_response]
+        client_mock.run_task.return_value = RESPONSE_WITHOUT_FAILURES
+        store = FakeTaskStateStore({"ecs_task_arn": old_task_arn})
+        ti = FakeTaskInstance()
+
+        self.ecs.execute({"ti": ti, "task_state_store": store})
+
+        client_mock.run_task.assert_called_once()
+        assert store.get("ecs_task_arn") == new_task_arn
+
+    @mock.patch.object(EcsBaseOperator, "client")
+    def test_retry_preserves_skip_exit_code(self, client_mock):
+        task_arn = f"arn:aws:ecs:us-east-1:012345678910:task/{TASK_ID}"
+        client_mock.describe_tasks.return_value = {
+            "failures": [],
+            "tasks": [
+                {
+                    "containers": [{"lastStatus": "STOPPED", "exitCode": 42}],
+                    "lastStatus": "STOPPED",
+                }
+            ],
+        }
+        store = FakeTaskStateStore({"ecs_task_arn": task_arn})
+        self.set_up_operator(skip_on_exit_code=42)
+
+        with pytest.raises(AirflowSkipException):
+            self.ecs.execute({"ti": FakeTaskInstance(), "task_state_store": store})
+
+        client_mock.run_task.assert_not_called()
+
+    @mock.patch.object(EcsRunTaskOperator, "_wait_for_task_ended", autospec=True)
+    @mock.patch.object(EcsBaseOperator, "client")
+    def test_persists_task_arn_before_polling(self, client_mock, wait_mock):
+        task_arn = f"arn:aws:ecs:us-east-1:012345678910:task/{TASK_ID}"
+        client_mock.run_task.return_value = RESPONSE_WITHOUT_FAILURES
+        client_mock.describe_tasks.return_value = SuccessfulEcsTaskClient(task_arn).describe_tasks()
+        store = FakeTaskStateStore()
+        ti = FakeTaskInstance()
+        wait_mock.side_effect = lambda _operator: (
+            store.get("ecs_task_arn") == task_arn
+            or pytest.fail("ECS task ARN was not persisted before polling")
+        )
+
+        self.ecs.execute({"ti": ti, "task_state_store": store})
+
+        assert store.get("ecs_task_arn") == task_arn
+
+    def test_durable_false_never_touches_task_state_store(self, monkeypatch):
+        task_arn = f"arn:aws:ecs:us-east-1:012345678910:task/{TASK_ID}"
+        client = SuccessfulEcsTaskClient(task_arn)
+        monkeypatch.setattr(EcsHook, "conn", client)
+        store = mock.MagicMock(spec_set=["get", "set"])
+        self.set_up_operator(durable=False)
+
+        self.ecs.execute({"ti": FakeTaskInstance(), "task_state_store": store})
+
+        assert client.run_task_calls == 1
+        store.get.assert_not_called()
+        store.set.assert_not_called()
+
+    def test_default_args_durable_reaches_operator(self):
+        with DAG(
+            dag_id="test_ecs_durable_default_args",
+            schedule=None,
+            start_date=datetime(2024, 1, 1),
+            default_args={"durable": False},
+        ):
+            self.set_up_operator()
+
+        assert self.ecs.durable is False
+
+    def test_reconnected_task_is_not_stopped_on_waiter_error(self, monkeypatch):
+        task_arn = f"arn:aws:ecs:us-east-1:012345678910:task/{TASK_ID}"
+        client = RunningThenSuccessfulEcsTaskClient(task_arn)
+        client.waiter.wait.side_effect = WaiterError("wait", "failed", {})
+        monkeypatch.setattr(EcsHook, "conn", client)
+        store = FakeTaskStateStore({"ecs_task_arn": task_arn})
+        ti = FakeTaskInstance()
+
+        with pytest.raises(WaiterError):
+            self.ecs.execute({"ti": ti, "task_state_store": store})
+
+        assert client.stop_task_calls == []
+        self.ecs.on_kill()
+        assert client.stop_task_calls == [
+            {
+                "cluster": "c",
+                "task": task_arn,
+                "reason": "Task killed by the user",
+            }
+        ]
 
     def test_task_id_parsing(self):
         id = EcsRunTaskOperator._get_ecs_task_id(f"arn:aws:ecs:us-east-1:012345678910:task/{TASK_ID}")
@@ -838,13 +1107,20 @@ class TestEcsRunTaskOperator(EcsBaseTestCase):
         client_mock.run_task.return_value = RESPONSE_WITHOUT_FAILURES
 
         mock_ti = mock.MagicMock()
-        mock_context = {"ti": mock_ti, "task_instance": mock_ti}
+        task_state_store = mock.MagicMock(spec_set=["get", "set"])
+        mock_context = {
+            "ti": mock_ti,
+            "task_instance": mock_ti,
+            "task_state_store": task_state_store,
+        }
 
         with pytest.raises(TaskDeferred) as deferred:
             self.ecs.execute(mock_context)
 
         assert isinstance(deferred.value.trigger, TaskDoneTrigger)
         assert deferred.value.trigger.task_arn == f"arn:aws:ecs:us-east-1:012345678910:task/{TASK_ID}"
+        task_state_store.get.assert_not_called()
+        task_state_store.set.assert_not_called()
 
     @mock.patch.object(EcsRunTaskOperator, "client")
     def test_with_defer_passes_awslogs_region_to_trigger(self, client_mock):
@@ -928,6 +1204,7 @@ class TestEcsRunTaskOperator(EcsBaseTestCase):
             {"tasks": [{"containers": [{"name": "resolved-container"}]}]},
         ]
         self.ecs._start_task()
+        self.ecs._resolve_container_name()
         assert client_mock.describe_tasks.call_count == 2
         assert self.ecs.container_name == "resolved-container"
 
@@ -944,6 +1221,7 @@ class TestEcsRunTaskOperator(EcsBaseTestCase):
         client_mock.describe_tasks.return_value = {"tasks": [{"containers": [{"name": None}]}]}
 
         self.ecs._start_task()
+        self.ecs._resolve_container_name()
 
         assert client_mock.describe_tasks.call_count == 2
         assert self.ecs.container_name is None
@@ -960,6 +1238,7 @@ class TestEcsRunTaskOperator(EcsBaseTestCase):
         )
         client_mock.run_task.return_value = RESPONSE_WITHOUT_NAME
         self.ecs._start_task()
+        self.ecs._resolve_container_name()
         assert client_mock.describe_tasks.call_count == 0
 
     @mock.patch.object(EcsBaseOperator, "client")
@@ -1052,6 +1331,21 @@ class TestEcsRunTaskOperator(EcsBaseTestCase):
 
         # Cleanup attempted despite failure.
         client_mock.stop_task.assert_called_once()
+
+
+class TestWarnAndDisableDurableAirflowPre3_3:
+    def test_no_warning_when_unset(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = _warn_and_disable_durable_pre_3_3(_DURABLE_UNSET)
+        assert result is False
+        assert caught == []
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_warns_and_disables_when_explicitly_set(self, value):
+        with pytest.warns(UserWarning, match="durable.*no effect"):
+            result = _warn_and_disable_durable_pre_3_3(value)
+        assert result is False
 
 
 class TestEcsCreateClusterOperator(EcsBaseTestCase):

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_ecs.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_ecs.py
@@ -46,6 +46,7 @@ from airflow.providers.amazon.aws.utils.task_log_fetcher import AwsTaskLogFetche
 from airflow.providers.amazon.version_compat import NOTSET
 from airflow.providers.common.compat.sdk import AirflowException, AirflowSkipException, TaskDeferred
 
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_3_PLUS
 from unit.amazon.aws.utils.test_template_fields import validate_template_fields
 
 CLUSTER_NAME = "test_cluster"
@@ -262,7 +263,7 @@ class TestEcsRunTaskOperator(EcsBaseTestCase):
         assert self.ecs.cluster == "c"
         assert self.ecs.overrides == {}
         assert self.ecs.awslogs_region is None
-        assert self.ecs.durable is True
+        assert self.ecs.durable is AIRFLOW_V_3_3_PLUS
 
     def test_get_task_log_fetcher_uses_region_name_when_awslogs_region_not_set(self):
         self.set_up_operator(
@@ -494,6 +495,7 @@ class TestEcsRunTaskOperator(EcsBaseTestCase):
         check_mock.assert_called_once_with()
         assert self.ecs.arn == f"arn:aws:ecs:us-east-1:012345678910:task/{TASK_ID}"
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="task_state_store requires Airflow 3.3+")
     def test_retry_after_remote_success_does_not_submit_duplicate(self, monkeypatch):
         task_arn = f"arn:aws:ecs:us-east-1:012345678910:task/{TASK_ID}"
         client = SuccessfulEcsTaskClient(task_arn)
@@ -507,6 +509,7 @@ class TestEcsRunTaskOperator(EcsBaseTestCase):
         assert client.describe_tasks_calls == [{"cluster": "c", "tasks": [task_arn]}]
         assert self.ecs.arn == task_arn
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="task_state_store requires Airflow 3.3+")
     @mock.patch.object(
         EcsRunTaskOperator,
         "_get_last_log_message",
@@ -532,6 +535,7 @@ class TestEcsRunTaskOperator(EcsBaseTestCase):
         assert ti.xcom_values == {"ecs_task_arn": task_arn}
         last_log_mock.assert_called_once_with(self.ecs)
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="task_state_store requires Airflow 3.3+")
     @mock.patch.object(EcsRunTaskOperator, "_get_task_log_fetcher", autospec=True)
     def test_retry_reattaches_to_active_task_and_returns_last_log(self, log_fetcher_mock, monkeypatch):
         task_arn = f"arn:aws:ecs:us-east-1:012345678910:task/{TASK_ID}"
@@ -553,6 +557,7 @@ class TestEcsRunTaskOperator(EcsBaseTestCase):
         assert client.describe_tasks_calls[0] == {"cluster": "c", "tasks": [task_arn]}
         client.waiter.wait.assert_called_once()
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="task_state_store requires Airflow 3.3+")
     @pytest.mark.parametrize(
         "stored_response",
         [
@@ -599,6 +604,7 @@ class TestEcsRunTaskOperator(EcsBaseTestCase):
         client_mock.run_task.assert_called_once()
         assert store.get("ecs_task_arn") == new_task_arn
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="task_state_store requires Airflow 3.3+")
     @mock.patch.object(EcsBaseOperator, "client")
     def test_retry_preserves_skip_exit_code(self, client_mock):
         task_arn = f"arn:aws:ecs:us-east-1:012345678910:task/{TASK_ID}"
@@ -619,6 +625,7 @@ class TestEcsRunTaskOperator(EcsBaseTestCase):
 
         client_mock.run_task.assert_not_called()
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="task_state_store requires Airflow 3.3+")
     @mock.patch.object(EcsRunTaskOperator, "_wait_for_task_ended", autospec=True)
     @mock.patch.object(EcsBaseOperator, "client")
     def test_persists_task_arn_before_polling(self, client_mock, wait_mock):
@@ -660,6 +667,7 @@ class TestEcsRunTaskOperator(EcsBaseTestCase):
 
         assert self.ecs.durable is False
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="task_state_store requires Airflow 3.3+")
     def test_reconnected_task_is_not_stopped_on_waiter_error(self, monkeypatch):
         task_arn = f"arn:aws:ecs:us-east-1:012345678910:task/{TASK_ID}"
         client = RunningThenSuccessfulEcsTaskClient(task_arn)


### PR DESCRIPTION
## Related Issue(s)

No issue.

## Why are the changes needed?

If an ECS task succeeds before Airflow retries its Airflow task, the retry can launch the workload again. `EcsRunTaskOperator(reattach=True)` searches only running ECS tasks, so it cannot recover the completed task.

AIP-103 task state records the exact ECS task ARN. A retry now describes that task, recognizes terminal success, or resumes waiting for it. Missing and failed tasks still resubmit. Existing reattach, deferrable, logging, cancellation, XCom, and no-wait behavior remain unchanged.

## What changes were proposed in this pull request?

Use `ResumableJobMixin` for synchronous ECS task execution and persist the task ARN before polling. Recovery reuses the operator's existing terminal status validation, including failed startup, nonzero exits, and skip exit codes.

## How was this patch tested?

| Scenario | Result |
| --- | --- |
| Retry after the stored ECS task already succeeded | Fails before the patch because `run_task()` is called once; passes after the patch without a new submission |
| ECS operator unit suite | 107 passed |
| Simulated Airflow before 3.3 | 6 existing/fallback cases passed; 9 recovery cases skipped |
| Forced pre-3.3 fallback import | `durable=False`; no task state access; submit, poll, and result behavior preserved |

<details>
<summary>Raw retry-path evidence</summary>

Against unmodified `upstream/main` with the regression test applied:

```console
$ uv run --project providers/amazon pytest providers/amazon/tests/unit/amazon/aws/operators/test_ecs.py::TestEcsRunTaskOperator::test_retry_after_remote_success_does_not_submit_duplicate -xvs
collected 1 item
providers/amazon/tests/unit/amazon/aws/operators/test_ecs.py::TestEcsRunTaskOperator::test_retry_after_remote_success_does_not_submit_duplicate FAILED
E   assert 1 == 0
E    +  where 1 = <SuccessfulEcsTaskClient>.run_task_calls
======================== 1 failed, 1 warning in 41.53s =========================
pytest_exit=1
```

On this branch:

```console
$ uv run --project providers/amazon pytest providers/amazon/tests/unit/amazon/aws/operators/test_ecs.py::TestEcsRunTaskOperator::test_retry_after_remote_success_does_not_submit_duplicate -xvs
collected 1 item
providers/amazon/tests/unit/amazon/aws/operators/test_ecs.py::TestEcsRunTaskOperator::test_retry_after_remote_success_does_not_submit_duplicate PASSED
======================== 1 passed, 1 warning in 33.61s =========================
pytest_exit=0

$ uv run --project providers/amazon pytest providers/amazon/tests/unit/amazon/aws/operators/test_ecs.py -xvs
======================= 107 passed, 1 warning in 44.57s ========================
```

</details>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only

## Checklist

- [x] My code follows the [style guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst) of this project.
- [x] I have conducted a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have checked my code and corrected any misspellings.
- [x] I have added the appropriate labels and release notes, if applicable.

## Release note needed?

No.

## Was generative AI tooling used to co-author this pull request?

- [x] Yes - GitHub Copilot CLI (GPT-5.6 Sol)
