### PR TITLE
Add the manifest format for manifest-backed versioned Dag bundles

### DIFF
--- a/airflow-core/src/airflow/dag_processing/bundles/manifest.py
+++ b/airflow-core/src/airflow/dag_processing/bundles/manifest.py
@@ -1,0 +1,412 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from airflow.exceptions import AirflowException
+
+MANIFEST_FILE_NAME = ".airflow-bundle-manifest.json"
+IGNORED_DIR_NAMES = frozenset({".git", "__pycache__"})
+# ".git" as a file name covers git-worktree checkouts, where .git is a pointer file.
+IGNORED_FILE_NAMES = frozenset({MANIFEST_FILE_NAME, ".git"})
+IGNORED_FILE_SUFFIXES = frozenset({".pyc"})
+MANIFEST_SCHEMA_VERSION = 1
+# "sha256-" (not "sha256:") keeps a version usable as a path segment: Airflow builds
+# cache and tracking paths from the raw value.
+SHA256_VERSION_PREFIX = "sha256-"
+
+
+class BundleManifestError(AirflowException):
+    """
+    Base class for bundle manifest errors.
+
+    Subclasses ``AirflowException`` because every Dag bundle entry point Airflow calls
+    is expected to fail with one, so a bundle that cannot be read is reported per
+    bundle rather than escaping as an unrelated error type.
+    """
+
+
+class BundleManifestSourceChangedError(BundleManifestError):
+    """Raised when bundle source files change while a manifest is being built."""
+
+
+@dataclass(frozen=True)
+class BundleSourceFile:
+    """A source file and the stat metadata used to detect source changes during publishing."""
+
+    path: Path
+    relative_path: str
+    size: int
+    mtime_ns: int
+    ctime_ns: int
+    mode: int
+
+    def build_signature_record(self) -> dict[str, Any]:
+        return {
+            "path": self.relative_path,
+            "size": self.size,
+            "mtime_ns": self.mtime_ns,
+            "ctime_ns": self.ctime_ns,
+            "mode": self.mode,
+        }
+
+
+@dataclass(frozen=True)
+class BundleSourceSnapshot:
+    """A deterministic snapshot of the source tree metadata."""
+
+    root: Path
+    files: tuple[BundleSourceFile, ...]
+    signature: str
+
+
+def is_ignored_bundle_file_name(file_name: str) -> bool:
+    """Return whether manifest collection excludes one file, judged by its name alone."""
+    return file_name in IGNORED_FILE_NAMES or PurePosixPath(file_name).suffix in IGNORED_FILE_SUFFIXES
+
+
+@dataclass(frozen=True)
+class BundleVersionManifest:
+    """Full manifest plus the compact release-reference payload written to latest.json."""
+
+    version: str
+    manifest: dict[str, Any]
+    ref_payload: dict[str, Any]
+    source_snapshot: BundleSourceSnapshot
+
+
+def _raise_source_walk_error(error: OSError) -> None:
+    raise BundleManifestSourceChangedError(
+        f"Bundle source changed or became unreadable while collecting manifest metadata: {error.filename}"
+    ) from error
+
+
+def _iter_manifest_file_paths(root: Path) -> Iterator[tuple[Path, os.stat_result]]:
+    for dirpath, dirnames, filenames in os.walk(
+        root,
+        followlinks=False,
+        onerror=_raise_source_walk_error,
+    ):
+        retained_dirnames: list[str] = []
+        for dirname in sorted(dirnames):
+            if dirname in IGNORED_DIR_NAMES:
+                continue
+            path = Path(dirpath) / dirname
+            try:
+                file_stat = path.lstat()
+            except FileNotFoundError as e:
+                raise BundleManifestSourceChangedError(
+                    f"Bundle source directory disappeared while collecting manifest metadata: {path}"
+                ) from e
+            if stat.S_ISLNK(file_stat.st_mode):
+                raise BundleManifestError(f"Bundle source contains symlinked directory: {path}")
+            if not stat.S_ISDIR(file_stat.st_mode):
+                raise BundleManifestError(f"Bundle source contains non-directory entry: {path}")
+            retained_dirnames.append(dirname)
+        dirnames[:] = retained_dirnames
+
+        for filename in sorted(filenames):
+            if is_ignored_bundle_file_name(filename):
+                continue
+            path = Path(dirpath) / filename
+            try:
+                file_stat = path.lstat()
+            except FileNotFoundError as e:
+                raise BundleManifestSourceChangedError(
+                    f"Bundle source file disappeared while collecting manifest metadata: {path}"
+                ) from e
+            if stat.S_ISLNK(file_stat.st_mode):
+                raise BundleManifestError(f"Bundle source contains symlinked file: {path}")
+            if not stat.S_ISREG(file_stat.st_mode):
+                raise BundleManifestError(f"Bundle source contains non-regular file: {path}")
+            yield path, file_stat
+
+
+def _build_source_file(root: Path, path: Path, file_stat: os.stat_result) -> BundleSourceFile:
+    return BundleSourceFile(
+        path=path,
+        relative_path=path.relative_to(root).as_posix(),
+        size=file_stat.st_size,
+        mtime_ns=file_stat.st_mtime_ns,
+        ctime_ns=file_stat.st_ctime_ns,
+        mode=stat.S_IMODE(file_stat.st_mode),
+    )
+
+
+def compute_file_sha256(path: Path) -> tuple[str, int]:
+    """Compute the sha256 hex digest and byte size of a file."""
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+            size += len(chunk)
+    return digest.hexdigest(), size
+
+
+def compute_bundle_version(files: list[dict[str, Any]]) -> str:
+    """
+    Compute the content-addressed bundle version from manifest file entries.
+
+    Only the identity fields (path, sha256, size, executable) participate, so the
+    version stays stable if file entries ever gain extra metadata.
+    """
+    payload = {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "files": [
+            {
+                "path": file_info["path"],
+                "sha256": file_info["sha256"],
+                "size": file_info["size"],
+                "executable": file_info["executable"],
+            }
+            for file_info in files
+        ],
+    }
+    return f"{SHA256_VERSION_PREFIX}{hashlib.sha256(_serialize_manifest_payload(payload)).hexdigest()}"
+
+
+def is_sha256_hex(value: str) -> bool:
+    """Return whether a string is exactly 64 lowercase hex characters."""
+    return len(value) == 64 and all(character in "0123456789abcdef" for character in value)
+
+
+def is_valid_bundle_version(version: str) -> bool:
+    """Return whether a string has the exact shape ``compute_bundle_version`` produces."""
+    digest = version.removeprefix(SHA256_VERSION_PREFIX)
+    return digest != version and is_sha256_hex(digest)
+
+
+def validate_bundle_version(version: str, *, source: str) -> str:
+    """
+    Return ``version`` if it is a well-formed bundle version, else raise.
+
+    Versions arrive from published documents and from operator-pinned configuration, and
+    Airflow joins them into cache and tracking paths, so they are checked before use.
+    """
+    if not is_valid_bundle_version(version):
+        raise BundleManifestError(f"Bundle {source} is not a valid sha256 version: {version!r}")
+    return version
+
+
+def validate_bundle_relative_path(relative_path: str) -> Path:
+    """
+    Return ``relative_path`` as a ``Path`` if it is safe to join onto a bundle root, else raise.
+
+    Manifest paths are written by whoever published the bundle, so a consumer must not
+    join one onto a local root before rejecting absolute paths, parent traversal, the
+    non-normalized spellings (``a//b``, ``a/./b``, trailing slash) that would resolve
+    somewhere other than where the manifest says, and control characters that no
+    filesystem can represent. A backslash is an ordinary character in a POSIX file
+    name, so it is accepted -- rejecting it would make a legitimate Dag file
+    publishable but never materializable.
+
+    This checks the path in isolation. Whether the manifest may legitimately name the
+    path at all -- that it is not the manifest file itself, not a duplicate, and not
+    excluded from collection -- is the caller's decision.
+    """
+    if any(character < " " for character in relative_path):
+        raise BundleManifestError(f"Bundle manifest contains unsafe relative path: {relative_path!r}")
+    path = Path(relative_path)
+    if (
+        path.is_absolute()
+        or any(segment in {"", ".", ".."} for segment in relative_path.split("/"))
+        or path.as_posix() != relative_path
+    ):
+        raise BundleManifestError(f"Bundle manifest contains unsafe relative path: {relative_path!r}")
+    return path
+
+
+def _serialize_manifest_payload(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+
+
+def serialize_bundle_version_manifest(manifest: dict[str, Any]) -> bytes:
+    """Serialize a bundle manifest deterministically for storage and verification."""
+    return _serialize_manifest_payload(manifest)
+
+
+def _validate_bundle_root(root: Path) -> Path:
+    root = Path(root)
+    if not root.exists():
+        raise FileNotFoundError(f"Bundle source path does not exist: {root}")
+    if not root.is_dir():
+        raise NotADirectoryError(f"Bundle source path is not a directory: {root}")
+    return root
+
+
+def collect_bundle_source_snapshot(root: Path) -> BundleSourceSnapshot:
+    """Collect deterministic source-file metadata without reading file contents."""
+    root = _validate_bundle_root(root)
+    files = [_build_source_file(root, path, file_stat) for path, file_stat in _iter_manifest_file_paths(root)]
+    files.sort(key=lambda source_file: source_file.relative_path)
+    signature_payload = {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "files": [file.build_signature_record() for file in files],
+    }
+    signature = f"sha256:{hashlib.sha256(_serialize_manifest_payload(signature_payload)).hexdigest()}"
+    return BundleSourceSnapshot(root=root, files=tuple(files), signature=signature)
+
+
+def _ensure_source_file_unchanged(source_file: BundleSourceFile) -> None:
+    try:
+        current_stat = source_file.path.lstat()
+    except FileNotFoundError as e:
+        raise BundleManifestSourceChangedError(
+            f"Bundle source file disappeared while verifying manifest metadata: {source_file.relative_path}"
+        ) from e
+
+    current_metadata = (
+        current_stat.st_size,
+        current_stat.st_mtime_ns,
+        current_stat.st_ctime_ns,
+        stat.S_IMODE(current_stat.st_mode),
+    )
+    expected_metadata = (
+        source_file.size,
+        source_file.mtime_ns,
+        source_file.ctime_ns,
+        source_file.mode,
+    )
+    if current_metadata != expected_metadata:
+        raise BundleManifestSourceChangedError(
+            f"Bundle source file changed while building manifest: {source_file.relative_path}"
+        )
+
+
+def build_ref_payload(
+    *,
+    bundle_name: str,
+    version: str,
+    backend: dict[str, Any],
+    manifest_sha256: str,
+    file_count: int,
+    total_size: int,
+) -> dict[str, Any]:
+    """Build the compact release-reference payload that defines the ``latest.json`` format."""
+    return {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "bundle_name": bundle_name,
+        "version": version,
+        "backend": backend,
+        "manifest": {
+            "path": MANIFEST_FILE_NAME,
+            "sha256": manifest_sha256,
+        },
+        "file_count": file_count,
+        "total_size": total_size,
+    }
+
+
+def _build_ref_payload_from_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
+    manifest_sha256 = hashlib.sha256(serialize_bundle_version_manifest(manifest)).hexdigest()
+    return build_ref_payload(
+        bundle_name=manifest["bundle_name"],
+        version=manifest["version"],
+        backend=manifest["backend"],
+        manifest_sha256=f"sha256:{manifest_sha256}",
+        file_count=manifest["file_count"],
+        total_size=manifest["total_size"],
+    )
+
+
+def build_bundle_version_manifest(
+    *,
+    bundle_name: str,
+    root: Path,
+    backend_type: str,
+    source_snapshot: BundleSourceSnapshot | None = None,
+    precomputed_file_sha256: Mapping[str, str] | None = None,
+) -> BundleVersionManifest:
+    """Build a deterministic content manifest for a materialized Dag bundle root."""
+    source_snapshot = source_snapshot or collect_bundle_source_snapshot(root)
+    root = _validate_bundle_root(root)
+    if source_snapshot.root != root:
+        raise ValueError("source_snapshot root does not match manifest root")
+    expected_paths = {source_file.relative_path for source_file in source_snapshot.files}
+    if precomputed_file_sha256 is not None and set(precomputed_file_sha256) != expected_paths:
+        raise BundleManifestError("Precomputed file hashes do not match the bundle source snapshot")
+
+    files: list[dict[str, Any]] = []
+    total_size = 0
+    for source_file in source_snapshot.files:
+        if precomputed_file_sha256 is None:
+            try:
+                file_digest, _ = compute_file_sha256(source_file.path)
+            except FileNotFoundError as e:
+                raise BundleManifestSourceChangedError(
+                    f"Bundle source file disappeared while building manifest: {source_file.relative_path}"
+                ) from e
+        else:
+            file_digest = precomputed_file_sha256[source_file.relative_path]
+            if not is_sha256_hex(file_digest):
+                raise BundleManifestError(
+                    f"Precomputed file hash is invalid for {source_file.relative_path!r}"
+                )
+        _ensure_source_file_unchanged(source_file)
+        files.append(
+            {
+                "path": source_file.relative_path,
+                "sha256": file_digest,
+                "size": source_file.size,
+                "executable": bool(source_file.mode & 0o111),
+            }
+        )
+        total_size += source_file.size
+
+    version = compute_bundle_version(files)
+    manifest = {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "bundle_name": bundle_name,
+        "version": version,
+        "backend": {"type": backend_type},
+        "file_count": len(files),
+        "total_size": total_size,
+        "files": files,
+    }
+    return BundleVersionManifest(
+        version=version,
+        manifest=manifest,
+        ref_payload=_build_ref_payload_from_manifest(manifest),
+        source_snapshot=source_snapshot,
+    )
+
+
+def verify_bundle_version_manifest(manifest: dict[str, Any], expected_sha256: str) -> None:
+    """
+    Check that a manifest serializes to ``expected_sha256``.
+
+    This proves only that the manifest is the document the digest was taken from. It does
+    not check the manifest against its own contents; a caller that did not choose
+    ``expected_sha256`` itself must additionally confirm that ``manifest["version"]``
+    equals ``compute_bundle_version(manifest["files"])``.
+    """
+    actual_sha256 = hashlib.sha256(serialize_bundle_version_manifest(manifest)).hexdigest()
+    expected_sha256 = expected_sha256.removeprefix("sha256:")
+    if actual_sha256 != expected_sha256:
+        raise BundleManifestError(
+            f"Bundle manifest digest mismatch: expected sha256:{expected_sha256}, got sha256:{actual_sha256}"
+        )

--- a/airflow-core/tests/unit/dag_processing/bundles/test_manifest.py
+++ b/airflow-core/tests/unit/dag_processing/bundles/test_manifest.py
@@ -1,0 +1,550 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import hashlib
+import json
+import stat
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from airflow.dag_processing.bundles import manifest as manifest_module
+from airflow.dag_processing.bundles.manifest import (
+    MANIFEST_FILE_NAME,
+    SHA256_VERSION_PREFIX,
+    BundleManifestError,
+    BundleManifestSourceChangedError,
+    build_bundle_version_manifest,
+    collect_bundle_source_snapshot,
+    compute_bundle_version,
+    is_ignored_bundle_file_name,
+    is_sha256_hex,
+    is_valid_bundle_version,
+    serialize_bundle_version_manifest,
+    validate_bundle_relative_path,
+    validate_bundle_version,
+    verify_bundle_version_manifest,
+)
+
+
+def _build_manifest(**kwargs):
+    return build_bundle_version_manifest(**kwargs).manifest
+
+
+def _write_file(root, relative_path, content):
+    path = root / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    return path
+
+
+def test_manifest_hash_is_stable_across_filesystem_creation_order(tmp_path):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+
+    _write_file(first, "dags/a.py", "print('a')")
+    _write_file(first, "dags/nested/b.py", "print('b')")
+    _write_file(second, "dags/nested/b.py", "print('b')")
+    _write_file(second, "dags/a.py", "print('a')")
+
+    first_manifest = _build_manifest(bundle_name="manifest-local", root=first, backend_type="local")
+    second_manifest = _build_manifest(bundle_name="manifest-local", root=second, backend_type="local")
+
+    assert first_manifest["version"] == second_manifest["version"]
+    assert first_manifest["files"] == second_manifest["files"]
+
+
+def test_manifest_hash_changes_when_file_content_changes(tmp_path):
+    source = tmp_path / "source"
+    _write_file(source, "dags/example.py", "print('first')")
+    first_manifest = _build_manifest(bundle_name="manifest-local", root=source, backend_type="local")
+
+    _write_file(source, "dags/example.py", "print('second')")
+    second_manifest = _build_manifest(bundle_name="manifest-local", root=source, backend_type="local")
+
+    assert first_manifest["version"] != second_manifest["version"]
+
+
+def test_bundle_version_only_uses_file_identity_fields():
+    file_info = {
+        "path": "example.py",
+        "sha256": "0" * 64,
+        "size": 1,
+        "executable": False,
+        "future_metadata": "ignored",
+    }
+
+    assert compute_bundle_version([file_info]) == compute_bundle_version(
+        [{key: value for key, value in file_info.items() if key != "future_metadata"}]
+    )
+
+
+def test_manifest_uses_complete_precomputed_file_hashes(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    content = "print('dag')"
+    _write_file(source, "dags/example.py", content)
+    source_snapshot = collect_bundle_source_snapshot(source)
+    expected_digest = hashlib.sha256(content.encode()).hexdigest()
+
+    def fail_hash(_):
+        raise AssertionError("precomputed hashes must skip a second source read")
+
+    monkeypatch.setattr(manifest_module, "compute_file_sha256", fail_hash)
+    result = build_bundle_version_manifest(
+        bundle_name="manifest-s3",
+        root=source,
+        backend_type="local",
+        source_snapshot=source_snapshot,
+        precomputed_file_sha256={"dags/example.py": expected_digest},
+    )
+
+    assert result.manifest["files"][0]["sha256"] == expected_digest
+
+
+@pytest.mark.parametrize(
+    ("precomputed_hashes", "expected_message"),
+    [
+        ({}, "Precomputed file hashes do not match"),
+        ({"other.py": "0" * 64}, "Precomputed file hashes do not match"),
+        ({"dags/example.py": "not-a-sha256"}, "Precomputed file hash is invalid"),
+        ({"dags/example.py": "z" * 64}, "Precomputed file hash is invalid"),
+        ({"dags/example.py": "A" * 64}, "Precomputed file hash is invalid"),
+    ],
+)
+def test_manifest_rejects_invalid_precomputed_file_hashes(tmp_path, precomputed_hashes, expected_message):
+    source = tmp_path / "source"
+    _write_file(source, "dags/example.py", "print('dag')")
+
+    with pytest.raises(BundleManifestError, match=expected_message):
+        build_bundle_version_manifest(
+            bundle_name="manifest-s3",
+            root=source,
+            backend_type="local",
+            precomputed_file_sha256=precomputed_hashes,
+        )
+
+
+def test_manifest_hash_changes_when_executable_bit_changes(tmp_path):
+    source = tmp_path / "source"
+    script = _write_file(source, "scripts/run.sh", "#!/bin/sh\n")
+    first_manifest = _build_manifest(bundle_name="manifest-local", root=source, backend_type="local")
+
+    script.chmod(stat.S_IMODE(script.stat().st_mode) | stat.S_IXUSR)
+    second_manifest = _build_manifest(bundle_name="manifest-local", root=source, backend_type="local")
+
+    assert first_manifest["version"] != second_manifest["version"]
+    assert first_manifest["files"][0]["executable"] is False
+    assert second_manifest["files"][0]["executable"] is True
+
+
+def test_manifest_rejects_source_symlink(tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    target = tmp_path / "outside.py"
+    target.write_text("print('outside')")
+    try:
+        (source / "linked.py").symlink_to(target)
+    except OSError as e:
+        pytest.skip(f"Symlinks are not supported in this test environment: {e}")
+
+    with pytest.raises(BundleManifestError, match="symlinked file"):
+        _build_manifest(bundle_name="manifest-local", root=source, backend_type="local")
+
+
+def test_manifest_rejects_source_symlinked_directory(tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    target = tmp_path / "outside"
+    target.mkdir()
+    try:
+        (source / "linked").symlink_to(target, target_is_directory=True)
+    except OSError as e:
+        pytest.skip(f"Symlinks are not supported in this test environment: {e}")
+
+    with pytest.raises(BundleManifestError, match="symlinked directory"):
+        _build_manifest(bundle_name="manifest-local", root=source, backend_type="local")
+
+
+@pytest.mark.parametrize(
+    ("file_name", "expected"),
+    [
+        (".airflow-bundle-manifest.json", True),
+        (".git", True),
+        ("example.pyc", True),
+        ("example.py", False),
+        (".pyc", False),
+    ],
+)
+def test_ignored_bundle_file_names(file_name, expected):
+    assert is_ignored_bundle_file_name(file_name) is expected
+
+
+def test_manifest_rejects_source_walk_error(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    source.mkdir()
+
+    def fail_walk(*args, onerror, **kwargs):
+        onerror(PermissionError(13, "Permission denied", str(source / "unreadable")))
+
+    monkeypatch.setattr(manifest_module.os, "walk", fail_walk)
+
+    with pytest.raises(BundleManifestSourceChangedError, match="changed or became unreadable"):
+        _build_manifest(bundle_name="manifest-local", root=source, backend_type="local")
+
+
+def test_manifest_ignores_cache_and_vcs_files(tmp_path):
+    source = tmp_path / "source"
+    _write_file(source, "dags/example.py", "print('dag')")
+    manifest_before = _build_manifest(bundle_name="manifest-local", root=source, backend_type="local")
+
+    _write_file(source, ".git/config", "[core]")
+    _write_file(source, MANIFEST_FILE_NAME, "{}")
+    _write_file(source, "dags/__pycache__/example.cpython-312.pyc", "compiled")
+    manifest_after = _build_manifest(bundle_name="manifest-local", root=source, backend_type="local")
+
+    assert manifest_after["version"] == manifest_before["version"]
+    assert [file_info["path"] for file_info in manifest_after["files"]] == ["dags/example.py"]
+
+
+def test_manifest_ignores_symlinked_ignored_directory(tmp_path):
+    source = tmp_path / "source"
+    _write_file(source, "dags/example.py", "print('dag')")
+    manifest_before = _build_manifest(bundle_name="manifest-local", root=source, backend_type="local")
+
+    real_git_dir = tmp_path / "real-git"
+    real_git_dir.mkdir()
+    try:
+        (source / ".git").symlink_to(real_git_dir, target_is_directory=True)
+    except OSError as e:
+        pytest.skip(f"Symlinks are not supported in this test environment: {e}")
+    manifest_after = _build_manifest(bundle_name="manifest-local", root=source, backend_type="local")
+
+    assert manifest_after["version"] == manifest_before["version"]
+
+
+def test_manifest_ignores_git_worktree_pointer_file(tmp_path):
+    source = tmp_path / "source"
+    _write_file(source, "dags/example.py", "print('dag')")
+    manifest_before = _build_manifest(bundle_name="manifest-local", root=source, backend_type="local")
+
+    _write_file(source, ".git", "gitdir: /repos/main/.git/worktrees/dags")
+    manifest_after = _build_manifest(bundle_name="manifest-local", root=source, backend_type="local")
+
+    assert manifest_after["version"] == manifest_before["version"]
+    assert [file_info["path"] for file_info in manifest_after["files"]] == ["dags/example.py"]
+
+
+def test_manifest_paths_are_relative_and_sorted(tmp_path):
+    source = tmp_path / "source"
+    _write_file(source, "z.py", "print('z')")
+    _write_file(source, "a/nested.py", "print('nested')")
+    _write_file(source, "a.py", "print('a')")
+
+    manifest = _build_manifest(bundle_name="manifest-local", root=source, backend_type="local")
+    paths = [file_info["path"] for file_info in manifest["files"]]
+
+    assert paths == ["a.py", "a/nested.py", "z.py"]
+    assert str(source) not in json.dumps(manifest)
+
+
+def test_ref_payload_is_compact_and_points_to_manifest(tmp_path):
+    source = tmp_path / "source"
+    _write_file(source, "dags/example.py", "print('dag')")
+
+    result = build_bundle_version_manifest(bundle_name="manifest-local", root=source, backend_type="local")
+
+    assert result.ref_payload == {
+        "schema_version": 1,
+        "bundle_name": "manifest-local",
+        "version": result.version,
+        "backend": {"type": "local"},
+        "manifest": {
+            "path": MANIFEST_FILE_NAME,
+            "sha256": result.ref_payload["manifest"]["sha256"],
+        },
+        "file_count": 1,
+        "total_size": len("print('dag')"),
+    }
+    assert result.ref_payload["manifest"]["sha256"].startswith("sha256:")
+    assert "files" not in result.ref_payload
+    assert str(source) not in json.dumps(result.ref_payload)
+
+
+@pytest.mark.parametrize(
+    ("source_name", "source_factory", "expected_exception"),
+    [
+        ("missing", lambda path: None, FileNotFoundError),
+        ("file", lambda path: path.write_text("not a directory"), NotADirectoryError),
+    ],
+)
+def test_manifest_rejects_invalid_source_roots(tmp_path, source_name, source_factory, expected_exception):
+    source = tmp_path / source_name
+    source_factory(source)
+
+    with pytest.raises(expected_exception):
+        collect_bundle_source_snapshot(source)
+
+
+def test_manifest_rejects_snapshot_from_another_root(tmp_path):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    _write_file(first, "example.py", "first")
+    _write_file(second, "example.py", "second")
+
+    with pytest.raises(ValueError, match="source_snapshot root"):
+        build_bundle_version_manifest(
+            bundle_name="manifest-local",
+            root=second,
+            backend_type="local",
+            source_snapshot=collect_bundle_source_snapshot(first),
+        )
+
+
+def test_manifest_rejects_file_removed_after_source_snapshot(tmp_path):
+    source = tmp_path / "source"
+    source_file = _write_file(source, "example.py", "content")
+    source_snapshot = collect_bundle_source_snapshot(source)
+    source_file.unlink()
+
+    with pytest.raises(BundleManifestSourceChangedError, match="disappeared while building manifest"):
+        build_bundle_version_manifest(
+            bundle_name="manifest-local",
+            root=source,
+            backend_type="local",
+            source_snapshot=source_snapshot,
+        )
+
+
+def test_manifest_rejects_file_metadata_changed_after_source_snapshot(tmp_path):
+    source = tmp_path / "source"
+    _write_file(source, "example.py", "content")
+    source_snapshot = collect_bundle_source_snapshot(source)
+    changed_file = replace(source_snapshot.files[0], size=source_snapshot.files[0].size + 1)
+
+    with pytest.raises(BundleManifestSourceChangedError, match="changed while building manifest"):
+        build_bundle_version_manifest(
+            bundle_name="manifest-local",
+            root=source,
+            backend_type="local",
+            source_snapshot=replace(source_snapshot, files=(changed_file,)),
+        )
+
+
+def test_manifest_verification_accepts_prefixed_and_bare_digests(tmp_path):
+    source = tmp_path / "source"
+    _write_file(source, "example.py", "content")
+    manifest = _build_manifest(bundle_name="manifest-local", root=source, backend_type="local")
+    digest = hashlib.sha256(serialize_bundle_version_manifest(manifest)).hexdigest()
+
+    verify_bundle_version_manifest(manifest, digest)
+    verify_bundle_version_manifest(manifest, f"sha256:{digest}")
+
+
+def test_manifest_verification_rejects_digest_mismatch(tmp_path):
+    source = tmp_path / "source"
+    _write_file(source, "example.py", "content")
+    manifest = _build_manifest(bundle_name="manifest-local", root=source, backend_type="local")
+
+    with pytest.raises(BundleManifestError, match="manifest digest mismatch"):
+        verify_bundle_version_manifest(manifest, "0" * 64)
+
+
+def test_computed_bundle_version_passes_its_own_validator(tmp_path):
+    source = tmp_path / "source"
+    _write_file(source, "dags/example.py", "print('dag')")
+
+    version = _build_manifest(bundle_name="manifest-local", root=source, backend_type="local")["version"]
+
+    assert version.startswith(SHA256_VERSION_PREFIX)
+    assert is_valid_bundle_version(version)
+    assert validate_bundle_version(version, source="test") == version
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "",
+        "../outside",
+        "sha256-bad",
+        f"sha256-{'A' * 64}",
+        f"sha256-{'a' * 63}",
+        f"sha256-{'a' * 65}",
+        f"sha256:{'a' * 64}",
+        "a" * 64,
+        f"sha256-{'a' * 63}/",
+        f"sha256-sha256-{'a' * 50}",
+    ],
+)
+def test_bundle_version_validation_rejects_malformed_versions(version):
+    assert is_valid_bundle_version(version) is False
+    with pytest.raises(BundleManifestError, match="valid sha256 version"):
+        validate_bundle_version(version, source="pinned bundle version")
+
+
+@pytest.mark.parametrize("relative_path", ["a.py", "dags/example.py", "dags/nested/example.py"])
+def test_bundle_relative_path_validation_keeps_accepted_paths_under_the_root(tmp_path, relative_path):
+    resolved = (tmp_path / validate_bundle_relative_path(relative_path)).resolve()
+
+    assert resolved.is_relative_to(tmp_path.resolve())
+    assert resolved != tmp_path.resolve()
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "",
+        "..",
+        "../evil.py",
+        "dags/../../evil.py",
+        "/tmp/evil.py",
+        "dags//example.py",
+        "dags/./example.py",
+        "dags/",
+        ".",
+        "./example.py",
+        "/",
+        "dags/ex\x00ample.py",
+        "dags/ex\nample.py",
+        "dags/ex\tample.py",
+    ],
+)
+def test_bundle_relative_path_validation_rejects_unsafe_paths(relative_path):
+    with pytest.raises(BundleManifestError, match="unsafe relative path"):
+        validate_bundle_relative_path(relative_path)
+
+
+def test_source_verification_does_not_follow_symlinks(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    source_file = _write_file(source, "example.py", "content")
+    source_snapshot = collect_bundle_source_snapshot(source)
+
+    followed: list[Path] = []
+    real_stat = Path.stat
+
+    # Path.lstat() delegates to Path.stat(follow_symlinks=False), so only the
+    # following calls distinguish "verified the file itself" from "verified its target".
+    def recording_stat(self, *, follow_symlinks=True):
+        if follow_symlinks:
+            followed.append(Path(self))
+        return real_stat(self, follow_symlinks=follow_symlinks)
+
+    monkeypatch.setattr(Path, "stat", recording_stat)
+    build_bundle_version_manifest(
+        bundle_name="manifest-local",
+        root=source,
+        backend_type="local",
+        source_snapshot=source_snapshot,
+    )
+
+    assert source_file not in followed
+
+
+def test_bundle_version_validation_names_the_source_in_the_message():
+    with pytest.raises(BundleManifestError, match="pinned bundle version"):
+        validate_bundle_version("sha256-bad", source="pinned bundle version")
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("a" * 64, True), ("0123456789abcdef" * 4, True), ("A" * 64, False), ("z" * 64, False)],
+)
+def test_sha256_hex_recognition(value, expected):
+    assert is_sha256_hex(value) is expected
+
+
+def test_manifest_ignores_non_bytecode_files_under_pycache(tmp_path):
+    source = tmp_path / "source"
+    _write_file(source, "dags/example.py", "print('dag')")
+    manifest_before = _build_manifest(bundle_name="manifest-local", root=source, backend_type="local")
+
+    _write_file(source, "dags/__pycache__/notes.txt", "not bytecode")
+    manifest_after = _build_manifest(bundle_name="manifest-local", root=source, backend_type="local")
+
+    assert manifest_after["version"] == manifest_before["version"]
+    assert [file_info["path"] for file_info in manifest_after["files"]] == ["dags/example.py"]
+
+
+def test_manifest_serialization_is_independent_of_key_insertion_order(tmp_path):
+    source = tmp_path / "source"
+    _write_file(source, "dags/example.py", "print('dag')")
+    manifest = _build_manifest(bundle_name="manifest-local", root=source, backend_type="local")
+    reordered = dict(reversed(list(manifest.items())))
+
+    assert list(reordered) != list(manifest)
+    assert serialize_bundle_version_manifest(reordered) == serialize_bundle_version_manifest(manifest)
+
+
+def test_source_snapshot_signature_covers_every_metadata_field(tmp_path):
+    source = tmp_path / "source"
+    _write_file(source, "example.py", "content")
+    source_snapshot = collect_bundle_source_snapshot(source)
+
+    assert source_snapshot.signature.startswith("sha256:")
+    for field, value in [("size", 1), ("mtime_ns", 1), ("ctime_ns", 1), ("mode", 0o600)]:
+        changed = replace(source_snapshot.files[0], **{field: value})
+        assert changed.build_signature_record() != source_snapshot.files[0].build_signature_record()
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("size", 999), ("mtime_ns", 1), ("ctime_ns", 1), ("mode", 0o600)],
+)
+def test_manifest_rejects_any_source_metadata_field_changing(tmp_path, field, value):
+    source = tmp_path / "source"
+    _write_file(source, "example.py", "content")
+    source_snapshot = collect_bundle_source_snapshot(source)
+    changed_file = replace(source_snapshot.files[0], **{field: value})
+
+    with pytest.raises(BundleManifestSourceChangedError, match="changed while building manifest"):
+        build_bundle_version_manifest(
+            bundle_name="manifest-local",
+            root=source,
+            backend_type="local",
+            source_snapshot=replace(source_snapshot, files=(changed_file,)),
+        )
+
+
+def test_manifest_rejects_file_removed_between_hashing_and_verification(tmp_path):
+    source = tmp_path / "source"
+    source_file = _write_file(source, "example.py", "content")
+    source_snapshot = collect_bundle_source_snapshot(source)
+    digest = hashlib.sha256(b"content").hexdigest()
+    source_file.unlink()
+
+    # Precomputed hashes skip the read, so verification is the first access to the file.
+    with pytest.raises(BundleManifestSourceChangedError, match="disappeared while verifying"):
+        build_bundle_version_manifest(
+            bundle_name="manifest-local",
+            root=source,
+            backend_type="local",
+            source_snapshot=source_snapshot,
+            precomputed_file_sha256={"example.py": digest},
+        )
+
+
+def test_backslash_in_a_posix_file_name_survives_publish_and_validation(tmp_path):
+    source = tmp_path / "source"
+    _write_file(source, "dags/weird\\name.py", "print('dag')")
+
+    manifest = _build_manifest(bundle_name="manifest-local", root=source, backend_type="local")
+    recorded_path = manifest["files"][0]["path"]
+
+    assert recorded_path == "dags/weird\\name.py"
+    assert validate_bundle_relative_path(recorded_path) == Path(recorded_path)


### PR DESCRIPTION
This is the first of several changes that add manifest-backed Dag bundles. A manifest lists every file in a bundle with its checksum, and the bundle version is a hash of that list.

Bundles get published and read on different machines, so both sides have to agree on how the list is written and on what makes a version or a file path valid. Keeping those rules in one place lets the storage backends that come next share them instead of each keeping its own copy.

POC: https://github.com/ephraimbuddy/airflow-manifest-bundle

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Opus 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
