### PR TITLE
Add support for connection-derived Kubernetes secrets in KPO

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kubernetes_helper_functions.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kubernetes_helper_functions.py
@@ -42,6 +42,10 @@ log = logging.getLogger(__name__)
 alphanum_lower = string.ascii_lowercase + string.digits
 
 POD_NAME_MAX_LENGTH = 63  # Matches Linux kernel's HOST_NAME_MAX default value minus 1.
+# Kubernetes Secret names follow the generic DNS subdomain naming convention (RFC 1123), which
+# allows up to 253 characters -- unlike pod names, they aren't also constrained by the shorter
+# Linux hostname limit.
+SECRET_NAME_MAX_LENGTH = 253
 
 
 class PodLaunchFailedException(AirflowException):

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -62,6 +62,7 @@ from airflow.providers.cncf.kubernetes.callbacks import ExecutionMode, Kubernete
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
 from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import (
     POD_NAME_MAX_LENGTH,
+    SECRET_NAME_MAX_LENGTH,
     add_unique_suffix,
     create_unique_id,
     generic_api_retry,
@@ -106,7 +107,7 @@ if TYPE_CHECKING:
     from pendulum import DateTime
 
     from airflow.providers.cncf.kubernetes.hooks.kubernetes import PodOperatorHookProtocol
-    from airflow.providers.cncf.kubernetes.secret import Secret
+    from airflow.providers.cncf.kubernetes.secret import KubernetesConnectionSecret, Secret
     from airflow.sdk import Context
 
 log = logging.getLogger(__name__)
@@ -173,6 +174,11 @@ class KubernetesPodOperator(BaseOperator):
     :param env_from: (Optional) List of sources to populate environment variables in the container. (templated)
     :param secrets: Kubernetes secrets to inject in the container.
         They can be exposed as environment vars or files in a volume.
+    :param connection_secrets: Airflow connections to expose to the container as Kubernetes
+        secrets. For each :class:`~airflow.providers.cncf.kubernetes.secret.KubernetesConnectionSecret`,
+        a Kubernetes secret containing the connection's URI is created immediately before the pod
+        is launched, and deleted once the pod's lifecycle ends (on completion or on kill) so the
+        connection's credentials never outlive the task.
     :param in_cluster: run kubernetes client with in_cluster configuration.
     :param cluster_context: context that points to kubernetes cluster.
         Ignored when in_cluster is True. If None, current-context is used. (templated)
@@ -337,6 +343,7 @@ class KubernetesPodOperator(BaseOperator):
         env_vars: list[k8s.V1EnvVar] | dict[str, str] | None = None,
         env_from: list[k8s.V1EnvFromSource] | None = None,
         secrets: list[Secret] | None = None,
+        connection_secrets: list[KubernetesConnectionSecret] | None = None,
         in_cluster: bool | None = None,
         cluster_context: str | None = None,
         labels: dict | None = None,
@@ -457,6 +464,8 @@ class KubernetesPodOperator(BaseOperator):
         volumes = [convert_volume(volume) for volume in volumes] if volumes else []
         self.volumes = volumes
         self.secrets = secrets or []
+        self.connection_secrets = connection_secrets or []
+        self._created_connection_secret_names: list[tuple[str, str]] = []
         self.in_cluster = in_cluster
         self.cluster_context = cluster_context
         self.durable = durable
@@ -1332,6 +1341,12 @@ class KubernetesPodOperator(BaseOperator):
         xcom_result: dict | None = None,
         context: Context | None = None,
     ) -> None:
+        # Connection-derived secrets must be cleaned up even if the pod itself was never created
+        # (e.g. pod creation failed) or was already cleaned up via on_kill(), so this runs before
+        # the early returns below. `_delete_connection_secrets` clears its own tracking list, so a
+        # second call here after on_kill() already ran is a no-op.
+        self._delete_connection_secrets()
+
         # Skip cleaning the pod in the following scenarios.
         # 1. If a task got marked as failed, "on_kill" method would be called and the pod will be cleaned up
         # there. Cleaning it up again will raise an exception (which might cause retry).
@@ -1555,6 +1570,7 @@ class KubernetesPodOperator(BaseOperator):
 
     def on_kill(self) -> None:
         self._killed = True
+        self._delete_connection_secrets()
         if self.on_kill_action == OnKillAction.KEEP_POD:
             self.log.info(
                 "Skipping pod deletion since on_kill_action is set to %r.", self.on_kill_action.value
@@ -1577,6 +1593,54 @@ class KubernetesPodOperator(BaseOperator):
                 _delete_with_retry()
             except kubernetes.client.exceptions.ApiException:
                 self.log.exception("Unable to delete pod %s", self.pod.metadata.name)
+
+    def _materialize_connection_secret(
+        self, connection_secret: KubernetesConnectionSecret, *, namespace: str, dry_run: bool
+    ) -> None:
+        """
+        Create the Kubernetes secret backing a single ``KubernetesConnectionSecret``.
+
+        A unique secret name is generated the same way pod names are (``dag_id-task_id-random``),
+        set on ``connection_secret`` so it can be attached to the pod like any other ``Secret``,
+        and -- unless this is a dry run -- the connection is read and the Kubernetes secret is
+        actually created. Created secret names are tracked so they can be cleaned up once the
+        pod's lifecycle ends, mirroring the create-then-cleanup lifecycle already used for the pod
+        itself.
+        """
+        secret_name = create_unique_id(
+            dag_id=self.dag_id, task_id=self.task_id, max_length=SECRET_NAME_MAX_LENGTH
+        )
+        connection_secret.secret = secret_name
+        if dry_run:
+            return
+        connection = BaseHook.get_connection(connection_secret.conn_id)
+        k8s_secret = k8s.V1Secret(
+            metadata=k8s.V1ObjectMeta(name=secret_name, namespace=namespace),
+            string_data={connection_secret.key: connection.get_uri()},
+        )
+
+        @generic_api_retry
+        def _create_with_retry():
+            self.client.create_namespaced_secret(namespace=namespace, body=k8s_secret)
+
+        _create_with_retry()
+        self._created_connection_secret_names.append((namespace, secret_name))
+
+    def _delete_connection_secrets(self) -> None:
+        """Delete any Kubernetes secrets created from connections for this task's pod."""
+        for namespace, secret_name in self._created_connection_secret_names:
+
+            @generic_api_retry
+            def _delete_with_retry(namespace=namespace, secret_name=secret_name):
+                self.client.delete_namespaced_secret(name=secret_name, namespace=namespace)
+
+            try:
+                _delete_with_retry()
+            except kubernetes.client.exceptions.ApiException:
+                self.log.exception(
+                    "Unable to delete Kubernetes secret %s generated from a connection", secret_name
+                )
+        self._created_connection_secret_names.clear()
 
     def build_pod_request_obj(self, context: Context | None = None, *, dry_run: bool = False) -> k8s.V1Pod:
         """
@@ -1678,6 +1742,12 @@ class KubernetesPodOperator(BaseOperator):
         for secret in self.secrets:
             self.log.debug("Adding secret to task %s", self.task_id)
             pod = secret.attach_to_pod(pod)
+        for connection_secret in self.connection_secrets:
+            self.log.debug("Adding connection-derived secret to task %s", self.task_id)
+            self._materialize_connection_secret(
+                connection_secret, namespace=pod.metadata.namespace, dry_run=dry_run
+            )
+            pod = connection_secret.attach_to_pod(pod)
         if self.do_xcom_push:
             self.log.debug("Adding xcom sidecar to task %s", self.task_id)
             pod = xcom_sidecar.add_xcom_sidecar(

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/secret.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/secret.py
@@ -126,3 +126,30 @@ class Secret(K8SModel):
 
     def __repr__(self):
         return f"Secret({self.deploy_type}, {self.deploy_target}, {self.secret}, {self.key})"
+
+
+class KubernetesConnectionSecret(Secret):
+    """
+    Defines a Kubernetes Secret populated from an Airflow connection.
+
+    Unlike :class:`Secret`, which references a Kubernetes secret that already exists,
+    ``KubernetesConnectionSecret`` describes a secret that
+    :class:`~airflow.providers.cncf.kubernetes.operators.pod.KubernetesPodOperator` creates for
+    the task's pod, using ``conn_id``'s serialized URI as the secret value. The generated
+    Kubernetes secret is given a unique, per-task-instance name and is deleted once the pod's
+    lifecycle ends, so the connection's credentials never outlive the task that used them.
+
+    :param deploy_type: The type of secret deploy in Kubernetes, either `env` or `volume`.
+    :param deploy_target: The environment variable when `deploy_type` is `env`, or file path
+        when `deploy_type` is `volume`, where the connection URI is exposed.
+    :param conn_id: ID of the Airflow connection whose credentials should be exposed to the pod.
+    :param key: Key under which the connection's URI is stored in the generated Kubernetes
+        secret. Defaults to ``"conn_uri"``.
+    """
+
+    def __init__(self, deploy_type: str, deploy_target: str, conn_id: str, key: str = "conn_uri"):
+        super().__init__(deploy_type=deploy_type, deploy_target=deploy_target, secret=None, key=key)
+        self.conn_id = conn_id
+
+    def __repr__(self):
+        return f"KubernetesConnectionSecret({self.deploy_type}, {self.deploy_target}, {self.conn_id}, {self.key})"

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/models/test_secret.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/models/test_secret.py
@@ -23,7 +23,7 @@ from kubernetes.client import ApiClient, models as k8s
 
 from airflow.providers.cncf.kubernetes.k8s_model import append_to_pod
 from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
-from airflow.providers.cncf.kubernetes.secret import Secret
+from airflow.providers.cncf.kubernetes.secret import KubernetesConnectionSecret, Secret
 
 
 class TestSecret:
@@ -123,3 +123,37 @@ class TestSecret:
                 ],
             },
         }
+
+
+class TestKubernetesConnectionSecret:
+    def test_init_defaults(self):
+        connection_secret = KubernetesConnectionSecret("env", "MY_CONN", "my_conn_id")
+        assert connection_secret.deploy_type == "env"
+        assert connection_secret.deploy_target == "MY_CONN"
+        assert connection_secret.conn_id == "my_conn_id"
+        assert connection_secret.key == "conn_uri"
+        assert connection_secret.secret is None
+
+    def test_init_custom_key(self):
+        connection_secret = KubernetesConnectionSecret("volume", "/etc/creds", "my_conn_id", key="my_uri_key")
+        assert connection_secret.key == "my_uri_key"
+
+    def test_repr(self):
+        connection_secret = KubernetesConnectionSecret("env", "MY_CONN", "my_conn_id")
+        assert repr(connection_secret) == "KubernetesConnectionSecret(env, MY_CONN, my_conn_id, conn_uri)"
+
+    def test_attach_to_pod_once_secret_is_materialized(self, data_file):
+        template_file = data_file("pods/generator_base.yaml").as_posix()
+        pod = PodGenerator(pod_template_file=template_file).ud_pod
+        connection_secret = KubernetesConnectionSecret("env", "TARGET", "my_conn_id", key="source_b")
+        # Simulates what KubernetesPodOperator does once the backing k8s Secret is created.
+        connection_secret.secret = "generated-secret-name"
+
+        pod = connection_secret.attach_to_pod(pod)
+
+        k8s_client = ApiClient()
+        result = k8s_client.sanitize_for_serialization(pod)
+        assert {
+            "name": "TARGET",
+            "valueFrom": {"secretKeyRef": {"key": "source_b", "name": "generated-secret-name"}},
+        } in result["spec"]["containers"][0]["env"]

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -40,7 +40,7 @@ from airflow.providers.cncf.kubernetes.operators.pod import (
     PodEventType,
     _optionally_suppress,
 )
-from airflow.providers.cncf.kubernetes.secret import Secret
+from airflow.providers.cncf.kubernetes.secret import KubernetesConnectionSecret, Secret
 from airflow.providers.cncf.kubernetes.triggers.pod import ContainerState, KubernetesPodTrigger
 from airflow.providers.cncf.kubernetes.utils.pod_manager import (
     OnFinishAction,
@@ -2564,6 +2564,160 @@ class TestKubernetesPodOperator:
         patch_already_checked_mock.assert_called_once_with(pod_1, reraise=False)
         process_pod_deletion_mock.assert_called_once_with(pod_1)
         assert result.metadata.name == pod_2.metadata.name
+
+
+class TestKubernetesPodOperatorConnectionSecrets:
+    @pytest.fixture(autouse=True)
+    def setup_tests(self):
+        # Mock out the whole hook (rather than just `_get_default_client`) so that resolving
+        # the operator's own `kubernetes_default` connection can't collide with the
+        # `BaseHook.get_connection` mock some tests below use for `connection_secrets`.
+        self.hook_patch = patch(HOOK_CLASS)
+        self.hook_patch.start()
+        yield
+        patch.stopall()
+
+    @patch(KPO_MODULE + ".create_unique_id")
+    @patch(KUB_OP_PATH.format("client"))
+    @patch(f"{KPO_MODULE}.BaseHook.get_connection")
+    def test_build_pod_request_obj_creates_and_attaches_connection_secret(
+        self, mocked_get_connection, mocked_client, mocked_create_unique_id
+    ):
+        mocked_create_unique_id.side_effect = ["pod-name-123", "secret-name-abc"]
+        mocked_get_connection.return_value.get_uri.return_value = "postgresql://user:pass@host/db"
+        connection_secret = KubernetesConnectionSecret(
+            deploy_type="env", deploy_target="MY_CONN", conn_id="my_conn"
+        )
+        k = KubernetesPodOperator(
+            task_id="task",
+            namespace="default",
+            connection_secrets=[connection_secret],
+        )
+
+        pod = k.build_pod_request_obj()
+
+        mocked_get_connection.assert_called_once_with("my_conn")
+        mocked_client.create_namespaced_secret.assert_called_once()
+        _, kwargs = mocked_client.create_namespaced_secret.call_args
+        assert kwargs["namespace"] == "default"
+        created_secret = kwargs["body"]
+        assert created_secret.metadata.name == "secret-name-abc"
+        assert created_secret.metadata.namespace == "default"
+        assert created_secret.string_data == {"conn_uri": "postgresql://user:pass@host/db"}
+        assert connection_secret.secret == "secret-name-abc"
+        assert k._created_connection_secret_names == [("default", "secret-name-abc")]
+        assert pod.spec.containers[0].env == [
+            k8s.V1EnvVar(
+                name="MY_CONN",
+                value_from=k8s.V1EnvVarSource(
+                    secret_key_ref=k8s.V1SecretKeySelector(name="secret-name-abc", key="conn_uri")
+                ),
+            )
+        ]
+
+    @patch(KUB_OP_PATH.format("client"))
+    @patch(f"{KPO_MODULE}.BaseHook.get_connection")
+    def test_build_pod_request_obj_creates_one_secret_per_connection_secret(
+        self, mocked_get_connection, mocked_client
+    ):
+        mocked_get_connection.return_value.get_uri.return_value = "postgresql://user:pass@host/db"
+        connection_secrets = [
+            KubernetesConnectionSecret(deploy_type="env", deploy_target="CONN_A", conn_id="conn_a"),
+            KubernetesConnectionSecret(deploy_type="env", deploy_target="CONN_B", conn_id="conn_b"),
+        ]
+        k = KubernetesPodOperator(
+            task_id="task",
+            namespace="default",
+            connection_secrets=connection_secrets,
+        )
+
+        k.build_pod_request_obj()
+
+        assert mocked_get_connection.call_args_list == [mock.call("conn_a"), mock.call("conn_b")]
+        assert mocked_client.create_namespaced_secret.call_count == 2
+        created_names = {connection_secret.secret for connection_secret in connection_secrets}
+        assert len(created_names) == 2, "each connection secret should get a unique generated name"
+        assert {name for _, name in k._created_connection_secret_names} == created_names
+
+    @patch(KUB_OP_PATH.format("client"))
+    @patch(f"{KPO_MODULE}.BaseHook.get_connection")
+    def test_build_pod_request_obj_dry_run_skips_secret_creation(self, mocked_get_connection, mocked_client):
+        connection_secret = KubernetesConnectionSecret(
+            deploy_type="env", deploy_target="MY_CONN", conn_id="my_conn"
+        )
+        k = KubernetesPodOperator(
+            task_id="task",
+            namespace="default",
+            connection_secrets=[connection_secret],
+        )
+
+        pod = k.build_pod_request_obj(dry_run=True)
+
+        mocked_get_connection.assert_not_called()
+        mocked_client.create_namespaced_secret.assert_not_called()
+        assert k._created_connection_secret_names == []
+        assert connection_secret.secret  # a preview name was still generated
+        assert pod.spec.containers[0].env[0].value_from.secret_key_ref.name == connection_secret.secret
+
+    @patch(KUB_OP_PATH.format("client"))
+    def test_delete_connection_secrets_removes_all_created_secrets(self, mocked_client):
+        k = KubernetesPodOperator(task_id="task")
+        k._created_connection_secret_names = [("ns-a", "secret-a"), ("ns-b", "secret-b")]
+
+        k._delete_connection_secrets()
+
+        mocked_client.delete_namespaced_secret.assert_has_calls(
+            [
+                mock.call(name="secret-a", namespace="ns-a"),
+                mock.call(name="secret-b", namespace="ns-b"),
+            ]
+        )
+        assert k._created_connection_secret_names == []
+
+    @patch(KUB_OP_PATH.format("client"))
+    def test_delete_connection_secrets_logs_and_clears_on_api_exception(self, mocked_client):
+        mocked_client.delete_namespaced_secret.side_effect = ApiException(status=404)
+        k = KubernetesPodOperator(task_id="task")
+        k._created_connection_secret_names = [("ns", "secret-a")]
+
+        k._delete_connection_secrets()  # must not raise
+
+        assert k._created_connection_secret_names == []
+
+    @patch(KUB_OP_PATH.format("client"))
+    def test_delete_connection_secrets_is_noop_without_created_secrets(self, mocked_client):
+        k = KubernetesPodOperator(task_id="task")
+
+        k._delete_connection_secrets()
+
+        mocked_client.delete_namespaced_secret.assert_not_called()
+
+    @patch(KUB_OP_PATH.format("_delete_connection_secrets"))
+    @patch(KUB_OP_PATH.format("client"))
+    def test_cleanup_deletes_connection_secrets_even_when_pod_never_ran(
+        self, mocked_client, mocked_delete_connection_secrets
+    ):
+        """Connection secrets must be cleaned up even if the pod itself was never created."""
+        k = KubernetesPodOperator(task_id="task")
+        pod = k8s.V1Pod(metadata=k8s.V1ObjectMeta(name=TEST_NAME, namespace=TEST_NAMESPACE))
+
+        k.cleanup(pod=pod, remote_pod=None)
+
+        mocked_delete_connection_secrets.assert_called_once_with()
+
+    @pytest.mark.parametrize("on_kill_action", ["delete_pod", "keep_pod"])
+    @patch(KUB_OP_PATH.format("_delete_connection_secrets"))
+    @patch(KUB_OP_PATH.format("client"))
+    def test_on_kill_deletes_connection_secrets_regardless_of_on_kill_action(
+        self, mocked_client, mocked_delete_connection_secrets, on_kill_action
+    ):
+        """Connection secrets never outlive the task, even when the pod itself is kept."""
+        k = KubernetesPodOperator(task_id="task", on_kill_action=on_kill_action)
+        k.pod = None
+
+        k.on_kill()
+
+        mocked_delete_connection_secrets.assert_called_once_with()
 
 
 _REATTACH_DEPRECATION_MESSAGE_PREFIX = (


### PR DESCRIPTION
Implements the design maintainers agreed on in 2023 (see issue thread) for `KubernetesPodOperator` to consume Connection-derived credentials as Kubernetes secrets, instead of requiring a pre-existing secret name.

- New `KubernetesConnectionSecret(Secret)` (`secret.py`), identified by `conn_id` rather than a pre-existing secret name.
- New `connection_secrets: list[KubernetesConnectionSecret]` param on `KubernetesPodOperator`.
- `_materialize_connection_secret()` creates a real Kubernetes secret (containing `BaseHook.get_connection(conn_id).get_uri()`) immediately before the pod is built, named via the existing `create_unique_id()` pod-naming helper, capped at Kubernetes' 253-char DNS-subdomain limit.
- `_delete_connection_secrets()` runs from both `cleanup()` and `on_kill()`, so the secret never outlives the task whether it succeeds, fails, or is killed.

Two prior attempts (#33680, #39003) were abandoned for contributor capacity, not design rejection — this implements the design that was already agreed.

closes: #28086

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)

Generated-by: Claude Code (Sonnet 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
