### PR TITLE
Pass `verify` and `botocore_config` to BatchJobTrigger in BatchSensor (#72278)

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/batch.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/batch.py
@@ -102,6 +102,8 @@ class BatchSensor(AwsBaseSensor[BatchClientHook]):
                     job_id=self.job_id,
                     aws_conn_id=self.aws_conn_id,
                     region_name=self.region_name,
+		    verify=self.verify,
+		    botocore_config=self.botocore_config,
                     waiter_delay=int(self.poke_interval),
                     waiter_max_attempts=self.max_retries,
                 ),

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_batch.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_batch.py
@@ -92,6 +92,28 @@ class TestBatchSensor:
             deferrable_batch_sensor.execute({})
         assert isinstance(exc.value.trigger, BatchJobTrigger), "Trigger is not a BatchJobTrigger"
 
+    def test_execute_in_deferrable_mode_passes_aws_configs(self):
+        """Asserts that verify and botocore_config survive into the serialized trigger payload."""
+        sensor = BatchSensor(
+            task_id="task",
+            job_id=JOB_ID,
+            region_name=AWS_REGION,
+            verify="/custom/ca_bundle.pem",
+            botocore_config={"read_timeout": 45},
+            deferrable=True,
+        )
+
+        with pytest.raises(TaskDeferred) as exc:
+            sensor.execute({})
+
+        trigger = exc.value.trigger
+        assert isinstance(trigger, BatchJobTrigger)
+
+        _, kwargs = trigger.serialize()
+        assert kwargs.get("region_name") == AWS_REGION
+        assert kwargs.get("verify") == "/custom/ca_bundle.pem"
+        assert kwargs.get("botocore_config") == {"read_timeout": 45}
+
     def test_execute_failure_in_deferrable_mode(self, deferrable_batch_sensor: BatchSensor):
         """Tests that an AirflowException is raised in case of error event"""
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your PR meets the following requirements:
- Pull Request title follows the conventional commit syntax.
- Related issues are linked.
-->

Closes: #72278
Related-to: #72144

### Description

In `BatchSensor`, when running in deferrable mode, `BatchJobTrigger` was initialized passing only `region_name`, omitting `verify` and `botocore_config`. 

Because `BatchSensor` inherits from `AwsBaseSensor`, it already captures these configurations during initialization. Without forwarding them to `BatchJobTrigger`, the triggerer process reconstructs the AWS Batch client hook using default connection settings, causing custom SSL certificates (`verify`) and custom `botocore_config` (such as timeouts, retries, and user agents) to be lost upon deferral.

This change:
1. Passes `verify=self.verify` and `botocore_config=self.botocore_config` to `BatchJobTrigger` in `BatchSensor.execute()` upon deferral (aligning with `BatchOperator`).
2. Adds unit test coverage asserting that `region_name`, `verify`, and `botocore_config` survive and persist into the serialized trigger payload.

---

### Use Case / Motivation

Preserves custom AWS configuration (e.g., custom CA bundles/SSL settings and botocore connection parameters) across task deferral boundaries when polling AWS Batch jobs asynchronously.

---

### Related Issues

- Closes #72278
- Sub-issue of #72144

---

### Code Changes Summary

| File | Change |
|---|---|
| `providers/amazon/src/airflow/providers/amazon/aws/sensors/batch.py` | Passed `verify=self.verify` and `botocore_config=self.botocore_config` to `BatchJobTrigger`. |
| `providers/amazon/tests/unit/amazon/aws/sensors/test_batch.py` | Added `test_execute_in_deferrable_mode_passes_aws_configs` verifying parameters in serialized trigger dictionary. |

---

### Checklists

- [x] Are you creating a PR in a personal branch instead of `main`?
- [x] Tests are added/updated and pass locally using Breeze:
  - `breeze testing providers-tests providers/amazon/tests/unit/amazon/aws/sensors/test_batch.py`
  - `breeze testing providers-tests providers/amazon/tests/unit/amazon/aws/triggers/test_batch.py`
- [x] Static checks pass:
  - `breeze static-checks --last-commit`
