### PR TITLE
Fix the prek cache key so the jobs that read it can hit it

### DIFF
--- a/.github/actions/install-prek/action.yml
+++ b/.github/actions/install-prek/action.yml
@@ -19,9 +19,6 @@
 name: 'Install prek'
 description: 'Installs prek and related packages'
 inputs:
-  python-version:
-    description: 'Python version to use'
-    default: "3.10"
   save-cache:
     description: "Whether to save prek cache"
     required: true
@@ -46,6 +43,21 @@ runs:
         echo "Extracted uv==${UV_VERSION}, prek==${PREK_VERSION}"
         echo "uv-version=${UV_VERSION}" >> "${GITHUB_OUTPUT}"
         echo "prek-version=${PREK_VERSION}" >> "${GITHUB_OUTPUT}"
+    - name: "Compute prek cache key"
+      id: cache-key
+      shell: bash
+      # Built here rather than assembled from a version each caller formats for itself, which is how
+      # the readers ended up asking for keys no job had ever saved under. uv resolves the hook
+      # environments against the Python on PATH, so callers must run this after Breeze sets it up.
+      env:
+        PLATFORM: ${{ inputs.platform }}
+        UV_VERSION: ${{ steps.versions.outputs.uv-version }}
+        PREK_CONFIG_HASH: ${{ hashFiles('**/.pre-commit-config.yaml') }}
+      run: |
+        PYTHON_VERSION=$(python3 -c 'import platform; print(platform.python_version())')
+        KEY="cache-prek-v9-${PLATFORM}-python${PYTHON_VERSION}-uv${UV_VERSION}-${PREK_CONFIG_HASH}"
+        echo "Prek cache key: ${KEY}"
+        echo "key=${KEY}" >> "${GITHUB_OUTPUT}"
     - name: "Install uv"
       shell: bash
       run: pip install "uv==${UV_VERSION}"
@@ -73,8 +85,7 @@ runs:
       # yamllint disable-line rule:line-length
       uses: apache/infrastructure-actions/stash/restore@61dcea11f19e2bbe1263f14d72235e8da17d3ad0  # restore/v1.0.0
       with:
-        # yamllint disable rule:line-length
-        key: cache-prek-v9-${{ inputs.platform }}-python${{ inputs.python-version }}-uv${{ steps.versions.outputs.uv-version }}-${{ hashFiles('**/.pre-commit-config.yaml') }}
+        key: ${{ steps.cache-key.outputs.key }}
         path: /tmp/
       id: restore-prek-cache
     - name: "Restore .cache from the tar file"
@@ -105,7 +116,9 @@ runs:
         ls -la ~/.cache/prek || true
         rm -rf ~/.cache/prek
       shell: bash
-      if: steps.restore-prek-cache.outputs.stash-hit != 'true' || steps.restore-prek-tar.outputs.tar-restored != 'true'
+      if: >
+        steps.restore-prek-cache.outputs.stash-hit != 'true'
+        || steps.restore-prek-tar.outputs.tar-restored != 'true'
     - name: Install prek hooks
       shell: bash
       run: prek install-hooks
@@ -122,8 +135,7 @@ runs:
     - name: "Save prek cache"
       uses: apache/infrastructure-actions/stash/save@61dcea11f19e2bbe1263f14d72235e8da17d3ad0  # save/v1.0.0
       with:
-        # yamllint disable rule:line-length
-        key: cache-prek-v9-${{ inputs.platform }}-python${{ inputs.python-version }}-uv${{ steps.versions.outputs.uv-version }}-${{ hashFiles('**/.pre-commit-config.yaml') }}
+        key: ${{ steps.cache-key.outputs.key }}
         path: /tmp/cache-prek.tar.gz
         if-no-files-found: 'error'
         retention-days: '2'

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -283,7 +283,6 @@ jobs:
         uses: ./.github/actions/install-prek
         id: prek
         with:
-          python-version: ${{ steps.breeze.outputs.host-python-version }}
           platform: ${{ inputs.platform }}
           save-cache: true
       - name: Fetch incoming commit ${{ github.sha }} with its parent

--- a/.github/workflows/ci-amd.yml
+++ b/.github/workflows/ci-amd.yml
@@ -387,7 +387,6 @@ jobs:
         uses: ./.github/actions/install-prek
         id: prek
         with:
-          python-version: ${{steps.breeze.outputs.host-python-version}}
           platform: ${{ needs.build-info.outputs.platform }}
           save-cache: false
       - name: "MyPy checks for providers"
@@ -429,7 +428,6 @@ jobs:
         uses: ./.github/actions/install-prek
         id: prek
         with:
-          python-version: ${{steps.breeze.outputs.host-python-version}}
           platform: ${{ needs.build-info.outputs.platform }}
           save-cache: false
       - name: "Migration round-trip check"

--- a/.github/workflows/ci-arm.yml
+++ b/.github/workflows/ci-arm.yml
@@ -376,7 +376,6 @@ jobs:
         uses: ./.github/actions/install-prek
         id: prek
         with:
-          python-version: ${{steps.breeze.outputs.host-python-version}}
           platform: ${{ needs.build-info.outputs.platform }}
           save-cache: false
       - name: "MyPy checks for providers"
@@ -418,7 +417,6 @@ jobs:
         uses: ./.github/actions/install-prek
         id: prek
         with:
-          python-version: ${{steps.breeze.outputs.host-python-version}}
           platform: ${{ needs.build-info.outputs.platform }}
           save-cache: false
       - name: "Migration round-trip check"

--- a/.github/workflows/ci-image-checks.yml
+++ b/.github/workflows/ci-image-checks.yml
@@ -145,7 +145,6 @@ jobs:
         uses: ./.github/actions/install-prek
         id: prek
         with:
-          python-version: ${{steps.breeze.outputs.host-python-version}}
           platform: ${{ inputs.platform }}
           save-cache: true
       - name: "Static checks"

--- a/.github/workflows/generate-constraints.yml
+++ b/.github/workflows/generate-constraints.yml
@@ -108,13 +108,6 @@ jobs:
         with:
           ref: ${{ inputs.checkout-ref }}
           persist-credentials: false
-      - name: "Install prek"
-        uses: ./.github/actions/install-prek
-        id: prek
-        with:
-          python-version: ${{ matrix.python-version }}
-          platform: ${{ inputs.platform }}
-          save-cache: false
       - name: "Prepare breeze & CI image: ${{ matrix.python-version }}"
         uses: ./.github/actions/prepare_breeze_and_image
         with:
@@ -122,6 +115,12 @@ jobs:
           python: ${{ matrix.python-version }}
           use-uv: ${{ inputs.use-uv }}
           make-mnt-writeable-and-cleanup: true
+      - name: "Install prek"
+        uses: ./.github/actions/install-prek
+        id: prek
+        with:
+          platform: ${{ inputs.platform }}
+          save-cache: false
       # Resolves the providers from the sources in this checkout. Skipped for a release, which
       # ships only the PyPI constraints and must not have a source tree answer for a provider.
       - name: "Source constraints"

--- a/.github/workflows/prod-image-build.yml
+++ b/.github/workflows/prod-image-build.yml
@@ -138,15 +138,15 @@ jobs:
         shell: bash
         run: rm -fv ./dist/* ./docker-context-files/*
         if: inputs.upload-package-artifact == 'true'
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
+        if: inputs.upload-package-artifact == 'true'
       - name: "Install prek"
         uses: ./.github/actions/install-prek
         id: prek
         with:
-          python-version: ${{ matrix.python-version }}
           platform: ${{ inputs.platform }}
           save-cache: false
-      - name: "Install Breeze"
-        uses: ./.github/actions/breeze
         if: inputs.upload-package-artifact == 'true'
       - name: "Prepare providers packages - all providers built from sources"
         shell: bash

--- a/.github/workflows/test-providers.yml
+++ b/.github/workflows/test-providers.yml
@@ -92,13 +92,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - name: "Install prek"
-        uses: ./.github/actions/install-prek
-        id: prek
-        with:
-          python-version: ${{ inputs.default-python-version }}
-          platform: ${{ inputs.platform }}
-          save-cache: false
       - name: "Prepare breeze & CI image: ${{ inputs.default-python-version }}"
         uses: ./.github/actions/prepare_breeze_and_image
         with:
@@ -106,6 +99,12 @@ jobs:
           python: "${{ inputs.default-python-version }}"
           use-uv: ${{ inputs.use-uv }}
           make-mnt-writeable-and-cleanup: true
+      - name: "Install prek"
+        uses: ./.github/actions/install-prek
+        id: prek
+        with:
+          platform: ${{ inputs.platform }}
+          save-cache: false
       - name: "Cleanup dist files"
         run: rm -fv ./dist/*
       - name: "Set current date as RELEASE_DATE variable"
@@ -202,13 +201,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - name: "Install prek"
-        uses: ./.github/actions/install-prek
-        id: prek
-        with:
-          python-version: ${{ matrix.compat.python-version }}
-          platform: ${{ inputs.platform }}
-          save-cache: false
       - name: "Prepare breeze & CI image: ${{ matrix.compat.python-version }}"
         uses: ./.github/actions/prepare_breeze_and_image
         with:
@@ -216,6 +208,12 @@ jobs:
           python: ${{ matrix.compat.python-version }}
           use-uv: ${{ inputs.use-uv }}
           make-mnt-writeable-and-cleanup: true
+      - name: "Install prek"
+        uses: ./.github/actions/install-prek
+        id: prek
+        with:
+          platform: ${{ inputs.platform }}
+          save-cache: false
       - name: "Cleanup dist files"
         run: rm -fv ./dist/*
       - name: "Prepare provider distributions: wheel"

--- a/.github/workflows/upgrade-check.yml
+++ b/.github/workflows/upgrade-check.yml
@@ -73,8 +73,6 @@ jobs:
         uses: ./.github/actions/install-prek
         id: prek
         with:
-          python-version: >-
-            ${{ steps.breeze.outputs.host-python-version }}
           platform: "linux/amd64"
           save-cache: false
       - name: >-


### PR DESCRIPTION
## Summary

The prek stash cache key was built using a Python version formatted independently by each caller. Some jobs used `python3.10.21`, while others used `python3.10` or even an empty value, causing cache misses and unnecessary hook reinstalls.

In [33525573182](https://github.com/apache/airflow/actions/runs/33525573182), this led to failures from a transient `go.dev` 500 while the cache-saving job was already warm.

## Change

- `install-prek` now computes the cache key itself and removes the `python-version` input.
- Move `install-prek` after Breeze in the four affected jobs so the configured Python version is available.
- Gate `install-prek` in `build-prod-packages` on `upload-package-artifact`.

The cache key format and namespace are unchanged, so existing stashes remain valid.

## Effect

Compared with [33741573194](https://github.com/apache/airflow/actions/runs/33741573194), all affected PR jobs become warm, while 10/14 canary jobs hit the cache.

The remaining four cold jobs use Python 3.11–3.14, for which no stash is currently saved.

#72382 addresses transient download failures during hook installation. This PR instead reduces how often hook installation is needed; neither subsumes the other.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
