### PR TITLE
Feature 72238 dag viewers audit logs

### DIFF
--- a/airflow-core/newsfragments/72463.feature.rst
+++ b/airflow-core/newsfragments/72463.feature.rst
@@ -1,0 +1,1 @@
+Grant DAG Viewers (users with DAG read permission) access to view audit logs for authorized DAGs.

--- a/airflow-core/src/airflow/api_fastapi/core_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/security.py
@@ -534,10 +534,26 @@ def requires_access_event_log(
             # than turning an unknown id into a permission error.
             dag_id = row.dag_id if row is not None else None
 
-        requires_access_dag(method, DagAccessEntity.AUDIT_LOG, dag_id)(
-            request,
-            user,
-        )
+        def is_authorized_event_log() -> bool:
+            auth_manager = get_auth_manager()
+            details = DagDetails(id=dag_id, team_name=DagModel.get_team_name(dag_id) if dag_id else None)
+            if auth_manager.is_authorized_dag(
+                method=method,
+                access_entity=DagAccessEntity.AUDIT_LOG,
+                details=details,
+                user=user,
+            ):
+                return True
+            if method == "GET" and auth_manager.is_authorized_dag(
+                method="GET",
+                access_entity=None,
+                details=details,
+                user=user,
+            ):
+                return True
+            return False
+
+        _requires_access(is_authorized_callback=is_authorized_event_log)
 
     return inner
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_event_logs.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_event_logs.py
@@ -229,12 +229,40 @@ class TestGetEventLog(TestEventLogsEndpoint):
             response = test_client.get(f"/eventLogs/{event_log_id}")
 
         assert response.status_code == 403
-        mock_is_authorized_dag.assert_called_once_with(
-            method="GET",
-            access_entity=DagAccessEntity.AUDIT_LOG,
-            details=DagDetails(id=DAG_ID, team_name=None),
-            user=mock.ANY,
+        mock_is_authorized_dag.assert_has_calls(
+            [
+                mock.call(
+                    method="GET",
+                    access_entity=DagAccessEntity.AUDIT_LOG,
+                    details=DagDetails(id=DAG_ID, team_name=None),
+                    user=mock.ANY,
+                ),
+                mock.call(
+                    method="GET",
+                    access_entity=None,
+                    details=DagDetails(id=DAG_ID, team_name=None),
+                    user=mock.ANY,
+                ),
+            ]
         )
+
+    def test_should_authorize_dag_viewer_for_event_log(self, test_client, setup):
+        """A user with DAG read access (even without explicit AUDIT_LOG access) can view event logs for authorized DAGs."""
+        event_log_id = setup[TASK_INSTANCE_EVENT].id
+
+        def side_effect(method, access_entity, details, user):
+            if access_entity == DagAccessEntity.AUDIT_LOG:
+                return False
+            return True
+
+        with mock.patch(
+            "airflow.api_fastapi.auth.managers.simple.simple_auth_manager.SimpleAuthManager.is_authorized_dag",
+            side_effect=side_effect,
+        ) as mock_is_authorized_dag:
+            response = test_client.get(f"/eventLogs/{event_log_id}")
+
+        assert response.status_code == 200
+        assert mock_is_authorized_dag.call_count == 2
 
     def test_should_authorize_with_event_log_dag_id(self, test_client, setup):
         """When the event log is bound to a DAG, authorization must scope to that DAG id."""

--- a/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 from json import JSONDecodeError
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, call, patch
 
 import pytest
 from fastapi import HTTPException, Request
@@ -569,12 +569,48 @@ class TestFastApiSecurity:
         with pytest.raises(HTTPException, match="Forbidden"):
             await inner(request, user, session)
 
-        auth_manager.is_authorized_dag.assert_called_once_with(
-            method="GET",
-            access_entity=DagAccessEntity.AUDIT_LOG,
-            details=DagDetails(id="unauthorized_dag", team_name=None),
-            user=user,
+        auth_manager.is_authorized_dag.assert_has_calls(
+            [
+                call(
+                    method="GET",
+                    access_entity=DagAccessEntity.AUDIT_LOG,
+                    details=DagDetails(id="unauthorized_dag", team_name=None),
+                    user=user,
+                ),
+                call(
+                    method="GET",
+                    access_entity=None,
+                    details=DagDetails(id="unauthorized_dag", team_name=None),
+                    user=user,
+                ),
+            ]
         )
+
+    @pytest.mark.db_test
+    @pytest.mark.asyncio
+    @patch.object(DagModel, "get_team_name")
+    @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
+    async def test_requires_access_event_log_dag_viewer_authorized(
+        self, mock_get_auth_manager, mock_get_team_name
+    ):
+        """DAG Viewer (DAG GET access without AUDIT_LOG access) is granted access to event log."""
+        auth_manager = Mock()
+        auth_manager.is_authorized_dag.side_effect = lambda method, access_entity, details, user: (
+            access_entity is None
+        )
+        mock_get_auth_manager.return_value = auth_manager
+        mock_get_team_name.return_value = "team1"
+
+        session = Mock()
+        session.execute.return_value.one_or_none.return_value = Mock(id=42, dag_id="event_log_dag_id")
+
+        request = Mock()
+        request.path_params = {"event_log_id": "42"}
+        user = Mock()
+
+        inner = requires_access_event_log("GET")
+        await inner(request, user, session)
+        assert auth_manager.is_authorized_dag.call_count == 2
 
     @pytest.mark.db_test
     @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #72238

Updates `requires_access_event_log` in `airflow-core/src/airflow/api_fastapi/core_api/security.py` to grant users with DAG read permissions (`GET` access on a DAG) access to view audit logs for their authorized DAGs. Includes newsfragment `72238.feature.rst`.
