### PR TITLE
Fix Dag scheduling stall after switching to a coarser cron

### DIFF
--- a/airflow-core/src/airflow/timetables/interval.py
+++ b/airflow-core/src/airflow/timetables/interval.py
@@ -32,6 +32,10 @@ if TYPE_CHECKING:
 
 Delta = datetime.timedelta | relativedelta
 
+# One step is provably enough for both shipped _DataIntervalTimetable subclasses
+# (see next_dagrun_info); this budgets one extra attempt of margin before failing loudly.
+_MAX_ALIGNMENT_RETRIES = 2
+
 
 class _DataIntervalTimetable(Timetable):
     """
@@ -111,19 +115,22 @@ class _DataIntervalTimetable(Timetable):
                 # Data interval starts from the end of the previous interval.
                 start = align_last_data_interval_end
 
-            # CronTriggerTimetable stores its runs as point-in-time intervals
-            # (start == end == logical_date). After a switch to a
-            # CronDataIntervalTimetable the aligned `start` lands back on that
-            # same logical_date, so without this guard we'd propose a run
-            # identical to the existing one — which collides with the
-            # (dag_id, logical_date) unique constraint and leaves the scheduler
-            # looping on "run already exists; skipping dagrun creation" until
-            # the next period elapses. Advance one period to skip past it.
-            if (
-                last_automated_data_interval.start == last_automated_data_interval.end
-                and start == last_automated_data_interval.start
-            ):
+            # A schedule change (e.g. a coarser cron) can realign `start` onto or
+            # before the previous run's start, colliding with the (dag_id,
+            # logical_date) unique constraint and stalling the scheduler on "run
+            # already exists; skipping dagrun creation". One retry past it is
+            # provably enough for both shipped subclasses; fail loudly instead of
+            # looping unbounded past that, which would hang the scheduler for
+            # every Dag if `_get_next` ever stopped strictly advancing.
+            attempts = 0
+            while start <= last_automated_data_interval.start:
+                if attempts >= _MAX_ALIGNMENT_RETRIES:
+                    raise AssertionError(
+                        f"{type(self).__name__}._get_next did not advance past "
+                        f"{last_automated_data_interval.start} after {_MAX_ALIGNMENT_RETRIES} attempts"
+                    )
                 start = self._get_next(start)
+                attempts += 1
         if restriction.latest is not None and start > restriction.latest:
             return None
         end = self._get_next(start)

--- a/airflow-core/src/airflow/timetables/interval.py
+++ b/airflow-core/src/airflow/timetables/interval.py
@@ -32,10 +32,6 @@ if TYPE_CHECKING:
 
 Delta = datetime.timedelta | relativedelta
 
-# One step is provably enough for both shipped _DataIntervalTimetable subclasses
-# (see next_dagrun_info); this budgets one extra attempt of margin before failing loudly.
-_MAX_ALIGNMENT_RETRIES = 2
-
 
 class _DataIntervalTimetable(Timetable):
     """
@@ -120,17 +116,15 @@ class _DataIntervalTimetable(Timetable):
             # logical_date) unique constraint and stalling the scheduler on "run
             # already exists; skipping dagrun creation". One retry past it is
             # provably enough for both shipped subclasses; fail loudly instead of
-            # looping unbounded past that, which would hang the scheduler for
-            # every Dag if `_get_next` ever stopped strictly advancing.
-            attempts = 0
-            while start <= last_automated_data_interval.start:
-                if attempts >= _MAX_ALIGNMENT_RETRIES:
+            # retrying indefinitely, which would hang the scheduler for every Dag
+            # if `_get_next` ever stopped strictly advancing.
+            if start <= last_automated_data_interval.start:
+                start = self._get_next(start)
+                if start <= last_automated_data_interval.start:
                     raise AssertionError(
                         f"{type(self).__name__}._get_next did not advance past "
-                        f"{last_automated_data_interval.start} after {_MAX_ALIGNMENT_RETRIES} attempts"
+                        f"{last_automated_data_interval.start} after one retry"
                     )
-                start = self._get_next(start)
-                attempts += 1
         if restriction.latest is not None and start > restriction.latest:
             return None
         end = self._get_next(start)

--- a/airflow-core/src/airflow/timetables/interval.py
+++ b/airflow-core/src/airflow/timetables/interval.py
@@ -121,7 +121,7 @@ class _DataIntervalTimetable(Timetable):
             if start <= last_automated_data_interval.start:
                 start = self._get_next(start)
                 if start <= last_automated_data_interval.start:
-                    raise AssertionError(
+                    raise ValueError(
                         f"{type(self).__name__}._get_next did not advance past "
                         f"{last_automated_data_interval.start} after one retry"
                     )

--- a/airflow-core/src/airflow/timetables/interval.py
+++ b/airflow-core/src/airflow/timetables/interval.py
@@ -122,7 +122,7 @@ class _DataIntervalTimetable(Timetable):
                 start = self._get_next(start)
                 if start <= last_automated_data_interval.start:
                     raise ValueError(
-                        f"{type(self).__name__}._get_next did not advance past "
+                        f"{type(self).__name__} timetable did not advance past "
                         f"{last_automated_data_interval.start} after one retry"
                     )
         if restriction.latest is not None and start > restriction.latest:

--- a/airflow-core/tests/unit/jobs/test_schedule_change_stall.py
+++ b/airflow-core/tests/unit/jobs/test_schedule_change_stall.py
@@ -1,0 +1,174 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Regression test for https://github.com/apache/airflow/issues/66754: changing a Dag's
+cron to a coarser one (e.g. hourly to daily) must not permanently stall DagRun creation.
+Calls the DagRun-creation and TI-scheduling code paths directly
+(``SchedulerJobRunner._create_dag_runs``, ``DagRun.update_state``,
+``DagRun.schedule_tis``) against a real Dag re-sync (``SerializedDAG.bulk_write_to_db``
+via ``dag_maker``) and real ``DagRun``/``TaskInstance`` rows, not just
+``CronDataIntervalTimetable`` in isolation, to prove the stall reproduces at the
+database level and that the guard in ``timetables/interval.py`` resolves it.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+import time_machine
+from sqlalchemy import select
+
+from airflow._shared.timezones import timezone
+from airflow.jobs.job import Job
+from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
+from airflow.models import DagRun
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.utils.state import DagRunState, TaskInstanceState
+
+from tests_common.test_utils.db import (
+    clear_db_assets,
+    clear_db_backfills,
+    clear_db_callbacks,
+    clear_db_dags,
+    clear_db_deadline,
+    clear_db_import_errors,
+    clear_db_jobs,
+    clear_db_pools,
+    clear_db_runs,
+    clear_db_triggers,
+)
+from tests_common.test_utils.mock_executor import MockExecutor
+
+pytestmark = pytest.mark.db_test
+
+DAG_ID = "schedule_change_stall_coarser_cron"
+START_DATE = timezone.datetime(2026, 5, 4)
+
+
+def _clean_db():
+    clear_db_dags()
+    clear_db_runs()
+    clear_db_backfills()
+    clear_db_pools()
+    clear_db_import_errors()
+    clear_db_jobs()
+    clear_db_assets()
+    clear_db_deadline()
+    clear_db_callbacks()
+    clear_db_triggers()
+
+
+@pytest.fixture(autouse=True)
+def clean_db():
+    _clean_db()
+    yield
+    _clean_db()
+
+
+def _make_runner():
+    job = Job()
+    return SchedulerJobRunner(job=job, executors=[MockExecutor()])
+
+
+@time_machine.travel(START_DATE, tick=False)
+def test_coarser_schedule_change_does_not_stall_dagrun_creation(dag_maker, session):
+    # 1. First Dag scheduling: hourly, catchup=True.
+    with dag_maker(
+        dag_id=DAG_ID,
+        schedule="0 * * * *",
+        start_date=START_DATE,
+        catchup=True,
+        max_active_runs=1,
+        session=session,
+    ):
+        BashOperator(task_id="do_something", bash_command="true")
+
+    dag_model = dag_maker.dag_model
+    assert dag_model.next_dagrun == START_DATE
+    assert dag_model.next_dagrun_create_after == START_DATE + datetime.timedelta(hours=1)
+
+    runner = _make_runner()
+
+    # Tick once the hourly run becomes due.
+    with time_machine.travel(START_DATE + datetime.timedelta(hours=1), tick=False):
+        runner._create_dag_runs([dag_model], session)
+        session.flush()
+
+    runs = session.scalars(select(DagRun).where(DagRun.dag_id == DAG_ID)).all()
+    assert len(runs) == 1, f"expected exactly one DagRun after the first tick, got {runs}"
+    hourly_run = runs[0]
+    assert hourly_run.logical_date == START_DATE
+    assert hourly_run.data_interval_end == START_DATE + datetime.timedelta(hours=1)
+
+    # 2. The first TI of the first Dag scheduling already ran.
+    ti = hourly_run.get_task_instances(session=session)[0]
+    ti.state = TaskInstanceState.SUCCESS
+    session.merge(ti)
+    session.flush()
+    hourly_run.dag = dag_maker.serialized_dag
+    hourly_run.update_state(session=session)
+    session.flush()
+    assert hourly_run.state == DagRunState.SUCCESS
+
+    # 3. Change the Dag scheduling (the second Dag): hourly to daily, drop end_date.
+    with dag_maker(
+        dag_id=DAG_ID,
+        schedule="0 0 * * *",
+        start_date=START_DATE,
+        catchup=True,
+        max_active_runs=1,
+        session=session,
+    ):
+        BashOperator(task_id="do_something", bash_command="true")
+
+    session.expire_all()
+    dag_model = dag_maker.dag_model
+
+    # 4. Advance past the next expected (daily) boundary and tick again.
+    with time_machine.travel(START_DATE + datetime.timedelta(days=1, minutes=5), tick=False):
+        runner._create_dag_runs([dag_model], session)
+        session.flush()
+
+    session.expire_all()
+    runs = session.scalars(select(DagRun).where(DagRun.dag_id == DAG_ID).order_by(DagRun.logical_date)).all()
+
+    expected_logical_date = START_DATE + datetime.timedelta(days=1)
+    new_runs = [r for r in runs if r.logical_date == expected_logical_date]
+    assert len(new_runs) == 1, (
+        f"expected a new DagRun at logical_date={expected_logical_date} (the next day's slot); "
+        f"instead the scheduler produced these runs: "
+        f"{[(r.run_id, r.logical_date, r.state) for r in runs]}. "
+        "This is the 'run already exists; skipping dagrun creation' stall: the scheduler is stuck "
+        "proposing the pre-existing hourly run's logical_date forever instead of advancing."
+    )
+
+    new_run = new_runs[0]
+    new_ti = new_run.get_task_instances(session=session)[0]
+    assert new_ti.state != TaskInstanceState.REMOVED
+
+    # Drive scheduling decisions for the new run and confirm its TI reaches SCHEDULED,
+    # i.e. it is not stuck in a not-yet-scheduled/None/queued limbo.
+    new_run.dag = dag_maker.serialized_dag
+    schedulable_tis, _ = new_run.update_state(session=session)
+    new_run.schedule_tis(schedulable_tis, session=session)
+    session.flush()
+    session.expire_all()
+    new_ti = new_run.get_task_instances(session=session)[0]
+    assert new_ti.state == TaskInstanceState.SCHEDULED, (
+        f"new run's TaskInstance should reach SCHEDULED, got {new_ti.state!r}, it is stuck."
+    )

--- a/airflow-core/tests/unit/jobs/test_schedule_change_stall.py
+++ b/airflow-core/tests/unit/jobs/test_schedule_change_stall.py
@@ -81,8 +81,7 @@ def clean_db():
 
 
 def _make_runner():
-    job = Job()
-    return SchedulerJobRunner(job=job, executors=[MockExecutor()])
+    return SchedulerJobRunner(job=Job(), executors=[MockExecutor()])
 
 
 @time_machine.travel(START_DATE, tick=False)

--- a/airflow-core/tests/unit/jobs/test_schedule_change_stall.py
+++ b/airflow-core/tests/unit/jobs/test_schedule_change_stall.py
@@ -124,7 +124,7 @@ def test_coarser_schedule_change_does_not_stall_dagrun_creation(dag_maker, sessi
     session.flush()
     assert hourly_run.state == DagRunState.SUCCESS
 
-    # 3. Change the Dag scheduling (the second Dag): hourly to daily, drop end_date.
+    # 3. Change the same Dag's schedule: hourly to daily, drop end_date.
     with dag_maker(
         dag_id=DAG_ID,
         schedule="0 0 * * *",

--- a/airflow-core/tests/unit/timetables/test_interval_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_interval_timetable.py
@@ -27,7 +27,11 @@ import time_machine
 from airflow._shared.timezones.timezone import utc
 from airflow.exceptions import AirflowTimetableInvalid
 from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction, Timetable
-from airflow.timetables.interval import CronDataIntervalTimetable, DeltaDataIntervalTimetable
+from airflow.timetables.interval import (
+    CronDataIntervalTimetable,
+    DeltaDataIntervalTimetable,
+    _DataIntervalTimetable,
+)
 
 START_DATE = pendulum.DateTime(2021, 9, 4, tzinfo=utc)
 
@@ -73,12 +77,13 @@ def test_no_catchup_first_starts_at_current_time(
 )
 @time_machine.travel(pendulum.DateTime(2021, 9, 7, 15, tzinfo=utc))
 def test_zero_length_last_interval_does_not_re_emit_logical_date(catchup: bool) -> None:
-    """A zero-length ``data_interval`` (``start == end``) on the previous run
-    must not cause ``next_dagrun_info`` to re-emit that run's logical_date.
-
-    These appear when a DAG was scheduled by ``CronTriggerTimetable`` and later
-    switched to ``CronDataIntervalTimetable``. Without the guard the scheduler
-    loops on "run already exists; skipping dagrun creation".
+    """A zero-length ``data_interval`` (``start == end``) on the previous run must not
+    cause ``next_dagrun_info`` to re-emit that run's logical_date. These appear when a
+    DAG was scheduled by ``CronTriggerTimetable`` and later switched to
+    ``CronDataIntervalTimetable``; without the guard the scheduler loops on "run
+    already exists; skipping dagrun creation". The guard retries in general (see
+    ``test_guard_retries_once_more_within_budget``), but for ``CronDataIntervalTimetable``
+    it always resolves in a single iteration.
     """
     timetable = CronDataIntervalTimetable("0 17 * * *", utc)
     last_run_at = pendulum.DateTime(2021, 9, 5, 17, tzinfo=utc)
@@ -90,6 +95,113 @@ def test_zero_length_last_interval_does_not_re_emit_logical_date(catchup: bool) 
     expected_start = pendulum.DateTime(2021, 9, 6, 17, tzinfo=utc)
     expected_end = pendulum.DateTime(2021, 9, 7, 17, tzinfo=utc)
     assert next_info == DagRunInfo.interval(start=expected_start, end=expected_end)
+
+
+@pytest.mark.parametrize(
+    "catchup",
+    [pytest.param(True, id="catchup_true"), pytest.param(False, id="catchup_false")],
+)
+@time_machine.travel(pendulum.DateTime(2021, 9, 7, 15, tzinfo=utc))
+def test_coarser_schedule_does_not_re_emit_logical_date(catchup: bool) -> None:
+    """Switching to a coarser cron must not re-emit the previous run's logical_date.
+    An hourly run leaves the interval [00:00, 01:00). Aligning that end to a daily
+    schedule lands back on 00:00, the logical_date the run already occupies, which
+    would stall the scheduler on "run already exists; skipping dagrun creation" if
+    the guard didn't advance past it. Resolves in a single iteration here (see
+    ``test_guard_retries_once_more_within_budget`` for a case where it is not enough).
+    """
+    timetable = CronDataIntervalTimetable("0 0 * * *", utc)
+    last = DataInterval(
+        start=pendulum.DateTime(2021, 9, 6, 0, tzinfo=utc),
+        end=pendulum.DateTime(2021, 9, 6, 1, tzinfo=utc),
+    )
+    next_info = timetable.next_dagrun_info(
+        last_automated_data_interval=last,
+        restriction=TimeRestriction(earliest=None, latest=None, catchup=catchup),
+    )
+    expected_start = pendulum.DateTime(2021, 9, 7, 0, tzinfo=utc)
+    expected_end = pendulum.DateTime(2021, 9, 8, 0, tzinfo=utc)
+    assert next_info == DagRunInfo.interval(start=expected_start, end=expected_end)
+
+
+class _FixedStepTimetable(_DataIntervalTimetable):
+    """Test double for a custom Timetable whose alignment isn't schedule-quantized.
+
+    The shipped subclasses guarantee (see the guard's comment in ``next_dagrun_info``)
+    that a single ``_get_next`` step past the realigned ``start`` clears
+    ``last_automated_data_interval.start``, but only because of invariants specific to
+    them. This double doesn't uphold those invariants: ``_align_to_prev`` overshoots to
+    a fixed point well before the reference interval, and ``_get_next`` only advances by
+    a small fixed step, so escaping the collision can need more than one retry.
+
+    Only the two methods this scenario reaches are implemented; the rest keep the base
+    class's ``NotImplementedError``.
+    """
+
+    def __init__(self, align_point: pendulum.DateTime, step: datetime.timedelta) -> None:
+        super().__init__()
+        self._align_point = align_point
+        self._step = step
+        self.get_next_call_count = 0
+
+    def _align_to_prev(self, current: pendulum.DateTime) -> pendulum.DateTime:
+        return self._align_point
+
+    def _get_next(self, current: pendulum.DateTime) -> pendulum.DateTime:
+        self.get_next_call_count += 1
+        return current + self._step
+
+    def infer_manual_data_interval(self, *, run_after: pendulum.DateTime) -> DataInterval:
+        raise NotImplementedError()
+
+
+def test_guard_retries_once_more_within_budget() -> None:
+    """The collision guard retries past a stale boundary, not just a single step.
+    Neither shipped ``_DataIntervalTimetable`` subclass can ever need more than one
+    iteration (proven, not just tested, by the invariant documented on the guard), so
+    this uses a test-only Timetable double for a case that needs the one extra retry
+    the guard budgets for: two steps clear ``last_automated_data_interval.start``, a
+    single step would not, so this fails if the retry budget drops back to one attempt.
+    """
+    last_start = pendulum.DateTime(2021, 9, 7, 15, tzinfo=utc)
+    last = DataInterval(start=last_start, end=last_start + datetime.timedelta(minutes=1))
+    align_point = last_start - datetime.timedelta(minutes=3)
+    step = datetime.timedelta(minutes=2)
+
+    single_step = align_point + step
+    assert single_step <= last.start, "test setup must reproduce the single-step failure case"
+
+    timetable = _FixedStepTimetable(align_point=align_point, step=step)
+    next_info = timetable.next_dagrun_info(
+        last_automated_data_interval=last,
+        restriction=TimeRestriction(earliest=None, latest=None, catchup=True),
+    )
+
+    # 2 retries inside the guard, plus 1 more to compute the returned interval's `end`.
+    assert timetable.get_next_call_count == 3
+    expected_start = last_start + datetime.timedelta(minutes=1)
+    expected_end = last_start + datetime.timedelta(minutes=3)
+    assert next_info == DagRunInfo.interval(start=expected_start, end=expected_end)
+
+
+def test_guard_raises_instead_of_looping_forever_when_retries_are_exhausted() -> None:
+    """The guard must fail loudly, not hang the scheduler, once retries run out.
+    A ``_get_next`` that never advances past the collision would spin an unbounded
+    loop forever, on a code path that runs for every Dag in every scheduler loop.
+    Bounding the retries and raising instead turns that into a clear, immediate
+    error rather than a wedged scheduler.
+    """
+    last_start = pendulum.DateTime(2021, 9, 7, 15, tzinfo=utc)
+    last = DataInterval(start=last_start, end=last_start + datetime.timedelta(minutes=1))
+    align_point = last_start - datetime.timedelta(minutes=6)
+    step = datetime.timedelta(minutes=2)
+
+    timetable = _FixedStepTimetable(align_point=align_point, step=step)
+    with pytest.raises(AssertionError, match="did not advance past"):
+        timetable.next_dagrun_info(
+            last_automated_data_interval=last,
+            restriction=TimeRestriction(earliest=None, latest=None, catchup=True),
+        )
 
 
 @pytest.mark.parametrize(

--- a/airflow-core/tests/unit/timetables/test_interval_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_interval_timetable.py
@@ -81,9 +81,8 @@ def test_zero_length_last_interval_does_not_re_emit_logical_date(catchup: bool) 
     cause ``next_dagrun_info`` to re-emit that run's logical_date. These appear when a
     DAG was scheduled by ``CronTriggerTimetable`` and later switched to
     ``CronDataIntervalTimetable``; without the guard the scheduler loops on "run
-    already exists; skipping dagrun creation". The guard retries in general (see
-    ``test_guard_retries_once_more_within_budget``), but for ``CronDataIntervalTimetable``
-    it always resolves in a single iteration.
+    already exists; skipping dagrun creation". The guard's single retry always
+    resolves this for ``CronDataIntervalTimetable``.
     """
     timetable = CronDataIntervalTimetable("0 17 * * *", utc)
     last_run_at = pendulum.DateTime(2021, 9, 5, 17, tzinfo=utc)
@@ -107,8 +106,8 @@ def test_coarser_schedule_does_not_re_emit_logical_date(catchup: bool) -> None:
     An hourly run leaves the interval [00:00, 01:00). Aligning that end to a daily
     schedule lands back on 00:00, the logical_date the run already occupies, which
     would stall the scheduler on "run already exists; skipping dagrun creation" if
-    the guard didn't advance past it. Resolves in a single iteration here (see
-    ``test_guard_retries_once_more_within_budget`` for a case where it is not enough).
+    the guard didn't advance past it. The guard's single retry resolves this here
+    (see ``test_guard_raises_when_one_retry_is_not_enough`` for a case where it isn't).
     """
     timetable = CronDataIntervalTimetable("0 0 * * *", utc)
     last = DataInterval(
@@ -132,7 +131,8 @@ class _FixedStepTimetable(_DataIntervalTimetable):
     ``last_automated_data_interval.start``, but only because of invariants specific to
     them. This double doesn't uphold those invariants: ``_align_to_prev`` overshoots to
     a fixed point well before the reference interval, and ``_get_next`` only advances by
-    a small fixed step, so escaping the collision can need more than one retry.
+    a small fixed step, so escaping the collision can need more steps than the guard's
+    single retry budgets for -- in which case the guard raises instead of retrying again.
 
     Only the two methods this scenario reaches are implemented; the rest keep the base
     class's ``NotImplementedError``.
@@ -155,21 +155,19 @@ class _FixedStepTimetable(_DataIntervalTimetable):
         raise NotImplementedError()
 
 
-def test_guard_retries_once_more_within_budget() -> None:
-    """The collision guard retries past a stale boundary, not just a single step.
-    Neither shipped ``_DataIntervalTimetable`` subclass can ever need more than one
-    iteration (proven, not just tested, by the invariant documented on the guard), so
-    this uses a test-only Timetable double for a case that needs the one extra retry
-    the guard budgets for: two steps clear ``last_automated_data_interval.start``, a
-    single step would not, so this fails if the retry budget drops back to one attempt.
+def test_guard_single_retry_resolves_collision() -> None:
+    """The collision guard's one retry is enough when a single step clears the
+    stale boundary. This uses a test-only Timetable double (not a shipped
+    subclass) to exercise the guard's mechanism directly, independent of any
+    real cron/timedelta alignment semantics.
     """
     last_start = pendulum.DateTime(2021, 9, 7, 15, tzinfo=utc)
     last = DataInterval(start=last_start, end=last_start + datetime.timedelta(minutes=1))
-    align_point = last_start - datetime.timedelta(minutes=3)
+    align_point = last_start - datetime.timedelta(minutes=1)
     step = datetime.timedelta(minutes=2)
 
     single_step = align_point + step
-    assert single_step <= last.start, "test setup must reproduce the single-step failure case"
+    assert single_step > last.start, "test setup must reproduce the single-retry success case"
 
     timetable = _FixedStepTimetable(align_point=align_point, step=step)
     next_info = timetable.next_dagrun_info(
@@ -177,19 +175,20 @@ def test_guard_retries_once_more_within_budget() -> None:
         restriction=TimeRestriction(earliest=None, latest=None, catchup=True),
     )
 
-    # 2 retries inside the guard, plus 1 more to compute the returned interval's `end`.
-    assert timetable.get_next_call_count == 3
+    # 1 retry inside the guard, plus 1 more to compute the returned interval's `end`.
+    assert timetable.get_next_call_count == 2
     expected_start = last_start + datetime.timedelta(minutes=1)
     expected_end = last_start + datetime.timedelta(minutes=3)
     assert next_info == DagRunInfo.interval(start=expected_start, end=expected_end)
 
 
-def test_guard_raises_instead_of_looping_forever_when_retries_are_exhausted() -> None:
-    """The guard must fail loudly, not hang the scheduler, once retries run out.
-    A ``_get_next`` that never advances past the collision would spin an unbounded
-    loop forever, on a code path that runs for every Dag in every scheduler loop.
-    Bounding the retries and raising instead turns that into a clear, immediate
-    error rather than a wedged scheduler.
+def test_guard_raises_when_one_retry_is_not_enough() -> None:
+    """The guard must fail loudly, not hang the scheduler, when its one retry
+    doesn't clear the collision. Retrying indefinitely on a ``_get_next`` that
+    never advances past the collision would spin an unbounded loop forever, on
+    a code path that runs for every Dag in every scheduler loop. Bounding the
+    guard to a single retry and raising instead turns that into a clear,
+    immediate error rather than a wedged scheduler.
     """
     last_start = pendulum.DateTime(2021, 9, 7, 15, tzinfo=utc)
     last = DataInterval(start=last_start, end=last_start + datetime.timedelta(minutes=1))

--- a/airflow-core/tests/unit/timetables/test_interval_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_interval_timetable.py
@@ -196,7 +196,7 @@ def test_guard_raises_when_one_retry_is_not_enough() -> None:
     step = datetime.timedelta(minutes=2)
 
     timetable = _FixedStepTimetable(align_point=align_point, step=step)
-    with pytest.raises(ValueError, match="did not advance past"):
+    with pytest.raises(ValueError, match="timetable did not advance past"):
         timetable.next_dagrun_info(
             last_automated_data_interval=last,
             restriction=TimeRestriction(earliest=None, latest=None, catchup=True),

--- a/airflow-core/tests/unit/timetables/test_interval_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_interval_timetable.py
@@ -79,7 +79,7 @@ def test_no_catchup_first_starts_at_current_time(
 def test_zero_length_last_interval_does_not_re_emit_logical_date(catchup: bool) -> None:
     """A zero-length ``data_interval`` (``start == end``) on the previous run must not
     cause ``next_dagrun_info`` to re-emit that run's logical_date. These appear when a
-    DAG was scheduled by ``CronTriggerTimetable`` and later switched to
+    Dag was scheduled by ``CronTriggerTimetable`` and later switched to
     ``CronDataIntervalTimetable``; without the guard the scheduler loops on "run
     already exists; skipping dagrun creation". The guard's single retry always
     resolves this for ``CronDataIntervalTimetable``.

--- a/airflow-core/tests/unit/timetables/test_interval_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_interval_timetable.py
@@ -196,7 +196,7 @@ def test_guard_raises_when_one_retry_is_not_enough() -> None:
     step = datetime.timedelta(minutes=2)
 
     timetable = _FixedStepTimetable(align_point=align_point, step=step)
-    with pytest.raises(AssertionError, match="did not advance past"):
+    with pytest.raises(ValueError, match="did not advance past"):
         timetable.next_dagrun_info(
             last_automated_data_interval=last,
             restriction=TimeRestriction(earliest=None, latest=None, catchup=True),


### PR DESCRIPTION
- closes: https://github.com/apache/airflow/issues/66754
- related: https://github.com/apache/airflow/pull/66132 -- is actual the same root case, but the previous patch only solved the `CronTriggerTimetable` to `CronDataIntervalTimetable` case, it didn't solved the hourly to daily case.
- suppress: #66754

## Why

Switching a Dag to a coarser cron (hourly to daily, for example) can make the realigned next run collide with the logical_date already on record, so the scheduler loops on "run already exists; skipping dagrun creation" forever instead of advancing.

## How: from a narrow zero-length check to a general regression check

The old guard only fired for one specific shape:

```python
if (
    last_automated_data_interval.start == last_automated_data_interval.end  # last run is a *point*
    and start == last_automated_data_interval.start                         # realignment reproduces it
):
    start = self._get_next(start)
```

That only covers a `CronTriggerTimetable` -> `CronDataIntervalTimetable` switch, where the run already on record is a zero-length point (`start == end`) and the realigned `start` lands back on that exact point.

A coarser-cron switch doesn't have that shape at all: the run on record is a normal, non-zero-length interval (e.g. `[2026-05-04T00:00, 2026-05-04T01:00)` under the old hourly schedule). `last.start == last.end` is `False`, so the old condition never holds, and `next_dagrun_info` keeps returning the same colliding interval forever -- the guard was simply never reachable for this bug.

The fix drops the zero-length precondition and widens the comparison itself:

```python
if start <= last_automated_data_interval.start:
    start = self._get_next(start)
    if start <= last_automated_data_interval.start:
        raise AssertionError(...)
```

The `last.end` doesn't matter. The only thing that matters is whether the *realigned* `start` failed to advance past the *previous run's start*. This is a strict superset of the old trigger: whenever the old condition held (`last.start == last.end and start == last.start`), `start <= last.start` holds too, so nothing previously caught stops being caught. It now also catches the general case this PR fixes: `start` landing at or before `last.start` regardless of whether `last.end` happened to equal `last.start`.

One retry past the collision is provably enough for both shipped `_DataIntervalTimetable` subclasses (`CronDataIntervalTimetable`, `DeltaDataIntervalTimetable`): realigning `start` to the previous run's end and then stepping once always lands past the previous run's start, because no schedule instant can exist strictly between a run's `start` and `end`.

That invariant isn't enforced by the base class though, so a custom `Timetable` could break it -- the guard raises immediately if the single retry doesn't clear the collision.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code Sonnet 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
