### PR TITLE
Enforce execution_timeout from the task supervisor

### DIFF
--- a/airflow-core/docs/core-concepts/tasks.rst
+++ b/airflow-core/docs/core-concepts/tasks.rst
@@ -119,7 +119,10 @@ Timeouts
 If you want a task to have a maximum runtime, set its ``execution_timeout`` attribute to a ``datetime.timedelta`` value
 that is the maximum permissible runtime. This applies to all Airflow tasks, including sensors. ``execution_timeout`` controls the
 maximum time allowed for every execution. If ``execution_timeout`` is breached, the task times out and
-``AirflowTaskTimeout`` is raised.
+``AirflowTaskTimeout`` is raised. For tasks executed by the Python task runner, the task supervisor enforces
+the timeout from outside the task process too: if the task has not stopped within a short grace period after
+``execution_timeout`` elapses (for example because it is blocked in native code that never returns control to
+Python), the supervisor terminates it.
 
 In addition, sensors have a ``timeout`` parameter. This only matters for sensors in ``reschedule`` mode. ``timeout`` controls the maximum
 time allowed for the sensor to succeed. If ``timeout`` is breached, ``AirflowSensorTimeout`` will be raised and the sensor fails immediately

--- a/airflow-core/newsfragments/72493.improvement.rst
+++ b/airflow-core/newsfragments/72493.improvement.rst
@@ -1,0 +1,1 @@
+``execution_timeout`` is now also enforced by the task supervisor. A task process that does not stop on its own within a short grace period after the timeout elapses is sent SIGTERM and then SIGKILL, so tasks stuck in native code or with a broken signal handler no longer run forever.

--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -2244,6 +2244,7 @@ class TestDagProcessingMessageTypes:
             "UpdateHITLDetail",
             "GetHITLDetailResponse",
             "SetRenderedMapIndex",
+            "SetExecutionTimeout",
             # AIP-103 task/asset store — Dag processor has no task execution context.
             "GetTaskStateStore",
             "SetTaskStateStore",

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -2771,6 +2771,7 @@ class TestTriggererMessageTypes:
             "ResendLoggingFD",
             "CreateHITLDetailPayload",
             "SetRenderedMapIndex",
+            "SetExecutionTimeout",
             "GetDag",
             # AIP-103 task store — triggerer has no task execution context.
             "GetTaskStateStore",

--- a/task-sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task-sdk/src/airflow/sdk/execution_time/comms.py
@@ -1092,6 +1092,13 @@ class SetRenderedMapIndex(BaseModel):
     type: Literal["SetRenderedMapIndex"] = "SetRenderedMapIndex"
 
 
+class SetExecutionTimeout(BaseModel):
+    """Tell the supervisor the task's ``execution_timeout`` so it can enforce it from outside the task process."""
+
+    timeout_seconds: Annotated[float, Field(gt=0)]
+    type: Literal["SetExecutionTimeout"] = "SetExecutionTimeout"
+
+
 class TriggerDagRun(TriggerDAGRunPayload):
     dag_id: str
     run_id: Annotated[str, Field(title="Dag Run Id")]
@@ -1290,6 +1297,7 @@ ToSupervisor = Annotated[
     | RetryTask
     | SetAssetStateStoreByName
     | SetAssetStateStoreByUri
+    | SetExecutionTimeout
     | SetRenderedFields
     | SetRenderedMapIndex
     | SetTaskStateStore

--- a/task-sdk/src/airflow/sdk/execution_time/schema/schema.json
+++ b/task-sdk/src/airflow/sdk/execution_time/schema/schema.json
@@ -3676,6 +3676,27 @@
       "title": "SetAssetStateStoreByUri",
       "type": "object"
     },
+    "SetExecutionTimeout": {
+      "description": "Tell the supervisor the task's ``execution_timeout`` so it can enforce it from outside the task process.",
+      "properties": {
+        "timeout_seconds": {
+          "exclusiveMinimum": 0,
+          "title": "Timeout Seconds",
+          "type": "number"
+        },
+        "type": {
+          "const": "SetExecutionTimeout",
+          "default": "SetExecutionTimeout",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "timeout_seconds"
+      ],
+      "title": "SetExecutionTimeout",
+      "type": "object"
+    },
     "SetRenderedFields": {
       "description": "Payload for setting RTIF for a task instance.",
       "properties": {

--- a/task-sdk/src/airflow/sdk/execution_time/schema/versions/__init__.py
+++ b/task-sdk/src/airflow/sdk/execution_time/schema/versions/__init__.py
@@ -39,11 +39,12 @@ def get_bundle() -> VersionBundle:
 
     from airflow.sdk.execution_time.schema.versions.v2026_10_30 import (
         AddArgBindingsToSupervisorTIRunContext,
+        AddExecutionTimeoutSupervisorMessage,
     )
 
     return VersionBundle(
         HeadVersion(),
-        Version("2026-10-30", AddArgBindingsToSupervisorTIRunContext),
+        Version("2026-10-30", AddArgBindingsToSupervisorTIRunContext, AddExecutionTimeoutSupervisorMessage),
         Version("2026-06-16"),
     )
 

--- a/task-sdk/src/airflow/sdk/execution_time/schema/versions/v2026_10_30.py
+++ b/task-sdk/src/airflow/sdk/execution_time/schema/versions/v2026_10_30.py
@@ -34,3 +34,16 @@ class AddArgBindingsToSupervisorTIRunContext(VersionChange):
     description = __doc__
 
     instructions_to_migrate_to_previous_version = (schema(TIRunContext).field("arg_bindings").didnt_exist,)
+
+
+class AddExecutionTimeoutSupervisorMessage(VersionChange):
+    """
+    Add the ``SetExecutionTimeout`` task-to-supervisor message.
+
+    This introduces a new message body, not a field on an existing body. Older runtimes do not send this
+    message, so there is no field-level downgrade instruction to apply.
+    """
+
+    description = __doc__
+
+    instructions_to_migrate_to_previous_version = ()

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -116,6 +116,7 @@ from airflow.sdk.execution_time.comms import (
     SentFDs,
     SetAssetStateStoreByName,
     SetAssetStateStoreByUri,
+    SetExecutionTimeout,
     SetRenderedFields,
     SetRenderedMapIndex,
     SetTaskStateStore,
@@ -189,6 +190,10 @@ SOCKET_CLEANUP_TIMEOUT: float = conf.getfloat("workers", "socket_cleanup_timeout
 # Maximum possible time (in seconds) that task will have for execution of auxiliary processes
 # like listeners after task is complete.
 TASK_OVERTIME_THRESHOLD: float = conf.getfloat("core", "task_success_overtime")
+
+# How long a task process gets to stop itself (raise AirflowTaskTimeout, run on_kill, report its state) after
+# execution_timeout elapses before the supervisor sends SIGTERM, and again before it escalates to SIGKILL.
+EXECUTION_TIMEOUT_GRACE_PERIOD: float = 5.0
 
 SERVER_TERMINATED = "SERVER_TERMINATED"
 
@@ -1394,6 +1399,11 @@ class ActivitySubprocess(WatchedSubprocess):
     _task_end_time_monotonic: float | None = attrs.field(default=None, init=False)
     _rendered_map_index: str | None = attrs.field(default=None, init=False)
 
+    _execution_timeout_seconds: float | None = attrs.field(default=None, init=False)
+    _execution_timeout_enforce_at: float | None = attrs.field(default=None, init=False)
+    """Monotonic time at which the supervisor sends ``_execution_timeout_next_signal``."""
+    _execution_timeout_next_signal: signal.Signals | None = attrs.field(default=None, init=False)
+
     decoder: ClassVar[TypeAdapter[ToSupervisor]] = TypeAdapter(ToSupervisor)
 
     ti: RuntimeTI | None = None
@@ -1623,6 +1633,8 @@ class ActivitySubprocess(WatchedSubprocess):
                     MIN_HEARTBEAT_INTERVAL,
                 ),
             )
+            if self._exit_code is None and (due_in := self._execution_timeout_due_in()) is not None:
+                max_wait_time = max(0, min(max_wait_time, due_in))
             # Block until events are ready or the timeout is reached
             # This listens for activity (e.g., subprocess output) on registered file objects
             alive = self._service_subprocess(max_wait_time=max_wait_time) is None
@@ -1648,6 +1660,7 @@ class ActivitySubprocess(WatchedSubprocess):
                 self._send_heartbeat_if_needed()
 
                 self._handle_process_overtime_if_needed()
+                self._handle_execution_timeout_if_needed()
 
     def _handle_process_overtime_if_needed(self):
         """Handle termination of auxiliary processes if the task exceeds the configured overtime."""
@@ -1665,6 +1678,58 @@ class ActivitySubprocess(WatchedSubprocess):
                 ti_id=self.id,
             )
             self.kill(signal.SIGTERM, force=True)
+
+    def _execution_timeout_due_in(self) -> float | None:
+        """Seconds until the supervisor must act on an overrunning task, or None if there is nothing to enforce."""
+        if (
+            self._execution_timeout_next_signal is None
+            or self._execution_timeout_enforce_at is None
+            or self._terminal_state
+            or self._pending_terminal_state_msg is not None
+        ):
+            return None
+        return self._execution_timeout_enforce_at - time.monotonic()
+
+    def _handle_execution_timeout_if_needed(self):
+        """
+        Enforce ``execution_timeout`` from outside the task process.
+
+        The task process raises ``AirflowTaskTimeout`` itself when the timeout elapses, which is the only
+        place ``on_kill``, the retry policy, callbacks and listeners can run. That needs a process that can
+        still run Python signal handlers; one that has not reported a terminal state within the grace period
+        is stuck (native code, a lock inherited across fork, SIGSEGV) and is sent SIGTERM, then SIGKILL.
+        """
+        due_in = self._execution_timeout_due_in()
+        if due_in is None or due_in > 0:
+            return
+
+        next_signal = self._execution_timeout_next_signal
+        if next_signal == signal.SIGTERM:
+            self.process_log.error(
+                "Task did not stop after execution_timeout elapsed; terminating process",
+                timeout_seconds=self._execution_timeout_seconds,
+                grace_period_seconds=EXECUTION_TIMEOUT_GRACE_PERIOD,
+            )
+            try:
+                self._signal_subprocess(signal.SIGTERM)
+            except self._process.ProcessNotFound:
+                self._execution_timeout_next_signal = None
+                self._execution_timeout_enforce_at = None
+                return
+            self._execution_timeout_next_signal = signal.SIGKILL
+            self._execution_timeout_enforce_at = time.monotonic() + EXECUTION_TIMEOUT_GRACE_PERIOD
+            return
+
+        if next_signal != signal.SIGKILL:
+            return
+
+        self.process_log.error(
+            "Task process did not exit after SIGTERM; killing it",
+            timeout_seconds=self._execution_timeout_seconds,
+        )
+        self._execution_timeout_next_signal = None
+        self._execution_timeout_enforce_at = None
+        self.kill(signal.SIGKILL)
 
     def _send_heartbeat_if_needed(self):
         """Send a heartbeat to the client if heartbeat interval has passed."""
@@ -1811,6 +1876,12 @@ class ActivitySubprocess(WatchedSubprocess):
                 log.debug("Skipping RTIF overwrite; task instance archived on retry/clear", ti_id=self.id)
         elif isinstance(msg, SetRenderedMapIndex):
             self.client.task_instances.set_rendered_map_index(self.id, msg.rendered_map_index)
+        elif isinstance(msg, SetExecutionTimeout):
+            self._execution_timeout_seconds = msg.timeout_seconds
+            self._execution_timeout_next_signal = signal.SIGTERM
+            self._execution_timeout_enforce_at = (
+                time.monotonic() + msg.timeout_seconds + EXECUTION_TIMEOUT_GRACE_PERIOD
+            )
         elif isinstance(msg, GetAssetByName):
             asset_resp = self.client.assets.get(name=msg.name)
             if isinstance(asset_resp, AssetResponse):

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -110,6 +110,7 @@ from airflow.sdk.execution_time.comms import (
     ResendLoggingFD,
     RetryTask,
     SentFDs,
+    SetExecutionTimeout,
     SetRenderedFields,
     SetRenderedMapIndex,
     SkipDownstreamTasks,
@@ -2194,6 +2195,7 @@ def _run_execute_callable(
             # It's possible we're already timed out, so fast-fail if true
             if timeout_seconds <= 0:
                 raise AirflowTaskTimeout()
+            SUPERVISOR_COMMS.send(SetExecutionTimeout(timeout_seconds=timeout_seconds))
             # Run task in timeout wrapper
             with timeout(timeout_seconds):
                 result = ctx.run(execute, context=context)

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -134,6 +134,7 @@ from airflow.sdk.execution_time.comms import (
     SentFDs,
     SetAssetStateStoreByName,
     SetAssetStateStoreByUri,
+    SetExecutionTimeout,
     SetRenderedFields,
     SetRenderedMapIndex,
     SetTaskStateStore,
@@ -1150,6 +1151,150 @@ class TestWatchedSubprocess:
             mock_kill.assert_not_called()
             mock_logger.warning.assert_not_called()
 
+    def test_set_execution_timeout_schedules_enforcement(self, mocker, monkeypatch):
+        monkeypatch.setattr("airflow.sdk.execution_time.supervisor.EXECUTION_TIMEOUT_GRACE_PERIOD", 5.0)
+        mocker.patch("time.monotonic", return_value=100.0)
+        proc = ActivitySubprocess(
+            process_log=mocker.MagicMock(),
+            id=TI_ID,
+            pid=12345,
+            stdin=mocker.Mock(),
+            process=mocker.Mock(),
+            client=mocker.Mock(),
+        )
+
+        proc._handle_request(SetExecutionTimeout(timeout_seconds=30), log=mocker.Mock(), req_id=1)
+
+        assert proc._execution_timeout_seconds == 30
+        assert proc._execution_timeout_enforce_at == 135.0
+        assert proc._execution_timeout_next_signal == signal.SIGTERM
+        assert proc._execution_timeout_due_in() == 35.0
+
+    @pytest.mark.parametrize(
+        ("enforce_at", "next_signal", "terminal_state", "pending_terminal_msg", "expected_action"),
+        [
+            pytest.param(None, None, None, False, None, id="no_timeout_set"),
+            pytest.param(25.0, signal.SIGTERM, None, False, None, id="not_due_yet"),
+            pytest.param(20.0, signal.SIGTERM, None, False, "sigterm", id="due_sends_sigterm"),
+            pytest.param(20.0, signal.SIGKILL, None, False, "sigkill", id="due_again_sends_sigkill"),
+            pytest.param(
+                15.0, signal.SIGTERM, TaskInstanceState.FAILED, False, None, id="terminal_state_reported"
+            ),
+            pytest.param(15.0, signal.SIGTERM, None, True, None, id="terminal_state_pending_api_retry"),
+        ],
+    )
+    def test_execution_timeout_enforcement(
+        self,
+        mocker,
+        monkeypatch,
+        enforce_at,
+        next_signal,
+        terminal_state,
+        pending_terminal_msg,
+        expected_action,
+    ):
+        monkeypatch.setattr("airflow.sdk.execution_time.supervisor.EXECUTION_TIMEOUT_GRACE_PERIOD", 5.0)
+        mocker.patch("time.monotonic", return_value=20.0)
+        mock_kill = mocker.patch("airflow.sdk.execution_time.supervisor.WatchedSubprocess.kill")
+        mock_signal = mocker.patch(
+            "airflow.sdk.execution_time.supervisor.WatchedSubprocess._signal_subprocess"
+        )
+        proc = ActivitySubprocess(
+            process_log=mocker.MagicMock(),
+            id=TI_ID,
+            pid=12345,
+            stdin=mocker.Mock(),
+            process=mocker.Mock(),
+            client=mocker.Mock(),
+        )
+        proc._execution_timeout_seconds = 30.0
+        proc._execution_timeout_enforce_at = enforce_at
+        proc._execution_timeout_next_signal = next_signal
+        proc._terminal_state = terminal_state
+        if pending_terminal_msg:
+            proc._pending_terminal_state_msg = SucceedTask(end_date=timezone.utcnow())
+
+        proc._handle_execution_timeout_if_needed()
+
+        if expected_action == "sigterm":
+            mock_signal.assert_called_once_with(signal.SIGTERM)
+            mock_kill.assert_not_called()
+            assert proc._execution_timeout_next_signal == signal.SIGKILL
+            assert proc._execution_timeout_enforce_at == 25.0
+            proc.process_log.error.assert_called_once_with(
+                "Task did not stop after execution_timeout elapsed; terminating process",
+                timeout_seconds=30.0,
+                grace_period_seconds=5.0,
+            )
+        elif expected_action == "sigkill":
+            mock_kill.assert_called_once_with(signal.SIGKILL)
+            mock_signal.assert_not_called()
+            assert proc._execution_timeout_next_signal is None
+            assert proc._execution_timeout_enforce_at is None
+            proc.process_log.error.assert_called_once_with(
+                "Task process did not exit after SIGTERM; killing it", timeout_seconds=30.0
+            )
+        else:
+            mock_signal.assert_not_called()
+            mock_kill.assert_not_called()
+            proc.process_log.error.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("stops_on_sigterm", "expected_exit_code"),
+        [
+            pytest.param(True, 0, id="task_reports_state_on_sigterm"),
+            pytest.param(False, -signal.SIGKILL, id="task_ignores_sigterm"),
+        ],
+    )
+    def test_execution_timeout_enforced_by_supervisor(
+        self, stops_on_sigterm, expected_exit_code, monkeypatch, captured_logs, client_with_ti_start
+    ):
+        monkeypatch.setattr("airflow.sdk.execution_time.supervisor.EXECUTION_TIMEOUT_GRACE_PERIOD", 0.3)
+        # Far longer than the test may take: the monitor loop has to wake up for the timeout on its own
+        monkeypatch.setattr("airflow.sdk.execution_time.supervisor.MIN_HEARTBEAT_INTERVAL", 30)
+
+        def subprocess_main():
+            import signal
+
+            comms = CommsDecoder()
+            comms._get_response()
+
+            def _on_term(signum, frame):
+                if stops_on_sigterm:
+                    comms.send(TaskState(state=TaskInstanceState.FAILED, end_date=timezone.utcnow()))
+                    exit(0)
+                print("Ignoring SIGTERM", file=sys.stderr)
+
+            signal.signal(signal.SIGTERM, _on_term)
+            comms.send(SetExecutionTimeout(timeout_seconds=0.1))
+            sleep(30)
+            exit(5)
+
+        proc = ActivitySubprocess.start(
+            dag_rel_path=os.devnull,
+            bundle_info=FAKE_BUNDLE,
+            what=TaskInstance(
+                id=TI_ID,
+                task_id="b",
+                dag_id="c",
+                run_id="d",
+                try_number=1,
+                dag_version_id=uuid7(),
+                queue="default",
+            ),
+            client=client_with_ti_start,
+            target=subprocess_main,
+        )
+
+        started = time.monotonic()
+        assert proc.wait() == expected_exit_code
+        assert time.monotonic() - started < 10
+        assert proc.final_state == TaskInstanceState.FAILED
+
+        events = [m["event"] for m in captured_logs]
+        assert "Task did not stop after execution_timeout elapsed; terminating process" in events
+        assert ("Task process did not exit after SIGTERM; killing it" in events) is not stops_on_sigterm
+
     @pytest.mark.parametrize(
         ("signal_to_raise", "log_pattern", "level"),
         (
@@ -2050,6 +2195,10 @@ REQUEST_TEST_CASES = [
             response=OKResponse(ok=True),
         ),
         test_id="set_rtif",
+    ),
+    RequestTestCase(
+        message=SetExecutionTimeout(timeout_seconds=30.0),
+        test_id="set_execution_timeout",
     ),
     RequestTestCase(
         message=SetRenderedMapIndex(rendered_map_index="Label: task_1"),

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -143,6 +143,7 @@ from airflow.sdk.execution_time.comms import (
     RetryTask,
     SetAssetStateStoreByName,
     SetAssetStateStoreByUri,
+    SetExecutionTimeout,
     SetRenderedFields,
     SetTaskStateStore,
     SetXCom,
@@ -1430,7 +1431,7 @@ def test_run_task_timeout(time_machine, create_runtime_ti, mock_supervisor_comms
     mock_supervisor_comms.send.assert_called_with(TaskState(state=TaskInstanceState.FAILED, end_date=instant))
 
 
-def test_execution_timeout(create_runtime_ti):
+def test_execution_timeout(create_runtime_ti, mock_supervisor_comms):
     def sleep_and_catch_other_exceptions():
         with contextlib.suppress(Exception):
             # Catching Exception should NOT catch AirflowTaskTimeout
@@ -6111,7 +6112,7 @@ class TestRunExecuteCallable:
         task.execution_timeout = execution_timeout
         return task
 
-    def test_runs_in_isolated_context_with_safeguard_tracker_set(self):
+    def test_runs_in_isolated_context_with_safeguard_tracker_set(self, mock_supervisor_comms):
         """The callable runs in an internal context copy that has the safeguard tracker set and does not leak."""
         var = contextvars.ContextVar("marker")
         var.set("outer")
@@ -6133,8 +6134,9 @@ class TestRunExecuteCallable:
         # The .set was confined to the copy, so the tracker never leaked to the caller's context.
         assert ExecutorSafeguard.tracker.get(None) is not task
         task.on_kill.assert_not_called()
+        mock_supervisor_comms.send.assert_not_called()
 
-    def test_applies_execution_timeout(self):
+    def test_applies_execution_timeout(self, mock_supervisor_comms):
         """When a timeout is set and the callable overruns, AirflowTaskTimeout is raised and on_kill is called."""
         task = self._make_task(execution_timeout=timedelta(milliseconds=10))
 
@@ -6145,8 +6147,9 @@ class TestRunExecuteCallable:
             _run_execute_callable(context={}, execute=execute, task=task)
 
         task.on_kill.assert_called_once()
+        mock_supervisor_comms.send.assert_called_once_with(SetExecutionTimeout(timeout_seconds=0.01))
 
-    def test_fast_fails_when_timeout_already_elapsed(self):
+    def test_fast_fails_when_timeout_already_elapsed(self, mock_supervisor_comms):
         """A non-positive timeout fast-fails before running the callable and still calls on_kill."""
         task = self._make_task(execution_timeout=timedelta(seconds=-1))
         execute = mock.MagicMock()
@@ -6156,6 +6159,7 @@ class TestRunExecuteCallable:
 
         execute.assert_not_called()
         task.on_kill.assert_called_once()
+        mock_supervisor_comms.send.assert_not_called()
 
     def test_emits_task_execute_span_at_detail_level_2(self):
         """At detail level 2, running the callable produces a recorded ``task.execute`` span."""


### PR DESCRIPTION
## Why

`execution_timeout` is only enforced by a SIGALRM handler inside the task runner process. When that process is stuck in native code, deadlocked on a lock inherited across fork, or hit by SIGSEGV, the handler never runs and the task stays running forever (#57174, #57712, #45930).

## What

The task process sends a new `SetExecutionTimeout` message to the supervisor right before it arms its own alarm, so both clocks start at the same point. If the task has not reported a terminal state within 5 seconds after the timeout, the supervisor sends SIGTERM to the process group, and SIGKILL 5 seconds later.

This keeps the task runner's SIGALRM handler instead of "moving it", which is a bit different from what #53337 asks for. The reason is that `on_kill`, the retry policy and the failure callbacks can only run inside the task process, and dropping the handler would skip them on every timeout.

closes: #53337, #57174, #57712
related: #45930

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5.1)

Generated-by: Claude Code (Fable 5.1) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)