### PR TITLE
Add missing tests for google.cloud.utils BigQuery helpers (#72276)

### DIFF
--- a/airflow-core/tests/unit/always/test_project_structure.py
+++ b/airflow-core/tests/unit/always/test_project_structure.py
@@ -167,8 +167,6 @@ class TestProjectStructure:
             "providers/google/tests/unit/google/cloud/sensors/vertex_ai/test_feature_store.py",
             "providers/google/tests/unit/google/cloud/transfers/test_bigquery_to_sql.py",
             "providers/google/tests/unit/google/cloud/transfers/test_presto_to_gcs.py",
-            "providers/google/tests/unit/google/cloud/utils/test_bigquery.py",
-            "providers/google/tests/unit/google/cloud/utils/test_bigquery_get_data.py",
             "providers/google/tests/unit/google/common/hooks/test_operation_helpers.py",
             "providers/google/tests/unit/google/test_go_module_utils.py",
             "providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_adls.py",

--- a/providers/google/tests/unit/google/cloud/utils/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/utils/test_bigquery.py
@@ -1,0 +1,47 @@
+import pytest
+from airflow.providers.google.cloud.utils.bigquery import bq_cast, convert_job_id
+
+class TestBqCast:
+    def test_bq_cast_none(self):
+        """bq_cast returns None for a None input regardless of the declared type."""
+        assert bq_cast(None, "INTEGER") is None
+
+    def test_bq_cast_integer_and_float(self):
+        """INTEGER casts to int, and FLOAT casts to float."""
+        assert bq_cast("123", "INTEGER") == 123
+        assert bq_cast("123.45", "FLOAT") == 123.45
+
+    def test_bq_cast_timestamp_returns_float(self):
+        """TIMESTAMP also casts to float (pinned behavior)."""
+        assert bq_cast("123.45", "TIMESTAMP") == 123.45
+
+    @pytest.mark.parametrize("value, expected", [("true", True), ("false", False)])
+    def test_bq_cast_boolean_valid(self, value, expected):
+        """BOOLEAN maps the strings true and false to real booleans."""
+        assert bq_cast(value, "BOOLEAN") is expected
+
+    def test_bq_cast_boolean_invalid_raises_value_error(self):
+        """BOOLEAN raises ValueError for anything else with the expected message."""
+        with pytest.raises(ValueError, match="invalid must have value 'true' or 'false'"):
+            bq_cast("invalid", "BOOLEAN")
+
+    def test_bq_cast_unrecognized_type(self):
+        """An unrecognised type falls through and returns the string unchanged."""
+        assert bq_cast("raw_string", "UNKNOWN_TYPE") == "raw_string"
+
+
+class TestConvertJobId:
+    def test_convert_single_job_id(self):
+        """Builds project_id:location:job_id for a single id."""
+        result = convert_job_id(job_id="job123", project_id="proj", location="EU")
+        assert result == "proj:EU:job123"
+
+    def test_convert_job_id_defaults_to_us(self):
+        """Defaults location to US when it is None."""
+        result = convert_job_id(job_id="job123", project_id="proj", location=None)
+        assert result == "proj:US:job123"
+
+    def test_convert_list_of_job_ids(self):
+        """Maps over the list form and returns a list."""
+        result = convert_job_id(job_id=["job1", "job2"], project_id="proj", location="EU")
+        assert result == ["proj:EU:job1", "proj:EU:job2"]

--- a/providers/google/tests/unit/google/cloud/utils/test_bigquery_get_data.py
+++ b/providers/google/tests/unit/google/cloud/utils/test_bigquery_get_data.py
@@ -1,0 +1,78 @@
+import logging
+import pytest
+from unittest import mock
+
+from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
+from airflow.providers.google.cloud.utils.bigquery_get_data import bigquery_get_data
+
+class TestBigqueryGetData:
+    def test_yields_successive_batches(self, caplog):
+        """
+        Successive batches are yielded as lists of row values, with start_index
+        advancing by batch_size on each call to BigQueryHook.list_rows.
+        The generator terminates when a batch comes back empty.
+        selected_fields and batch_size are passed through to list_rows unmodified.
+        """
+        mock_hook = mock.MagicMock(spec=BigQueryHook)
+
+        # Simulate BigQuery Row objects returning dictionary values
+        mock_row_1 = mock.MagicMock()
+        mock_row_1.values.return_value = {"col1": "A"}
+        mock_row_2 = mock.MagicMock()
+        mock_row_2.values.return_value = {"col1": "B"}
+
+        # Return two batches of 1, then an empty list to terminate
+        mock_hook.list_rows.side_effect = [
+            [mock_row_1],
+            [mock_row_2],
+            []
+        ]
+
+        logger = logging.getLogger(__name__)
+
+        results = list(bigquery_get_data(
+            logger=logger,
+            dataset_id="my_dataset",
+            table_id="my_table",
+            big_query_hook=mock_hook,
+            batch_size=1,
+            selected_fields=["col1"]
+        ))
+
+        assert results == [
+            [{"col1": "A"}],
+            [{"col1": "B"}]
+        ]
+
+        # Verify list_rows was called 3 times and start_index advanced correctly
+        assert mock_hook.list_rows.call_count == 3
+        mock_hook.list_rows.assert_has_calls([
+            mock.call(dataset_id="my_dataset", table_id="my_table", max_results=1, selected_fields=["col1"], start_index=0),
+            mock.call(dataset_id="my_dataset", table_id="my_table", max_results=1, selected_fields=["col1"], start_index=1),
+            mock.call(dataset_id="my_dataset", table_id="my_table", max_results=1, selected_fields=["col1"], start_index=2),
+        ])
+
+        # Verify logging assertions via structured caplog checks
+        assert "Job Finished" in caplog.text
+
+    def test_raises_type_error_for_row_iterator(self):
+        """A RowIterator return raises TypeError (guards against return_iterator=True)."""
+        mock_hook = mock.MagicMock(spec=BigQueryHook)
+
+        # A real RowIterator doesn't have a __len__ method. We simulate this by having len() raise TypeError
+        mock_iterator = mock.MagicMock()
+        type(mock_iterator).__len__ = mock.PropertyMock(side_effect=TypeError("object of type 'RowIterator' has no len()"))
+        mock_hook.list_rows.return_value = mock_iterator
+
+        logger = logging.getLogger(__name__)
+
+        with pytest.raises(TypeError):
+            # Using list() consumes the generator and triggers the len(rows) check which will raise
+            list(bigquery_get_data(
+                logger=logger,
+                dataset_id="my_dataset",
+                table_id="my_table",
+                big_query_hook=mock_hook,
+                batch_size=1,
+                selected_fields=["col1"]
+            ))


### PR DESCRIPTION
Added missing test modules for `google.cloud.utils` BigQuery helpers to improve test coverage.

Specifically, this PR:
- Adds `providers/google/tests/unit/google/cloud/utils/test_bigquery.py` to test `bq_cast` and `convert_job_id`.
- Adds `providers/google/tests/unit/google/cloud/utils/test_bigquery_get_data.py` to test the `bigquery_get_data` generator function and exceptions.
- Removes both source files from the `OVERLOOKED_TESTS` allowlist in `airflow-core/tests/unit/always/test_project_structure.py`.

closes: #72276