### PR TITLE
Fix airflowctl list argument parsing

### DIFF
--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -641,7 +641,7 @@ class CommandFactory:
             "bool": bool,
             "str": str,
             "bytes": bytes,
-            "list": list,
+            "list": string_list_type,
             "dict": json_dict_type,
             "tuple": tuple,
             "set": set,

--- a/airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py
@@ -341,6 +341,14 @@ class TestCommandFactory:
 
         assert parsed_conf == {"my-key": "my-value"}
 
+    def test_command_factory_parses_comma_separated_list_fields(self):
+        """List fields should parse comma-separated CLI values as whole items."""
+        command_factory = CommandFactory()
+
+        list_type = command_factory._python_type_from_string("list")
+
+        assert list_type("dag1, dag2") == ["dag1", "dag2"]
+
     def test_json_dict_type_returns_dict_input_unchanged(self):
         """A dict input is returned as-is without re-parsing."""
         value = {"my-key": "my-value"}


### PR DESCRIPTION
## Summary

Use Airflow's existing `string_list_type` parser when `airflowctl` generates arguments for OpenAPI `list` parameters.
Add a focused regression test for comma-separated values.

## Why

The generated CLI currently maps `list` to Python's built-in `list`. In an argparse `type=` callback, that turns `dag1,dag2` into a list of characters rather than two DAG IDs. The repository already uses `string_list_type` for comma-separated list arguments, and the adjacent `dict` mapping was recently corrected to use `json_dict_type` in [PR #68985](https://github.com/apache/airflow/pull/68985).

## Tests

- `uv run --project /Users/ming/code/apache/airflow-pr-attempt50/airflow-ctl pytest airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py -q`
- `uv run --project /Users/ming/code/apache/airflow-pr-attempt50/airflow-ctl ruff check airflow-ctl/src/airflowctl/ctl/cli_config.py airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py`
- `uv run --project /Users/ming/code/apache/airflow-pr-attempt50/airflow-ctl ruff format --check airflow-ctl/src/airflowctl/ctl/cli_config.py airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py`

## Real behavior proof

- Behavior or issue addressed: `airflowctl` list parameters now preserve comma-separated item boundaries instead of splitting each value into characters.
- Real environment tested: Airflow `main` at commit `38401f8704162b4dfcdc642cd15150677f0fd14b` in an isolated worktree.
- Exact steps or command run after this patch: The targeted `test_cli_config.py` suite was run with `uv`, followed by Ruff checks.
- Evidence after fix: 46 targeted tests passed; Ruff reported all checks passed and formatting was unchanged.
- Observed result after fix: `_python_type_from_string("list")("dag1, dag2")` returns `["dag1", "dag2"]`.
- What was not tested: A live Airflow API server and an end-to-end authenticated `airflowctl dags get-stats` request were not run locally.

