### PR TITLE
Fix mismatched AirflowConfigException in celery and edge3

### DIFF
--- a/providers/celery/src/airflow/providers/celery/cli/celery_command.py
+++ b/providers/celery/src/airflow/providers/celery/cli/celery_command.py
@@ -36,14 +36,13 @@ from lockfile.pidlockfile import read_pid_from_pidfile, remove_existing_pidfile
 
 from airflow import settings
 from airflow.cli.simple_table import AirflowConsole
-from airflow.exceptions import AirflowConfigException
 from airflow.providers.celery.version_compat import (
     AIRFLOW_V_3_0_PLUS,
     AIRFLOW_V_3_1_PLUS,
     AIRFLOW_V_3_2_PLUS,
     AIRFLOW_V_3_3_PLUS,
 )
-from airflow.providers.common.compat.sdk import conf
+from airflow.providers.common.compat.sdk import AirflowConfigException, conf
 from airflow.utils import cli as cli_utils
 from airflow.utils.cli import setup_locations
 

--- a/providers/celery/src/airflow/providers/celery/executors/default_celery.py
+++ b/providers/celery/src/airflow/providers/celery/executors/default_celery.py
@@ -25,9 +25,9 @@ import re
 import ssl
 from typing import TYPE_CHECKING
 
-from airflow.exceptions import AirflowConfigException
+from airflow.exceptions import AirflowConfigException as CoreAirflowConfigException
 from airflow.providers.celery.version_compat import AIRFLOW_V_3_0_PLUS
-from airflow.providers.common.compat.sdk import AirflowException, conf
+from airflow.providers.common.compat.sdk import AirflowConfigException, AirflowException, conf
 
 if TYPE_CHECKING:
     from typing import Any
@@ -195,7 +195,9 @@ def get_default_celery_config(team_conf: AirflowSDKConfigParser | Any) -> dict[s
     # Handle SSL configuration
     try:
         celery_ssl_active = team_conf.getboolean("celery", "SSL_ACTIVE", fallback=False)
-    except AirflowConfigException:
+    # ``team_conf`` is the Task SDK parser at module scope and core's ``ExecutorConf`` on the
+    # multi-team path. Their ``AirflowConfigException`` classes share a name but are not the same class.
+    except (AirflowConfigException, CoreAirflowConfigException):
         log.warning("Celery Executor will run without SSL")
         celery_ssl_active = False
 

--- a/providers/celery/tests/unit/celery/cli/test_celery_command.py
+++ b/providers/celery/tests/unit/celery/cli/test_celery_command.py
@@ -799,6 +799,15 @@ def test_stale_bundle_cleanup(mock_process):
     assert actual[0] is _bundle_cleanup_main
 
 
+@patch("airflow.providers.celery.cli.celery_command.Process")
+@pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Doesn't apply to pre-3.0")
+@conf_vars({("dag_processor", "stale_bundle_cleanup_interval"): "not-an-int"})
+def test_stale_bundle_cleanup_skipped_on_non_integer_interval(mock_process):
+    with _run_stale_bundle_cleanup():
+        ...
+    mock_process.assert_not_called()
+
+
 @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Doesn't apply to pre-3.0")
 def test_bundle_cleanup_main_is_picklable():
     """Regression test: _bundle_cleanup_main must be a module-level function so it can be

--- a/providers/celery/tests/unit/celery/executors/test_celery_executor.py
+++ b/providers/celery/tests/unit/celery/executors/test_celery_executor.py
@@ -1571,6 +1571,25 @@ class TestAmqpsSslConfig:
         assert "certfile" not in broker_ssl
 
 
+@pytest.mark.parametrize(
+    "get_team_conf",
+    [
+        pytest.param(lambda: conf, id="sdk_conf"),
+        pytest.param(
+            lambda: ExecutorConf(team_name=None),
+            id="executor_conf",
+            marks=pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="ExecutorConf requires Airflow 3.2+"),
+        ),
+    ],
+)
+@conf_vars({("celery", "SSL_ACTIVE"): "yes"})
+def test_non_boolean_ssl_active_degrades_to_no_ssl(get_team_conf):
+    """A malformed [celery] ssl_active must degrade to a no-SSL config instead of raising."""
+    config = default_celery.get_default_celery_config(get_team_conf())
+
+    assert "broker_use_ssl" not in config
+
+
 class TestCreateCeleryAppTeamIsolation:
     """Tests for create_celery_app() multi-team config isolation."""
 

--- a/providers/edge3/src/airflow/providers/edge3/plugins/edge_executor_plugin.py
+++ b/providers/edge3/src/airflow/providers/edge3/plugins/edge_executor_plugin.py
@@ -20,8 +20,7 @@ from __future__ import annotations
 import sys
 from typing import TYPE_CHECKING, Any
 
-from airflow.exceptions import AirflowConfigException
-from airflow.providers.common.compat.sdk import AirflowPlugin, conf
+from airflow.providers.common.compat.sdk import AirflowConfigException, AirflowPlugin, conf
 from airflow.providers.edge3.version_compat import AIRFLOW_V_3_1_PLUS
 from airflow.utils.session import NEW_SESSION, provide_session
 

--- a/providers/edge3/tests/unit/edge3/plugins/test_edge_executor_plugin.py
+++ b/providers/edge3/tests/unit/edge3/plugins/test_edge_executor_plugin.py
@@ -43,6 +43,13 @@ def test_plugin_inactive():
         assert len(rep.appbuilder_views) == 0
 
 
+def test_plugin_inactive_on_non_boolean_api_enabled():
+    with conf_vars({("edge", "api_enabled"): "yes"}):
+        importlib.reload(edge_executor_plugin)
+
+        assert edge_executor_plugin.EDGE_EXECUTOR_ACTIVE is False
+
+
 @pytest.mark.db_test
 def test_plugin_active_apiserver():
     mock_cli = ["airflow", "api-server"]


### PR DESCRIPTION
## Why
- #60000 moved providers to `from airflow.providers.common.compat.sdk import conf`. celery and edge3 took the new `conf` but left `AirflowConfigException` coming from `airflow.exceptions`.
- The compat `conf` resolves to the Task SDK parser, which raises `airflow.sdk._shared.configuration.exceptions.AirflowConfigException`. The handlers name `airflow.exceptions.AirflowConfigException`, so they never catch what the parser raises.
- `default_celery.py` needs both classes in the handler, because `get_default_celery_config()` also receives core's `ExecutorConf` on the multi-team path.

## How
- The edge3 plugin and `celery_command.py` only ever see the compat `conf`, so `AirflowConfigException` now comes from the same compat import line.
- `get_default_celery_config()` gets the compat `conf` at module scope and core's `ExecutorConf` on the multi-team path. Those two raise different classes, so the handler in `default_celery.py` catches both.

## Verification

- `uv run --project providers/celery pytest "providers/celery/tests/unit/celery/executors/test_celery_executor.py" "providers/celery/tests/unit/celery/cli/test_celery_command.py" "providers/edge3/tests/unit/edge3/plugins/test_edge_executor_plugin.py" -v` 
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
