### PR TITLE
Fix dead Docker Desktop networking links in the docker-compose guide

### DIFF
--- a/airflow-core/docs/howto/docker-compose/index.rst
+++ b/airflow-core/docs/howto/docker-compose/index.rst
@@ -387,7 +387,7 @@ If you have a custom config file and wish to use it in your Airflow instance, yo
 Networking
 ==========
 
-In general, if you want to use Airflow locally, your Dags may try to connect to servers which are running on the host. In order to achieve that, an extra configuration must be added in ``docker-compose.yaml``. For example, on Linux the configuration must be in the section ``services: airflow-worker`` adding ``extra_hosts: - "host.docker.internal:host-gateway"``; and use ``host.docker.internal`` instead of ``localhost``. This configuration vary in different platforms. Please check the Docker documentation for `Windows <https://docs.docker.com/desktop/windows/networking/#use-cases-and-workarounds>`_ and `Mac <https://docs.docker.com/desktop/mac/networking/#use-cases-and-workarounds>`_ for further information.
+In general, if you want to use Airflow locally, your Dags may try to connect to servers which are running on the host. In order to achieve that, an extra configuration must be added in ``docker-compose.yaml``. For example, on Linux the configuration must be in the section ``services: airflow-worker`` adding ``extra_hosts: - "host.docker.internal:host-gateway"``; and use ``host.docker.internal`` instead of ``localhost``. This configuration vary in different platforms. Please check the Docker documentation on `Docker Desktop networking <https://docs.docker.com/desktop/features/networking/networking-how-tos/>`_ for further information.
 
 Debug Airflow inside docker container using PyCharm
 ===================================================


### PR DESCRIPTION
The Networking section of `airflow-core/docs/howto/docker-compose/index.rst` sends readers to two per-platform Docker pages for the `host.docker.internal` workaround:

- `docs.docker.com/desktop/windows/networking/#use-cases-and-workarounds`
- `docs.docker.com/desktop/mac/networking/#use-cases-and-workarounds`

Both return 404. Docker retired the per-platform pages, and the `use-cases-and-workarounds` anchor does not exist on the replacement either — I fetched `desktop/features/networking/` and it has no such id, and no `host` anchors at all.

The guidance the paragraph actually needs is now on `docs.docker.com/desktop/features/networking/networking-how-tos/`, which returns 200 and does mention `host.docker.internal`. I checked: `desktop/features/networking/` alone does not mention it, so the how-tos page is the right target rather than the section index. Since Docker no longer splits this by platform, the two links collapse into one and the sentence loses the "for Windows and Mac" split.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

Tool: Claude Opus 5 in Claude Code. It swept every URL under `airflow-core/docs`, requested each one, located the replacement page, and drafted this description. Every URL and anchor claim above was verified with a request rather than inferred, and the diff is one prose line which I reviewed.

Two other dead links in that tree I am deliberately not touching, because I could not establish the right target:

- `authoring-and-scheduling/language-sdks/typescript.rst` links `airflow.apache.org/docs/ts-sdk/stable/` for the TypeScript SDK API reference. That 404s, and the docs index lists only `/docs/task-sdk/stable/` (the Python Task SDK), so it looks like the TypeScript SDK reference is not published under any name yet rather than merely moved.
- `logging-monitoring/logging-tasks.rst` links `docs.gunicorn.org/en/latest/settings.html`. That 404s, but so does `docs.gunicorn.org/en/latest/` itself, so their docs host looks broken rather than restructured and I would rather not repoint a link based on an outage.

No newsfragment: this is a documentation link fix with no user-facing behaviour change.