### PR TITLE
Reconnect dbt Cloud runs after worker crashes

### DIFF
--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py
@@ -20,10 +20,11 @@ import json
 import time
 import warnings
 from functools import cached_property
+from http import HTTPStatus
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
-from airflow.providers.common.compat.sdk import BaseOperator, BaseOperatorLink, XCom, conf
+from airflow.providers.common.compat.sdk import AirflowException, BaseOperator, BaseOperatorLink, XCom, conf
 from airflow.providers.dbt.cloud.hooks.dbt import (
     DbtCloudHook,
     DbtCloudJobRunException,
@@ -34,6 +35,7 @@ from airflow.providers.dbt.cloud.triggers.dbt import DbtCloudRunJobTrigger
 from airflow.providers.dbt.cloud.utils.openlineage import generate_openlineage_events_from_dbt_cloud_run
 
 _DURABLE_UNSET = object()
+_DBT_CLOUD_RUN_NOT_FOUND_STATUS: str = "NOT_FOUND"
 
 
 if TYPE_CHECKING:
@@ -340,15 +342,29 @@ class DbtCloudRunJobOperator(ResumableJobMixin, BaseOperator):
 
     def get_job_status(self, external_id: JsonValue, context: Context) -> str:
         run_id = cast("int", external_id)
-        job_run = self.hook.get_job_run(run_id=run_id, account_id=self.account_id).json()["data"]
+        self.run_id = run_id
+        try:
+            job_run: dict[str, Any] = self.hook.get_job_run(run_id=run_id, account_id=self.account_id).json()[
+                "data"
+            ]
+        except AirflowException as error:
+            if str(error).startswith(f"{HTTPStatus.NOT_FOUND.value}:"):
+                return _DBT_CLOUD_RUN_NOT_FOUND_STATUS
+            raise
         self._set_run(run_id=run_id, job_run_url=job_run["href"])
         return DbtCloudJobRunStatus(job_run["status"]).name
 
     def is_job_active(self, status: str) -> bool:
-        return DbtCloudJobRunStatus[status].value in DbtCloudJobRunStatus.NON_TERMINAL_STATUSES.value
+        return (
+            status != _DBT_CLOUD_RUN_NOT_FOUND_STATUS
+            and DbtCloudJobRunStatus[status].value in DbtCloudJobRunStatus.NON_TERMINAL_STATUSES.value
+        )
 
     def is_job_succeeded(self, status: str) -> bool:
-        return DbtCloudJobRunStatus[status] == DbtCloudJobRunStatus.SUCCESS
+        return (
+            status != _DBT_CLOUD_RUN_NOT_FOUND_STATUS
+            and DbtCloudJobRunStatus[status] == DbtCloudJobRunStatus.SUCCESS
+        )
 
     def poll_until_complete(self, external_id: JsonValue, context: Context) -> None:
         self.run_id = cast("int", external_id)

--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py
@@ -21,7 +21,7 @@ import time
 import warnings
 from functools import cached_property
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from airflow.providers.common.compat.sdk import BaseOperator, BaseOperatorLink, XCom, conf
 from airflow.providers.dbt.cloud.hooks.dbt import (
@@ -33,9 +33,53 @@ from airflow.providers.dbt.cloud.hooks.dbt import (
 from airflow.providers.dbt.cloud.triggers.dbt import DbtCloudRunJobTrigger
 from airflow.providers.dbt.cloud.utils.openlineage import generate_openlineage_events_from_dbt_cloud_run
 
+_DURABLE_UNSET = object()
+
+
 if TYPE_CHECKING:
+    from typing import Protocol
+
+    from pydantic import JsonValue
+
+    from airflow.providers.common.compat.sdk import Context
     from airflow.providers.openlineage.extractors import OperatorLineage
-    from airflow.sdk import Context
+
+    class _ResumableJob(Protocol):
+        def submit_job(self, context: Context) -> JsonValue: ...
+
+        def poll_until_complete(self, external_id: JsonValue, context: Context) -> None: ...
+
+        def get_job_result(self, external_id: JsonValue, context: Context) -> Any: ...
+
+
+def _warn_and_disable_durable_pre_3_3(durable: Any) -> bool:
+    if durable is not _DURABLE_UNSET:
+        warnings.warn(
+            "`durable` has no effect on Airflow versions below 3.3.",
+            UserWarning,
+            stacklevel=3,
+        )
+    return False
+
+
+try:
+    from airflow.sdk import ResumableJobMixin
+except ImportError:
+
+    class ResumableJobMixin:  # type: ignore[no-redef]
+        """Disable durable execution when task state is unavailable."""
+
+        external_id_key: str = "dbt_cloud_run_id"
+
+        def __init__(self, *, durable: Any = _DURABLE_UNSET, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+            self.durable = _warn_and_disable_durable_pre_3_3(durable)
+
+        def execute_resumable(self, context: Context) -> Any:
+            resumable_job = cast("_ResumableJob", self)
+            external_id = resumable_job.submit_job(context=context)
+            resumable_job.poll_until_complete(external_id=external_id, context=context)
+            return resumable_job.get_job_result(external_id=external_id, context=context)
 
 
 class DbtCloudRunJobOperatorLink(BaseOperatorLink):
@@ -47,7 +91,7 @@ class DbtCloudRunJobOperatorLink(BaseOperatorLink):
         return XCom.get_value(key="job_run_url", ti_key=ti_key)
 
 
-class DbtCloudRunJobOperator(BaseOperator):
+class DbtCloudRunJobOperator(ResumableJobMixin, BaseOperator):
     """
     Executes a dbt Cloud job.
 
@@ -84,6 +128,8 @@ class DbtCloudRunJobOperator(BaseOperator):
         run. For more information on retry logic, see:
         https://docs.getdbt.com/dbt-cloud/api-v2#/operations/Retry%20Failed%20Job
     :param deferrable: Run operator in the deferrable mode
+    :param durable: Enable crash recovery for synchronous waits. On retry, reconnect to the exact dbt
+        Cloud run submitted by this task. Requires Airflow 3.3 or later.
     :param hook_params: Extra arguments passed to the DbtCloudHook constructor.
     :param execution_timeout: Maximum time allowed for the task to run. If exceeded, the dbt Cloud
         job will be cancelled and the task will fail. When both ``execution_timeout`` and
@@ -91,6 +137,7 @@ class DbtCloudRunJobOperator(BaseOperator):
     :return: The ID of the triggered dbt Cloud job run.
     """
 
+    external_id_key: str = "dbt_cloud_run_id"
     template_fields = (
         "dbt_cloud_conn_id",
         "job_id",
@@ -126,8 +173,11 @@ class DbtCloudRunJobOperator(BaseOperator):
         retry_from_failure: bool = False,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
         hook_params: dict[str, Any] | None = None,
-        **kwargs,
+        durable: bool | None = None,
+        **kwargs: Any,
     ) -> None:
+        if durable is not None:
+            kwargs["durable"] = durable
         super().__init__(**kwargs)
         self.dbt_cloud_conn_id = dbt_cloud_conn_id
         self.account_id = account_id
@@ -143,6 +193,8 @@ class DbtCloudRunJobOperator(BaseOperator):
         self.check_interval = check_interval
         self.additional_run_config = additional_run_config or {}
         self.run_id: int | None = None
+        self._job_run_url: str | None = None
+        self._xcom_run_id: int | None = None
         self.reuse_existing_run = reuse_existing_run
         self.retry_from_failure = retry_from_failure
         self.deferrable = deferrable
@@ -199,6 +251,20 @@ class DbtCloudRunJobOperator(BaseOperator):
 
         return run_id, job_run_url
 
+    def _set_run(self, *, run_id: int, job_run_url: str) -> None:
+        self.run_id = run_id
+        self._job_run_url = job_run_url
+
+    def _restore_run(self, *, run_id: int, context: Context) -> None:
+        if self.run_id != run_id or self._job_run_url is None:
+            job_run = self.hook.get_job_run(run_id=run_id, account_id=self.account_id).json()["data"]
+            self._set_run(run_id=run_id, job_run_url=job_run["href"])
+        if self._xcom_run_id == run_id:
+            return
+        context["ti"].xcom_push(key="job_run_url", value=self._job_run_url)
+        context["ti"].xcom_push(key="job_run_id", value=run_id)
+        self._xcom_run_id = run_id
+
     def _handle_terminal_status(self, status: int) -> int | None:
 
         if status == DbtCloudJobRunStatus.SUCCESS.value:
@@ -213,7 +279,7 @@ class DbtCloudRunJobOperator(BaseOperator):
 
         return None
 
-    def execute(self, context: Context):
+    def execute(self, context: Context) -> int | None:
         if self.trigger_reason is None:
             self.trigger_reason = (
                 f"Triggered via Apache Airflow by task {self.task_id!r} in the {self.dag.dag_id} DAG."
@@ -221,31 +287,15 @@ class DbtCloudRunJobOperator(BaseOperator):
 
         self.job_id = self._resolve_job_id()
 
-        self.run_id, job_run_url = self._get_or_trigger_run(context)
+        if self.wait_for_termination and not self.deferrable:
+            run_id = self.execute_resumable(context=context)
+            return self.run_id if run_id is None else cast("int", run_id)
 
-        # Push the ``job_run_url`` and ``job_run_id`` value to XCom regardless of what happens during execution.
-        # This enables job monitoring via the operator link and provides direct access
-        # to the job run ID without requiring users to parse the URL manually
-        context["ti"].xcom_push(key="job_run_url", value=job_run_url)
-        context["ti"].xcom_push(key="job_run_id", value=self.run_id)
+        self.run_id, job_run_url = self._get_or_trigger_run(context)
+        self._set_run(run_id=self.run_id, job_run_url=job_run_url)
+        self._restore_run(run_id=self.run_id, context=context)
 
         if self.wait_for_termination and isinstance(self.run_id, int):
-            if self.deferrable is False:
-                self.log.info("Waiting for job run %s to terminate.", self.run_id)
-
-                if self.hook.wait_for_job_run_status(
-                    run_id=self.run_id,
-                    account_id=self.account_id,
-                    expected_statuses=DbtCloudJobRunStatus.SUCCESS.value,
-                    check_interval=self.check_interval,
-                    timeout=self.timeout,
-                ):
-                    self.log.info("Job run %s has completed successfully.", self.run_id)
-                else:
-                    raise DbtCloudJobRunException(f"Job run {self.run_id} has failed or has been cancelled.")
-
-                return self.run_id
-
             # Derive absolute deadlines for deferrable execution.
             # execution_timeout is a hard task-level limit (cancels the job),
             # while timeout only limits how long we wait for the job to finish.
@@ -282,6 +332,42 @@ class DbtCloudRunJobOperator(BaseOperator):
                     stacklevel=2,
                 )
             return self.run_id
+
+    def submit_job(self, context: Context) -> JsonValue:
+        run_id, job_run_url = self._get_or_trigger_run(context=context)
+        self._set_run(run_id=run_id, job_run_url=job_run_url)
+        return run_id
+
+    def get_job_status(self, external_id: JsonValue, context: Context) -> str:
+        run_id = cast("int", external_id)
+        job_run = self.hook.get_job_run(run_id=run_id, account_id=self.account_id).json()["data"]
+        self._set_run(run_id=run_id, job_run_url=job_run["href"])
+        return DbtCloudJobRunStatus(job_run["status"]).name
+
+    def is_job_active(self, status: str) -> bool:
+        return DbtCloudJobRunStatus[status].value in DbtCloudJobRunStatus.NON_TERMINAL_STATUSES.value
+
+    def is_job_succeeded(self, status: str) -> bool:
+        return DbtCloudJobRunStatus[status] == DbtCloudJobRunStatus.SUCCESS
+
+    def poll_until_complete(self, external_id: JsonValue, context: Context) -> None:
+        self.run_id = cast("int", external_id)
+        self._restore_run(run_id=self.run_id, context=context)
+        self.log.info("Waiting for job run %s to terminate.", self.run_id)
+        if not self.hook.wait_for_job_run_status(
+            run_id=self.run_id,
+            account_id=self.account_id,
+            expected_statuses=DbtCloudJobRunStatus.SUCCESS.value,
+            check_interval=self.check_interval,
+            timeout=self.timeout,
+        ):
+            raise DbtCloudJobRunException(f"Job run {self.run_id} has failed or has been cancelled.")
+        self.log.info("Job run %s has completed successfully.", self.run_id)
+
+    def get_job_result(self, external_id: JsonValue, context: Context) -> int:
+        self.run_id = cast("int", external_id)
+        self._restore_run(run_id=self.run_id, context=context)
+        return self.run_id
 
     def execute_complete(self, context: Context, event: dict[str, Any]) -> int:
         """Execute when the trigger fires - returns immediately."""
@@ -347,7 +433,7 @@ class DbtCloudRunJobOperator(BaseOperator):
             )
 
     @cached_property
-    def hook(self):
+    def hook(self) -> DbtCloudHook:
         """Returns DBT Cloud hook."""
         return DbtCloudHook(self.dbt_cloud_conn_id, **self.hook_params)
 

--- a/providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py
@@ -17,7 +17,9 @@
 from __future__ import annotations
 
 import os
+import warnings
 from datetime import timedelta
+from typing import Any
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
@@ -26,14 +28,16 @@ from airflow.models import DAG, Connection
 from airflow.providers.common.compat.sdk import TaskDeferred, timezone
 from airflow.providers.dbt.cloud.hooks.dbt import DbtCloudHook, DbtCloudJobRunException, DbtCloudJobRunStatus
 from airflow.providers.dbt.cloud.operators.dbt import (
+    _DURABLE_UNSET,
     DbtCloudGetJobRunArtifactOperator,
     DbtCloudListJobRunsOperator,
     DbtCloudListJobsOperator,
     DbtCloudRunJobOperator,
+    _warn_and_disable_durable_pre_3_3,
 )
 from airflow.providers.dbt.cloud.triggers.dbt import DbtCloudRunJobTrigger
 
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_3_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
     from airflow.sdk.execution_time.comms import XComResult
@@ -94,6 +98,21 @@ def mock_response_json(response: dict):
     run_response = MagicMock(**response)
     run_response.json.return_value = response
     return run_response
+
+
+class FakeTaskStateStore:
+    def __init__(self, values: dict[str, int] | None = None) -> None:
+        self.values = values or {}
+        self.get_calls: list[str] = []
+        self.set_calls: list[tuple[str, int]] = []
+
+    def get(self, key: str) -> int | None:
+        self.get_calls.append(key)
+        return self.values.get(key)
+
+    def set(self, key: str, value: int) -> None:
+        self.set_calls.append((key, value))
+        self.values[key] = value
 
 
 # TODO: Potential performance issue, converted setup_module to a setup_connections function level fixture
@@ -405,7 +424,7 @@ class TestDbtCloudRunJobOperator:
             timeout=3,
             dag=self.dag,
         )
-        dbt_op.execute(MagicMock())
+        dbt_op.execute(self.mock_context)
         mock_trigger_job_run.assert_called_once()
 
     @pytest.mark.parametrize(
@@ -688,6 +707,7 @@ class TestDbtCloudRunJobOperator:
             retry_from_failure=True,
             **self.config,
         )
+        operator.poll_until_complete = MagicMock()
 
         assert operator.dbt_cloud_conn_id == conn_id
         assert operator.job_id == self.config["job_id"]
@@ -727,6 +747,7 @@ class TestDbtCloudRunJobOperator:
             retry_from_failure=True,
             **self.config,
         )
+        operator.poll_until_complete = MagicMock()
         self.mock_context["ti"].try_number = 1
 
         assert operator.dbt_cloud_conn_id == conn_id
@@ -762,6 +783,7 @@ class TestDbtCloudRunJobOperator:
             retry_from_failure=True,
             **self.config,
         )
+        operator.poll_until_complete = MagicMock()
         self.mock_context["ti"].try_number = 2
 
         assert operator.dbt_cloud_conn_id == conn_id
@@ -794,6 +816,7 @@ class TestDbtCloudRunJobOperator:
             dag=self.dag,
             **self.config,
         )
+        operator.poll_until_complete = MagicMock()
 
         assert operator.trigger_reason == custom_trigger_reason
 
@@ -914,6 +937,273 @@ class TestDbtCloudRunJobOperator:
                 run_id=_run_response["data"]["id"],
             )
         )
+
+
+@pytest.mark.skipif(
+    not AIRFLOW_V_3_3_PLUS,
+    reason="ResumableJobMixin reconnect requires task_state_store, available in Airflow 3.3+",
+)
+class TestDbtCloudRunJobOperatorResumability:
+    def setup_method(self) -> None:
+        self.dag = DAG("test_dbt_cloud_job_run_resumability", schedule=None, start_date=DEFAULT_DATE)
+        self.ti = MagicMock(try_number=1, stats_tags={})
+        self.store = FakeTaskStateStore()
+        self.context = {"ti": self.ti, "task_state_store": self.store}
+
+    def create_operator(self, **kwargs: Any) -> DbtCloudRunJobOperator:
+        return DbtCloudRunJobOperator(
+            dbt_cloud_conn_id=ACCOUNT_ID_CONN,
+            task_id=TASK_ID,
+            job_id=JOB_ID,
+            check_interval=1,
+            timeout=3,
+            dag=self.dag,
+            **kwargs,
+        )
+
+    @staticmethod
+    def create_run_response(run_id: int, status: DbtCloudJobRunStatus) -> MagicMock:
+        return mock_response_json(
+            {
+                "data": {
+                    "id": run_id,
+                    "href": EXPECTED_JOB_RUN_OP_EXTRA_LINK.format(
+                        account_id=DEFAULT_ACCOUNT_ID,
+                        project_id=PROJECT_ID,
+                        run_id=run_id,
+                    ),
+                    "status": status.value,
+                }
+            }
+        )
+
+    def test_fresh_submit_persists_run_and_pushes_xcoms(self) -> None:
+        operator = self.create_operator()
+        operator.hook = MagicMock()
+        operator.hook.trigger_job_run.return_value = self.create_run_response(
+            run_id=RUN_ID, status=DbtCloudJobRunStatus.QUEUED
+        )
+        persisted_before_poll: list[int | None] = []
+
+        def wait_for_job_run_status(**_: Any) -> bool:
+            persisted_before_poll.append(self.store.get("dbt_cloud_run_id"))
+            return True
+
+        operator.hook.wait_for_job_run_status.side_effect = wait_for_job_run_status
+
+        assert operator.execute(self.context) == RUN_ID
+
+        assert self.store.values == {"dbt_cloud_run_id": RUN_ID}
+        assert persisted_before_poll == [RUN_ID]
+        self.ti.xcom_push.assert_any_call(
+            key="job_run_url",
+            value=EXPECTED_JOB_RUN_OP_EXTRA_LINK.format(
+                account_id=DEFAULT_ACCOUNT_ID, project_id=PROJECT_ID, run_id=RUN_ID
+            ),
+        )
+        self.ti.xcom_push.assert_any_call(key="job_run_id", value=RUN_ID)
+        assert self.ti.xcom_push.call_count == 2
+
+    def test_xcom_failure_after_submission_keeps_durable_run_id(self) -> None:
+        operator = self.create_operator()
+        operator.hook = MagicMock()
+        operator.hook.trigger_job_run.return_value = self.create_run_response(
+            run_id=RUN_ID, status=DbtCloudJobRunStatus.QUEUED
+        )
+        self.ti.xcom_push.side_effect = RuntimeError("xcom unavailable")
+
+        with pytest.raises(RuntimeError, match="xcom unavailable"):
+            operator.execute(self.context)
+
+        assert self.store.values == {"dbt_cloud_run_id": RUN_ID}
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            DbtCloudJobRunStatus.QUEUED,
+            DbtCloudJobRunStatus.STARTING,
+            DbtCloudJobRunStatus.RUNNING,
+        ],
+    )
+    def test_active_run_reconnects_by_exact_id(self, status: DbtCloudJobRunStatus) -> None:
+        self.store.values["dbt_cloud_run_id"] = RUN_ID
+        operator = self.create_operator(reuse_existing_run=True)
+        operator.hook = MagicMock()
+        operator.hook.get_job_run.return_value = self.create_run_response(run_id=RUN_ID, status=status)
+        operator.hook.wait_for_job_run_status.return_value = True
+
+        assert operator.execute(self.context) == RUN_ID
+
+        operator.hook.get_job_run.assert_called_once_with(run_id=RUN_ID, account_id=None)
+        operator.hook.get_job_runs.assert_not_called()
+        operator.hook.trigger_job_run.assert_not_called()
+        assert operator.run_id == RUN_ID
+
+    def test_successful_run_recovers_without_submission_or_polling(self) -> None:
+        self.store.values["dbt_cloud_run_id"] = RUN_ID
+        operator = self.create_operator()
+        operator.hook = MagicMock()
+        operator.hook.get_job_run.return_value = self.create_run_response(
+            run_id=RUN_ID, status=DbtCloudJobRunStatus.SUCCESS
+        )
+
+        assert operator.execute(self.context) == RUN_ID
+
+        operator.hook.trigger_job_run.assert_not_called()
+        operator.hook.wait_for_job_run_status.assert_not_called()
+        assert operator.run_id == RUN_ID
+        self.ti.xcom_push.assert_any_call(key="job_run_id", value=RUN_ID)
+        self.ti.xcom_push.assert_any_call(
+            key="job_run_url",
+            value=EXPECTED_JOB_RUN_OP_EXTRA_LINK.format(
+                account_id=DEFAULT_ACCOUNT_ID, project_id=PROJECT_ID, run_id=RUN_ID
+            ),
+        )
+
+    @pytest.mark.parametrize("status", [DbtCloudJobRunStatus.ERROR, DbtCloudJobRunStatus.CANCELLED])
+    def test_terminal_run_submits_fresh(self, status: DbtCloudJobRunStatus) -> None:
+        new_run_id = RUN_ID + 1
+        self.store.values["dbt_cloud_run_id"] = RUN_ID
+        operator = self.create_operator()
+        operator.hook = MagicMock()
+        operator.hook.get_job_run.return_value = self.create_run_response(run_id=RUN_ID, status=status)
+        operator.hook.trigger_job_run.return_value = self.create_run_response(
+            run_id=new_run_id, status=DbtCloudJobRunStatus.QUEUED
+        )
+        operator.hook.wait_for_job_run_status.return_value = True
+
+        assert operator.execute(self.context) == new_run_id
+
+        assert self.store.values["dbt_cloud_run_id"] == new_run_id
+        assert operator.run_id == new_run_id
+
+    def test_terminal_run_preserves_retry_from_failure(self) -> None:
+        new_run_id = RUN_ID + 1
+        self.store.values["dbt_cloud_run_id"] = RUN_ID
+        self.ti.try_number = 2
+        operator = self.create_operator(retry_from_failure=True)
+        operator.hook = MagicMock()
+        operator.hook.get_job_run.return_value = self.create_run_response(
+            run_id=RUN_ID, status=DbtCloudJobRunStatus.ERROR
+        )
+        operator.hook.trigger_job_run.return_value = self.create_run_response(
+            run_id=new_run_id, status=DbtCloudJobRunStatus.QUEUED
+        )
+        operator.hook.wait_for_job_run_status.return_value = True
+
+        operator.execute(self.context)
+
+        operator.hook.trigger_job_run.assert_called_once_with(
+            account_id=None,
+            job_id=JOB_ID,
+            cause=ANY,
+            steps_override=None,
+            schema_override=None,
+            retry_from_failure=True,
+            additional_run_config={},
+        )
+
+    def test_deferrable_execution_does_not_use_task_state_store(self) -> None:
+        operator = self.create_operator(deferrable=True)
+        operator.hook = MagicMock()
+        operator.hook.trigger_job_run.return_value = self.create_run_response(
+            run_id=RUN_ID, status=DbtCloudJobRunStatus.QUEUED
+        )
+        operator.hook.get_job_run_status.return_value = DbtCloudJobRunStatus.RUNNING.value
+
+        with pytest.raises(TaskDeferred):
+            operator.execute(self.context)
+
+        assert self.store.get_calls == []
+        assert self.store.set_calls == []
+
+    def test_no_wait_execution_does_not_use_task_state_store(self) -> None:
+        operator = self.create_operator(wait_for_termination=False)
+        operator.hook = MagicMock()
+        operator.hook.trigger_job_run.return_value = self.create_run_response(
+            run_id=RUN_ID, status=DbtCloudJobRunStatus.QUEUED
+        )
+
+        assert operator.execute(self.context) == RUN_ID
+
+        assert self.store.get_calls == []
+        assert self.store.set_calls == []
+
+    def test_durable_false_uses_fresh_execution(self) -> None:
+        self.store.values["dbt_cloud_run_id"] = RUN_ID
+        new_run_id = RUN_ID + 1
+        operator = self.create_operator(durable=False)
+        operator.hook = MagicMock()
+        operator.hook.trigger_job_run.return_value = self.create_run_response(
+            run_id=new_run_id, status=DbtCloudJobRunStatus.QUEUED
+        )
+        operator.hook.wait_for_job_run_status.return_value = True
+
+        assert operator.execute(self.context) == new_run_id
+
+        assert self.store.get_calls == []
+        assert self.store.set_calls == []
+
+    def test_missing_task_state_store_uses_fresh_execution(self) -> None:
+        operator = self.create_operator()
+        operator.hook = MagicMock()
+        operator.hook.trigger_job_run.return_value = self.create_run_response(
+            run_id=RUN_ID, status=DbtCloudJobRunStatus.QUEUED
+        )
+        operator.hook.wait_for_job_run_status.return_value = True
+
+        assert operator.execute({"ti": self.ti}) == RUN_ID
+
+        operator.hook.trigger_job_run.assert_called_once()
+
+    def test_default_args_can_disable_durable_execution(self) -> None:
+        with DAG(
+            "test_default_args_durable",
+            schedule=None,
+            start_date=DEFAULT_DATE,
+            default_args={"durable": False},
+        ) as dag:
+            operator = DbtCloudRunJobOperator(task_id=TASK_ID, job_id=JOB_ID)
+
+        assert dag.task_dict[TASK_ID] is operator
+        assert operator.durable is False
+
+    @patch("airflow.providers.dbt.cloud.operators.dbt.generate_openlineage_events_from_dbt_cloud_run")
+    def test_recovered_run_is_available_to_openlineage_and_on_kill(
+        self, mock_generate_openlineage_events: MagicMock
+    ) -> None:
+        self.store.values["dbt_cloud_run_id"] = RUN_ID
+        operator = self.create_operator()
+        operator.hook = MagicMock()
+        operator.hook.get_job_run.return_value = self.create_run_response(
+            run_id=RUN_ID, status=DbtCloudJobRunStatus.RUNNING
+        )
+        operator.hook.wait_for_job_run_status.return_value = True
+
+        operator.execute(self.context)
+        operator.get_openlineage_facets_on_complete(self.ti)
+        operator.on_kill()
+
+        assert operator.run_id == RUN_ID
+        mock_generate_openlineage_events.assert_called_once_with(operator=operator, task_instance=self.ti)
+        operator.hook.cancel_job_run.assert_called_once_with(run_id=RUN_ID, account_id=None)
+
+
+class TestWarnAndDisableDurableAirflowPre3_3:
+    def test_no_warning_when_unset(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = _warn_and_disable_durable_pre_3_3(_DURABLE_UNSET)
+
+        assert result is False
+        assert caught == []
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_warns_and_disables_when_explicitly_set(self, value: bool) -> None:
+        with pytest.warns(UserWarning, match="durable.*no effect"):
+            result = _warn_and_disable_durable_pre_3_3(value)
+
+        assert result is False
 
 
 class TestDbtCloudGetJobRunArtifactOperator:

--- a/providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py
@@ -23,9 +23,10 @@ from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
+from requests import exceptions as requests_exceptions
 
 from airflow.models import DAG, Connection
-from airflow.providers.common.compat.sdk import TaskDeferred, timezone
+from airflow.providers.common.compat.sdk import AirflowException, TaskDeferred, timezone
 from airflow.providers.dbt.cloud.hooks.dbt import DbtCloudHook, DbtCloudJobRunException, DbtCloudJobRunStatus
 from airflow.providers.dbt.cloud.operators.dbt import (
     _DURABLE_UNSET,
@@ -1109,6 +1110,58 @@ class TestDbtCloudRunJobOperatorResumability:
             retry_from_failure=True,
             additional_run_config={},
         )
+
+    def test_missing_run_submits_fresh(self) -> None:
+        self.store.values["dbt_cloud_run_id"] = RUN_ID
+        new_run_id = RUN_ID + 1
+        operator = self.create_operator()
+        operator.hook = MagicMock()
+        operator.hook.get_job_run.side_effect = AirflowException("404:Not Found")
+        operator.hook.trigger_job_run.return_value = self.create_run_response(
+            run_id=new_run_id, status=DbtCloudJobRunStatus.QUEUED
+        )
+        operator.hook.wait_for_job_run_status.return_value = True
+
+        assert operator.execute(self.context) == new_run_id
+
+        assert self.store.values["dbt_cloud_run_id"] == new_run_id
+        operator.hook.trigger_job_run.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            AirflowException("401:Unauthorized"),
+            AirflowException("500:Internal Server Error"),
+            requests_exceptions.ConnectionError("connection failed"),
+        ],
+    )
+    def test_recovery_lookup_propagates_other_errors(self, error: Exception) -> None:
+        self.store.values["dbt_cloud_run_id"] = RUN_ID
+        operator = self.create_operator()
+        operator.hook = MagicMock()
+        operator.hook.get_job_run.side_effect = error
+
+        with pytest.raises(type(error)) as exc_info:
+            operator.execute(self.context)
+
+        assert exc_info.value is error
+        operator.hook.trigger_job_run.assert_not_called()
+
+    def test_on_kill_can_cancel_during_recovery_lookup(self) -> None:
+        self.store.values["dbt_cloud_run_id"] = RUN_ID
+        operator = self.create_operator()
+        operator.hook = MagicMock()
+        operator.hook.wait_for_job_run_status.return_value = True
+
+        def get_job_run(*, run_id: int, account_id: int | None) -> MagicMock:
+            operator.on_kill()
+            return self.create_run_response(run_id=run_id, status=DbtCloudJobRunStatus.RUNNING)
+
+        operator.hook.get_job_run.side_effect = get_job_run
+
+        assert operator.execute(self.context) == RUN_ID
+
+        operator.hook.cancel_job_run.assert_called_once_with(run_id=RUN_ID, account_id=None)
 
     def test_deferrable_execution_does_not_use_task_state_store(self) -> None:
         operator = self.create_operator(deferrable=True)

--- a/providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import os
 import warnings
 from datetime import timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
@@ -41,6 +41,10 @@ from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V
 
 if AIRFLOW_V_3_0_PLUS:
     from airflow.sdk.execution_time.comms import XComResult
+
+if TYPE_CHECKING:
+    from airflow.sdk import Context
+    from airflow.sdk.execution_time.context import TaskStateStoreAccessor
 
 DEFAULT_DATE = timezone.datetime(2021, 1, 1)
 TASK_ID = "run_job_op"
@@ -948,7 +952,10 @@ class TestDbtCloudRunJobOperatorResumability:
         self.dag = DAG("test_dbt_cloud_job_run_resumability", schedule=None, start_date=DEFAULT_DATE)
         self.ti = MagicMock(try_number=1, stats_tags={})
         self.store = FakeTaskStateStore()
-        self.context = {"ti": self.ti, "task_state_store": self.store}
+        self.context: Context = {
+            "ti": self.ti,
+            "task_state_store": cast("TaskStateStoreAccessor", self.store),
+        }
 
     def create_operator(self, **kwargs: Any) -> DbtCloudRunJobOperator:
         return DbtCloudRunJobOperator(


### PR DESCRIPTION
A synchronous dbt Cloud task can leave its remote run active after the worker crashes. A retry then starts another run. If the saved run is later deleted, every retry fails during lookup, and cancellation can miss the saved ID while that lookup is in flight.

Synchronous retries now store the exact run ID, reconnect active runs, return successful runs, and submit fresh after terminal states or an exact `404:` response. Other lookup errors still propagate. Recovery restores `run_id` before lookup so `on_kill()` can cancel the saved run. Deferrable, no-wait, reuse, and retry-from-failure behavior is unchanged.

## Testing

<details>
<summary>Missing-run and cancellation regression</summary>

```console
$ git checkout a351cf4d16563ceaff486dedf07743533f8e4ac1 -- providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py
$ uv run --project providers/dbt/cloud pytest \
    providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py::TestDbtCloudRunJobOperatorResumability::test_missing_run_submits_fresh \
    providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py::TestDbtCloudRunJobOperatorResumability::test_recovery_lookup_propagates_other_errors \
    providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py::TestDbtCloudRunJobOperatorResumability::test_on_kill_can_cancel_during_recovery_lookup -q
FAILED ...::test_missing_run_submits_fresh - airflow.exceptions.AirflowException: 404:Not Found
FAILED ...::test_on_kill_can_cancel_during_recovery_lookup - AssertionError: Expected 'cancel_job_run' to be called once. Called 0 times.
2 failed, 3 passed

$ git checkout HEAD -- providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py
$ uv run --project providers/dbt/cloud pytest \
    providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py::TestDbtCloudRunJobOperatorResumability::test_missing_run_submits_fresh \
    providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py::TestDbtCloudRunJobOperatorResumability::test_recovery_lookup_propagates_other_errors \
    providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py::TestDbtCloudRunJobOperatorResumability::test_on_kill_can_cancel_during_recovery_lookup -q
========================= 5 passed, 1 warning in 9.69s =========================
```

</details>

<details>
<summary>Crash and retry through the task-state store</summary>

Save this as `dev/dbt_cloud_resumability_e2e.py`:

```python
from __future__ import annotations

import json
import subprocess
import sys
import types
from typing import Any
from unittest.mock import patch
from uuid import UUID

from airflow.providers.dbt.cloud.hooks.dbt import DbtCloudJobRunStatus
from airflow.providers.dbt.cloud.operators.dbt import DbtCloudRunJobOperator as ResumableOperator
from airflow.sdk._shared.state import TaskScope
from airflow.sdk.execution_time import task_runner
from airflow.sdk.execution_time.comms import GetTaskStateStore, SetTaskStateStore, TaskStateStoreResult
from airflow.sdk.execution_time.context import TaskStateStoreAccessor

SOURCE_PATH = "providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py"


class _WorkerCrash(RuntimeError):
    pass


class _LocalResponse:
    def __init__(self, *, run_id: int, status: DbtCloudJobRunStatus) -> None:
        self.run_id = run_id
        self.status = status

    def json(self) -> dict[str, Any]:
        return {
            "data": {
                "id": self.run_id,
                "href": f"https://cloud.getdbt.com/deploy/1/projects/2/runs/{self.run_id}/",
                "status": self.status.value,
            }
        }


class _LocalSupervisorComms:
    def __init__(self) -> None:
        self.values: dict[str, Any] = {}

    def send(self, message: Any) -> Any:
        if isinstance(message, GetTaskStateStore):
            return TaskStateStoreResult(value=self.values.get(message.key))
        if isinstance(message, SetTaskStateStore):
            self.values[message.key] = message.value
            return None
        raise TypeError(type(message).__name__)


class _LocalDbtHook:
    def __init__(self) -> None:
        self.submissions: list[int] = []
        self.lookups: list[int] = []
        self.waits = 0

    def trigger_job_run(self, **_: Any) -> _LocalResponse:
        run_id = 1000 + len(self.submissions) + 1
        self.submissions.append(run_id)
        return _LocalResponse(run_id=run_id, status=DbtCloudJobRunStatus.QUEUED)

    def get_job_run(self, *, run_id: int, account_id: int | None) -> _LocalResponse:
        self.lookups.append(run_id)
        return _LocalResponse(run_id=run_id, status=DbtCloudJobRunStatus.RUNNING)

    def wait_for_job_run_status(self, **_: Any) -> bool:
        self.waits += 1
        if self.waits == 1:
            raise _WorkerCrash("simulated worker crash")
        return True


class _LocalTaskInstance:
    def __init__(self, *, try_number: int) -> None:
        self.try_number = try_number
        self.stats_tags: dict[str, str] = {}
        self.xcom: dict[str, Any] = {}

    def xcom_push(self, *, key: str, value: Any) -> None:
        self.xcom[key] = value


def load_upstream_operator() -> type:
    source = subprocess.run(
        ["git", "show", f"upstream/main:{SOURCE_PATH}"],
        check=True,
        capture_output=True,
        text=True,
    ).stdout
    module = types.ModuleType("upstream_dbt_operator")
    module.__file__ = f"upstream/main:{SOURCE_PATH}"
    sys.modules[module.__name__] = module
    exec(compile(source, module.__file__, "exec"), module.__dict__)
    return module.DbtCloudRunJobOperator


def run_case(label: str, operator_class: type) -> None:
    hook = _LocalDbtHook()
    comms = _LocalSupervisorComms()
    accessor = TaskStateStoreAccessor(
        ti_id=UUID("01900000-0000-0000-0000-000000000001"),
        scope=TaskScope(dag_id="dbt", run_id="manual__retry", task_id="run_job"),
    )

    print(label)
    with patch.object(task_runner, "SUPERVISOR_COMMS", comms, create=True):
        for attempt in (1, 2):
            task_instance = _LocalTaskInstance(try_number=attempt)
            operator = operator_class(
                task_id="run_job",
                job_id=42,
                trigger_reason="resumability e2e",
                check_interval=0,
            )
            operator.hook = hook
            context = {"task_state_store": accessor, "ti": task_instance}
            try:
                result = operator.execute(context=context)
            except _WorkerCrash as error:
                print(json.dumps({"attempt": attempt, "error": str(error)}))
            else:
                print(json.dumps({"attempt": attempt, "result": result, "xcom": task_instance.xcom}))
    print(
        json.dumps(
            {
                "lookups": hook.lookups,
                "stored_run_id": comms.values.get("dbt_cloud_run_id"),
                "submissions": hook.submissions,
            }
        )
    )


run_case("upstream/main", load_upstream_operator())
run_case("resumable change", ResumableOperator)
```

```console
$ AIRFLOW_HOME=$(mktemp -d) uv run --project providers/dbt/cloud \
    python dev/dbt_cloud_resumability_e2e.py 2>&1 |
    grep -E '^(upstream/main|resumable change|\{)'
upstream/main
{"attempt": 1, "error": "simulated worker crash"}
{"attempt": 2, "result": 1002, "xcom": {"job_run_url": "https://cloud.getdbt.com/deploy/1/projects/2/runs/1002/", "job_run_id": 1002}}
{"lookups": [], "stored_run_id": null, "submissions": [1001, 1002]}
resumable change
{"attempt": 1, "error": "simulated worker crash"}
{"attempt": 2, "result": 1001, "xcom": {"job_run_url": "https://cloud.getdbt.com/deploy/1/projects/2/runs/1001/", "job_run_id": 1001}}
{"lookups": [1001], "stored_run_id": 1001, "submissions": [1001]}
```

</details>

<details>
<summary>Provider suite</summary>

```console
$ uv run --project providers/dbt/cloud pytest providers/dbt/cloud/tests/unit/dbt/cloud -q
======================= 286 passed, 1 warning in 44.50s ========================
```

</details>

<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (GitHub Copilot CLI, GPT-5.6 Sol)

Generated-by: GitHub Copilot CLI (GPT-5.6 Sol) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
