### PR TITLE
Prefer reachable Docker contexts including Colima in Breeze

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -24,6 +24,7 @@ import os
 import platform
 import re
 import shlex
+import socket
 import subprocess
 import sys
 import time
@@ -839,14 +840,52 @@ def remove_docker_volumes(volumes: list[str] | None = None) -> None:
 # because the docker socket to use is created in the .docker/ directory in the user's home directory
 # and it does not require the user to belong to the "docker" group.
 # The "rancher-desktop" context is the preferred context for the Rancher dockerd (moby) Container Engine.
+# The "colima" context is created by Colima's default profile (a common lightweight Docker runtime on macOS).
 # The "default" context is the traditional one that requires "/var/run/docker.sock" to be writeable by the
 # user running the docker command.
-PREFERRED_CONTEXTS = ["orbstack", "desktop-linux", "rancher-desktop", "default"]
+PREFERRED_CONTEXTS = ["orbstack", "desktop-linux", "rancher-desktop", "colima", "default"]
+
+
+def _is_docker_context_usable(context: dict) -> bool:
+    """
+    Return whether a docker context looks usable for breeze.
+
+    Skips WSL-only Windows pipes, contexts docker reports as errored, and absolute
+    Unix sockets that are missing or not accepting connections (typical when Docker
+    Desktop or Colima left a stale context after the engine stopped).
+    """
+    if context.get("Error"):
+        return False
+    endpoint = context.get("DockerEndpoint") or ""
+    # On Windows, some contexts are used for WSL2. We don't want to use those.
+    if endpoint == "npipe:////./pipe/dockerDesktopLinuxEngine":
+        return False
+    if not endpoint.startswith("unix://"):
+        return True
+    socket_path = endpoint.removeprefix("unix://")
+    # Non-absolute paths are unusual (and used in unit tests); treat them as usable.
+    if not socket_path.startswith("/"):
+        return True
+    if not os.path.exists(socket_path):
+        return False
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.settimeout(0.2)
+    try:
+        sock.connect(socket_path)
+    except OSError:
+        return False
+    finally:
+        sock.close()
+    return True
 
 
 def autodetect_docker_context():
     """
     Auto-detects which docker context to use.
+
+    Prefers known developer-friendly contexts, but only if their endpoint is
+    reachable — so a leftover ``desktop-linux`` context after quitting Docker
+    Desktop does not win over a working Colima or default socket.
 
     :return: name of the docker context to use
     """
@@ -874,8 +913,11 @@ def autodetect_docker_context():
             context = known_contexts[preferred_context_name]
         except KeyError:
             continue
-        # On Windows, some contexts are used for WSL2. We don't want to use those.
-        if context["DockerEndpoint"] == "npipe:////./pipe/dockerDesktopLinuxEngine":
+        if not _is_docker_context_usable(context):
+            console_print(
+                f"[warning]Skipping preferred docker context {preferred_context_name!r}: "
+                f"endpoint is not usable.[/]"
+            )
             continue
         console_print(f"[info]Using {preferred_context_name!r} as context.[/]")
         return preferred_context_name

--- a/dev/breeze/tests/test_docker_command_utils.py
+++ b/dev/breeze/tests/test_docker_command_utils.py
@@ -269,6 +269,42 @@ def _fake_ctx_output(*names: str) -> str:
             "desktop-linux",
             "[info]Using 'desktop-linux' as context",
         ),
+        (
+            _fake_ctx_output("a", "default", "colima"),
+            "colima",
+            "[info]Using 'colima' as context",
+        ),
+        (
+            "\n".join(
+                [
+                    json.dumps(
+                        {
+                            "Name": "desktop-linux",
+                            "DockerEndpoint": "unix:///nonexistent/docker-desktop.sock",
+                        }
+                    ),
+                    json.dumps({"Name": "colima", "DockerEndpoint": "unix://colima"}),
+                ]
+            ),
+            "colima",
+            "[info]Using 'colima' as context",
+        ),
+        (
+            "\n".join(
+                [
+                    json.dumps(
+                        {
+                            "Name": "desktop-linux",
+                            "DockerEndpoint": "unix://desktop-linux",
+                            "Error": "Cannot connect to the Docker daemon",
+                        }
+                    ),
+                    json.dumps({"Name": "default", "DockerEndpoint": "unix://default"}),
+                ]
+            ),
+            "default",
+            "[info]Using 'default' as context",
+        ),
     ],
 )
 def test_autodetect_docker_context(context_output: str, selected_context: str, console_output: str):
@@ -277,8 +313,7 @@ def test_autodetect_docker_context(context_output: str, selected_context: str, c
         mock_run_command.return_value.stdout = context_output
         with mock.patch("airflow_breeze.utils.docker_command_utils.console_print") as mock_console_print:
             assert autodetect_docker_context() == selected_context
-            mock_console_print.assert_called_once()
-            assert console_output in mock_console_print.call_args[0][0]
+            assert any(console_output in call.args[0] for call in mock_console_print.call_args_list)
 
 
 SOCKET_INFO = json.dumps(


### PR DESCRIPTION
## Summary

Breeze preferred `desktop-linux` even when that context pointed at a missing or dead Docker Desktop socket. That is common after quitting Desktop, or when using Colima only — and it made `breeze` fail before it could talk to a working engine.

This change:

- Skips preferred contexts whose Unix socket is missing, not accepting connections, or already reported as errored
- Adds Colima's default `colima` context to the preferred list
- Extends unit coverage for Colima preference and stale Desktop fallback

Companion docs (workaround + Colima setup): #72431

## Test plan

- [x] `cd dev/breeze && uv run --project . pytest tests/test_docker_command_utils.py::test_autodetect_docker_context -o addopts=` (10 passed)
- [ ] With only Colima running and a leftover `desktop-linux` context: confirm Breeze selects `colima`
- [ ] With Docker Desktop running: confirm Breeze still prefers `desktop-linux` / OrbStack / Rancher when reachable