### PR TITLE
Recover Databricks SQL statements after task retries

### DIFF
--- a/providers/databricks/docs/operators/sql_statements.rst
+++ b/providers/databricks/docs/operators/sql_statements.rst
@@ -50,6 +50,23 @@ but not limited to:
   (``dag_id``, ``task_id``, ``run_id``, ``try_number``, ``map_index``) is merged into
   ``query_tags`` automatically. Set to ``False`` to suppress these automatic tags.
 
+Durable execution
+-----------------
+
+Synchronous executions that wait for termination persist the Databricks
+statement ID before polling. When a task retries after a worker crash, the
+operator reconnects to a pending or running statement and recovers a
+successful statement without submitting it again. A failed, canceled, closed,
+or missing statement is replaced with a new submission.
+
+The recovered statement ID is restored on the operator and in the
+``statement_id`` XCom, preserving task cancellation, operator links, and
+OpenLineage metadata. Fire-and-forget and deferrable executions retain their
+existing behavior. Set ``durable=False`` to disable recovery.
+
+Durable execution requires Airflow 3.3 or newer. On older Airflow versions,
+the operator uses the previous non-durable behavior.
+
 Examples
 --------
 

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
@@ -1644,7 +1644,10 @@ class DatabricksSQLStatementsOperator(DatabricksSQLStatementsMixin, ResumableJob
 
     def submit_job(self, context: Context) -> str:
         statement_id: str = self._hook.post_sql_statement(json=self._build_statement_payload(context))
-        self._restore_statement_id(statement_id=statement_id, context=context)
+        if self.durable and self.wait_for_termination and not self.deferrable:
+            self.statement_id = statement_id
+        else:
+            self._restore_statement_id(statement_id=statement_id, context=context)
         self.log.info("SQL Statement submitted with statement_id: %s", statement_id)
         return statement_id
 

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
@@ -28,6 +28,7 @@ import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from functools import cached_property
+from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, cast
 
 from airflow.providers.common.compat.sdk import AirflowException, BaseOperator, BaseOperatorLink, XCom, conf
@@ -1496,7 +1497,7 @@ class DatabricksRunNowOperator(ResumableJobMixin, BaseOperator):
             self.log.error("Error: Task: %s with invalid run_id was requested to be cancelled.", self.task_id)
 
 
-class DatabricksSQLStatementsOperator(DatabricksSQLStatementsMixin, BaseOperator):
+class DatabricksSQLStatementsOperator(DatabricksSQLStatementsMixin, ResumableJobMixin, BaseOperator):
     """
     Submits a Databricks SQL Statement to Databricks using the api/2.0/sql/statements/ API endpoint.
 
@@ -1536,6 +1537,8 @@ class DatabricksSQLStatementsOperator(DatabricksSQLStatementsMixin, BaseOperator
         See https://docs.databricks.com/api/workspace/statementexecution/executestatement
     :param include_airflow_query_tags: If True, add Airflow DAG/task/run metadata as query tags.
         Defaults to True.
+    :param durable: Reconnect to an unfinished SQL statement after a worker crash or task retry.
+        This applies only when waiting synchronously for termination.
     """
 
     # Used in airflow.models.BaseOperator
@@ -1564,9 +1567,12 @@ class DatabricksSQLStatementsOperator(DatabricksSQLStatementsMixin, BaseOperator
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
         query_tags: dict[str, str | None] | None = None,
         include_airflow_query_tags: bool = True,
+        durable: bool | None = None,
         **kwargs,
     ) -> None:
         """Create a new ``DatabricksSQLStatementsOperator``."""
+        if durable is not None:
+            kwargs["durable"] = durable
         super().__init__(**kwargs)
         self.statement = statement
         self.warehouse_id = warehouse_id
@@ -1595,16 +1601,22 @@ class DatabricksSQLStatementsOperator(DatabricksSQLStatementsMixin, BaseOperator
 
     def _get_hook(self, caller: str) -> DatabricksHook:
         return DatabricksHook(
-            self.databricks_conn_id,
+            databricks_conn_id=self.databricks_conn_id,
             retry_limit=self.databricks_retry_limit,
             retry_delay=self.databricks_retry_delay,
             retry_args=self.databricks_retry_args,
             caller=caller,
         )
 
-    def execute(self, context: Context):
-        tags = build_query_tags(context, self.query_tags, self.include_airflow_query_tags)
-        json = {
+    external_id_key: str = "databricks_sql_statement_id"
+
+    def _build_statement_payload(self, context: Context) -> dict[str, Any]:
+        tags = build_query_tags(
+            context=context,
+            user_query_tags=self.query_tags,
+            include_airflow_query_tags=self.include_airflow_query_tags,
+        )
+        payload: dict[str, Any] = {
             "statement": self.statement,
             "warehouse_id": self.warehouse_id,
             "catalog": self.catalog,
@@ -1616,18 +1628,58 @@ class DatabricksSQLStatementsOperator(DatabricksSQLStatementsMixin, BaseOperator
             "wait_timeout": "0s",
         }
         if tags:
-            json["query_tags"] = dict_to_query_tag_list(tags)
-        self.statement_id = self._hook.post_sql_statement(json)
-        if self.do_xcom_push and context is not None:
-            context["ti"].xcom_push(key=XCOM_STATEMENT_ID_KEY, value=self.statement_id)
+            payload["query_tags"] = dict_to_query_tag_list(tags)
+        return payload
 
-        self.log.info("SQL Statement submitted with statement_id: %s", self.statement_id)
+    def _restore_statement_id(self, statement_id: str, context: Context) -> None:
+        self.statement_id = statement_id
+        if (
+            self.do_xcom_push
+            and context is not None
+            and context.get("ti") is not None
+            and not getattr(self, "_statement_id_xcom_pushed", False)
+        ):
+            context["ti"].xcom_push(key=XCOM_STATEMENT_ID_KEY, value=statement_id)
+            self._statement_id_xcom_pushed = True
+
+    def submit_job(self, context: Context) -> str:
+        statement_id: str = self._hook.post_sql_statement(json=self._build_statement_payload(context))
+        self._restore_statement_id(statement_id=statement_id, context=context)
+        self.log.info("SQL Statement submitted with statement_id: %s", statement_id)
+        return statement_id
+
+    def get_job_status(self, external_id: JsonValue, context: Context) -> str:
+        self.statement_id = cast("str", external_id)
+        try:
+            return self._hook.get_sql_statement_state(statement_id=cast("str", external_id)).state
+        except DatabricksApiError as error:
+            if error.http_status_code == HTTPStatus.NOT_FOUND:
+                return "NOT_FOUND"
+            raise
+
+    @staticmethod
+    def is_job_active(status: str) -> bool:
+        return status in {"PENDING", "RUNNING"}
+
+    @staticmethod
+    def is_job_succeeded(status: str) -> bool:
+        return status == "SUCCEEDED"
+
+    def poll_until_complete(self, external_id: JsonValue, context: Context) -> None:
+        self._restore_statement_id(statement_id=cast("str", external_id), context=context)
+        self._handle_execution()  # type: ignore[misc]
+
+    def get_job_result(self, external_id: JsonValue, context: Context) -> None:
+        self._restore_statement_id(statement_id=cast("str", external_id), context=context)
+
+    def execute(self, context: Context) -> None:
+        if self.wait_for_termination and not self.deferrable:
+            return self.execute_resumable(context or cast("Context", {}))
+
+        self.submit_job(context)
         if not self.wait_for_termination:
             return
-        if self.deferrable:
-            self._handle_deferrable_execution(defer_method_name=DEFER_METHOD_NAME)  # type: ignore[misc]
-        else:
-            self._handle_execution()  # type: ignore[misc]
+        self._handle_deferrable_execution(defer_method_name=DEFER_METHOD_NAME)  # type: ignore[misc]
 
     def get_openlineage_facets_on_complete(self, _) -> OperatorLineage:
         """Implement _on_complete because we use statement_id."""

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks.py
@@ -3695,6 +3695,34 @@ class TestDatabricksSQLStatementsOperatorDurable:
         assert op.statement_id == STATEMENT_ID
 
     @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_xcom_failure_after_submit_keeps_statement_id_for_retry(self, db_mock_class):
+        stored: dict[str, Any] = {}
+        task_store = MagicMock(spec_set=["get", "set"])
+        task_store.get.side_effect = stored.get
+        task_store.set.side_effect = stored.__setitem__
+        db_mock = db_mock_class.return_value
+        db_mock.post_sql_statement.return_value = STATEMENT_ID
+        db_mock.get_sql_statement_state.side_effect = [
+            SQLStatementState("RUNNING"),
+            SQLStatementState("SUCCEEDED"),
+        ]
+        first_context = self._context(task_store)
+        first_context["ti"].xcom_push.side_effect = RuntimeError("xcom unavailable")
+
+        with pytest.raises(RuntimeError, match="xcom unavailable"):
+            self._operator().execute(first_context)
+
+        assert stored == {"databricks_sql_statement_id": STATEMENT_ID}
+
+        retry_context = self._context(task_store)
+        retry = self._operator()
+        retry.execute(retry_context)
+
+        db_mock.post_sql_statement.assert_called_once()
+        retry_context["ti"].xcom_push.assert_called_once_with(key="statement_id", value=STATEMENT_ID)
+        assert retry.statement_id == STATEMENT_ID
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
     def test_reconnects_to_active_statement_without_resubmitting(self, db_mock_class):
         op = self._operator()
         db_mock = db_mock_class.return_value
@@ -3781,12 +3809,14 @@ class TestDatabricksSQLStatementsOperatorDurable:
         db_mock = db_mock_class.return_value
         db_mock.post_sql_statement.return_value = STATEMENT_ID
         task_store = MagicMock(spec_set=["get", "set"])
+        context = self._context(task_store)
 
-        assert op.execute(self._context(task_store)) is None
+        assert op.execute(context) is None
 
         db_mock.post_sql_statement.assert_called_once()
         task_store.get.assert_not_called()
         task_store.set.assert_not_called()
+        context["ti"].xcom_push.assert_called_once_with(key="statement_id", value=STATEMENT_ID)
 
     @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
     def test_deferrable_does_not_use_task_state_store(self, db_mock_class):
@@ -3795,13 +3825,15 @@ class TestDatabricksSQLStatementsOperatorDurable:
         db_mock.post_sql_statement.return_value = STATEMENT_ID
         db_mock.get_sql_statement_state.return_value = SQLStatementState("RUNNING")
         task_store = MagicMock(spec_set=["get", "set"])
+        context = self._context(task_store)
 
         with pytest.raises(TaskDeferred):
-            op.execute(self._context(task_store))
+            op.execute(context)
 
         db_mock.post_sql_statement.assert_called_once()
         task_store.get.assert_not_called()
         task_store.set.assert_not_called()
+        context["ti"].xcom_push.assert_called_once_with(key="statement_id", value=STATEMENT_ID)
 
     @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
     def test_durable_false_does_not_use_task_state_store(self, db_mock_class):

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks.py
@@ -3271,14 +3271,14 @@ class TestDatabricksSQLStatementsOperator:
         op.execute(None)
 
         db_mock_class.assert_called_once_with(
-            DEFAULT_CONN_ID,
+            databricks_conn_id=DEFAULT_CONN_ID,
             retry_limit=op.databricks_retry_limit,
             retry_delay=op.databricks_retry_delay,
             retry_args=None,
             caller="DatabricksSQLStatementsOperator",
         )
 
-        db_mock.post_sql_statement.assert_called_once_with(expected_json)
+        db_mock.post_sql_statement.assert_called_once_with(json=expected_json)
         db_mock.get_sql_statement_state.assert_called_once_with(STATEMENT_ID)
         assert op.statement_id == STATEMENT_ID
 
@@ -3300,7 +3300,7 @@ class TestDatabricksSQLStatementsOperator:
             op.execute(None)
 
         db_mock_class.assert_called_once_with(
-            DEFAULT_CONN_ID,
+            databricks_conn_id=DEFAULT_CONN_ID,
             retry_limit=op.databricks_retry_limit,
             retry_delay=op.databricks_retry_delay,
             retry_args=None,
@@ -3583,7 +3583,7 @@ class TestDatabricksSQLStatementsOperator:
         )
         op.execute(None)
 
-        posted_json = db_mock.post_sql_statement.call_args[0][0]
+        posted_json = db_mock.post_sql_statement.call_args.kwargs["json"]
         assert posted_json["query_tags"] == [{"key": "team", "value": "data"}]
 
     @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
@@ -3599,7 +3599,7 @@ class TestDatabricksSQLStatementsOperator:
         )
         op.execute(None)
 
-        posted_json = db_mock.post_sql_statement.call_args[0][0]
+        posted_json = db_mock.post_sql_statement.call_args.kwargs["json"]
         assert "query_tags" not in posted_json
 
     @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
@@ -3613,16 +3613,19 @@ class TestDatabricksSQLStatementsOperator:
             warehouse_id=WAREHOUSE_ID,
             query_tags={"custom": "value"},
         )
-        mock_ti = mock.MagicMock(spec=["dag_id", "task_id", "run_id", "try_number", "map_index", "xcom_push"])
+        mock_ti = mock.MagicMock(
+            spec=["dag_id", "task_id", "run_id", "try_number", "map_index", "stats_tags", "xcom_push"]
+        )
         mock_ti.dag_id = "my_dag"
         mock_ti.task_id = "my_task"
         mock_ti.run_id = "run_1"
         mock_ti.try_number = 1
         mock_ti.map_index = -1
+        mock_ti.stats_tags = {}
 
         op.execute(context={"ti": mock_ti})
 
-        posted_json = db_mock.post_sql_statement.call_args[0][0]
+        posted_json = db_mock.post_sql_statement.call_args.kwargs["json"]
         tag_keys = {t["key"] for t in posted_json["query_tags"]}
         assert "airflow_dag_id" in tag_keys
         assert "custom" in tag_keys
@@ -3638,18 +3641,201 @@ class TestDatabricksSQLStatementsOperator:
             warehouse_id=WAREHOUSE_ID,
             query_tags={"airflow_dag_id": "overridden"},
         )
-        mock_ti = mock.MagicMock(spec=["dag_id", "task_id", "run_id", "try_number", "map_index", "xcom_push"])
+        mock_ti = mock.MagicMock(
+            spec=["dag_id", "task_id", "run_id", "try_number", "map_index", "stats_tags", "xcom_push"]
+        )
         mock_ti.dag_id = "original"
         mock_ti.task_id = "t"
         mock_ti.run_id = "r"
         mock_ti.try_number = 1
         mock_ti.map_index = -1
+        mock_ti.stats_tags = {}
 
         op.execute(context={"ti": mock_ti})
 
-        posted_json = db_mock.post_sql_statement.call_args[0][0]
+        posted_json = db_mock.post_sql_statement.call_args.kwargs["json"]
         tag_map = {t["key"]: t["value"] for t in posted_json["query_tags"]}
         assert tag_map["airflow_dag_id"] == "overridden"
+
+
+@pytest.mark.skipif(
+    not AIRFLOW_V_3_3_PLUS, reason="task_state_store (durable execution) requires Airflow 3.3+"
+)
+class TestDatabricksSQLStatementsOperatorDurable:
+    @staticmethod
+    def _context(task_store: Any | None = None) -> dict[str, Any]:
+        context: dict[str, Any] = {"ti": MagicMock(stats_tags={})}
+        if task_store is not None:
+            context["task_state_store"] = task_store
+        return context
+
+    @staticmethod
+    def _operator(**kwargs: Any) -> DatabricksSQLStatementsOperator:
+        return DatabricksSQLStatementsOperator(
+            task_id=TASK_ID,
+            statement="select * from test.test;",
+            warehouse_id=WAREHOUSE_ID,
+            polling_period_seconds=0,
+            **kwargs,
+        )
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_persists_statement_id_on_fresh_submit(self, db_mock_class):
+        op = self._operator()
+        db_mock = db_mock_class.return_value
+        db_mock.post_sql_statement.return_value = STATEMENT_ID
+        db_mock.get_sql_statement_state.return_value = SQLStatementState("SUCCEEDED")
+        task_store = MagicMock(spec_set=["get", "set"])
+        task_store.get.return_value = None
+
+        op.execute(self._context(task_store))
+
+        db_mock.post_sql_statement.assert_called_once()
+        task_store.set.assert_called_once_with("databricks_sql_statement_id", STATEMENT_ID)
+        assert op.statement_id == STATEMENT_ID
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_reconnects_to_active_statement_without_resubmitting(self, db_mock_class):
+        op = self._operator()
+        db_mock = db_mock_class.return_value
+        db_mock.get_sql_statement_state.side_effect = [
+            SQLStatementState("RUNNING"),
+            SQLStatementState("SUCCEEDED"),
+        ]
+        task_store = MagicMock(spec_set=["get", "set"])
+        task_store.get.return_value = STATEMENT_ID
+        context = self._context(task_store)
+
+        op.execute(context)
+
+        db_mock.post_sql_statement.assert_not_called()
+        task_store.set.assert_not_called()
+        context["ti"].xcom_push.assert_called_once_with(key="statement_id", value=STATEMENT_ID)
+        assert op.statement_id == STATEMENT_ID
+
+    @mock.patch(
+        "airflow.providers.databricks.operators.databricks.DatabricksSQLStatementsMixin._handle_execution"
+    )
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_recovers_succeeded_statement_without_polling(self, db_mock_class, mock_poll):
+        op = self._operator()
+        db_mock = db_mock_class.return_value
+        db_mock.host = "host"
+        db_mock.get_sql_statement_state.return_value = SQLStatementState("SUCCEEDED")
+        task_store = MagicMock(spec_set=["get", "set"])
+        task_store.get.return_value = STATEMENT_ID
+        context = self._context(task_store)
+
+        assert op.execute(context) is None
+
+        db_mock.post_sql_statement.assert_not_called()
+        mock_poll.assert_not_called()
+        context["ti"].xcom_push.assert_called_once_with(key="statement_id", value=STATEMENT_ID)
+        assert op.statement_id == STATEMENT_ID
+        assert (
+            op.get_openlineage_facets_on_complete(None).run_facets["externalQuery"].externalQueryId
+            == STATEMENT_ID
+        )
+
+    @pytest.mark.parametrize("terminal_state", ["FAILED", "CANCELED", "CLOSED"])
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_resubmits_after_terminal_statement(self, db_mock_class, terminal_state):
+        op = self._operator()
+        db_mock = db_mock_class.return_value
+        db_mock.post_sql_statement.return_value = STATEMENT_ID
+        db_mock.get_sql_statement_state.side_effect = [
+            SQLStatementState(terminal_state),
+            SQLStatementState("SUCCEEDED"),
+        ]
+        task_store = MagicMock(spec_set=["get", "set"])
+        task_store.get.return_value = "terminal_statement_id"
+        context = self._context(task_store)
+
+        op.execute(context)
+
+        db_mock.post_sql_statement.assert_called_once()
+        task_store.set.assert_called_once_with("databricks_sql_statement_id", STATEMENT_ID)
+        context["ti"].xcom_push.assert_called_once_with(key="statement_id", value=STATEMENT_ID)
+        assert op.statement_id == STATEMENT_ID
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_resubmits_when_stored_statement_no_longer_exists(self, db_mock_class):
+        op = self._operator()
+        db_mock = db_mock_class.return_value
+        db_mock.post_sql_statement.return_value = STATEMENT_ID
+        db_mock.get_sql_statement_state.side_effect = [
+            DatabricksApiError("Response: RESOURCE_DOES_NOT_EXIST, Status Code: 404", http_status_code=404),
+            SQLStatementState("SUCCEEDED"),
+        ]
+        task_store = MagicMock(spec_set=["get", "set"])
+        task_store.get.return_value = "missing_statement_id"
+
+        op.execute(self._context(task_store))
+
+        db_mock.post_sql_statement.assert_called_once()
+        task_store.set.assert_called_once_with("databricks_sql_statement_id", STATEMENT_ID)
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_fire_and_forget_does_not_use_task_state_store(self, db_mock_class):
+        op = self._operator(wait_for_termination=False)
+        db_mock = db_mock_class.return_value
+        db_mock.post_sql_statement.return_value = STATEMENT_ID
+        task_store = MagicMock(spec_set=["get", "set"])
+
+        assert op.execute(self._context(task_store)) is None
+
+        db_mock.post_sql_statement.assert_called_once()
+        task_store.get.assert_not_called()
+        task_store.set.assert_not_called()
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_deferrable_does_not_use_task_state_store(self, db_mock_class):
+        op = self._operator(deferrable=True)
+        db_mock = db_mock_class.return_value
+        db_mock.post_sql_statement.return_value = STATEMENT_ID
+        db_mock.get_sql_statement_state.return_value = SQLStatementState("RUNNING")
+        task_store = MagicMock(spec_set=["get", "set"])
+
+        with pytest.raises(TaskDeferred):
+            op.execute(self._context(task_store))
+
+        db_mock.post_sql_statement.assert_called_once()
+        task_store.get.assert_not_called()
+        task_store.set.assert_not_called()
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_durable_false_does_not_use_task_state_store(self, db_mock_class):
+        op = self._operator(durable=False)
+        db_mock = db_mock_class.return_value
+        db_mock.post_sql_statement.return_value = STATEMENT_ID
+        db_mock.get_sql_statement_state.return_value = SQLStatementState("SUCCEEDED")
+        task_store = MagicMock(spec_set=["get", "set"])
+
+        op.execute(self._context(task_store))
+
+        db_mock.post_sql_statement.assert_called_once()
+        task_store.get.assert_not_called()
+        task_store.set.assert_not_called()
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_cancellation_during_reconnect_status_check_uses_stored_statement_id(self, db_mock_class):
+        op = self._operator()
+        db_mock = db_mock_class.return_value
+        db_mock.get_sql_statement_state.side_effect = lambda statement_id: (
+            op.on_kill(),
+            SQLStatementState("SUCCEEDED"),
+        )[1]
+        task_store = MagicMock(spec_set=["get", "set"])
+        task_store.get.return_value = STATEMENT_ID
+
+        op.execute(self._context(task_store))
+
+        db_mock.cancel_sql_statement.assert_called_once_with(STATEMENT_ID)
+
+    def test_default_args_durable_reaches_operator(self):
+        op = self._operator(default_args={"durable": False})
+
+        assert op.durable is False
 
 
 class TestDatabricksNotebookOperator:


### PR DESCRIPTION
When a worker dies after submitting a Databricks SQL statement, a synchronous task retry submits the statement again. The original statement can still be running, so users can get duplicate work and cost.

Before this change, the retry submits `statement-2` while `statement-1` remains active. After this change, Airflow 3.3+ stores `statement-1` in task state and reconnects to it. A retry also returns an already successful statement without resubmitting, and starts fresh only after failure, cancellation, closure, or a missing statement.

This uses the AIP-103 `ResumableJobMixin` contract only when `wait_for_termination=True` and `deferrable=False`. The statement ID reaches task state before its XCom is published, so an XCom error cannot reopen the duplicate-submission window. Fire-and-forget and deferrable execution keep their existing paths.

## Testing

The driver below calls `execute()` twice with the real task-state accessor and supervisor messages. Its local Databricks hook forces statement-ID XCom publication to fail after the first submission.

<details>
<summary>Live task-state and XCom ordering proof</summary>

```python
from __future__ import annotations

import importlib
import importlib.util
import os
import sys
from pathlib import Path
from typing import Any
from unittest import mock
from uuid import UUID

from airflow.providers.databricks.hooks.databricks import SQLStatementState
from airflow.sdk._shared.state import TaskScope
from airflow.sdk.execution_time import task_runner
from airflow.sdk.execution_time.comms import GetTaskStateStore, SetTaskStateStore, TaskStateStoreResult
from airflow.sdk.execution_time.context import TaskStateStoreAccessor

MODULE_NAME = "airflow.providers.databricks.operators.databricks"
if source_path := os.environ.get("DATABRICKS_OPERATOR_SOURCE"):
    module_spec = importlib.util.spec_from_file_location(MODULE_NAME, Path(source_path))
    if module_spec is None or module_spec.loader is None:
        raise RuntimeError(f"cannot load {source_path}")
    databricks_module = importlib.util.module_from_spec(module_spec)
    sys.modules[MODULE_NAME] = databricks_module
    module_spec.loader.exec_module(databricks_module)
else:
    databricks_module = importlib.import_module(MODULE_NAME)

DatabricksSQLStatementsOperator = databricks_module.DatabricksSQLStatementsOperator


class LocalDatabricksHook:
    def __init__(self) -> None:
        self.submissions = 0
        self.status_checks = 0

    def post_sql_statement(self, json: dict[str, Any]) -> str:
        self.submissions += 1
        return f"statement-{self.submissions}"

    def get_sql_statement_state(self, statement_id: str) -> SQLStatementState:
        self.status_checks += 1
        if self.status_checks == 1:
            return SQLStatementState("RUNNING")
        return SQLStatementState("SUCCEEDED")


def main(expected_submissions: int) -> None:
    stored: dict[str, Any] = {}

    def send(message: Any) -> TaskStateStoreResult | None:
        if isinstance(message, GetTaskStateStore):
            value = stored.get(message.key)
            return TaskStateStoreResult(value=value) if value is not None else None
        if isinstance(message, SetTaskStateStore):
            stored[message.key] = message.value
        return None

    task_state_store = TaskStateStoreAccessor(
        ti_id=UUID("00000000-0000-0000-0000-000000000001"),
        scope=TaskScope(dag_id="proof", run_id="run", task_id="sql"),
    )
    first_ti = mock.MagicMock(stats_tags={})
    first_ti.xcom_push.side_effect = RuntimeError("xcom unavailable")
    first_context = {"task_state_store": task_state_store, "ti": first_ti}
    retry_ti = mock.MagicMock(stats_tags={})
    retry_context = {"task_state_store": task_state_store, "ti": retry_ti}
    hook = LocalDatabricksHook()

    with (
        mock.patch.object(task_runner, "SUPERVISOR_COMMS", mock.Mock(send=mock.Mock(side_effect=send)), create=True),
        mock.patch.object(DatabricksSQLStatementsOperator, "_get_hook", return_value=hook),
    ):
        first = DatabricksSQLStatementsOperator(
            task_id="sql",
            statement="SELECT 1",
            warehouse_id="warehouse",
            polling_period_seconds=0,
        )
        try:
            first.execute(first_context)
        except RuntimeError as error:
            print(f"first_attempt={error}")
        print(f"stored_after_first={stored}")

        retry = DatabricksSQLStatementsOperator(
            task_id="sql",
            statement="SELECT 1",
            warehouse_id="warehouse",
            polling_period_seconds=0,
        )
        retry.execute(retry_context)

    print(f"stored_after_retry={stored}")
    print(f"submissions={hook.submissions}")
    print(f"retry_statement_id={retry.statement_id}")
    print(f"retry_xcom_calls={retry_ti.xcom_push.call_args_list}")
    if hook.submissions != expected_submissions:
        raise RuntimeError(f"expected {expected_submissions} submission")


if __name__ == "__main__":
    main(expected_submissions=int(sys.argv[1]))
```

Save the driver as `dev/databricks_xcom_ordering_e2e.py`, then run it against the previous PR head:

```console
mkdir -p dev/databricks-xcom-ordering-pre-fix
git archive 82cddda96f6265acad56a285a54ad2f1a05df177 \
  providers/databricks/src/airflow/providers/databricks/operators/databricks.py \
  | tar -x -C dev/databricks-xcom-ordering-pre-fix
DATABRICKS_OPERATOR_SOURCE="$PWD/dev/databricks-xcom-ordering-pre-fix/providers/databricks/src/airflow/providers/databricks/operators/databricks.py" \
AIRFLOW_HOME="$PWD/dev/databricks-xcom-ordering-red-airflow-home" \
AIRFLOW__CORE__LOAD_EXAMPLES=False \
.venv/bin/uv run --project providers/databricks python dev/databricks_xcom_ordering_e2e.py 1
```

```text
first_attempt=xcom unavailable
stored_after_first={}
stored_after_retry={'databricks_sql_statement_id': 'statement-2'}
submissions=2
retry_statement_id=statement-2
retry_xcom_calls=[call(key='statement_id', value='statement-2')]
RuntimeError: expected 1 submission
```

Run the same driver against this branch:

```console
AIRFLOW_HOME="$PWD/dev/databricks-xcom-ordering-green-airflow-home" \
AIRFLOW__CORE__LOAD_EXAMPLES=False \
.venv/bin/uv run --project providers/databricks python dev/databricks_xcom_ordering_e2e.py 1
```

```text
first_attempt=xcom unavailable
stored_after_first={'databricks_sql_statement_id': 'statement-1'}
Reconnecting to existing job external_id=statement-1 external_id_key=databricks_sql_statement_id status=RUNNING
stored_after_retry={'databricks_sql_statement_id': 'statement-1'}
submissions=1
retry_statement_id=statement-1
retry_xcom_calls=[call(key='statement_id', value='statement-1')]
```

</details>

---

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] New Provider
- [ ] Improvement
- [ ] Documentation Fix
- [ ] Refactoring
- [ ] Other

### Relevant Issue(s)

None.

### Description

See above.

### How did you test it?

See the live proof above.

### Did you add documentation?

Yes. The SQL statements guide covers the recovery behavior and version floor.

### Does this introduce a breaking change?

No.

### Checklist

- [x] I have checked that there are no existing pull requests for the same change.
- [x] I have added a commit message that describes my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation accordingly.

### Do you use Generative AI to contribute to this PR?

- [ ] No
- [x] Yes, I used GitHub Copilot CLI (GPT-5.6 Sol) to assist with this pull request.

### AI-assisted review checklist

- [x] I have manually reviewed all AI-generated code and verified its correctness.
- [x] I have added comprehensive tests for AI-generated code paths.
- [x] I have verified that no sensitive data or secrets were included in AI prompts.
- [x] I understand that I am responsible for the entire content of this PR.

### PR Checklist

- [x] I have locally rebased my branch onto the latest main.
- [x] I have run relevant tests and they pass.
- [x] I have run pre-commit checks and they pass.
- [x] I have updated documentation where applicable.