### PR TITLE
Add missing unit tests for the apache.hive macros plugin

### DIFF
--- a/airflow-core/tests/unit/always/test_project_structure.py
+++ b/airflow-core/tests/unit/always/test_project_structure.py
@@ -81,7 +81,6 @@ class TestProjectStructure:
             "providers/amazon/tests/unit/amazon/aws/waiters/test_base_waiter.py",
             "providers/apache/hdfs/tests/unit/apache/hdfs/hooks/test_hdfs.py",
             "providers/apache/hdfs/tests/unit/apache/hdfs/sensors/test_hdfs.py",
-            "providers/apache/hive/tests/unit/apache/hive/plugins/test_hive.py",
             "providers/celery/tests/unit/celery/executors/test_celery_executor_utils.py",
             "providers/celery/tests/unit/celery/executors/test_default_celery.py",
             "providers/cloudant/tests/unit/cloudant/test_cloudant_fake.py",

--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -709,8 +709,8 @@ class CommandFactory:
         """Create Arg for non-primitive type Pydantic."""
         parameter_type_map = getattr(generated_datamodels, parameter_type)
         commands = []
-        if parameter_type_map not in self.datamodels_extended_map.keys():
-            self.datamodels_extended_map[parameter_type] = []
+        # Rebuilt per visit: datamodels are shared across operations, so appending would duplicate fields.
+        self.datamodels_extended_map[parameter_type] = []
         for field, field_type in parameter_type_map.model_fields.items():
             if field in self.excluded_parameters:
                 continue

--- a/providers/apache/hive/tests/unit/apache/hive/plugins/__init__.py
+++ b/providers/apache/hive/tests/unit/apache/hive/plugins/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/apache/hive/tests/unit/apache/hive/plugins/test_hive.py
+++ b/providers/apache/hive/tests/unit/apache/hive/plugins/test_hive.py
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from airflow.providers.apache.hive.macros.hive import closest_ds_partition, max_partition
+from airflow.providers.apache.hive.plugins.hive import HivePlugin
+from airflow.providers.common.compat.sdk import AirflowPlugin
+from airflow.sdk._shared.module_loading import import_string
+
+
+class TestHivePlugin:
+    def test_name_is_hive(self):
+        assert HivePlugin.name == "hive"
+
+    def test_exposed_macros(self):
+        assert max_partition in HivePlugin.macros
+        assert closest_ds_partition in HivePlugin.macros
+
+    def subclasses_airflow_plugin(self):
+        assert issubclass(HivePlugin, AirflowPlugin)
+
+    def test_hive_plugin_dotted_path(self):
+        path = "airflow.providers.apache.hive.plugins.hive.HivePlugin"
+        resolved_class = import_string(path)
+
+        assert resolved_class is HivePlugin

--- a/providers/apache/hive/tests/unit/apache/hive/plugins/test_hive.py
+++ b/providers/apache/hive/tests/unit/apache/hive/plugins/test_hive.py
@@ -31,7 +31,7 @@ class TestHivePlugin:
         assert max_partition in HivePlugin.macros
         assert closest_ds_partition in HivePlugin.macros
 
-    def subclasses_airflow_plugin(self):
+    def test_subclasses_airflow_plugin(self):
         assert issubclass(HivePlugin, AirflowPlugin)
 
     def test_hive_plugin_dotted_path(self):


### PR DESCRIPTION
This PR resolves https://github.com/apache/airflow/issues/72267

Added unit testing addressing the conditions specified by the corresponding issue, and removed the file from `OVERLOOKED_TESTS`

Run these tests using: `breeze testing providers-tests providers/apache/hive/tests/unit/apache/hive/plugins/test_hive.py`

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->