### PR TITLE
Fix clipping of Last run state badge

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/FilterBar/FilterBar.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FilterBar/FilterBar.test.tsx
@@ -19,9 +19,11 @@
 import type { PropsWithChildren } from "react";
 
 import "@testing-library/jest-dom";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { StateBadge } from "src/components/StateBadge";
 
 import { BaseWrapper } from "src/utils/Wrapper";
 
@@ -104,6 +106,29 @@ describe("FilterBar boolean filters", () => {
 
     expect(screen.queryByTestId("needs_review-pill")).not.toBeInTheDocument();
     await waitFor(() => expect(onFiltersChange).toHaveBeenCalledWith({}));
+  });
+});
+
+describe("FilterBar select filters", () => {
+  it("keeps a selected rich option label fully visible", () => {
+    const selectConfig: FilterConfig = {
+      key: "state",
+      label: "State",
+      options: [{ label: <StateBadge state="failed">Failed</StateBadge>, value: "failed" }],
+      type: "select",
+    };
+
+    render(
+      <FilterBar configs={[selectConfig]} initialValues={{ state: "failed" }} onFiltersChange={vi.fn()} />,
+      { wrapper },
+    );
+
+    fireEvent.click(screen.getByTestId("state-pill"));
+
+    const valueText = within(screen.getByTestId("state-filter")).getByTestId("state-badge").parentElement;
+
+    expect(valueText).not.toBeNull();
+    expect(globalThis.getComputedStyle(valueText as HTMLElement).overflow).toBe("visible");
   });
 });
 

--- a/airflow-core/src/airflow/ui/src/components/FilterBar/filters/SelectFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FilterBar/filters/SelectFilter.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useRef } from "react";
+import { useRef, type ReactNode } from "react";
 
 import { Box, createListCollection } from "@chakra-ui/react";
 
@@ -26,7 +26,7 @@ import { FilterPill } from "../FilterPill";
 import type { FilterConfig, FilterPluginProps } from "../types";
 
 type SelectOption = {
-  label: string;
+  label: ReactNode;
   value: string;
 };
 
@@ -59,6 +59,8 @@ export const SelectFilter = ({ filter, onChange, onRemove }: FilterPluginProps) 
   const displayValue = config.options.find(
     (option) => option.value === (typeof filter.value === "string" ? filter.value : ""),
   )?.label;
+  // Chakra line-clamps value text by default, which clips padded elements such as state badges.
+  const hasRichDisplayValue = displayValue !== undefined && typeof displayValue !== "string";
 
   return (
     <FilterPill
@@ -118,7 +120,11 @@ export const SelectFilter = ({ filter, onChange, onRemove }: FilterPluginProps) 
             value={hasValue && typeof filter.value === "string" ? [filter.value] : []}
           >
             <Select.Trigger dataTestId={`${filter.config.key}-filter`} triggerProps={{ border: "none" }}>
-              <Select.ValueText placeholder={filter.config.placeholder} />
+              <Select.ValueText
+                lineClamp={hasRichDisplayValue ? "none" : undefined}
+                overflow={hasRichDisplayValue ? "visible" : undefined}
+                placeholder={filter.config.placeholder}
+              />
             </Select.Trigger>
             <Select.Content>
               {config.options.map((option) => (


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
        https://www.apache.org/licenses/LICENSE-2.0 -->

Prevent Chakra's default select value clamping from clipping rich selected labels such as state badges in the Dags "Last run" filter.

Keep the existing clamping behavior for plain-text labels while allowing rich labels to render with visible overflow. Add a regression test covering a selected failed state badge.

closes: #72283

 ### Validation

- `pnpm test src/components/FilterBar/FilterBar.test.tsx
 src/pages/DagsList/DagsList.test.tsx` — 17 tests passed
- `pnpm lint`
- `pnpm build`
- Live Breeze and Playwright verification
- Confirm `overflow: visible` and `-webkit-line-clamp: none` in the rendered select value

### Screenshots

#### Before

<img width="1120" height="600" alt="airflow-72283-pr-before-crop" src="https://github.com/user-attachments/assets/bd212739-5c81-424a-8bb0-47c0410eb4ce" />

#### After

<img width="1120" height="600" alt="airflow-72283-pr-after-crop" src="https://github.com/user-attachments/assets/fe7d3269-58f2-414e-913f-40219281ae7d" />

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — assisted by Pi coding agent, with gpt-5.6-sol max effort

Generated-by: Pi coding agent following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions )

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)**
 for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
   * For fundamental code changes, an Airflow Improvement Proposal
 ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
   * When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
   * For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).