### PR TITLE
Preserve AWS waiter outcomes in trigger events

### DIFF
--- a/generated/known_airflow_exceptions.txt
+++ b/generated/known_airflow_exceptions.txt
@@ -125,7 +125,7 @@ providers/amazon/src/airflow/providers/amazon/aws/triggers/sqs.py::1
 providers/amazon/src/airflow/providers/amazon/aws/utils/__init__.py::1
 providers/amazon/src/airflow/providers/amazon/aws/utils/connection_wrapper.py::2
 providers/amazon/src/airflow/providers/amazon/aws/utils/waiter.py::1
-providers/amazon/src/airflow/providers/amazon/aws/utils/waiter_with_logging.py::6
+providers/amazon/src/airflow/providers/amazon/aws/utils/waiter_with_logging.py::2
 providers/amazon/tests/unit/amazon/aws/operators/test_ecs.py::1
 providers/apache/beam/src/airflow/providers/apache/beam/hooks/beam.py::8
 providers/apache/beam/src/airflow/providers/apache/beam/operators/beam.py::4

--- a/providers/amazon/src/airflow/providers/amazon/aws/exceptions.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/exceptions.py
@@ -17,6 +17,8 @@
 # under the License.
 from __future__ import annotations
 
+from typing import Any
+
 from airflow.providers.common.compat.sdk import AirflowException
 
 # Note: Any AirflowException raised is expected to cause the TaskInstance
@@ -106,3 +108,15 @@ class DataSyncTaskCreationError(AirflowException):
 
 class DataSyncTaskExecutionFailedError(AirflowException):
     """Raised when a DataSync task execution could not be started or did not complete successfully."""
+
+
+class WaiterTerminalFailure(AirflowException):
+    """Raised when an AWS waiter reaches a terminal failure state."""
+
+    def __init__(self, message: str, last_response: dict[str, Any]):
+        super().__init__(message)
+        self.last_response = last_response
+
+
+class WaiterMaxAttemptsError(AirflowException):
+    """Raised when an AWS waiter exhausts its configured attempts."""

--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/base.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/base.py
@@ -141,6 +141,15 @@ class AwsBaseWaiterTrigger(BaseTrigger):
     def hook(self) -> AwsGenericHook:
         """Override in subclasses to return the right hook."""
 
+    def _event_from_exception(self, error: AirflowException) -> TriggerEvent:
+        return TriggerEvent(
+            {
+                "status": "error",
+                "message": str(error),
+                self.return_key: self.return_value,
+            }
+        )
+
     async def run(self) -> AsyncIterator[TriggerEvent]:
         hook = self.hook()
         async with await hook.get_async_conn() as client:
@@ -160,7 +169,7 @@ class AwsBaseWaiterTrigger(BaseTrigger):
                     self.status_message,
                     self.status_queries,
                 )
-            except AirflowException as e:
-                yield TriggerEvent({"status": "error", "message": str(e), self.return_key: self.return_value})
+            except AirflowException as error:
+                yield self._event_from_exception(error)
             else:
                 yield TriggerEvent({"status": "success", self.return_key: self.return_value})

--- a/providers/amazon/src/airflow/providers/amazon/aws/utils/waiter_with_logging.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/utils/waiter_with_logging.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any
 import jmespath
 from botocore.exceptions import NoCredentialsError, WaiterError
 
+from airflow.providers.amazon.aws.exceptions import WaiterMaxAttemptsError, WaiterTerminalFailure
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
@@ -105,7 +106,10 @@ def wait(
 
             if "terminal failure" in error_reason:
                 log.error("%s: %s", failure_message, _LazyStatusFormatter(status_args, last_response))
-                raise AirflowException(f"{failure_message}: {error}")
+                raise WaiterTerminalFailure(
+                    f"{failure_message}: {error}",
+                    last_response=last_response,
+                )
 
             if (
                 "An error occurred" in error_reason
@@ -130,7 +134,7 @@ def wait(
             break
         attempt += 1
     else:
-        raise AirflowException("Waiter error: max attempts reached")
+        raise WaiterMaxAttemptsError("Waiter error: max attempts reached")
 
 
 async def async_wait(
@@ -184,8 +188,9 @@ async def async_wait(
             last_response = error.last_response
 
             if "terminal failure" in error_reason:
-                raise AirflowException(
-                    f"{failure_message}: {_LazyStatusFormatter(status_args, last_response)}\n{error}"
+                raise WaiterTerminalFailure(
+                    f"{failure_message}: {_LazyStatusFormatter(status_args, last_response)}\n{error}",
+                    last_response=last_response,
                 )
 
             if (
@@ -211,7 +216,7 @@ async def async_wait(
             break
         attempt += 1
     else:
-        raise AirflowException("Waiter error: max attempts reached")
+        raise WaiterMaxAttemptsError("Waiter error: max attempts reached")
 
 
 class _LazyStatusFormatter:

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_base.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_base.py
@@ -144,3 +144,15 @@ class TestAwsBaseWaiterTrigger:
         assert res.payload["status"] == "error"
         assert "AWS Glue job failed." in res.payload["message"]
         assert res.payload["hello"] == "world"
+
+    def test_event_from_exception(self):
+        self.trigger.return_key = "hello"
+        self.trigger.return_value = "world"
+
+        event = self.trigger._event_from_exception(AirflowException("AWS Glue job failed."))
+
+        assert event.payload == {
+            "status": "error",
+            "message": "AWS Glue job failed.",
+            "hello": "world",
+        }

--- a/providers/amazon/tests/unit/amazon/aws/utils/test_waiter_with_logging.py
+++ b/providers/amazon/tests/unit/amazon/aws/utils/test_waiter_with_logging.py
@@ -25,6 +25,10 @@ from unittest.mock import AsyncMock
 import pytest
 from botocore.exceptions import WaiterError
 
+from airflow.providers.amazon.aws.exceptions import (
+    WaiterMaxAttemptsError,
+    WaiterTerminalFailure,
+)
 from airflow.providers.amazon.aws.utils.waiter_with_logging import _LazyStatusFormatter, async_wait, wait
 from airflow.providers.common.compat.sdk import AirflowException
 
@@ -141,7 +145,7 @@ class TestWaiter:
             last_response=generate_response("Pending"),
         )
         mock_waiter.wait.side_effect = [error, error, error]
-        with pytest.raises(AirflowException) as exc:
+        with pytest.raises(WaiterMaxAttemptsError) as exc:
             wait(
                 waiter=mock_waiter,
                 waiter_delay=123,
@@ -162,6 +166,30 @@ class TestWaiter:
         assert mock_waiter.wait.call_count == 2
         mock_sleep.assert_called_with(123)
 
+    @pytest.mark.asyncio
+    async def test_async_wait_max_attempts_exceeded(self):
+        mock_waiter = mock.MagicMock()
+        error = WaiterError(
+            name="test_waiter",
+            reason="test_reason",
+            last_response=generate_response("Pending"),
+        )
+        mock_waiter.wait = AsyncMock(side_effect=error)
+
+        with pytest.raises(WaiterMaxAttemptsError) as exc:
+            await async_wait(
+                waiter=mock_waiter,
+                waiter_delay=0,
+                waiter_max_attempts=2,
+                args={"test_arg": "test_value"},
+                failure_message="test failure message",
+                status_message="test status message",
+                status_args=["Status.State"],
+            )
+
+        assert "Waiter error: max attempts reached" in str(exc.value)
+        assert mock_waiter.wait.call_count == 2
+
     @mock.patch("time.sleep")
     def test_wait_with_failure(self, mock_sleep):
         mock_sleep.return_value = True
@@ -178,7 +206,7 @@ class TestWaiter:
         )
         mock_waiter.wait.side_effect = [error, error, error, failure_error]
 
-        with pytest.raises(AirflowException) as exc:
+        with pytest.raises(WaiterTerminalFailure) as exc:
             wait(
                 waiter=mock_waiter,
                 waiter_delay=123,
@@ -197,6 +225,37 @@ class TestWaiter:
             },
         )
         assert mock_waiter.wait.call_count == 4
+
+    @pytest.mark.asyncio
+    async def test_async_wait_with_failure(self):
+        mock_waiter = mock.MagicMock()
+        error = WaiterError(
+            name="test_waiter",
+            reason="test_reason",
+            last_response=generate_response("Pending"),
+        )
+        last_response = generate_response("Failure")
+        failure_error = WaiterError(
+            name="test_waiter",
+            reason="terminal failure in waiter",
+            last_response=last_response,
+        )
+        mock_waiter.wait = AsyncMock(side_effect=[error, error, failure_error])
+
+        with pytest.raises(WaiterTerminalFailure) as exc:
+            await async_wait(
+                waiter=mock_waiter,
+                waiter_delay=0,
+                waiter_max_attempts=10,
+                args={"test_arg": "test_value"},
+                failure_message="test failure message",
+                status_message="test status message",
+                status_args=["Status.State"],
+            )
+
+        assert "test failure message" in str(exc.value)
+        assert exc.value.last_response == last_response
+        assert mock_waiter.wait.call_count == 3
 
     @mock.patch("time.sleep")
     def test_wait_with_unknown_failure(self, mock_sleep):


### PR DESCRIPTION
**Description**

This change introduces dedicated exceptions for terminal waiter failures and max-attempt exhaustion in the shared AWS waiter utilities.

Both `wait` and `async_wait` now preserve these outcomes through `WaiterTerminalFailure` and `WaiterMaxAttemptsError`, while retaining the existing `AirflowException` hierarchy and existing handling for AWS API errors. `WaiterTerminalFailure` also preserves the waiter's last response so consumers can interpret service-specific terminal states.

`AwsBaseWaiterTrigger` now provides an overridable exception-to-event translation method, allowing individual AWS triggers to expose more specific trigger outcomes without reimplementing the shared polling, retry, throttling, credential, and timeout handling.

**Rationale**

AWS triggers may need to distinguish between different waiter outcomes while still relying on the shared and well-tested waiter lifecycle. Previously, `AwsBaseWaiterTrigger` flattened all waiter failures into a generic error event, requiring triggers that need richer state information to take ownership of the polling loop.

Preserving structured waiter outcomes and providing an explicit translation extension point keeps lifecycle handling centralized while allowing service-specific triggers to interpret terminal states where necessary.

**Tests**

* Added sync and async coverage for terminal waiter failures and preserved waiter responses.
* Added sync and async coverage for max-attempt exhaustion.
* Added coverage for the default exception-to-event translation in `AwsBaseWaiterTrigger`.

**Backwards Compatibility**

The new waiter exceptions subclass `AirflowException`, so existing callers handling `AirflowException` continue to work. The default `AwsBaseWaiterTrigger` behavior remains unchanged, with unsuccessful waiter outcomes emitted as generic error events unless a trigger explicitly overrides the translation behavior.

###### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: [GPT 5.6] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)