### PR TITLE
Add opt-in deterministic jitter to cron-based timetables

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/timetable.rst
+++ b/airflow-core/docs/authoring-and-scheduling/timetable.rst
@@ -152,6 +152,56 @@ must be a :class:`datetime.timedelta` or ``dateutil.relativedelta.relativedelta`
         pass
 
 
+Jittering cron-based schedules
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Every Dag scheduled with the same cron expression fires at the same instant: all ``@daily`` Dags, for
+example, start at exactly midnight. In larger deployments this "thundering herd" can overload the
+scheduler and workers at that boundary. All cron-based timetables (CronTriggerTimetable_,
+MultipleCronTriggerTimetable_, CronDataIntervalTimetable_ and ``CronPartitionTimetable``) accept two
+optional arguments to spread these runs out:
+
+* ``seed``: a stable, unique-per-Dag string (the Dag id is a natural choice).
+* ``max_jitter``: a :class:`datetime.timedelta` upper bound for the shift.
+
+Each run is then shifted by a fixed offset derived from the seed and spread across ``[0, max_jitter)``.
+The offset is deterministic, so runs stay predictable across scheduler restarts and serialization, and
+different seeds land in different slots. With ``max_jitter`` left at its default of zero the timetable
+behaves exactly as before.
+
+.. code-block:: python
+
+    from datetime import timedelta
+
+    from airflow.timetables.trigger import CronTriggerTimetable
+
+
+    # Fires daily, shifted by a fixed amount in [0, 1h) that is unique to this Dag.
+    @dag(
+        schedule=CronTriggerTimetable(
+            "0 0 * * *",
+            timezone="UTC",
+            seed="example_dag",
+            max_jitter=timedelta(hours=1),
+        ),
+        ...,
+    )
+    def example_dag():
+        pass
+
+A few things to keep in mind:
+
+* ``seed`` must be non-empty whenever ``max_jitter`` is set; otherwise every Dag would receive the
+  same offset and the herd would simply move instead of spreading out.
+* The offset shifts the fire time and, with it, the run's ``logical_date`` and ``data_interval``. For
+  CronDataIntervalTimetable_ this means the whole data interval moves by the offset: it keeps its
+  length and consecutive runs stay contiguous, but it no longer starts exactly on the cron time
+  (e.g. 00:35 to 00:35 instead of 00:00 to 00:00). Keep ``max_jitter`` well within the gap between
+  cron boundaries.
+* MultipleCronTriggerTimetable_ applies one common offset to all of its cron expressions, so the
+  Dag's fire times keep their relative spacing.
+
+
 .. _MultipleCronTriggerTimetable:
 
 MultipleCronTriggerTimetable
@@ -226,6 +276,7 @@ trigger points, and triggers a Dag run at the end of each data interval. You can
 
 .. seealso:: `Differences between "trigger" and "data interval" timetables`_
 .. seealso:: `Differences between the cron and delta data interval timetables`_
+.. seealso:: `Jittering cron-based schedules`_
 
 .. code-block:: python
 

--- a/airflow-core/newsfragments/72475.feature.rst
+++ b/airflow-core/newsfragments/72475.feature.rst
@@ -1,0 +1,1 @@
+Add opt-in deterministic jitter (``seed``/``max_jitter``) to all cron-based timetables (``CronTriggerTimetable``, ``CronDataIntervalTimetable``, ``MultipleCronTriggerTimetable``, ``CronPartitionTimetable``) to spread out Dags that share a cron expression.

--- a/airflow-core/src/airflow/serialization/encoders.py
+++ b/airflow-core/src/airflow/serialization/encoders.py
@@ -381,7 +381,16 @@ class _Serializer:
 
     @serialize_timetable.register
     def _(self, timetable: CronDataIntervalTimetable) -> dict[str, Any]:
-        return {"expression": timetable.expression, "timezone": encode_timezone(timetable.timezone)}
+        data: dict[str, Any] = {
+            "expression": timetable.expression,
+            "timezone": encode_timezone(timetable.timezone),
+        }
+
+        if timetable.max_jitter:
+            data["seed"] = timetable.seed
+            data["max_jitter"] = timetable.max_jitter.total_seconds()
+
+        return data
 
     @serialize_timetable.register
     def _(self, timetable: DeltaDataIntervalTimetable) -> dict[str, Any]:
@@ -389,22 +398,30 @@ class _Serializer:
 
     @serialize_timetable.register
     def _(self, timetable: CronTriggerTimetable) -> dict[str, Any]:
-        return {
+        data = {
             "expression": timetable.expression,
             "timezone": encode_timezone(timetable.timezone),
             "interval": encode_interval(timetable.interval),
             "run_immediately": encode_run_immediately(timetable.run_immediately),
         }
+        if timetable.max_jitter:
+            data["seed"] = timetable.seed
+            data["max_jitter"] = timetable.max_jitter.total_seconds()
+        return data
 
     @serialize_timetable.register
     def _(self, timetable: CronPartitionTimetable) -> dict[str, Any]:
-        return {
+        data: dict[str, Any] = {
             "expression": timetable.expression,
             "timezone": encode_timezone(timetable.timezone),
             "run_immediately": encode_run_immediately(timetable.run_immediately),
             "run_offset": timetable.run_offset,
             "key_format": timetable.key_format,
         }
+        if timetable.max_jitter:
+            data["seed"] = timetable.seed
+            data["max_jitter"] = timetable.max_jitter.total_seconds()
+        return data
 
     @serialize_timetable.register
     def _(self, timetable: DeltaTriggerTimetable) -> dict[str, Any]:
@@ -418,12 +435,16 @@ class _Serializer:
         # All timetables share the same timezone, interval, and run_immediately
         # values, so we can just use the first to represent them.
         representitive = timetable.timetables[0]
-        return {
+        data: dict[str, Any] = {
             "expressions": [t.expression for t in timetable.timetables],
             "timezone": encode_timezone(representitive.timezone),
             "interval": encode_interval(representitive.interval),
             "run_immediately": encode_run_immediately(representitive.run_immediately),
         }
+        if representitive.max_jitter:
+            data["seed"] = representitive.seed
+            data["max_jitter"] = representitive.max_jitter.total_seconds()
+        return data
 
     @serialize_timetable.register
     def _(self, timetable: AssetOrTimeSchedule) -> dict[str, Any]:

--- a/airflow-core/src/airflow/timetables/_cron.py
+++ b/airflow-core/src/airflow/timetables/_cron.py
@@ -25,6 +25,7 @@ from croniter import CroniterBadCronError, CroniterBadDateError, croniter
 from airflow._shared.timezones.timezone import convert_to_utc, make_aware, make_naive, parse_timezone
 from airflow.exceptions import AirflowTimetableInvalid
 from airflow.utils.dates import cron_presets
+from airflow.utils.hashlib_wrapper import md5
 
 if TYPE_CHECKING:
     from pendulum import DateTime
@@ -61,14 +62,53 @@ def _covers_every_hour(cron: croniter) -> bool:
 
 
 class CronMixin:
-    """Mixin to provide interface to work with croniter."""
+    """
+    Mixin to provide interface to work with croniter.
 
-    def __init__(self, cron: str, timezone: str | Timezone | FixedTimezone) -> None:
+    Optionally applies a deterministic, per-DAG jitter to every scheduled time.
+    When ``max_jitter`` is set, each cron boundary is shifted by a fixed offset
+    derived from ``seed`` and spread across ``[0, max_jitter)``. This spreads out
+    DAGs that share a cron expression (e.g. every ``@daily`` DAG firing at
+    midnight) so they no longer all fire at the same instant. The offset is stable
+    for a given seed, so runs stay predictable across scheduler restarts and
+    serialization.
+
+    The offset shifts every cron-derived time uniformly. For data-interval
+    timetables this means the whole interval moves by the offset (the window keeps
+    its length and consecutive intervals stay contiguous), not just the fire time.
+
+    :param cron: cron expression (or a preset such as ``@daily``) defining the schedule.
+    :param timezone: timezone used to interpret the cron expression.
+    :param seed: stable, unique-per-DAG string the offset is derived from; the DAG id
+        is a natural choice. Must be non-empty whenever ``max_jitter`` is set.
+    :param max_jitter: upper bound of the jitter window; the offset falls in
+        ``[0, max_jitter)``. Defaults to zero, i.e. no jitter. Keep it small relative
+        to the gap between cron boundaries.
+    """
+
+    def __init__(
+        self,
+        cron: str,
+        timezone: str | Timezone | FixedTimezone,
+        *,
+        seed: str = "",
+        max_jitter: datetime.timedelta = datetime.timedelta(),
+    ) -> None:
         self._expression = cron_presets.get(cron, cron)
 
         if isinstance(timezone, str):
             timezone = parse_timezone(timezone)
         self._timezone = timezone
+
+        if max_jitter > datetime.timedelta(0) and not seed:
+            raise ValueError("seed must be a non-empty, unique-per-DAG string when max_jitter > 0")
+        h = int(md5(seed.encode()).hexdigest(), 16)
+        max_jitter_us = max_jitter // datetime.timedelta(microseconds=1)
+        self._offset = (
+            datetime.timedelta(microseconds=h % max_jitter_us) if max_jitter_us > 0 else datetime.timedelta(0)
+        )
+        self._seed = seed
+        self._max_jitter = max_jitter
 
         try:
             # checking for more than 5 parameters in Cron and avoiding evaluation for now,
@@ -80,6 +120,14 @@ class CronMixin:
 
         except (CroniterBadCronError, FormatException, MissingFieldException):
             self.description = ""
+
+    def _apply(self, t: DateTime) -> DateTime:
+        """Shift a cron-aligned time forward by this timetable's jitter offset."""
+        return t + self._offset
+
+    def _strip(self, t: DateTime) -> DateTime:
+        """Remove the jitter offset, mapping a jittered time back onto the plain cron timeline."""
+        return t - self._offset
 
     def _describe_with_dom_dow_fix(self, expression: str) -> str:
         """
@@ -120,7 +168,10 @@ class CronMixin:
 
     def __eq__(self, other: object) -> bool:
         """
-        Both expression and timezone should match.
+        Expression, timezone and jitter settings (``seed`` and ``max_jitter``) should all match.
+
+        Two timetables that share a cron expression and timezone but differ in jitter
+        produce different schedules, so they are not considered equal.
 
         This is only for testing purposes and should not be relied on otherwise.
         """
@@ -128,10 +179,15 @@ class CronMixin:
 
         if not isinstance(other := coerce_to_core_timetable(other), type(self)):
             return NotImplemented
-        return self._expression == other._expression and self._timezone == other._timezone
+        return (
+            self._expression == other._expression
+            and self._timezone == other._timezone
+            and self._seed == other._seed
+            and self._max_jitter == other._max_jitter
+        )
 
     def __hash__(self):
-        return hash((self._expression, self._timezone))
+        return hash((self._expression, str(self._timezone), self._seed, self._max_jitter))
 
     @property
     def summary(self) -> str:
@@ -154,7 +210,22 @@ class CronMixin:
         return convert_to_utc(make_aware(dt.replace(tzinfo=None), self._timezone))
 
     def _get_next(self, current: DateTime) -> DateTime:
-        """Get the first schedule after specified time, with DST fixed."""
+        """
+        Get the first (jittered) schedule after the specified time.
+
+        ``current`` may already carry the jitter offset, so it is stripped back onto
+        the plain cron timeline before the next boundary is found, and the offset is
+        applied once to the result. This keeps the shift from compounding when
+        results are fed back in (e.g. by ``_align_to_next``).
+        """
+        return self._apply(self._get_next_cron(self._strip(current)))
+
+    def _get_prev(self, current: DateTime) -> DateTime:
+        """Get the first (jittered) schedule strictly before the specified time; see ``_get_next``."""
+        return self._apply(self._get_prev_cron(self._strip(current)))
+
+    def _get_next_cron(self, current: DateTime) -> DateTime:
+        """Get the first schedule after specified time on the plain cron timeline (no jitter), with DST fixed."""
         naive = make_naive(current, self._timezone)
         cron = croniter(self._expression, start_time=naive)
         scheduled = cron.get_next(datetime.datetime)
@@ -165,8 +236,8 @@ class CronMixin:
         delta = scheduled - naive
         return convert_to_utc(current.in_timezone(self._timezone) + delta)
 
-    def _get_prev(self, current: DateTime) -> DateTime:
-        """Get the first schedule strictly before specified time, with DST fixed."""
+    def _get_prev_cron(self, current: DateTime) -> DateTime:
+        """Get the first schedule strictly before specified time on the plain cron timeline (no jitter), with DST fixed."""
         naive = make_naive(current, self._timezone)
         cron = croniter(self._expression, start_time=naive)
         scheduled = cron.get_prev(datetime.datetime)

--- a/airflow-core/src/airflow/timetables/interval.py
+++ b/airflow-core/src/airflow/timetables/interval.py
@@ -142,16 +142,33 @@ class CronDataIntervalTimetable(CronMixin, _DataIntervalTimetable):
     when determining the next/previous time.
 
     Don't pass ``@once`` in here; use ``OnceTimetable`` instead.
+
+    Optional ``seed``/``max_jitter`` jitter (see ``CronMixin``) shifts every cron boundary by a
+    fixed per-Dag offset. Because the boundaries define the data interval, the whole window moves
+    by that offset: it keeps its length and consecutive runs stay contiguous, but it no longer
+    starts exactly on the cron time (e.g. 00:35 to 00:35 instead of 00:00 to 00:00). Keep
+    ``max_jitter`` small relative to the schedule period.
     """
 
     @classmethod
     def deserialize(cls, data: dict[str, Any]) -> Timetable:
-        return cls(data["expression"], parse_timezone(data["timezone"]))
+        return cls(
+            data["expression"],
+            parse_timezone(data["timezone"]),
+            seed=data.get("seed", ""),
+            max_jitter=datetime.timedelta(seconds=data.get("max_jitter", 0)),
+        )
 
     def serialize(self) -> dict[str, Any]:
         from airflow.serialization.encoders import encode_timezone
 
-        return {"expression": self._expression, "timezone": encode_timezone(self._timezone)}
+        data: dict[str, Any] = {"expression": self._expression, "timezone": encode_timezone(self._timezone)}
+
+        if self._max_jitter:
+            data["seed"] = self._seed
+            data["max_jitter"] = self._max_jitter.total_seconds()
+
+        return data
 
     def _skip_to_latest(self, earliest: DateTime | None) -> DateTime:
         """

--- a/airflow-core/src/airflow/timetables/trigger.py
+++ b/airflow-core/src/airflow/timetables/trigger.py
@@ -172,6 +172,10 @@ class CronTriggerTimetable(CronMixin, _TriggerTimetable):
     :param cron: cron string that defines when to run
     :param timezone: Which timezone to use to interpret the cron string
     :param interval: timedelta that defines the data interval start. Default 0.
+    :param seed: stable, unique-per-DAG string the jitter offset is derived from; must be
+        non-empty when ``max_jitter`` is set. See ``CronMixin``.
+    :param max_jitter: upper bound of the jitter window; the run is shifted by a fixed offset
+        in ``[0, max_jitter)``. Default 0 (no jitter). See ``CronMixin``.
 
     *run_immediately* controls, if no *start_time* is given to the DAG, when
     the first run of the DAG should be scheduled. It has no effect if there
@@ -195,8 +199,10 @@ class CronTriggerTimetable(CronMixin, _TriggerTimetable):
         timezone: str | Timezone | FixedTimezone,
         interval: datetime.timedelta | relativedelta = datetime.timedelta(),
         run_immediately: bool | datetime.timedelta = False,
+        seed: str = "",
+        max_jitter: datetime.timedelta = datetime.timedelta(),
     ) -> None:
-        super().__init__(cron, timezone)
+        super().__init__(cron, timezone, seed=seed, max_jitter=max_jitter)
         self._interval = interval
         self._run_immediately = run_immediately
 
@@ -209,17 +215,23 @@ class CronTriggerTimetable(CronMixin, _TriggerTimetable):
             timezone=parse_timezone(data["timezone"]),
             interval=decode_interval(data["interval"]),
             run_immediately=decode_run_immediately(data.get("run_immediately", False)),
+            seed=data.get("seed", ""),
+            max_jitter=datetime.timedelta(seconds=data.get("max_jitter", 0)),
         )
 
     def serialize(self) -> dict[str, Any]:
         from airflow.serialization.encoders import encode_interval, encode_run_immediately, encode_timezone
 
-        return {
+        data = {
             "expression": self._expression,
             "timezone": encode_timezone(self._timezone),
             "interval": encode_interval(self._interval),
             "run_immediately": encode_run_immediately(self._run_immediately),
         }
+        if self._max_jitter:
+            data["seed"] = self._seed
+            data["max_jitter"] = self._max_jitter.total_seconds()
+        return data
 
     def _calc_first_run(self) -> DateTime:
         """
@@ -254,6 +266,10 @@ class MultipleCronTriggerTimetable(Timetable):
 
     Only at most one run is triggered for any given time, even if more than one
     timetable fires at the same time.
+
+    All cron expressions share the same optional ``seed``/``max_jitter`` jitter settings, so the
+    whole Dag is shifted by one common offset and its fire times keep their relative spacing.
+    See ``CronTriggerTimetable``.
     """
 
     def __init__(
@@ -262,11 +278,20 @@ class MultipleCronTriggerTimetable(Timetable):
         timezone: str | Timezone | FixedTimezone,
         interval: datetime.timedelta | relativedelta = datetime.timedelta(),
         run_immediately: bool | datetime.timedelta = False,
+        seed: str = "",
+        max_jitter: datetime.timedelta = datetime.timedelta(),
     ) -> None:
         if not crons:
             raise ValueError("cron expression required")
         self._timetables = [
-            CronTriggerTimetable(cron, timezone=timezone, interval=interval, run_immediately=run_immediately)
+            CronTriggerTimetable(
+                cron,
+                timezone=timezone,
+                interval=interval,
+                run_immediately=run_immediately,
+                seed=seed,
+                max_jitter=max_jitter,
+            )
             for cron in crons
         ]
         self.description = ", ".join(t.description for t in self._timetables)
@@ -280,6 +305,8 @@ class MultipleCronTriggerTimetable(Timetable):
             timezone=parse_timezone(data["timezone"]),
             interval=decode_interval(data["interval"]),
             run_immediately=decode_run_immediately(data["run_immediately"]),
+            seed=data.get("seed", ""),
+            max_jitter=datetime.timedelta(seconds=data.get("max_jitter", 0)),
         )
 
     def serialize(self) -> dict[str, Any]:
@@ -288,12 +315,16 @@ class MultipleCronTriggerTimetable(Timetable):
         # All timetables share the same timezone, interval, and run_immediately
         # values, so we can just use the first to represent them.
         timetable = self._timetables[0]
-        return {
+        data: dict[str, Any] = {
             "expressions": [t._expression for t in self._timetables],
             "timezone": encode_timezone(timetable._timezone),
             "interval": encode_interval(timetable._interval),
             "run_immediately": encode_run_immediately(timetable._run_immediately),
         }
+        if timetable._max_jitter:
+            data["seed"] = timetable._seed
+            data["max_jitter"] = timetable._max_jitter.total_seconds()
+        return data
 
     @property
     def summary(self) -> str:
@@ -380,6 +411,10 @@ class CronPartitionTimetable(CronTriggerTimetable):
     :param run_offset: Integer offset that determines which partition date to run for.
         The partition key will be derived from the partition date.
     :param key_format: How to translate the partition date into a string partition key.
+    :param seed: stable, unique-per-DAG string the jitter offset is derived from; must be
+        non-empty when ``max_jitter`` is set. See ``CronMixin``.
+    :param max_jitter: upper bound of the jitter window; the run is shifted by a fixed offset
+        in ``[0, max_jitter)``. Default 0 (no jitter). See ``CronMixin``.
 
     *run_immediately* controls, if no *start_time* is given to the Dag, when
     the first run of the Dag should be scheduled. It has no effect if there
@@ -406,8 +441,12 @@ class CronPartitionTimetable(CronTriggerTimetable):
         run_offset: int | datetime.timedelta | relativedelta | None = None,
         run_immediately: bool | datetime.timedelta = False,
         key_format: str = r"%Y-%m-%dT%H:%M:%S",
+        seed: str = "",
+        max_jitter: datetime.timedelta = datetime.timedelta(),
     ) -> None:
-        super().__init__(cron, timezone=timezone, run_immediately=run_immediately)
+        super().__init__(
+            cron, timezone=timezone, run_immediately=run_immediately, seed=seed, max_jitter=max_jitter
+        )
         if not isinstance(run_offset, (int, NoneType)):
             raise ValueError("Run offset other than integer not supported yet.")
         self._run_offset = run_offset or 0
@@ -431,18 +470,24 @@ class CronPartitionTimetable(CronTriggerTimetable):
             run_offset=offset,
             run_immediately=decode_run_immediately(data.get("run_immediately", False)),
             key_format=data["key_format"],
+            seed=data.get("seed", ""),
+            max_jitter=datetime.timedelta(seconds=data.get("max_jitter", 0)),
         )
 
     def serialize(self) -> dict[str, Any]:
         from airflow.serialization.encoders import encode_run_immediately, encode_timezone
 
-        return {
+        data: dict[str, Any] = {
             "expression": self._expression,
             "timezone": encode_timezone(self._timezone),
             "run_immediately": encode_run_immediately(self._run_immediately),
             "run_offset": self._run_offset,
             "key_format": self._key_format,
         }
+        if self._max_jitter:
+            data["seed"] = self._seed
+            data["max_jitter"] = self._max_jitter.total_seconds()
+        return data
 
     def _get_partition_date(self, *, run_date) -> DateTime:
         if self._run_offset == 0:

--- a/airflow-core/tests/unit/timetables/test_cron_timetable_jitter.py
+++ b/airflow-core/tests/unit/timetables/test_cron_timetable_jitter.py
@@ -1,0 +1,317 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pendulum
+import pytest
+import time_machine
+
+from airflow._shared.timezones.timezone import utc
+from airflow.sdk import (
+    CronDataIntervalTimetable as SdkCronDataIntervalTimetable,
+    CronPartitionTimetable as SdkCronPartitionTimetable,
+    CronTriggerTimetable as SdkCronTriggerTimetable,
+    MultipleCronTriggerTimetable as SdkMultipleCronTriggerTimetable,
+)
+from airflow.serialization.decoders import decode_timetable
+from airflow.serialization.encoders import encode_timetable
+from airflow.timetables.base import DataInterval, TimeRestriction
+from airflow.timetables.interval import CronDataIntervalTimetable
+from airflow.timetables.trigger import (
+    CronPartitionTimetable,
+    CronTriggerTimetable,
+    MultipleCronTriggerTimetable,
+)
+
+CRON = "0 0 * * *"  # daily at midnight
+START_DATE = pendulum.DateTime(2021, 9, 4, tzinfo=utc)
+# seed/window known to produce a non-zero offset (used across the behavioural tests)
+SEED = "my_dag"
+MAX_JITTER = timedelta(hours=1)
+
+
+def _catchup_run_afters(timetable, count, *, earliest):
+    """Return the ``run_after`` of the first ``count`` catchup runs, feeding each back in."""
+    run_afters = []
+    last = None
+    for _ in range(count):
+        info = timetable.next_dagrun_info(
+            last_automated_data_interval=last,
+            restriction=TimeRestriction(earliest=earliest, latest=None, catchup=True),
+        )
+        assert info is not None
+        run_afters.append(info.run_after)
+        last = DataInterval.exact(info.run_after)
+    return run_afters
+
+
+@pytest.mark.parametrize(
+    "timezone_name",
+    [
+        pytest.param("UTC", id="utc"),
+        # Daily runs across the 2026-03-08 spring-forward in this zone: the offset must be
+        # applied identically on both sides of the transition.
+        pytest.param("America/New_York", id="dst-spring-forward"),
+    ],
+)
+def test_jittered_runs_equal_base_runs_plus_offset(timezone_name):
+    """Every jittered run is the plain-cron run shifted by the fixed per-DAG offset.
+
+    Cron/DST correctness is delegated to the un-jittered timetable; this asserts the offset is
+    applied consistently across a catchup sequence (including a DST transition), i.e. the
+    strip -> cron -> apply wrappers never drift.
+    """
+    earliest = pendulum.datetime(2026, 3, 6, tz=timezone_name)
+    base = CronTriggerTimetable(CRON, timezone=timezone_name)
+    jittered = CronTriggerTimetable(CRON, timezone=timezone_name, seed=SEED, max_jitter=MAX_JITTER)
+    offset = jittered._offset
+    assert offset > timedelta(0), "seed/window must produce a real shift, else the test is vacuous"
+
+    base_runs = _catchup_run_afters(base, 5, earliest=earliest)
+    jittered_runs = _catchup_run_afters(jittered, 5, earliest=earliest)
+
+    assert jittered_runs == [run + offset for run in base_runs]
+
+
+@pytest.mark.parametrize("catchup", [True, False])
+def test_zero_max_jitter_matches_plain_cron(catchup):
+    """A zero window yields a zero offset, so the timetable behaves exactly like a plain cron one."""
+    base = CronTriggerTimetable(CRON, timezone=utc)
+    jittered = CronTriggerTimetable(CRON, timezone=utc, seed=SEED, max_jitter=timedelta(0))
+    assert jittered._offset == timedelta(0)
+
+    last = DataInterval.exact(pendulum.DateTime(2022, 7, 26, tzinfo=utc))
+    restriction = TimeRestriction(earliest=START_DATE, latest=None, catchup=catchup)
+    # travel so the no-catchup branch (which reads utcnow()) is deterministic
+    with time_machine.travel(pendulum.DateTime(2022, 7, 27, 5, 30, tzinfo=utc)):
+        assert jittered.next_dagrun_info(
+            last_automated_data_interval=last, restriction=restriction
+        ) == base.next_dagrun_info(last_automated_data_interval=last, restriction=restriction)
+
+
+def test_offsets_are_deterministic_bounded_and_spread():
+    """Same seed -> same offset (stable hash, not process-salted); offsets stay in [0, max_jitter) and spread."""
+    assert (
+        CronTriggerTimetable(CRON, timezone=utc, seed="dag_a", max_jitter=MAX_JITTER)._offset
+        == CronTriggerTimetable(CRON, timezone=utc, seed="dag_a", max_jitter=MAX_JITTER)._offset
+    )
+
+    offsets = [
+        CronTriggerTimetable(CRON, timezone=utc, seed=f"dag_{i}", max_jitter=MAX_JITTER)._offset
+        for i in range(25)
+    ]
+    assert all(timedelta(0) <= offset < MAX_JITTER for offset in offsets)
+    assert len(set(offsets)) > 1, "distinct seeds should not all collide on one slot"
+
+
+def test_serialize_round_trip_preserves_offset():
+    """The core ``serialize``/``deserialize`` round-trips seed + window (as seconds) and the derived offset."""
+    tt = CronTriggerTimetable(CRON, timezone=utc, seed=SEED, max_jitter=MAX_JITTER)
+    data = tt.serialize()
+    assert data["seed"] == SEED
+    assert data["max_jitter"] == 3600.0  # serialized as plain seconds
+
+    restored = CronTriggerTimetable.deserialize(data)
+    assert isinstance(restored, CronTriggerTimetable)
+    assert restored._seed == tt._seed
+    assert restored._max_jitter == tt._max_jitter
+    assert restored._offset == tt._offset
+
+
+def test_encode_decode_round_trip_across_layers():
+    """SDK class -> encode_timetable (dispatch keyed on the SDK class) -> decode_timetable -> core class."""
+    sdk_tt = SdkCronTriggerTimetable(CRON, timezone="UTC", seed=SEED, max_jitter=MAX_JITTER)
+
+    restored = decode_timetable(encode_timetable(sdk_tt))
+
+    assert isinstance(restored, CronTriggerTimetable)  # rebuilt as the core scheduler-side class
+    assert restored._max_jitter == MAX_JITTER
+    expected_offset = CronTriggerTimetable(CRON, timezone=utc, seed=SEED, max_jitter=MAX_JITTER)._offset
+    assert restored._offset == expected_offset
+
+
+def test_sub_second_max_jitter_is_bounded_and_does_not_divide_by_zero():
+    """A sub-second window keeps full precision (microsecond math) instead of truncating to a 0s divisor."""
+    window = timedelta(milliseconds=500)
+    offset = CronTriggerTimetable(CRON, timezone=utc, seed=SEED, max_jitter=window)._offset
+    assert timedelta(0) <= offset < window
+
+
+@pytest.mark.parametrize(
+    "timetable_cls",
+    [
+        pytest.param(CronTriggerTimetable, id="trigger-core"),
+        pytest.param(SdkCronTriggerTimetable, id="trigger-sdk"),
+        pytest.param(CronDataIntervalTimetable, id="interval-core"),
+        pytest.param(SdkCronDataIntervalTimetable, id="interval-sdk"),
+        pytest.param(CronPartitionTimetable, id="partition-core"),
+        pytest.param(SdkCronPartitionTimetable, id="partition-sdk"),
+        pytest.param(MultipleCronTriggerTimetable, id="multiple-core"),
+        pytest.param(SdkMultipleCronTriggerTimetable, id="multiple-sdk"),
+    ],
+)
+def test_empty_seed_requires_zero_jitter(timetable_cls):
+    """An empty seed with a real window would give every DAG the same offset -> reject in both layers."""
+    with pytest.raises(ValueError, match="seed"):
+        timetable_cls(CRON, timezone="UTC", seed="", max_jitter=MAX_JITTER)
+
+    # ...but an empty seed is fine when jitter is off (degrades to a plain cron timetable).
+    timetable_cls(CRON, timezone="UTC", seed="", max_jitter=timedelta(0))
+
+
+def test_jitter_is_part_of_equality():
+    """Timetables differing only in jitter produce different schedules, so they must not compare equal."""
+    plain = CronTriggerTimetable(CRON, timezone=utc)
+    jittered = CronTriggerTimetable(CRON, timezone=utc, seed=SEED, max_jitter=MAX_JITTER)
+    assert plain != jittered
+
+    # Identical jitter settings are equal and hash-consistent (the eq/hash invariant).
+    same = CronTriggerTimetable(CRON, timezone=utc, seed=SEED, max_jitter=MAX_JITTER)
+    assert jittered == same
+    assert hash(jittered) == hash(same)
+
+
+def test_data_interval_jitter_shifts_whole_window_uniformly():
+    """For a data-interval timetable the offset moves both bounds and the fire time equally.
+
+    The window keeps its length and consecutive runs stay contiguous; only the calendar
+    alignment of the boundaries shifts (00:35 -> 00:35 instead of 00:00 -> 00:00).
+    """
+    restriction = TimeRestriction(
+        earliest=pendulum.DateTime(2026, 3, 6, tzinfo=utc), latest=None, catchup=True
+    )
+    plain = CronDataIntervalTimetable(CRON, timezone=utc)
+    jittered = CronDataIntervalTimetable(CRON, timezone=utc, seed=SEED, max_jitter=MAX_JITTER)
+    offset = jittered._offset
+    assert offset > timedelta(0)
+
+    p = plain.next_dagrun_info(last_automated_data_interval=None, restriction=restriction)
+    j = jittered.next_dagrun_info(last_automated_data_interval=None, restriction=restriction)
+    assert j.data_interval.start == p.data_interval.start + offset
+    assert j.data_interval.end == p.data_interval.end + offset
+    assert j.run_after == j.data_interval.end
+    # pendulum ``DateTime - DateTime`` is an Interval compared by endpoints, so compare durations
+    assert (j.data_interval.end - j.data_interval.start).total_seconds() == (
+        p.data_interval.end - p.data_interval.start
+    ).total_seconds()
+
+    following = jittered.next_dagrun_info(
+        last_automated_data_interval=j.data_interval, restriction=restriction
+    )
+    assert following.data_interval.start == j.data_interval.end
+
+
+def test_data_interval_serialize_round_trip_preserves_offset():
+    """``CronDataIntervalTimetable`` persists seed + window and rebuilds the same offset."""
+    tt = CronDataIntervalTimetable(CRON, timezone=utc, seed=SEED, max_jitter=MAX_JITTER)
+    data = tt.serialize()
+    assert data["seed"] == SEED
+    assert data["max_jitter"] == 3600.0
+
+    restored = CronDataIntervalTimetable.deserialize(data)
+    assert isinstance(restored, CronDataIntervalTimetable)
+    assert restored._offset == tt._offset
+
+
+@pytest.mark.parametrize(
+    "timetable_cls", [CronTriggerTimetable, CronDataIntervalTimetable, CronPartitionTimetable]
+)
+def test_unjittered_timetable_serializes_without_jitter_keys(timetable_cls):
+    """Without jitter the serialized form is unchanged, so existing DAGs are not re-serialized on upgrade."""
+    data = timetable_cls(CRON, timezone=utc).serialize()
+    assert "seed" not in data
+    assert "max_jitter" not in data
+    assert timetable_cls.deserialize(data)._offset == timedelta(0)
+
+
+def test_data_interval_encode_decode_round_trip_across_layers():
+    """SDK ``CronDataIntervalTimetable`` -> encode -> decode -> core class with the same offset."""
+    sdk_tt = SdkCronDataIntervalTimetable(CRON, timezone="UTC", seed=SEED, max_jitter=MAX_JITTER)
+    restored = decode_timetable(encode_timetable(sdk_tt))
+    assert isinstance(restored, CronDataIntervalTimetable)
+    expected = CronDataIntervalTimetable(CRON, timezone=utc, seed=SEED, max_jitter=MAX_JITTER)._offset
+    assert restored._offset == expected
+
+
+def test_cron_partition_serialize_round_trip_preserves_offset():
+    """``CronPartitionTimetable`` persists seed + window and rebuilds the same offset."""
+    tt = CronPartitionTimetable(CRON, timezone=utc, seed=SEED, max_jitter=MAX_JITTER)
+    data = tt.serialize()
+    assert data["seed"] == SEED
+    assert data["max_jitter"] == 3600.0
+    assert CronPartitionTimetable.deserialize(data)._offset == tt._offset
+
+
+def test_multiple_cron_children_share_one_offset():
+    """Every cron in a ``MultipleCronTriggerTimetable`` gets the same seed, so the whole DAG shifts in lockstep.
+
+    The offset depends only on the seed, not the cron expression, so it also equals the offset a
+    single ``CronTriggerTimetable`` with the same seed would get.
+    """
+    tt = MultipleCronTriggerTimetable(
+        "10 1 * * *", "40 2 * * *", timezone=utc, seed=SEED, max_jitter=MAX_JITTER
+    )
+    offsets = {t._offset for t in tt._timetables}
+    assert len(offsets) == 1
+    assert offsets.pop() == CronTriggerTimetable(CRON, timezone=utc, seed=SEED, max_jitter=MAX_JITTER)._offset
+
+
+def test_multiple_cron_serialize_round_trip_preserves_offset():
+    """``MultipleCronTriggerTimetable`` persists the shared seed + window and rebuilds the same child offsets."""
+    tt = MultipleCronTriggerTimetable(
+        "10 1 * * *", "40 2 * * *", timezone=utc, seed=SEED, max_jitter=MAX_JITTER
+    )
+    data = tt.serialize()
+    assert data["seed"] == SEED
+    assert data["max_jitter"] == 3600.0
+    restored = MultipleCronTriggerTimetable.deserialize(data)
+    assert [t._offset for t in restored._timetables] == [t._offset for t in tt._timetables]
+
+    unjittered = MultipleCronTriggerTimetable("10 1 * * *", "40 2 * * *", timezone=utc).serialize()
+    assert "seed" not in unjittered
+    assert "max_jitter" not in unjittered
+
+
+@pytest.mark.parametrize(
+    ("sdk_timetable", "core_cls"),
+    [
+        pytest.param(
+            SdkCronPartitionTimetable(CRON, timezone="UTC", seed=SEED, max_jitter=MAX_JITTER),
+            CronPartitionTimetable,
+            id="partition",
+        ),
+        pytest.param(
+            SdkMultipleCronTriggerTimetable(
+                "10 1 * * *", "40 2 * * *", timezone="UTC", seed=SEED, max_jitter=MAX_JITTER
+            ),
+            MultipleCronTriggerTimetable,
+            id="multiple",
+        ),
+    ],
+)
+def test_partition_and_multiple_encode_decode_round_trip_across_layers(sdk_timetable, core_cls):
+    """SDK class -> encode -> decode -> core class, with the jitter offset intact."""
+    restored = decode_timetable(encode_timetable(sdk_timetable))
+    assert isinstance(restored, core_cls)
+    expected = CronTriggerTimetable(CRON, timezone=utc, seed=SEED, max_jitter=MAX_JITTER)._offset
+    if core_cls is MultipleCronTriggerTimetable:
+        offsets = [t._offset for t in restored._timetables]
+    else:
+        offsets = [restored._offset]
+    assert offsets == [expected] * len(offsets)

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -918,6 +918,10 @@ jinja
 Jira
 jira
 jitter
+Jittered
+jittered
+Jittering
+jittering
 JobComplete
 JobDetails
 JobExists

--- a/task-sdk/src/airflow/sdk/definitions/timetables/_cron.py
+++ b/task-sdk/src/airflow/sdk/definitions/timetables/_cron.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import datetime
 from typing import TYPE_CHECKING
 
 import attrs
@@ -41,16 +42,33 @@ CRON_PRESETS: dict[str, str] = {
 
 @attrs.define
 class CronMixin:
-    """Mixin to provide interface to work with croniter."""
+    """
+    Mixin to provide interface to work with croniter.
+
+    Optionally applies a deterministic, per-DAG jitter: when ``max_jitter`` is set, every
+    cron boundary is shifted by a fixed offset derived from ``seed`` and spread across
+    ``[0, max_jitter)``, so DAGs sharing a cron expression no longer all fire at the same
+    instant. The offset is computed scheduler-side; this class only carries and validates
+    the settings.
+
+    :param seed: stable, unique-per-DAG string the offset is derived from (the DAG id is a
+        natural choice). Must be non-empty whenever ``max_jitter`` is set.
+    :param max_jitter: upper bound of the jitter window; the offset falls in
+        ``[0, max_jitter)``. Defaults to zero, i.e. no jitter.
+    """
 
     expression: str
     timezone: str | Timezone | FixedTimezone
+    seed: str = attrs.field(kw_only=True, default="")
+    max_jitter: datetime.timedelta = attrs.field(kw_only=True, default=datetime.timedelta())
 
     def __attrs_post_init__(self) -> None:
         # Resolve preset aliases (e.g. "@quarterly") to their cron expressions
         # in-place. After this point the original preset string is lost;
         # attrs.evolve, equality, and serialisation all see the resolved form.
         self.expression = CRON_PRESETS.get(self.expression, self.expression)
+        if self.max_jitter > datetime.timedelta(0) and not self.seed:
+            raise ValueError("seed must be a non-empty, unique-per-DAG string when max_jitter > 0")
 
     def validate(self) -> None:
         try:

--- a/task-sdk/src/airflow/sdk/definitions/timetables/interval.py
+++ b/task-sdk/src/airflow/sdk/definitions/timetables/interval.py
@@ -41,6 +41,12 @@ class CronDataIntervalTimetable(CronMixin, BaseTimetable):
     Using this class is equivalent to supplying a cron expression dire
 
     Don't pass ``@once`` in here; use ``OnceTimetable`` instead.
+
+    Optional ``seed``/``max_jitter`` jitter (see ``CronMixin``) shifts every cron boundary by a
+    fixed per-Dag offset. Because the boundaries define the data interval, the whole window moves
+    by that offset: it keeps its length and consecutive runs stay contiguous, but it no longer
+    starts exactly on the cron time (e.g. 00:35 to 00:35 instead of 00:00 to 00:00). Keep
+    ``max_jitter`` small relative to the schedule period.
     """
 
 

--- a/task-sdk/src/airflow/sdk/definitions/timetables/trigger.py
+++ b/task-sdk/src/airflow/sdk/definitions/timetables/trigger.py
@@ -66,6 +66,10 @@ class CronTriggerTimetable(CronMixin, BaseTimetable):
     :param cron: cron string that defines when to run
     :param timezone: Which timezone to use to interpret the cron string
     :param interval: timedelta that defines the data interval start. Default 0.
+    :param seed: stable, unique-per-DAG string the jitter offset is derived from; must be
+        non-empty when ``max_jitter`` is set. See ``CronMixin``.
+    :param max_jitter: upper bound of the jitter window; the run is shifted by a fixed offset
+        in ``[0, max_jitter)``. Default 0 (no jitter). See ``CronMixin``.
 
     *run_immediately* controls, if no *start_time* is given to the Dag, when
     the first run of the Dag should be scheduled. It has no effect if there
@@ -96,6 +100,10 @@ class MultipleCronTriggerTimetable(BaseTimetable):
 
     Only at most one run is triggered for any given time, even if more than one
     timetable fires at the same time.
+
+    All cron expressions share the same optional ``seed``/``max_jitter`` jitter settings, so the
+    whole Dag is shifted by one common offset and its fire times keep their relative spacing.
+    See ``CronTriggerTimetable``.
     """
 
     timetables: list[CronTriggerTimetable]
@@ -106,12 +114,21 @@ class MultipleCronTriggerTimetable(BaseTimetable):
         timezone: str | Timezone | FixedTimezone,
         interval: datetime.timedelta | relativedelta = datetime.timedelta(),
         run_immediately: bool | datetime.timedelta = False,
+        seed: str = "",
+        max_jitter: datetime.timedelta = datetime.timedelta(),
     ) -> None:
         if not crons:
             raise ValueError("cron expression required")
         self.__attrs_init__(  # type: ignore[attr-defined]
             [
-                CronTriggerTimetable(cron, timezone, interval=interval, run_immediately=run_immediately)
+                CronTriggerTimetable(
+                    cron,
+                    timezone,
+                    interval=interval,
+                    run_immediately=run_immediately,
+                    seed=seed,
+                    max_jitter=max_jitter,
+                )
                 for cron in crons
             ],
         )
@@ -137,6 +154,10 @@ class CronPartitionTimetable(CronTriggerTimetable):
     :param run_offset: Integer offset that determines which partition date to run for.
         The partition key will be derived from the partition date.
     :param key_format: How to translate the partition date into a string partition key.
+    :param seed: stable, unique-per-DAG string the jitter offset is derived from; must be
+        non-empty when ``max_jitter`` is set. See ``CronMixin``.
+    :param max_jitter: upper bound of the jitter window; the run is shifted by a fixed offset
+        in ``[0, max_jitter)``. Default 0 (no jitter). See ``CronMixin``.
 
     *run_immediately* controls, if no *start_time* is given to the Dag, when
     the first run of the Dag should be scheduled. It has no effect if there already exist runs for this Dag.
@@ -163,6 +184,8 @@ class CronPartitionTimetable(CronTriggerTimetable):
         run_offset: int | datetime.timedelta | relativedelta | None = None,
         run_immediately: bool | datetime.timedelta = False,
         key_format: str = r"%Y-%m-%dT%H:%M:%S",
+        seed: str = "",
+        max_jitter: datetime.timedelta = datetime.timedelta(),
     ) -> None:
         if not isinstance(run_offset, (int, NoneType)):
             raise ValueError("Run offset other than integer not supported yet.")
@@ -172,4 +195,6 @@ class CronPartitionTimetable(CronTriggerTimetable):
             run_offset=run_offset,
             run_immediately=run_immediately,
             key_format=key_format,
+            seed=seed,
+            max_jitter=max_jitter,
         )


### PR DESCRIPTION
Add opt-in, deterministic jitter to every cron-based timetable via `CronMixin`: two kw-only params, `seed` and `max_jitter`, on `CronTriggerTimetable`, `CronDataIntervalTimetable`, `MultipleCronTriggerTimetable` and `CronPartitionTimetable`, in both the Task SDK and airflow-core, with serialization wired through. Each DAG's runs are shifted by a fixed offset drawn from `[0, max_jitter)`, so DAGs that share a cron expression no longer all fire at the same instant.

This is the follow-up @uranusjr suggested on #69705 (https://github.com/apache/airflow/pull/69705#issuecomment-5232872059): rather than a standalone timetable, the jitter lives in `CronMixin` so all cron scheduling inherits it. It supersedes #69705, which I will close once this lands. cc @kaxil, who reviewed the original.

### Why

`@daily` expands to `0 0 * * *`, so **every** daily DAG in a deployment is scheduled at exactly midnight, and the same holds for any shared cron expression. The existing ways to deal with this don't actually spread the schedule:

| Existing option | Why it doesn't spread the schedule |
| --- | --- |
| Hand-pick a unique minute per DAG | Manual, drifts and re-collides as the DAG count grows, and throws away the `@daily` intent |
| Hash the DAG id into a literal cron string | Same loss of intent; not reusable across DAGs/teams; every author re-implements it ad hoc |
| Pools / concurrency limits (`parallelism`, `max_active_tasks_per_dag`, pool slots) | Cap how many tasks run at once, but the runs are still *scheduled* at the same instant. They manage contention downstream; jitter reduces the peak at the source. The two are complementary, not alternatives. |

Jitter is peak shaving on top of concurrency control, not a replacement for it. It is the same idea as Jenkins' `H` cron syntax. The offset is deterministic: the same `seed` (e.g. the DAG id) always maps to the same offset, so runs stay stable across scheduler restarts and serialization. Motivated by the discussion in https://github.com/apache/airflow/discussions/69027.

### What

- `seed`/`max_jitter` added to `CronMixin` in both layers, so all four cron timetables inherit them; the concrete classes thread the params through their constructors and `serialize`/`deserialize`, and the `encoders.py` variants emit them.
- The offset is `md5(seed) % max_jitter`, computed in integer microseconds (FIPS-safe `hashlib_wrapper.md5`), and applied as a "strip → cron → apply" coordinate shift in `CronMixin._get_next`/`_get_prev`. Because `_align_to_next`/`_align_to_prev` build on those primitives, every cron timetable inherits the shift with no per-class scheduling code.
- **Fully opt-in and safe by default**: with `max_jitter` at its default of zero the offset is zero and every timetable behaves *identically* to before. Nothing changes for anyone who doesn't use it.

### Design decisions

- **Uniform shift for data-interval timetables.** The cron boundaries define the window, so the whole interval moves by the offset: same length, consecutive runs stay contiguous, but it no longer starts exactly on the cron time (00:35 to 00:35 instead of 00:00 to 00:00). Documented, with guidance to keep `max_jitter` small relative to the period.
- **`MultipleCronTriggerTimetable` children share one offset.** The same `seed`/`max_jitter` is passed to every child, so the whole DAG shifts in lockstep and its fire times keep their relative spacing.
- **Serialization only emits `seed`/`max_jitter` when jitter is set.** The wire format of existing DAGs is unchanged (so nothing is re-serialized on upgrade) and `deserialize` tolerates missing keys. The existing serialization tests pass untouched.
- **Jitter is part of `__eq__`/`__hash__`**, since timetables differing only in jitter produce different schedules. While adding this I fixed a latent bug: `__hash__` included the pendulum `Timezone` object, which is unhashable, so `hash()` on any cron timetable raised; it now hashes `str(timezone)`.
- **Empty `seed` with `max_jitter > 0` raises** in both layers: it would give every DAG the same offset and merely move the herd instead of spreading it.

### Tests

`airflow-core/tests/unit/timetables/test_cron_timetable_jitter.py` (28 tests), modeled on the existing `test_trigger_timetable.py`:

- jittered runs equal plain cron runs shifted by the fixed offset, across a catchup sequence including a DST spring-forward (`America/New_York`);
- zero `max_jitter` reproduces the plain timetable exactly (catchup on/off);
- offsets are deterministic for a given seed, bounded to `[0, max_jitter)`, spread across distinct seeds, and correct for sub-second windows;
- the empty-seed guard fires in both layers for all four timetables;
- core `serialize`/`deserialize` and SDK encode → decode round-trips preserve the offset for all four timetables;
- data-interval jitter shifts both bounds uniformly and keeps consecutive runs contiguous;
- `MultipleCronTriggerTimetable` children share a single offset;
- un-jittered timetables serialize without the jitter keys;
- jitter participates in equality, and equal timetables hash equal.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude (Claude Code), following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

related: #69705
related: https://github.com/apache/airflow/discussions/69027
