### PR TITLE
Fix broken hierarchical_alphabetical_sort with SerializedTaskGroup

### DIFF
--- a/airflow-core/src/airflow/serialization/definitions/taskgroup.py
+++ b/airflow-core/src/airflow/serialization/definitions/taskgroup.py
@@ -216,6 +216,22 @@ class SerializedTaskGroup(TaskGroupMixin, DAGNode):
                 yield group
             group = group.parent_group
 
+    def hierarchical_alphabetical_sort(self) -> list[DAGNode]:
+        """
+        Sort children in hierarchical alphabetical order.
+
+        - groups in alphabetical order first
+        - tasks in alphabetical order after them.
+
+        Mirrors ``TaskGroup.hierarchical_alphabetical_sort`` in task-sdk; the UI
+        structure and grid endpoints call this on serialized task groups when
+        ``[api] grid_view_sorting_order`` is set to ``hierarchical_alphabetical``.
+        """
+        return sorted(
+            self.children.values(),
+            key=lambda node: (not isinstance(node, SerializedTaskGroup), node.node_id),
+        )
+
     def topological_sort(
         self, *, group_dict: dict[str | None, SerializedTaskGroup] | None = None
     ) -> list[DAGNode]:

--- a/airflow-core/tests/unit/serialization/test_dag_serialization.py
+++ b/airflow-core/tests/unit/serialization/test_dag_serialization.py
@@ -3428,6 +3428,48 @@ def test_mapped_task_group_serde():
     assert serde_tg._expand_input == SchedulerDictOfListsExpandInput({"a": [".", ".."]})
 
 
+def test_serialized_task_group_hierarchical_alphabetical_sort():
+    from airflow.providers.standard.operators.empty import EmptyOperator
+    from airflow.serialization.definitions.taskgroup import SerializedTaskGroup
+
+    with DAG("test_dag", schedule=None, start_date=datetime(2020, 1, 1)) as dag:
+        EmptyOperator(task_id="a")
+        EmptyOperator(task_id="b")
+        with TaskGroup("c"):
+            EmptyOperator(task_id="d")
+        with TaskGroup("e"):
+            EmptyOperator(task_id="f")
+        with TaskGroup("h"):
+            with TaskGroup("i"):
+                EmptyOperator(task_id="j")
+                EmptyOperator(task_id="k")
+                EmptyOperator(task_id="l")
+            EmptyOperator(task_id="m")
+            EmptyOperator(task_id="n")
+
+    serialized_dag = DagSerialization.deserialize_dag(DagSerialization.serialize_dag(dag))
+
+    def nested(group):
+        return [
+            nested(node) if isinstance(node, SerializedTaskGroup) else node.task_id
+            for node in group.hierarchical_alphabetical_sort()
+        ]
+
+    assert nested(serialized_dag.task_group) == [
+        # groups first, alphabetically
+        ["c.d"],  # c
+        ["e.f"],  # e
+        [  # h
+            ["h.i.j", "h.i.k", "h.i.l"],  # i (group first)
+            "h.m",  # tasks after
+            "h.n",
+        ],
+        # tasks after, alphabetically
+        "a",
+        "b",
+    ]
+
+
 @pytest.mark.db_test
 def test_mapped_task_with_operator_extra_links_property():
     class _DummyOperator(BaseOperator):


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

Setting `[api] grid_view_sorting_order = hierarchical_alphabetical` breaks the Grid view on Airflow 3. `get_task_group_children_getter()` (`api_fastapi/core_api/services/ui/task_group.py`) resolves that value to `hierarchical_alphabetical_sort()` and calls it on the scheduler-side `SerializedTaskGroup`, but only the task-sdk `TaskGroup` implements the method, so every `/ui/structure/structure_data` and grid request fails with:

```
AttributeError: 'SerializedTaskGroup' object has no attribute 'hierarchical_alphabetical_sort'
```

This PR adds `hierarchical_alphabetical_sort()` to `SerializedTaskGroup`, mirroring the task-sdk implementation (groups first, then tasks, each sorted alphabetically by `node_id`), plus a unit test covering nested groups.

Supersedes #61877 (closed as stale); same fix rebased onto the current `SerializedTaskGroup` layout. Before/after screenshots of the Grid view are in that PR.

* related: #61877

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
