### PR TITLE
Add machine-readable RBAC reference to BaseAuthManager

### DIFF
--- a/airflow-core/docs/core-concepts/auth-manager/index.rst
+++ b/airflow-core/docs/core-concepts/auth-manager/index.rst
@@ -41,6 +41,7 @@ If you want to check which auth manager is currently set, you can use the
     :hidden:
 
     simple/index
+    rbac-reference
 
 Available auth managers to use
 ------------------------------

--- a/airflow-core/docs/core-concepts/auth-manager/rbac-reference.rst
+++ b/airflow-core/docs/core-concepts/auth-manager/rbac-reference.rst
@@ -1,0 +1,48 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+RBAC reference
+==============
+
+Auth managers like the Keycloak auth manager need to model the Airflow RBAC
+permissions in an external system (for example Keycloak clients). To avoid
+hand-maintaining a copy of that model,
+``BaseAuthManager.get_rbac_reference()`` returns a machine-readable reference
+of every resource the auth manager authorizes. The reference is introspected
+from the ``is_authorized_*`` methods, so it stays in sync automatically
+whenever resources are added or changed. Call it at runtime for the
+authoritative reference rather than copying values from this page:
+
+.. code-block:: python
+
+    from airflow.api_fastapi.auth.managers.base_auth_manager import BaseAuthManager
+
+    reference = BaseAuthManager.get_rbac_reference()
+    # {"asset": {"method": "is_authorized_asset", "actions": ["GET", "POST", ...], ...}, ...}
+
+Each entry is keyed by resource name (for example ``"dag"``) and holds:
+
+* ``method``: the ``is_authorized_*`` method that authorizes the resource.
+* ``actions``: the allowed actions (``GET``, ``POST``, ``PUT``, ``DELETE``).
+  Absent for resources authorized without an HTTP method, such as views.
+* ``scope``: the enum that further scopes the check, when present (for example
+  ``DagAccessEntity`` for Dags, ``AccessView`` for views), with its values.
+* ``details``: the details dataclass and its fields, when the request carries
+  details (for example ``DagDetails`` with ``id`` and ``team_name``).
+* ``description``: a short description of the resource.
+
+See :doc:`index` for the full list of authorization methods and their semantics.

--- a/airflow-core/newsfragments/72465.feature.rst
+++ b/airflow-core/newsfragments/72465.feature.rst
@@ -1,6 +1,0 @@
-Added ``BaseAuthManager.get_rbac_reference()``, a machine-readable reference of the
-RBAC resources the auth manager authorizes. It is introspected from the
-``is_authorized_*`` methods, so provider auth managers (e.g. Keycloak) can model
-Airflow permissions in an external system without hand-maintaining a copy, and it
-stays in sync automatically when resources change. See the new "RBAC reference"
-docs page under Auth manager concepts.

--- a/airflow-core/newsfragments/72465.feature.rst
+++ b/airflow-core/newsfragments/72465.feature.rst
@@ -1,0 +1,6 @@
+Added ``BaseAuthManager.get_rbac_reference()``, a machine-readable reference of the
+RBAC resources the auth manager authorizes. It is introspected from the
+``is_authorized_*`` methods, so provider auth managers (e.g. Keycloak) can model
+Airflow permissions in an external system without hand-maintaining a copy, and it
+stays in sync automatically when resources change. See the new "RBAC reference"
+docs page under Auth manager concepts.

--- a/airflow-core/newsfragments/72495.feature.rst
+++ b/airflow-core/newsfragments/72495.feature.rst
@@ -1,0 +1,1 @@
+Added ``BaseAuthManager.get_rbac_reference()``, a machine-readable reference of the RBAC resources the auth manager authorizes, introspected from the ``is_authorized_*`` methods so provider auth managers can model Airflow permissions externally without hand-maintaining a copy.

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/base_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/base_auth_manager.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import dataclasses
 import inspect
 import logging
 import warnings
@@ -25,14 +26,20 @@ from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from functools import cache, cached_property
-from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
+from types import UnionType
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, Union, get_args, get_origin, get_type_hints
 
 from jwt import InvalidTokenError
 from sqlalchemy import select
 
 from airflow.api_fastapi.auth.managers.models.base_user import BaseUser
 from airflow.api_fastapi.auth.managers.models.resource_details import (
+    AccessView,
+    AssetAliasDetails,
+    AssetDetails,
+    ConfigurationDetails,
     ConnectionDetails,
+    DagAccessEntity,
     DagDetails,
     PoolDetails,
     TeamDetails,
@@ -68,13 +75,6 @@ if TYPE_CHECKING:
         IsAuthorizedDagRequest,
         IsAuthorizedPoolRequest,
         IsAuthorizedVariableRequest,
-    )
-    from airflow.api_fastapi.auth.managers.models.resource_details import (
-        AccessView,
-        AssetAliasDetails,
-        AssetDetails,
-        ConfigurationDetails,
-        DagAccessEntity,
     )
     from airflow.cli.cli_config import CLICommand
 
@@ -216,6 +216,69 @@ class BaseAuthManager(Generic[T], LoggingMixin, metaclass=ABCMeta):
         server latency will increase.
         """
         return None
+
+    @classmethod
+    def get_rbac_reference(cls) -> dict[str, dict[str, Any]]:
+        """
+        Return a machine-readable reference of the RBAC resources this auth manager authorizes.
+
+        Provider auth managers (e.g. Keycloak) model Airflow permissions in an external
+        system. This reference lets them do so without hand-maintaining a copy of the
+        RBAC surface: it is introspected from the ``is_authorized_*`` methods, so it
+        stays in sync automatically whenever resources are added or changed.
+
+        Each entry is keyed by resource name (e.g. ``"dag"``) and holds the authorizing
+        method, the allowed actions, the scoping enum when the resource is further
+        scoped (e.g. ``DagAccessEntity``), the details dataclass fields when the
+        request carries details (e.g. ``DagDetails``), and a short description.
+
+        :return: mapping of resource name to its authorization reference entry.
+        """
+        reference: dict[str, dict[str, Any]] = {}
+        for name in dir(cls):
+            if not name.startswith("is_authorized_"):
+                continue
+            method = getattr(cls, name)
+            try:
+                hints = get_type_hints(method)
+            except Exception:
+                log.debug("Skipping %s: type hints could not be resolved", name)
+                continue
+            if "method" not in hints and "access_view" not in hints:
+                # Not a resource permission (e.g. the is_authorized_hitl_task approval check).
+                continue
+            entry: dict[str, Any] = {"method": name}
+            actions_hint = hints.get("method")
+            if isinstance(actions_hint, type) and issubclass(actions_hint, Enum):
+                entry["actions"] = [action.value for action in actions_hint]
+            doc = inspect.getdoc(method)
+            entry["description"] = doc.splitlines()[0] if doc else ""
+            for param_name in inspect.signature(method).parameters:
+                if param_name in {"self", "user", "method"}:
+                    continue
+                hint = hints.get(param_name)
+                if hint is None:
+                    continue
+                if isinstance(hint, UnionType) or get_origin(hint) is Union:
+                    non_none = [arg for arg in get_args(hint) if arg is not type(None)]
+                    hint = non_none[0] if len(non_none) == 1 else hint
+                if isinstance(hint, type) and issubclass(hint, Enum):
+                    entry["scope"] = {
+                        "parameter": param_name,
+                        "enum": hint.__name__,
+                        "values": [value.value for value in hint],
+                    }
+                elif isinstance(hint, type) and dataclasses.is_dataclass(hint):
+                    entry["details"] = {
+                        "parameter": param_name,
+                        "type": hint.__name__,
+                        "fields": [field.name for field in dataclasses.fields(hint)],
+                    }
+                else:
+                    extra = entry.setdefault("extra_params", {})
+                    extra[param_name] = getattr(hint, "__name__", str(hint))
+            reference[name.removeprefix("is_authorized_")] = entry
+        return dict(sorted(reference.items()))
 
     @abstractmethod
     def is_authorized_configuration(

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/test_base_auth_manager.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/test_base_auth_manager.py
@@ -817,3 +817,33 @@ class TestBaseAuthManager:
         user = BaseAuthManagerUserTest(name=user_id)
         result = auth_manager.is_authorized_hitl_task(assigned_users=assigned_users, user=user)
         assert result == expected
+
+
+class TestGetRbacReference:
+    def test_reference_lists_every_resource_permission_method(self):
+        reference = BaseAuthManager.get_rbac_reference()
+        for name in dir(BaseAuthManager):
+            if name.startswith("is_authorized_") and name != "is_authorized_hitl_task":
+                assert name.removeprefix("is_authorized_") in reference
+        # is_authorized_hitl_task is an approval check, not a resource permission.
+        assert "hitl_task" not in reference
+
+    def test_reference_is_json_serializable(self):
+        import json
+
+        json.dumps(BaseAuthManager.get_rbac_reference())
+
+    def test_dag_entry_has_scope_and_details(self):
+        entry = BaseAuthManager.get_rbac_reference()["dag"]
+        assert entry["method"] == "is_authorized_dag"
+        assert entry["actions"] == ["GET", "POST", "PUT", "DELETE"]
+        assert entry["scope"]["enum"] == "DagAccessEntity"
+        assert "RUN" in entry["scope"]["values"]
+        assert entry["details"]["type"] == "DagDetails"
+        assert set(entry["details"]["fields"]) >= {"id", "team_name"}
+
+    def test_view_entry_uses_access_view_scope(self):
+        entry = BaseAuthManager.get_rbac_reference()["view"]
+        assert "actions" not in entry
+        assert entry["scope"]["enum"] == "AccessView"
+        assert "CLUSTER_ACTIVITY" in entry["scope"]["values"]


### PR DESCRIPTION
## Summary

Closes #72465.

Provider auth managers like the Keycloak auth manager need to model the Airflow RBAC permissions in an external system, which today means hand-maintaining a copy of the RBAC surface. This adds `BaseAuthManager.get_rbac_reference()`, a machine-readable reference introspected from the `is_authorized_*` methods, so it stays in sync automatically whenever resources are added or changed.

Each entry is keyed by resource name (e.g. `"dag"`) and holds the authorizing method, allowed actions, scoping enum with values (e.g. `DagAccessEntity`, `AccessView`), details dataclass fields (e.g. `DagDetails`), and a short description. The reference is JSON-serializable so external systems can consume it directly.

Also adds an "RBAC reference" docs page under Auth manager concepts, unit tests, and a newsfragment.

Skipped: a dedicated Sphinx extension or prek codegen hook. The runtime-introspected method cannot drift by construction; add codegen only if a static artifact is ever required.

## Test Plan

- [x] New `TestGetRbacReference` tests pass (64 passed in `test_base_auth_manager.py`)
- [x] `ruff check` and `ruff format --check` pass on changed files
- [x] `mypy-airflow-core` prek hook passes
- [x] `prek run --from-ref apache/main --stage pre-commit` passes (includes newsfragment validation)
