### PR TITLE
Document DAG.test() behavior change in 2.7.0 release notes

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -6441,6 +6441,17 @@ You can achieve it also by installing airflow with ``[celery]``, ``[cncf.kuberne
 Users who base their images on the ``apache/airflow`` reference image (not slim) should be unaffected - the base
 reference image comes with all the three providers installed.
 
+``DAG.test()`` now returns a ``DagRun`` and no longer stops at the first task failure (#32820)
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+This was an undocumented side effect of adding support for setup/teardown tasks in mapped task
+groups. Previously, ``DAG.test()`` returned ``None``, and if any task raised an exception, the
+whole test run stopped immediately without running the DAG's other schedulable tasks. Now,
+``DAG.test()`` returns the ``DagRun`` it executed, and a failing task no longer aborts the run:
+the remaining tasks keep running according to their trigger rules, just like in a real scheduled
+run. This makes it possible to use ``DAG.test()`` to test DAGs where a task is expected to fail
+but downstream tasks with a different trigger rule (or a parallel mapped task group) should still
+run, without having to fall back to the ``DebugExecutor``.
+
 Improvement Changes
 ^^^^^^^^^^^^^^^^^^^
 

--- a/reproducible_build.yaml
+++ b/reproducible_build.yaml
@@ -1,2 +1,2 @@
-release-notes-hash: 0016af03b467abd6a1e3f1de176adc2f
-source-date-epoch: 1786526826
+release-notes-hash: 450e43a9dd38329434e5f90e2762ff8c
+source-date-epoch: 1788437511


### PR DESCRIPTION
The Airflow 2.7.0 changelog never documented a real behavior change to `DAG.test()` introduced by #32820: it now returns the executed `DagRun` instead of `None`, and a task failure no longer aborts the whole test run — remaining tasks keep running per their trigger rules, matching real scheduled-run behavior. This lets `DAG.test()` exercise DAGs with expected-to-fail tasks (trigger-rule branches, parallel mapped task groups) without falling back to the `DebugExecutor`.

A prior attempt (#58418) got explicit changes-requested from a maintainer: the wording read as AI-generated boilerplate, it used a newsfragment even though newsfragments are only for future releases (this needs to land directly in the already-published 2.7.0 section), and it cited the issue number instead of the PR that actually changed the behavior. This addresses all three: hand-edited the historical "Airflow 2.7.0" section of `RELEASE_NOTES.rst` directly with a plain-prose entry citing #32820.

closes: #34490

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)

Generated-by: Claude Code (Sonnet 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
