### PR TITLE
Add missing tests for sftp exceptions

### DIFF
--- a/airflow-core/tests/unit/always/test_project_structure.py
+++ b/airflow-core/tests/unit/always/test_project_structure.py
@@ -177,7 +177,6 @@ class TestProjectStructure:
             "providers/standard/tests/unit/standard/operators/test_empty.py",
             "providers/standard/tests/unit/standard/operators/test_latest_only.py",
             "providers/standard/tests/unit/standard/sensors/test_external_task.py",
-            "providers/sftp/tests/unit/sftp/test_exceptions.py",
         ]
         modules_files: list[pathlib.Path] = list(
             AIRFLOW_PROVIDERS_ROOT_PATH.glob("**/src/airflow/providers/**/*.py")

--- a/providers/sftp/tests/unit/sftp/test_exceptions.py
+++ b/providers/sftp/tests/unit/sftp/test_exceptions.py
@@ -1,0 +1,82 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import pytest
+
+from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.sftp.exceptions import ConnectionNotOpenedException
+from airflow.providers.sftp.hooks.sftp import handle_connection_management
+
+
+class StubHook:
+    """Minimal stand-in for ``SFTPHook`` that exercises only the decorator."""
+
+    def __init__(self, *, use_managed_conn: bool, conn=None, managed_conn=None):
+        self.use_managed_conn = use_managed_conn
+        self.conn = conn
+        self._managed_conn = managed_conn
+        self.conn_seen_by_call: list[object] = []
+        self.managed_conn_entries = 0
+
+    @contextmanager
+    def get_managed_conn(self):
+        self.managed_conn_entries += 1
+        yield self._managed_conn
+
+    @handle_connection_management
+    def do_work(self, value: int) -> int:
+        self.conn_seen_by_call.append(self.conn)
+        return value * 2
+
+
+class TestConnectionNotOpenedException:
+    def test_derives_from_airflow_exception(self):
+        # Callers catch the base class, so narrowing this later would be a breaking change.
+        assert issubclass(ConnectionNotOpenedException, AirflowException)
+
+
+class TestHandleConnectionManagement:
+    def test_unmanaged_without_open_connection_raises(self):
+        hook = StubHook(use_managed_conn=False, conn=None)
+
+        with pytest.raises(ConnectionNotOpenedException, match=r"hook\.get_managed_conn\(\)"):
+            hook.do_work(21)
+
+        assert hook.conn_seen_by_call == []
+        assert hook.managed_conn_entries == 0
+
+    def test_unmanaged_with_open_connection_delegates(self):
+        conn = MagicMock()
+        hook = StubHook(use_managed_conn=False, conn=conn)
+
+        assert hook.do_work(21) == 42
+        assert hook.conn_seen_by_call == [conn]
+        assert hook.managed_conn_entries == 0
+
+    def test_managed_opens_connection_instead_of_raising(self):
+        managed_conn = MagicMock()
+        hook = StubHook(use_managed_conn=True, conn=None, managed_conn=managed_conn)
+
+        assert hook.do_work(21) == 42
+        assert hook.managed_conn_entries == 1
+        # The managed connection is set on the hook for the duration of the call.
+        assert hook.conn_seen_by_call == [managed_conn]


### PR DESCRIPTION
## Summary

exceptions.py in the sftp provider had no tests. Nothing in providers/*/tests/ imported it either, so it wasn't getting covered by accident.

There's not much point in testing the exception class by itself. The one place that raises it is the handle_connection_management decorator, which had no tests of its own, so this covers the decorator and picks up the exception on the way through.

The test walks through four cases. With no open connection and use_managed_conn=False, it raises, and the message points you at hook.get_managed_conn(). With a connection already open, it just delegates and returns. With use_managed_conn=True, it opens a managed connection instead of raising, and sets it on the hook for the length of the call. And the exception subclasses AirflowException, which is worth pinning down since anyone catching the base class is counting on it.

Everything runs against a stub hook, so you don't need an SFTP server to run it.

I also removed the OVERLOOKED_TESTS entry.

Closes: #72268

## Test Plan

The four tests pass against `apache-airflow-providers-sftp` on Airflow 3.3.1 / Python 3.12, importing the real decorator and exception. `ruff check` and `ruff format --check` pass using Airflow's own ruff configuration.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Tests drafted with Claude Code (Opus 5); reviewed and verified by @vitorantoniazzi
