### PR TITLE
Fix ExternalTaskSensor example DAGs to use matching, non-None schedules

### DIFF
--- a/providers/standard/src/airflow/providers/standard/example_dags/example_external_task_marker_dag.py
+++ b/providers/standard/src/airflow/providers/standard/example_dags/example_external_task_marker_dag.py
@@ -36,9 +36,16 @@ with multiple downstream tasks
 ExternalTaskSensor times out. In this case, ExternalTaskSensor will raise AirflowSkipException
 or AirflowSensorTimeout exception
 
+Both Dags must share the same schedule (and must not use ``schedule=None``) so that a parent
+Dag run and its corresponding child Dag run share the same logical date. ExternalTaskSensor
+matches task instances by logical date by default, so unrelated logical dates (e.g. from two
+independently, manually triggered runs) will never be found.
+
 """
 
 from __future__ import annotations
+
+from datetime import timedelta
 
 import pendulum
 
@@ -52,7 +59,7 @@ with DAG(
     dag_id="example_external_task_marker_parent",
     start_date=start_date,
     catchup=False,
-    schedule=None,
+    schedule=timedelta(minutes=30),
     tags=["example", "example2"],
 ) as parent_dag:
     # [START howto_operator_external_task_marker]
@@ -66,7 +73,7 @@ with DAG(
 with DAG(
     dag_id="example_external_task_marker_child",
     start_date=start_date,
-    schedule=None,
+    schedule=timedelta(minutes=30),
     catchup=False,
     tags=["example", "example2"],
 ) as child_dag:


### PR DESCRIPTION
Both the parent and child DAGs in `example_external_task_marker_dag.py` had `schedule=None`, so independent manually-triggered runs got mismatched logical dates and `ExternalTaskSensor` (which matches by logical date by default) could never find the parent's `ExternalTaskMarker` task instance — exactly as reported.

Sets both DAGs to the same `schedule=timedelta(minutes=30)` and documents why the schedule must match and must not be `None`.

closes: #13681

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)

Generated-by: Claude Code (Sonnet 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
