### PR TITLE
Fix SageMaker Unified Studio trigger hook config

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/sagemaker_unified_studio_notebook.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/sagemaker_unified_studio_notebook.py
@@ -195,6 +195,9 @@ class SageMakerUnifiedStudioNotebookOperator(AwsBaseOperator[SageMakerUnifiedStu
                     owning_project_identifier=self.owning_project_identifier,
                     waiter_delay=self.waiter_delay,
                     timeout_configuration=self.timeout_configuration,
+                    region_name=self.region_name,
+                    verify=self.verify,
+                    botocore_config=self.botocore_config,
                 ),
                 method_name="execute_complete",
             )

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_sagemaker_unified_studio_notebook.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_sagemaker_unified_studio_notebook.py
@@ -296,12 +296,12 @@ class TestSageMakerUnifiedStudioNotebookOperator:
         assert trigger.waiter_delay == 20
         assert trigger.timeout_configuration == {"runTimeoutInMinutes": 120}
 
-        serialized_payload = trigger.serialize()[1]
+        _, kwargs = trigger.serialize()
 
-        assert serialized_payload["region_name"] == "us-west-2"
-        assert serialized_payload["verify"] == "/tmp/custom-ca.pem"
-        assert serialized_payload["botocore_config"] == botocore_config
-        assert serialized_payload["waiter_max_attempts"] == 360
+        assert kwargs["region_name"] == "us-west-2"
+        assert kwargs["verify"] == "/tmp/custom-ca.pem"
+        assert kwargs["botocore_config"] == botocore_config
+        assert kwargs["waiter_max_attempts"] == 360
 
         assert exc_info.value.method_name == "execute_complete"
         mock_hook.wait_for_notebook_run.assert_not_called()

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_sagemaker_unified_studio_notebook.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_sagemaker_unified_studio_notebook.py
@@ -264,6 +264,13 @@ class TestSageMakerUnifiedStudioNotebookOperator:
         mock_hook_prop.return_value = mock_hook
         mock_hook.start_notebook_run.return_value = {"id": NOTEBOOK_RUN_ID}
 
+        botocore_config = {
+            "retries": {
+                "max_attempts": 7,
+                "mode": "standard",
+            }
+        }
+
         op = SageMakerUnifiedStudioNotebookOperator(
             task_id=TASK_ID,
             notebook_identifier=NOTEBOOK_ID,
@@ -272,18 +279,30 @@ class TestSageMakerUnifiedStudioNotebookOperator:
             deferrable=True,
             waiter_delay=20,
             timeout_configuration={"runTimeoutInMinutes": 120},
+            region_name="us-west-2",
+            verify="/tmp/custom-ca.pem",
+            botocore_config=botocore_config,
         )
 
         with pytest.raises(TaskDeferred) as exc_info:
             op.execute(_make_context())
 
         trigger = exc_info.value.trigger
+
         assert isinstance(trigger, SageMakerUnifiedStudioNotebookTrigger)
         assert trigger.notebook_run_id == NOTEBOOK_RUN_ID
         assert trigger.domain_identifier == DOMAIN_ID
         assert trigger.owning_project_identifier == PROJECT_ID
         assert trigger.waiter_delay == 20
         assert trigger.timeout_configuration == {"runTimeoutInMinutes": 120}
+
+        serialized_payload = trigger.serialize()[1]
+
+        assert serialized_payload["region_name"] == "us-west-2"
+        assert serialized_payload["verify"] == "/tmp/custom-ca.pem"
+        assert serialized_payload["botocore_config"] == botocore_config
+        assert serialized_payload["waiter_max_attempts"] == 360
+
         assert exc_info.value.method_name == "execute_complete"
         mock_hook.wait_for_notebook_run.assert_not_called()
 


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

### Description

Forward `region_name`, `verify`, and `botocore_config` from
`SageMakerUnifiedStudioNotebookOperator` to
`SageMakerUnifiedStudioNotebookTrigger` when execution is deferred.

Previously, these AWS hook configuration values were not forwarded to the
trigger. As a result, the triggerer could construct its hook using different
AWS configuration from the operator that originally started the notebook run,
including potentially polling a different AWS region.

This change ensures that the deferred trigger receives and serializes the same
AWS hook configuration used by the operator.

Closes #72279

### Tests

Extended the deferrable operator unit test to verify that:

- `region_name` survives trigger serialization.
- `verify` survives trigger serialization.
- `botocore_config` survives trigger serialization.
- The derived `waiter_max_attempts` behavior remains unchanged.

Tested locally with:

```bash
breeze testing providers-tests providers/amazon/tests/unit/amazon/aws/operators/test_sagemaker_unified_studio_notebook.py

breeze testing providers-tests providers/amazon/tests/unit/amazon/aws/triggers/test_sagemaker_unified_studio_notebook.py

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)
<!-- Generated-by: ChatGPT following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
