### PR TITLE
Mask password-format Param values in conf, logs, and rendered templates

### DIFF
--- a/airflow-core/docs/core-concepts/params.rst
+++ b/airflow-core/docs/core-concepts/params.rst
@@ -251,6 +251,10 @@ The following features are supported in the Trigger UI Form:
               | input field accepting ISO 8601 duration
               | strings (e.g. ``P1D``, ``PT15M``, ``PT2H``)
             * ``format="multiline"``: Generate a multi-line textarea
+            * | ``format="password"``: Generate a masked input
+              | with a show/hide toggle. See
+              | :ref:`Masking Sensitive Param Values <params-masking>`
+              | for what this does and does not protect.
             * | ``enum=["a", "b", "c"]``: Generates a
               | drop-down select list for scalar values.
               | If the choices come from an external config file,
@@ -452,6 +456,50 @@ Finally the fourth section shows advanced form elements.
     By default custom HTML is not allowed to prevent injection of scripts or other malicious HTML code. The previous field named
     ``description_html`` is now super-seeded with the attribute ``description_md``. ``description_html`` is not supported anymore.
     Custom form elements using the attribute ``custom_html_form`` was deprecated in version 2.8.0 and support was removed in 3.0.0.
+
+.. _params-masking:
+
+Masking Sensitive Param Values
+-------------------------------
+
+.. versionadded:: 3.4.0
+
+If a ``string``-typed :class:`~airflow.sdk.definitions.param.Param` is declared with ``format="password"``,
+its value is masked wherever Airflow already masks sensitive values:
+
+.. code-block::
+
+    with DAG(
+        "the_dag",
+        params={
+            "api_token": Param(
+                default="",
+                type="string",
+                format="password",
+            ),
+        },
+    ):
+
+This is masked in:
+
+- The Trigger UI Form, as a password-style input with a show/hide toggle.
+- Task Logs, if the value is referenced in task code (e.g. via ``print()`` or ``logging``).
+- Rendered Templates, if the value is used in a templated field.
+- The DAG Run Details page and the REST API, wherever ``conf`` is returned (this includes
+  fetching, listing, triggering, patching, and clearing DagRuns).
+
+This is **not** masked in:
+
+- XCom: if a task pushes the value to XCom, it will still appear in plain text wherever
+  XComs are displayed.
+- The metadata database: ``conf`` is stored as plain JSON. ``format="password"`` only
+  controls display-time masking, it does not encrypt the value at rest.
+
+.. note::
+    ``format="password"`` is intended for ad-hoc, trigger-time values (for example, a token
+    used to authorize a single manual run). For credentials that are reused across runs or
+    need to be stored securely, use :doc:`../authoring-and-scheduling/connections` or
+    :doc:`variables` instead.
 
 Disabling Runtime Param Modification
 ------------------------------------

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -129,6 +129,36 @@ dag_run_router = AirflowRouter(tags=["DagRun"], prefix="/dags/{dag_id}/dagRuns")
 dag_run_at_dag_router = AirflowRouter(tags=["DagRun"], prefix="/dags/{dag_id}")
 
 
+def _mask_password_conf(dag, conf: dict | None) -> dict | None:
+    """Redact conf values for keys whose declared Param uses schema format="password"."""
+    if not conf or dag is None:
+        return conf
+    params = getattr(dag, "params", None)
+    if not params:
+        return conf
+    masked = dict(conf)
+    for key in masked:
+        if key not in params:
+            continue
+        schema = params.get_param(key).schema
+        if schema.get("type") == "string" and schema.get("format") == "password":
+            masked[key] = "***"
+    return masked
+
+
+def _build_masked_dag_run_responses(dag_runs, dag_bag, session) -> list[DAGRunResponse]:
+    """Convert ORM DagRuns to DAGRunResponse, redacting password-format conf keys per-run."""
+    dag_cache: dict[str, object] = {}
+    responses = []
+    for dag_run in dag_runs:
+        response = DAGRunResponse.model_validate(dag_run)
+        if dag_run.dag_id not in dag_cache:
+            dag_cache[dag_run.dag_id] = get_dag_for_run(dag_bag, dag_run, session=session)
+        response.conf = _mask_password_conf(dag_cache[dag_run.dag_id], response.conf)
+        responses.append(response)
+    return responses
+
+
 @dag_run_router.get(
     "/{dag_run_id}",
     responses=create_openapi_http_exception_doc(
@@ -138,7 +168,7 @@ dag_run_at_dag_router = AirflowRouter(tags=["DagRun"], prefix="/dags/{dag_id}")
     ),
     dependencies=[Depends(requires_access_dag(method="GET", access_entity=DagAccessEntity.RUN))],
 )
-def get_dag_run(dag_id: str, dag_run_id: str, session: SessionDep) -> DAGRunResponse:
+def get_dag_run(dag_id: str, dag_run_id: str, session: SessionDep, dag_bag: DagBagDep) -> DAGRunResponse:
     dag_run = session.scalar(
         select(DagRun)
         .filter_by(dag_id=dag_id, run_id=dag_run_id)
@@ -149,7 +179,10 @@ def get_dag_run(dag_id: str, dag_run_id: str, session: SessionDep) -> DAGRunResp
             status.HTTP_404_NOT_FOUND,
             f"The DagRun with dag_id: `{dag_id}` and run_id: `{dag_run_id}` was not found",
         )
-    return dag_run
+    response = DAGRunResponse.model_validate(dag_run)
+    dag = get_dag_for_run(dag_bag, dag_run, session=session)
+    response.conf = _mask_password_conf(dag, response.conf)
+    return response
 
 
 @dag_run_router.delete(
@@ -716,7 +749,7 @@ def get_dag_runs(
             statement=query, filters=filters, session=session
         )
         return DAGRunCollectionResponse(
-            dag_runs=dag_runs,
+            dag_runs=_build_masked_dag_run_responses(dag_runs, dag_bag, session),
             total_entries=total_entries,
             total_entries_limit=total_entries_limit,
             next_cursor=(encode_cursor(dag_runs[-1], order_by) if has_next and dag_runs else None),
@@ -737,7 +770,7 @@ def get_dag_runs(
     attach_dag_versions_to_runs(dag_runs, session=session)
 
     return DAGRunCollectionResponse(
-        dag_runs=dag_runs,
+        dag_runs=_build_masked_dag_run_responses(dag_runs, dag_bag, session),
         total_entries=total_entries,
     )
 
@@ -926,6 +959,7 @@ def get_list_dag_runs_batch(
     body: DAGRunsBatchBody,
     readable_dag_runs_filter: ReadableDagRunsFilterDep,
     session: SessionDep,
+    dag_bag: DagBagDep,
 ) -> DAGRunCollectionResponse:
     """Get a list of Dag Runs."""
     dag_ids = FilterParam(DagRun.dag_id, body.dag_ids, FilterOptionEnum.IN)  # type: ignore[arg-type]
@@ -1022,6 +1056,6 @@ def get_list_dag_runs_batch(
     attach_dag_versions_to_runs(dag_runs, session=session)
 
     return DAGRunCollectionResponse(
-        dag_runs=dag_runs,
+        dag_runs=_build_masked_dag_run_responses(dag_runs, dag_bag, session),
         total_entries=total_entries,
     )

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -380,7 +380,7 @@ def clear_dag_run(
             total_entries=len(task_instances),
         )
 
-    return perform_clear_dag_run(
+    cleared_dag_run = perform_clear_dag_run(
         session=session,
         dag=dag,
         dag_run=dag_run,
@@ -391,6 +391,9 @@ def clear_dag_run(
         note=body.note,
         user=user,
     )
+    response = DAGRunResponse.model_validate(cleared_dag_run)
+    response.conf = _mask_password_conf(dag, response.conf)
+    return response
 
 
 @dag_run_at_dag_router.post(

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -147,14 +147,19 @@ def _mask_password_conf(dag, conf: dict | None) -> dict | None:
 
 
 def _build_masked_dag_run_responses(dag_runs, dag_bag, session) -> list[DAGRunResponse]:
-    """Convert ORM DagRuns to DAGRunResponse, redacting password-format conf keys per-run."""
-    dag_cache: dict[str, object] = {}
+    """
+    Convert ORM DagRuns to DAGRunResponse, redacting password-format conf keys per-run.
+
+    Deliberately does not cache DAGs by dag_id: two DagRuns can share a dag_id but resolve to
+    different Dag versions (get_dag_for_run keys off dag_run.created_dag_version_id), and a param's
+    format="password" declaration can differ between versions. dag_bag itself already caches by
+    dag_version_id internally, so this stays cheap without an extra, incorrect layer on top.
+    """
     responses = []
     for dag_run in dag_runs:
         response = DAGRunResponse.model_validate(dag_run)
-        if dag_run.dag_id not in dag_cache:
-            dag_cache[dag_run.dag_id] = get_dag_for_run(dag_bag, dag_run, session=session)
-        response.conf = _mask_password_conf(dag_cache[dag_run.dag_id], response.conf)
+        dag = get_dag_for_run(dag_bag, dag_run, session=session)
+        response.conf = _mask_password_conf(dag, response.conf)
         responses.append(response)
     return responses
 
@@ -280,7 +285,9 @@ def patch_dag_run(
     if not final_dag_run:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Dag run not found after update")
 
-    return final_dag_run
+    response = DAGRunResponse.model_validate(final_dag_run)
+    response.conf = _mask_password_conf(dag, response.conf)
+    return response
 
 
 @dag_run_router.patch(
@@ -489,7 +496,7 @@ def clear_dag_runs(
             )
         )
     return DAGRunCollectionResponse(
-        dag_runs=cleared_runs,
+        dag_runs=_build_masked_dag_run_responses(cleared_runs, dag_bag, session),
         total_entries=len(cleared_runs),
     )
 
@@ -867,7 +874,9 @@ def trigger_dag_run(
         if dag_run_note:
             current_user_id = user.get_id()
             dag_run.note = (dag_run_note, current_user_id)
-        return dag_run
+        response = DAGRunResponse.model_validate(dag_run)
+        response.conf = _mask_password_conf(context_dag, response.conf)
+        return response
 
     except (ParamValidationError, ValueError) as e:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, str(e)) from e

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -408,6 +408,75 @@ class TestGetDagRun:
         assert response.status_code == 403
 
 
+class TestGetDagRunMasksPasswordConf:
+    def test_masks_conf_value_for_password_format_param(self, test_client, dag_maker, session):
+        with dag_maker(
+            "test_dag_password_param",
+            schedule=None,
+            start_date=START_DATE1,
+            params={"api_token": Param("default", type="string", format="password")},
+            serialized=True,
+        ):
+            EmptyOperator(task_id="task_1")
+
+        dag_run = dag_maker.create_dagrun(
+            run_id="run_with_secret",
+            state=DagRunState.SUCCESS,
+            run_type=DagRunType.MANUAL,
+            triggered_by=DagRunTriggeredByType.UI,
+            logical_date=LOGICAL_DATE1,
+        )
+        dag_run.conf = {"api_token": "super-secret-value", "note": "not-a-secret"}
+        session.merge(dag_run)
+        session.commit()
+
+        response = test_client.get("/dags/test_dag_password_param/dagRuns/run_with_secret")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["conf"]["api_token"] == "***"
+        assert body["conf"]["note"] == "not-a-secret"
+
+    def test_does_not_mask_conf_without_declared_password_param(self, test_client):
+        # DAG2_ID's params (DAG2_PARAM) declare no password-format param, so conf stays as-is.
+        response = test_client.get(f"/dags/{DAG2_ID}/dagRuns/{DAG2_RUN1_ID}")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["conf"] == {"env": "staging", "test_mode": True}
+
+
+class TestGetDagRunsMasksPasswordConf:
+    def test_list_across_all_dags_masks_only_relevant_runs(self, test_client, dag_maker, session):
+        with dag_maker(
+            "test_dag_password_param_list",
+            schedule=None,
+            start_date=START_DATE1,
+            params={"api_token": Param("default", type="string", format="password")},
+            serialized=True,
+        ):
+            EmptyOperator(task_id="task_1")
+
+        dag_run = dag_maker.create_dagrun(
+            run_id="run_with_secret_list",
+            state=DagRunState.SUCCESS,
+            run_type=DagRunType.MANUAL,
+            triggered_by=DagRunTriggeredByType.UI,
+            logical_date=LOGICAL_DATE1,
+        )
+        dag_run.conf = {"api_token": "super-secret-value"}
+        session.merge(dag_run)
+        session.commit()
+
+        response = test_client.get(
+            "/dags/~/dagRuns", params={"dag_ids": ["test_dag_password_param_list", DAG2_ID]}
+        )
+        assert response.status_code == 200
+        by_run_id = {run["dag_run_id"]: run for run in response.json()["dag_runs"]}
+
+        assert by_run_id["run_with_secret_list"]["conf"]["api_token"] == "***"
+        # DAG2's runs declare no password-format param, must stay untouched
+        assert by_run_id[DAG2_RUN1_ID]["conf"] == {"env": "staging", "test_mode": True}
+
+
 class TestGetDagRuns:
     @pytest.mark.parametrize(
         ("dag_id", "total_entries"),

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -408,6 +408,134 @@ class TestGetDagRun:
         assert response.status_code == 403
 
 
+class TestGetDagRunsMasksPasswordConfAcrossVersions:
+    def test_list_masks_only_the_version_that_declares_password(self, test_client, dag_maker, session):
+        from airflow.models.dag_version import DagVersion
+
+        # Version 1 of the Dag: api_token is a plain string param (not masked).
+        with dag_maker(
+            "test_dag_password_versioned",
+            schedule=None,
+            start_date=START_DATE1,
+            params={"api_token": Param("default", type="string")},
+            serialized=True,
+        ):
+            EmptyOperator(task_id="task_1")
+
+        version_1 = session.scalar(
+            select(DagVersion)
+            .where(DagVersion.dag_id == "test_dag_password_versioned")
+            .order_by(DagVersion.version_number.desc())
+        )
+
+        run_v1 = dag_maker.create_dagrun(
+            run_id="run_v1_not_password",
+            state=DagRunState.SUCCESS,
+            run_type=DagRunType.MANUAL,
+            triggered_by=DagRunTriggeredByType.UI,
+            logical_date=LOGICAL_DATE1,
+        )
+        run_v1.conf = {"api_token": "not-actually-a-secret"}
+        # dag_maker doesn't set bundle_version by default, and DBDagBag._version_from_dag_run
+        # falls back to the *latest* Dag version whenever bundle_version is falsy, regardless of
+        # created_dag_version_id. Pin both explicitly so this run actually resolves to version 1,
+        # which is the exact behavior this test needs to exercise.
+        run_v1.created_dag_version_id = version_1.id
+        run_v1.bundle_version = "test-bundle-v1"
+        session.merge(run_v1)
+        session.commit()
+
+        # Version 2 of the SAME dag_id: api_token is now declared format="password".
+        # Re-entering dag_maker with a different params schema produces a new DagVersion.
+        with dag_maker(
+            "test_dag_password_versioned",
+            schedule=None,
+            start_date=START_DATE1,
+            params={"api_token": Param("default", type="string", format="password")},
+            serialized=True,
+        ):
+            EmptyOperator(task_id="task_1")
+
+        version_2 = session.scalar(
+            select(DagVersion)
+            .where(DagVersion.dag_id == "test_dag_password_versioned")
+            .order_by(DagVersion.version_number.desc())
+        )
+        assert version_2.id != version_1.id, "expected a new Dag version to have been created"
+
+        run_v2 = dag_maker.create_dagrun(
+            run_id="run_v2_is_password",
+            state=DagRunState.SUCCESS,
+            run_type=DagRunType.MANUAL,
+            triggered_by=DagRunTriggeredByType.UI,
+            logical_date=LOGICAL_DATE2,
+        )
+        run_v2.conf = {"api_token": "super-secret-v2"}
+        run_v2.created_dag_version_id = version_2.id
+        run_v2.bundle_version = "test-bundle-v2"
+        session.merge(run_v2)
+        session.commit()
+
+        response = test_client.get("/dags/~/dagRuns", params={"dag_ids": ["test_dag_password_versioned"]})
+        assert response.status_code == 200
+        by_run_id = {run["dag_run_id"]: run for run in response.json()["dag_runs"]}
+
+        # v1's run must stay unmasked: its Dag version never declared format="password".
+        assert by_run_id["run_v1_not_password"]["conf"]["api_token"] == "not-actually-a-secret"
+        # v2's run must be masked: its Dag version does declare format="password".
+        assert by_run_id["run_v2_is_password"]["conf"]["api_token"] == "***"
+
+
+class TestTriggerDagRunMasksPasswordConf:
+    def test_trigger_response_masks_password_conf(self, test_client, dag_maker):
+        with dag_maker(
+            "test_dag_password_trigger",
+            schedule=None,
+            start_date=START_DATE1,
+            params={"api_token": Param("default", type="string", format="password")},
+            serialized=True,
+        ):
+            EmptyOperator(task_id="task_1")
+
+        now = timezone.utcnow().isoformat()
+        response = test_client.post(
+            "/dags/test_dag_password_trigger/dagRuns",
+            json={"conf": {"api_token": "super-secret-value"}, "logical_date": now},
+        )
+        assert response.status_code == 200
+        assert response.json()["conf"]["api_token"] == "***"
+
+
+class TestPatchDagRunMasksPasswordConf:
+    def test_patch_response_masks_password_conf(self, test_client, dag_maker, session):
+        with dag_maker(
+            "test_dag_password_patch",
+            schedule=None,
+            start_date=START_DATE1,
+            params={"api_token": Param("default", type="string", format="password")},
+            serialized=True,
+        ):
+            EmptyOperator(task_id="task_1")
+
+        dag_run = dag_maker.create_dagrun(
+            run_id="run_patch_secret",
+            state=DagRunState.QUEUED,
+            run_type=DagRunType.MANUAL,
+            triggered_by=DagRunTriggeredByType.UI,
+            logical_date=LOGICAL_DATE1,
+        )
+        dag_run.conf = {"api_token": "super-secret-value"}
+        session.merge(dag_run)
+        session.commit()
+
+        response = test_client.patch(
+            "/dags/test_dag_password_patch/dagRuns/run_patch_secret",
+            json={"note": "updated note"},
+        )
+        assert response.status_code == 200
+        assert response.json()["conf"]["api_token"] == "***"
+
+
 class TestGetDagRunMasksPasswordConf:
     def test_masks_conf_value_for_password_format_param(self, test_client, dag_maker, session):
         with dag_maker(
@@ -578,7 +706,11 @@ class TestGetDagRuns:
     def test_return_correct_results_with_order_by(self, test_client, order_by, expected_order):
         # Test ascending order
 
-        with assert_queries_count(7):
+        # +2 vs. the pre-masking baseline: one query to resolve the Dag version for these runs and
+        # one to fetch/cache the serialized Dag, needed to check each run's Param schema for
+        # format="password" conf keys to redact. Both rows share one Dag/version here, so the cost
+        # is paid once, not per-row (see DBDagBag's per-version cache in models/dagbag.py).
+        with assert_queries_count(9):
             response = test_client.get("/dags/test_dag1/dagRuns", params={"order_by": order_by})
 
         assert response.status_code == 200
@@ -1303,7 +1435,9 @@ class TestGetDagRuns:
 class TestListDagRunsBatch:
     @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
     def test_list_dag_runs_return_200(self, test_client, session):
-        with assert_queries_count(5):
+        # +6 vs. the pre-masking baseline: this page spans multiple distinct dag_ids/versions, each
+        # needing its own Dag-version resolve+fetch to check for format="password" conf keys.
+        with assert_queries_count(11):
             response = test_client.post("/dags/~/dagRuns/list", json={})
         assert response.status_code == 200
         body = response.json()
@@ -1345,7 +1479,11 @@ class TestListDagRunsBatch:
     )
     @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
     def test_list_dag_runs_with_dag_ids_filter(self, test_client, dag_ids, status_code, expected_dag_id_list):
-        with assert_queries_count(5):
+        # Upper bound covers all three parametrized cases: filtering to one dag_id costs less
+        # (8, fewer distinct Dag versions to resolve for conf masking) than no filter (11, all
+        # dags in play); assert_queries_count only checks an upper bound, so one number with
+        # margin is enough rather than a per-case expectation.
+        with assert_queries_count(8, margin=3):
             response = test_client.post("/dags/~/dagRuns/list", json={"dag_ids": dag_ids})
         assert response.status_code == status_code
         assert set([each["dag_run_id"] for each in response.json()["dag_runs"]]) == set(expected_dag_id_list)

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -408,6 +408,38 @@ class TestGetDagRun:
         assert response.status_code == 403
 
 
+class TestClearDagRunMasksPasswordConf:
+    def test_single_run_clear_response_masks_password_conf(self, test_client, dag_maker, session):
+        with dag_maker(
+            "test_dag_password_clear",
+            schedule=None,
+            start_date=START_DATE1,
+            params={"api_token": Param("default", type="string", format="password")},
+            serialized=True,
+        ):
+            EmptyOperator(task_id="task_1")
+
+        dag_run = dag_maker.create_dagrun(
+            run_id="run_clear_secret",
+            state=DagRunState.SUCCESS,
+            run_type=DagRunType.MANUAL,
+            triggered_by=DagRunTriggeredByType.UI,
+            logical_date=LOGICAL_DATE1,
+        )
+        dag_run.conf = {"api_token": "super-secret-value"}
+        session.merge(dag_run)
+        session.commit()
+
+        # dry_run=False so the response comes from perform_clear_dag_run(), not the dry-run
+        # ClearTaskInstanceCollectionResponse branch.
+        response = test_client.post(
+            "/dags/test_dag_password_clear/dagRuns/run_clear_secret/clear",
+            json={"dry_run": False},
+        )
+        assert response.status_code == 200
+        assert response.json()["conf"]["api_token"] == "***"
+
+
 class TestGetDagRunsMasksPasswordConfAcrossVersions:
     def test_list_masks_only_the_version_that_declares_password(self, test_client, dag_maker, session):
         from airflow.models.dag_version import DagVersion

--- a/task-sdk/src/airflow/sdk/definitions/param.py
+++ b/task-sdk/src/airflow/sdk/definitions/param.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal
 from airflow.sdk.definitions._internal.mixins import ResolveMixin
 from airflow.sdk.definitions._internal.types import NOTSET, is_arg_set
 from airflow.sdk.exceptions import ParamValidationError
+from airflow.sdk.log import mask_secret
 
 if TYPE_CHECKING:
     from airflow.sdk.definitions.context import Context
@@ -384,4 +385,20 @@ def process_params(
     if conf.getboolean("core", "dag_run_conf_overrides_params") and dagrun_conf:
         logger.debug("Updating task params (%s) with DagRun.conf (%s)", params, dagrun_conf)
         params.update(dagrun_conf)
-    return params.validate()
+
+    resolved_params = params.validate()
+    _mask_password_params(params, resolved_params)
+    return resolved_params
+
+
+def _mask_password_params(params: ParamsDict, resolved: dict[str, Any]) -> None:
+    """Register string params declared with schema format="password" as secrets."""
+    for key, value in resolved.items():
+        if not isinstance(value, str):
+            continue
+        try:
+            param_schema = params.get_param(key).schema
+        except KeyError:
+            continue
+        if param_schema.get("type") == "string" and param_schema.get("format") == "password":
+            mask_secret(value)

--- a/task-sdk/src/airflow/sdk/definitions/param.py
+++ b/task-sdk/src/airflow/sdk/definitions/param.py
@@ -383,17 +383,22 @@ def process_params(
     if task.params:
         params.update(task.params)
     if conf.getboolean("core", "dag_run_conf_overrides_params") and dagrun_conf:
+        # Mask before logging: dag.params/task.params are already merged into `params` at this
+        # point, so the declared format="password" schema for a key is available here even though
+        # dagrun_conf hasn't been merged in yet. Registering first ensures the debug log below is
+        # redacted by the SecretsMasker logging filter rather than emitting the raw value.
+        _mask_password_values(params, dagrun_conf)
         logger.debug("Updating task params (%s) with DagRun.conf (%s)", params, dagrun_conf)
         params.update(dagrun_conf)
 
     resolved_params = params.validate()
-    _mask_password_params(params, resolved_params)
+    _mask_password_values(params, resolved_params)
     return resolved_params
 
 
-def _mask_password_params(params: ParamsDict, resolved: dict[str, Any]) -> None:
-    """Register string params declared with schema format="password" as secrets."""
-    for key, value in resolved.items():
+def _mask_password_values(params: ParamsDict, values: dict[str, Any]) -> None:
+    """Register string values declared with schema format="password" as secrets."""
+    for key, value in values.items():
         if not isinstance(value, str):
             continue
         try:

--- a/task-sdk/src/airflow/sdk/definitions/param.py
+++ b/task-sdk/src/airflow/sdk/definitions/param.py
@@ -382,12 +382,19 @@ def process_params(
         params.update(dag.params)
     if task.params:
         params.update(task.params)
-    if conf.getboolean("core", "dag_run_conf_overrides_params") and dagrun_conf:
-        # Mask before logging: dag.params/task.params are already merged into `params` at this
-        # point, so the declared format="password" schema for a key is available here even though
-        # dagrun_conf hasn't been merged in yet. Registering first ensures the debug log below is
-        # redacted by the SecretsMasker logging filter rather than emitting the raw value.
+
+    if dagrun_conf:
+        # Mask dagrun_conf's password-format values unconditionally, regardless of
+        # dag_run_conf_overrides_params: dag_run.conf remains accessible to task code and
+        # templates via context["dag_run"].conf even when this setting is False, so those values
+        # need to be registered with the masker either way, not only when merged into task params.
         _mask_password_values(params, dagrun_conf)
+
+    if conf.getboolean("core", "dag_run_conf_overrides_params") and dagrun_conf:
+        # Mask params' own current values before logging params below: dag.params/task.params
+        # may carry a password-format default that was never overridden by dagrun_conf, and that
+        # default would otherwise be logged raw here before the final masking call after validate().
+        _mask_password_values(params, params.dump())
         logger.debug("Updating task params (%s) with DagRun.conf (%s)", params, dagrun_conf)
         params.update(dagrun_conf)
 

--- a/task-sdk/tests/task_sdk/definitions/test_param.py
+++ b/task-sdk/tests/task_sdk/definitions/test_param.py
@@ -410,7 +410,11 @@ class TestProcessParamsMasksPassword:
         resolved = process_params(dag, task, {"api_token": "super-secret-value"}, suppress_exception=False)
 
         assert resolved["api_token"] == "super-secret-value"
-        mock_mask_secret.assert_called_once_with("super-secret-value")
+        # Called twice for the same value: once against dagrun_conf before the debug log line,
+        # once against the final resolved_params after validate(). Both calls register the same
+        # string with the masker, which is harmless (SecretsMasker patterns are a set, not a list).
+        assert mock_mask_secret.call_count == 2
+        mock_mask_secret.assert_called_with("super-secret-value")
 
     @patch("airflow.sdk.definitions.param.mask_secret")
     def test_does_not_mask_plain_string_param(self, mock_mask_secret):
@@ -443,3 +447,25 @@ class TestProcessParamsMasksPassword:
 
         assert resolved["undeclared_key"] == "value"
         mock_mask_secret.assert_not_called()
+
+    @patch("airflow.sdk.definitions.param.logger")
+    @patch("airflow.sdk.definitions.param.mask_secret")
+    def test_masks_dagrun_conf_value_before_debug_log(self, mock_mask_secret, mock_logger):
+        # Regression test: dag_run_conf_overrides_params=True (the default) logs dagrun_conf via
+        # logger.debug(). mask_secret() must be called before that log line, not after, or the
+        # SecretsMasker filter won't yet know to redact the value from the emitted log record.
+        manager = MagicMock()
+        manager.attach_mock(mock_mask_secret, "mask_secret")
+        manager.attach_mock(mock_logger.debug, "debug")
+
+        dag = self._make_dag({"api_token": Param("default", type="string", format="password")})
+        task = self._make_task()
+
+        process_params(dag, task, {"api_token": "super-secret-value"}, suppress_exception=False)
+
+        call_names = [call[0] for call in manager.mock_calls]
+        assert "mask_secret" in call_names
+        assert "debug" in call_names
+        assert call_names.index("mask_secret") < call_names.index("debug"), (
+            "mask_secret must be registered before the debug log referencing dagrun_conf"
+        )

--- a/task-sdk/tests/task_sdk/definitions/test_param.py
+++ b/task-sdk/tests/task_sdk/definitions/test_param.py
@@ -18,10 +18,11 @@ from __future__ import annotations
 
 from contextlib import nullcontext
 from typing import Literal
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from airflow.sdk.definitions.param import Param, ParamsDict
+from airflow.sdk.definitions.param import Param, ParamsDict, process_params
 from airflow.sdk.exceptions import ParamValidationError
 from airflow.serialization.definitions.param import SerializedParam
 from airflow.serialization.serialized_objects import BaseSerialization
@@ -388,3 +389,57 @@ class TestParamsDict:
                 "key2": Param("value", source="task"),
             }
         )
+
+
+class TestProcessParamsMasksPassword:
+    def _make_dag(self, params: dict) -> MagicMock:
+        dag = MagicMock()
+        dag.params = ParamsDict(params)
+        return dag
+
+    def _make_task(self) -> MagicMock:
+        task = MagicMock()
+        task.params = None
+        return task
+
+    @patch("airflow.sdk.definitions.param.mask_secret")
+    def test_masks_string_param_declared_as_password(self, mock_mask_secret):
+        dag = self._make_dag({"api_token": Param("default", type="string", format="password")})
+        task = self._make_task()
+
+        resolved = process_params(dag, task, {"api_token": "super-secret-value"}, suppress_exception=False)
+
+        assert resolved["api_token"] == "super-secret-value"
+        mock_mask_secret.assert_called_once_with("super-secret-value")
+
+    @patch("airflow.sdk.definitions.param.mask_secret")
+    def test_does_not_mask_plain_string_param(self, mock_mask_secret):
+        dag = self._make_dag({"greeting": Param("default", type="string")})
+        task = self._make_task()
+
+        resolved = process_params(dag, task, {"greeting": "hello"}, suppress_exception=False)
+
+        assert resolved["greeting"] == "hello"
+        mock_mask_secret.assert_not_called()
+
+    @patch("airflow.sdk.definitions.param.mask_secret")
+    def test_ignores_non_string_password_format_param(self, mock_mask_secret):
+        # format="password" on a non-string type is not a supported combination;
+        # it must not crash and must not attempt to mask a non-string value.
+        dag = self._make_dag({"retry_count": Param(3, type="integer", format="password")})
+        task = self._make_task()
+
+        resolved = process_params(dag, task, {"retry_count": 5}, suppress_exception=False)
+
+        assert resolved["retry_count"] == 5
+        mock_mask_secret.assert_not_called()
+
+    @patch("airflow.sdk.definitions.param.mask_secret")
+    def test_does_not_mask_when_key_has_no_declared_param(self, mock_mask_secret):
+        dag = self._make_dag({})
+        task = self._make_task()
+
+        resolved = process_params(dag, task, {"undeclared_key": "value"}, suppress_exception=False)
+
+        assert resolved["undeclared_key"] == "value"
+        mock_mask_secret.assert_not_called()

--- a/task-sdk/tests/task_sdk/definitions/test_param.py
+++ b/task-sdk/tests/task_sdk/definitions/test_param.py
@@ -27,6 +27,8 @@ from airflow.sdk.exceptions import ParamValidationError
 from airflow.serialization.definitions.param import SerializedParam
 from airflow.serialization.serialized_objects import BaseSerialization
 
+from tests_common.test_utils.config import conf_vars
+
 
 class TestParam:
     def test_param_without_schema(self):
@@ -410,10 +412,14 @@ class TestProcessParamsMasksPassword:
         resolved = process_params(dag, task, {"api_token": "super-secret-value"}, suppress_exception=False)
 
         assert resolved["api_token"] == "super-secret-value"
-        # Called twice for the same value: once against dagrun_conf before the debug log line,
-        # once against the final resolved_params after validate(). Both calls register the same
-        # string with the masker, which is harmless (SecretsMasker patterns are a set, not a list).
-        assert mock_mask_secret.call_count == 2
+        # Three calls: (1) dagrun_conf's raw value, masked unconditionally before any merge;
+        # (2) params.dump()'s current value before the debug log line, which at that point is
+        # still the stale unresolved default ("default"), since this runs before
+        # params.update(dagrun_conf); (3) the final resolved_params value after validate(). All
+        # three are harmless to register even where they coincide or cover a placeholder default,
+        # SecretsMasker patterns are a set, not a list.
+        assert mock_mask_secret.call_count == 3
+        mock_mask_secret.assert_any_call("default")
         mock_mask_secret.assert_called_with("super-secret-value")
 
     @patch("airflow.sdk.definitions.param.mask_secret")
@@ -469,3 +475,54 @@ class TestProcessParamsMasksPassword:
         assert call_names.index("mask_secret") < call_names.index("debug"), (
             "mask_secret must be registered before the debug log referencing dagrun_conf"
         )
+
+    @patch("airflow.sdk.definitions.param.logger")
+    @patch("airflow.sdk.definitions.param.mask_secret")
+    def test_masks_password_default_before_debug_log(self, mock_mask_secret, mock_logger):
+        # Regression test: a password-format param's *default* value (never overridden by
+        # dagrun_conf) must also be registered before the debug log line, since that log line
+        # renders `params` itself, not just `dagrun_conf`. Masking only dagrun_conf's values
+        # would miss this default entirely.
+        manager = MagicMock()
+        manager.attach_mock(mock_mask_secret, "mask_secret")
+        manager.attach_mock(mock_logger.debug, "debug")
+
+        dag = self._make_dag({"api_token": Param("default-secret-value", type="string", format="password")})
+        task = self._make_task()
+
+        # dagrun_conf touches an unrelated key only; api_token keeps its default.
+        process_params(dag, task, {"unrelated_key": "not-a-secret"}, suppress_exception=False)
+
+        call_names_and_args = [
+            (call[0], call.args) for call in manager.mock_calls if call[0] == "mask_secret"
+        ]
+        assert any(args and args[0] == "default-secret-value" for _, args in call_names_and_args), (
+            "the password param's default value must be registered with mask_secret before "
+            "the debug log line, not just values coming from dagrun_conf"
+        )
+        debug_call_index = [call[0] for call in manager.mock_calls].index("debug")
+        default_mask_index = next(
+            i
+            for i, call in enumerate(manager.mock_calls)
+            if call[0] == "mask_secret" and call.args and call.args[0] == "default-secret-value"
+        )
+        assert default_mask_index < debug_call_index, (
+            "the default value must be masked before the debug log, not after"
+        )
+
+    @conf_vars({("core", "dag_run_conf_overrides_params"): "False"})
+    @patch("airflow.sdk.definitions.param.mask_secret")
+    def test_masks_dagrun_conf_even_when_overrides_params_disabled(self, mock_mask_secret):
+        # Regression test: dag_run.conf remains readable from task code/templates via
+        # context["dag_run"].conf regardless of dag_run_conf_overrides_params, so a password-format
+        # value in dagrun_conf must be masked even when this setting is False and dagrun_conf never
+        # gets merged into task params at all.
+        dag = self._make_dag({"api_token": Param("default", type="string", format="password")})
+        task = self._make_task()
+
+        resolved = process_params(dag, task, {"api_token": "super-secret-value"}, suppress_exception=False)
+
+        # With the override disabled, the task's resolved params keep the default, not the conf
+        # value, but the conf value itself must still have been registered with the masker.
+        assert resolved["api_token"] == "default"
+        mock_mask_secret.assert_any_call("super-secret-value")


### PR DESCRIPTION
Adds `format="password"` as a supported JSON Schema keyword for `Param`, and closes the loop on where that value ends up plaintext today.

The trigger-form input side of this already worked (`FieldPassword.tsx` already masks the input whenever `schema.format == "password"`), but nothing downstream of that respected the declaration. This PR:

- Registers password-format param values with `mask_secret()` in `process_params()` (task-sdk), so they're redacted in **Task Logs** and **Rendered Templates**. Verified this in source: `_serialize_rendered_fields()` in `task-sdk/src/airflow/sdk/execution_time/task_runner.py` calls `redact()` against the same masker singleton, in the worker, before rendered fields are sent to the API server.
- Redacts `conf` in the **DAG Run Details page and REST API**: a helper checks each top-level `conf` key against its DAG's declared `Param` schema and replaces the value with `***` when `format == "password"`. Applied to `get_dag_run`, both pagination branches of `get_dag_runs` (including the `dag_id="~"` all-DAGs case, resolved per-run against that run's own DAG), and `get_list_dag_runs_batch`.

**Deliberately out of scope for this PR** (discussed on the issue):
- XCom display a value pushed to XCom isn't touched by any of the above, since neither the XCom model nor its API routes run values through `redact()`. This is the same known limitation that already applies to `Connection.password` today (confirmed: `_mask_connection_secrets()` masks it "from logs" per its own docstring, nothing else).
- Fernet encryption of `conf` at rest in the metadata DB is flagged as a separate, larger discussion rather than folded into this fix.
- Nested object schemas with their own `format` on a sub-property `format="password"` is only honored on string-typed params for now.

Docs for `format="password"` in `core-concepts/params.rst` will follow in a follow-up commit on this PR (or a fast-follow), explicitly stating what's covered and what isn't so nobody assumes broader coverage than what's implemented.

Closes: #72377

---
##### Was generative AI tooling used to co-author this PR?
- [X] Yes (please specify the tool below)

Generated-by: Claude (Anthropic) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
