### PR TITLE
Skip GCS folder-marker keys in GCSToS3Operator

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/gcs_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/gcs_to_s3.py
@@ -164,6 +164,29 @@ class GCSToS3Operator(BaseOperator):
             return os.path.basename(file_path)
         return file_path
 
+    @staticmethod
+    def _strip_overlapping_folder_markers(keys: list[str]) -> tuple[list[str], list[str]]:
+        """
+        Drop trailing-slash keys that are strict prefixes of other listed keys.
+
+        Treated as directory markers. A lone trailing-slash key with no overlap
+        (e.g. ``lonely/``) is preserved, and a non-slash key that happens to be a
+        strict prefix of another (e.g. ``abc`` of ``abcdef``) is also preserved.
+        Returns ``(kept, dropped)``.
+        """
+        if not keys:
+            return [], []
+        ordered = sorted(set(keys))
+        kept: list[str] = []
+        dropped: list[str] = []
+        for current, nxt in zip(ordered, ordered[1:]):
+            if current.endswith("/") and nxt.startswith(current):
+                dropped.append(current)
+            else:
+                kept.append(current)
+        kept.append(ordered[-1])
+        return kept, dropped
+
     def execute(self, context: Context) -> list[str]:
         # list all files in an Google Cloud Storage bucket
         gcs_hook = GCSHook(
@@ -186,6 +209,18 @@ class GCSToS3Operator(BaseOperator):
             list_kwargs["match_glob"] = self.match_glob
 
         gcs_files = gcs_hook.list(**list_kwargs)  # type: ignore
+
+        gcs_files, dropped_keys = self._strip_overlapping_folder_markers(gcs_files)
+        if self.flatten_structure:
+            # A kept marker like lonely/ has no basename, so flattening would hit the destination prefix.
+            dropped_keys += [file for file in gcs_files if not self._transform_file_path(file)]
+            gcs_files = [file for file in gcs_files if self._transform_file_path(file)]
+        if dropped_keys:
+            self.log.info(
+                "Skipping %s GCS folder-marker key(s) (omitted from transfer and XCom output): %s",
+                len(dropped_keys),
+                dropped_keys,
+            )
 
         s3_hook = S3Hook(
             aws_conn_id=self.dest_aws_conn_id, verify=self.dest_verify, extra_args=self.dest_s3_extra_args

--- a/providers/amazon/tests/unit/amazon/aws/transfers/test_gcs_to_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/transfers/test_gcs_to_s3.py
@@ -187,6 +187,73 @@ class TestGCSToS3Operator:
             assert sorted(MOCK_FILES) == sorted(uploaded_files)
             assert sorted(MOCK_FILES) == sorted(hook.list_keys("bucket", delimiter="/"))
 
+    @pytest.mark.parametrize(
+        ("keys", "expected_kept", "expected_dropped"),
+        [
+            ([], [], []),
+            (["a"], ["a"], []),
+            (["a", "b"], ["a", "b"], []),
+            # Non-slash prefix overlaps must NOT be treated as folder markers.
+            (["a", "ax"], ["a", "ax"], []),
+            (["abc", "abcdef"], ["abc", "abcdef"], []),
+            (["foo/", "foo/bar.txt"], ["foo/bar.txt"], ["foo/"]),
+            (
+                ["data/", "data/sub/", "data/sub/file.txt"],
+                ["data/sub/file.txt"],
+                ["data/", "data/sub/"],
+            ),
+            # A lone trailing-slash key with no overlap is a real object and stays.
+            (["lonely/"], ["lonely/"], []),
+            (["lonely/", "report.csv"], ["lonely/", "report.csv"], []),
+        ],
+    )
+    def test_strip_overlapping_folder_markers(self, keys, expected_kept, expected_dropped):
+        """Folder-marker detection: requires both strict-prefix overlap AND trailing slash."""
+        kept, dropped = GCSToS3Operator._strip_overlapping_folder_markers(keys)
+        assert kept == expected_kept
+        assert dropped == expected_dropped
+
+    @mock.patch("airflow.providers.amazon.aws.transfers.gcs_to_s3.GCSHook")
+    def test_execute_skips_overlapping_folder_markers(self, mock_hook):
+        mock_hook.return_value.list.return_value = ["src/", "src/airflow.png", "lonely/"]
+        with NamedTemporaryFile() as f:
+            gcs_provide_file = mock_hook.return_value.provide_file
+            gcs_provide_file.return_value.__enter__.return_value.name = f.name
+
+            operator = GCSToS3Operator(
+                task_id=TASK_ID,
+                gcs_bucket=GCS_BUCKET,
+                dest_aws_conn_id="aws_default",
+                dest_s3_key=S3_BUCKET,
+                replace=True,
+            )
+            hook, _ = _create_test_bucket()
+
+            uploaded_files = operator.execute(None)
+            assert uploaded_files == ["lonely/", "src/airflow.png"]
+            assert hook.list_keys("bucket") == ["lonely/", "src/airflow.png"]
+
+    @mock.patch("airflow.providers.amazon.aws.transfers.gcs_to_s3.GCSHook")
+    def test_execute_skips_markers_without_a_basename_when_flattening(self, mock_hook):
+        mock_hook.return_value.list.return_value = ["src/", "src/airflow.png", "lonely/"]
+        with NamedTemporaryFile() as f:
+            gcs_provide_file = mock_hook.return_value.provide_file
+            gcs_provide_file.return_value.__enter__.return_value.name = f.name
+
+            operator = GCSToS3Operator(
+                task_id=TASK_ID,
+                gcs_bucket=GCS_BUCKET,
+                dest_aws_conn_id="aws_default",
+                dest_s3_key="s3://bucket/dest/",
+                flatten_structure=True,
+                replace=True,
+            )
+            hook, _ = _create_test_bucket()
+
+            uploaded_files = operator.execute(None)
+            assert uploaded_files == ["src/airflow.png"]
+            assert hook.list_keys("bucket") == ["dest/airflow.png"]
+
     @mock.patch("airflow.providers.amazon.aws.transfers.gcs_to_s3.GCSHook")
     def test_execute_with_replace(self, mock_hook):
         mock_hook.return_value.list.return_value = MOCK_FILES


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

`GCSToS3Operator` copies every name `GCSHook.list()` returns, including the trailing-`/` folder markers a GCS listing contains. They land in S3 as spurious empty keys and in the XCom output. With `flatten_structure=True` a marker has no basename, so it resolves to the destination prefix itself and a zero-byte object is written over it.

This applies the same overlap-aware rule `S3ToGCSOperator` uses (#65724): a trailing-`/` key is dropped only when it is also a strict prefix of another key in the same listing, so a real object like `lonely/` is kept. Flattening needs one addition — a kept `lonely/` still flattens to an empty name, so keys with no basename are dropped as well. Skipped keys are logged, and the returned list is now sorted and de-duplicated.

related: #64966, #65724

## Before / After

Verified end to end against a real GCS bucket and a real S3 bucket. Listing: `src/` (a marker), `src/file.txt`, and `lonely/` (a real object ending in `/`).

|  | S3 keys | XCom |
|---|---|---|
| Before | `src/`, `src/file.txt`, `lonely/` | all three |
| After  | `src/file.txt`, `lonely/` | those two |

With `flatten_structure=True` into `s3://bucket/dest/`:

|  | S3 keys | XCom |
|---|---|---|
| Before | `dest/`, `dest/file.txt` | all three |
| After  | `dest/file.txt` | `src/file.txt` |

`dest/` is a zero-byte object on the destination prefix, because both markers flatten to an empty basename. `lonely/` is dropped only under flattening, where it has no name left.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
  - Opus 5

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
