### PR TITLE
Add rerank support to Cohere provider

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1446,6 +1446,8 @@ requeue
 requeued
 requeues
 requeuing
+rerank
+reranking
 reserialize
 Reserializing
 resetdb

--- a/providers/cohere/docs/index.rst
+++ b/providers/cohere/docs/index.rst
@@ -19,16 +19,18 @@
 ``apache-airflow-providers-cohere``
 ======================================
 
-The ``cohere`` provider gives Dags direct access to Cohere's own Embed API — this page
+The ``cohere`` provider gives Dags direct access to Cohere's Embed and Rerank APIs — this page
 compares that choice against ``common.ai``.
 
 When to use this provider
 --------------------------
 
-Use ``cohere`` when a Dag needs Cohere's native embedding models specifically:
+Use ``cohere`` when a Dag needs Cohere's native embedding or reranking models:
 
 * ``CohereEmbeddingOperator`` — call Cohere's
   `Embed API <https://docs.cohere.com/docs/embeddings>`__ directly via ``CohereHook``.
+* ``CohereRerankOperator`` — reorder documents with Cohere's
+  `Rerank API <https://docs.cohere.com/docs/rerank-overview>`__.
 
 Use :doc:`apache-airflow-providers-common-ai:index` instead when the embedding step should
 stay vendor-neutral:
@@ -53,6 +55,7 @@ stay vendor-neutral:
 
     Connection types <connections>
     Operators <operators/embedding>
+    Rerank operator <operators/rerank>
 
 .. toctree::
     :hidden:

--- a/providers/cohere/docs/operators/rerank.rst
+++ b/providers/cohere/docs/operators/rerank.rst
@@ -1,0 +1,69 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+.. _howto/operator:CohereRerankOperator:
+
+CohereRerankOperator
+====================
+
+Use :class:`~airflow.providers.cohere.operators.rerank.CohereRerankOperator` to reorder
+documents by their relevance to a query with Cohere's
+`Rerank API <https://docs.cohere.com/docs/rerank-overview>`__.
+
+Before you begin
+^^^^^^^^^^^^^^^^
+
+Configure a :ref:`Cohere connection <howto/connection:cohere>`. The operator uses the
+``cohere_default`` connection unless another ``conn_id`` is provided.
+
+The operator requires:
+
+* ``query``: The search query used to evaluate relevance.
+* ``documents``: A list of text documents to rank.
+
+The model is configured by the hook. Use ``top_n`` to limit the number of results and
+``max_tokens_per_doc`` to control how much of each document Cohere processes. The query,
+documents, and both limits are templated fields.
+
+Using the operator
+^^^^^^^^^^^^^^^^^^
+
+.. exampleinclude:: /../../cohere/tests/system/cohere/example_cohere_rerank_operator.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_cohere_rerank]
+    :end-before: [END howto_operator_cohere_rerank]
+
+Output
+^^^^^^
+
+The operator converts the Cohere response to an XCom-serializable dictionary. Its ``results``
+list is ordered from most to least relevant. Each result contains the original document's
+zero-based ``index`` and its ``relevance_score``. Use the index to associate a result with the
+corresponding item in the input ``documents`` list.
+
+An abbreviated response looks like this:
+
+.. code-block:: json
+
+    {
+      "id": "rerank-request-id",
+      "results": [
+        {"index": 1, "relevance_score": 0.99},
+        {"index": 0, "relevance_score": 0.12}
+      ]
+    }

--- a/providers/cohere/docs/operators/rerank.rst
+++ b/providers/cohere/docs/operators/rerank.rst
@@ -35,9 +35,11 @@ The operator requires:
 * ``query``: The search query used to evaluate relevance.
 * ``documents``: A list of text documents to rank.
 
-The model is configured by the hook. Use ``top_n`` to limit the number of results and
+The operator uses ``rerank-v3.5`` by default. Set ``model`` to use another Cohere model or
+an endpoint-specific deployment name. Use ``top_n`` to limit the number of results and
 ``max_tokens_per_doc`` to control how much of each document Cohere processes. The query,
-documents, and both limits are templated fields.
+documents, and both limits are templated fields; rendered limit values are converted to integers
+before they are sent to Cohere.
 
 Using the operator
 ^^^^^^^^^^^^^^^^^^

--- a/providers/cohere/provider.yaml
+++ b/providers/cohere/provider.yaml
@@ -62,6 +62,7 @@ integrations:
     external-doc-url: https://docs.cohere.com/docs
     how-to-guide:
       - /docs/apache-airflow-providers-cohere/operators/embedding.rst
+      - /docs/apache-airflow-providers-cohere/operators/rerank.rst
     tags: [software]
 
 hooks:
@@ -73,6 +74,7 @@ operators:
   - integration-name: Cohere
     python-modules:
       - airflow.providers.cohere.operators.embedding
+      - airflow.providers.cohere.operators.rerank
 
 connection-types:
   - hook-class-name: airflow.providers.cohere.hooks.cohere.CohereHook

--- a/providers/cohere/src/airflow/providers/cohere/get_provider_info.py
+++ b/providers/cohere/src/airflow/providers/cohere/get_provider_info.py
@@ -30,7 +30,10 @@ def get_provider_info():
             {
                 "integration-name": "Cohere",
                 "external-doc-url": "https://docs.cohere.com/docs",
-                "how-to-guide": ["/docs/apache-airflow-providers-cohere/operators/embedding.rst"],
+                "how-to-guide": [
+                    "/docs/apache-airflow-providers-cohere/operators/embedding.rst",
+                    "/docs/apache-airflow-providers-cohere/operators/rerank.rst",
+                ],
                 "tags": ["software"],
             }
         ],
@@ -38,7 +41,13 @@ def get_provider_info():
             {"integration-name": "Cohere", "python-modules": ["airflow.providers.cohere.hooks.cohere"]}
         ],
         "operators": [
-            {"integration-name": "Cohere", "python-modules": ["airflow.providers.cohere.operators.embedding"]}
+            {
+                "integration-name": "Cohere",
+                "python-modules": [
+                    "airflow.providers.cohere.operators.embedding",
+                    "airflow.providers.cohere.operators.rerank",
+                ],
+            }
         ],
         "connection-types": [
             {

--- a/providers/cohere/src/airflow/providers/cohere/hooks/cohere.py
+++ b/providers/cohere/src/airflow/providers/cohere/hooks/cohere.py
@@ -110,6 +110,25 @@ class CohereHook(BaseHook):
             raise ValueError("Embeddings response is missing float_ field")
         return response.embeddings.float_
 
+    def rerank(
+        self,
+        *,
+        query: str,
+        documents: list[str],
+        model: str = "Cohere-rerank-v4.0-pro",
+        top_n: int | None = None,
+        max_tokens_per_doc: int | None = None,
+    ) -> dict[str, Any]:
+        response = self.get_conn().rerank(
+            query=query,
+            documents=documents,
+            model=model,
+            top_n=top_n,
+            max_tokens_per_doc=max_tokens_per_doc,
+            request_options=self.request_options,
+        )
+        return response.model_dump(mode="json")
+
     @classmethod
     def get_ui_field_behaviour(cls) -> dict[str, Any]:
         return {

--- a/providers/cohere/src/airflow/providers/cohere/hooks/cohere.py
+++ b/providers/cohere/src/airflow/providers/cohere/hooks/cohere.py
@@ -115,17 +115,24 @@ class CohereHook(BaseHook):
         *,
         query: str,
         documents: list[str],
-        model: str = "Cohere-rerank-v4.0-pro",
+        model: str = "rerank-v3.5",
         top_n: int | None = None,
         max_tokens_per_doc: int | None = None,
     ) -> dict[str, Any]:
+        """Rerank documents by their relevance to a query."""
+        rerank_kwargs: dict[str, Any] = {
+            "query": query,
+            "documents": documents,
+            "model": model,
+            "request_options": self.request_options,
+        }
+        if top_n is not None:
+            rerank_kwargs["top_n"] = top_n
+        if max_tokens_per_doc is not None:
+            rerank_kwargs["max_tokens_per_doc"] = max_tokens_per_doc
+
         response = self.get_conn().rerank(
-            query=query,
-            documents=documents,
-            model=model,
-            top_n=top_n,
-            max_tokens_per_doc=max_tokens_per_doc,
-            request_options=self.request_options,
+            **rerank_kwargs,
         )
         return response.model_dump(mode="json")
 

--- a/providers/cohere/src/airflow/providers/cohere/operators/rerank.py
+++ b/providers/cohere/src/airflow/providers/cohere/operators/rerank.py
@@ -1,0 +1,86 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from functools import cached_property
+from typing import TYPE_CHECKING, Any
+
+from airflow.providers.cohere.hooks.cohere import CohereHook
+from airflow.providers.common.compat.sdk import BaseOperator
+
+if TYPE_CHECKING:
+    from cohere.core.request_options import RequestOptions
+
+    from airflow.providers.common.compat.sdk import Context
+
+
+class CohereRerankOperator(BaseOperator):
+    """
+    Rerank documents by their relevance to a query using Cohere's Rerank API.
+
+    :param query: The search query used to rank the documents.
+    :param documents: Text documents to compare with the query.
+    :param top_n: Maximum number of ranked documents to return. By default, all are returned.
+    :param max_tokens_per_doc: Maximum number of tokens retained from each document.
+    :param conn_id: Cohere connection id.
+    :param timeout: Request timeout in seconds.
+    :param request_options: Request-specific configuration passed to the Cohere client.
+    """
+
+    template_fields: Sequence[str] = ("query", "documents", "top_n", "max_tokens_per_doc")
+    template_fields_renderers = {"documents": "json"}
+
+    def __init__(
+        self,
+        *,
+        query: str,
+        documents: list[str],
+        top_n: int | None = None,
+        max_tokens_per_doc: int | None = None,
+        conn_id: str = CohereHook.default_conn_name,
+        timeout: int | None = None,
+        request_options: RequestOptions | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.query = query
+        self.documents = documents
+        self.top_n = top_n
+        self.max_tokens_per_doc = max_tokens_per_doc
+        self.conn_id = conn_id
+        self.timeout = timeout
+        self.request_options = request_options
+
+    @cached_property
+    def hook(self) -> CohereHook:
+        """Return a Cohere hook."""
+        return CohereHook(
+            conn_id=self.conn_id,
+            timeout=self.timeout,
+            request_options=self.request_options,
+        )
+
+    def execute(self, context: Context) -> dict[str, Any]:
+        """Rerank the documents and return an XCom-serializable response."""
+        return self.hook.rerank(
+            query=self.query,
+            documents=self.documents,
+            top_n=self.top_n,
+            max_tokens_per_doc=self.max_tokens_per_doc,
+        )

--- a/providers/cohere/src/airflow/providers/cohere/operators/rerank.py
+++ b/providers/cohere/src/airflow/providers/cohere/operators/rerank.py
@@ -34,8 +34,13 @@ class CohereRerankOperator(BaseOperator):
     """
     Rerank documents by their relevance to a query using Cohere's Rerank API.
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CohereRerankOperator`
+
     :param query: The search query used to rank the documents.
     :param documents: Text documents to compare with the query.
+    :param model: Model to use for reranking. Uses the hook's default when omitted.
     :param top_n: Maximum number of ranked documents to return. By default, all are returned.
     :param max_tokens_per_doc: Maximum number of tokens retained from each document.
     :param conn_id: Cohere connection id.
@@ -51,6 +56,7 @@ class CohereRerankOperator(BaseOperator):
         *,
         query: str,
         documents: list[str],
+        model: str | None = None,
         top_n: int | None = None,
         max_tokens_per_doc: int | None = None,
         conn_id: str = CohereHook.default_conn_name,
@@ -61,6 +67,7 @@ class CohereRerankOperator(BaseOperator):
         super().__init__(**kwargs)
         self.query = query
         self.documents = documents
+        self.model = model
         self.top_n = top_n
         self.max_tokens_per_doc = max_tokens_per_doc
         self.conn_id = conn_id
@@ -78,9 +85,11 @@ class CohereRerankOperator(BaseOperator):
 
     def execute(self, context: Context) -> dict[str, Any]:
         """Rerank the documents and return an XCom-serializable response."""
-        return self.hook.rerank(
-            query=self.query,
-            documents=self.documents,
-            top_n=self.top_n,
-            max_tokens_per_doc=self.max_tokens_per_doc,
-        )
+        rerank_kwargs: dict[str, Any] = {"query": self.query, "documents": self.documents}
+        if self.model is not None:
+            rerank_kwargs["model"] = self.model
+        if self.top_n is not None:
+            rerank_kwargs["top_n"] = int(self.top_n)
+        if self.max_tokens_per_doc is not None:
+            rerank_kwargs["max_tokens_per_doc"] = int(self.max_tokens_per_doc)
+        return self.hook.rerank(**rerank_kwargs)

--- a/providers/cohere/tests/system/cohere/example_cohere_rerank_operator.py
+++ b/providers/cohere/tests/system/cohere/example_cohere_rerank_operator.py
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from airflow import DAG
+from airflow.providers.cohere.operators.rerank import CohereRerankOperator
+
+with DAG("example_cohere_rerank", schedule=None, start_date=datetime(2023, 1, 1), catchup=False) as dag:
+    # [START howto_operator_cohere_rerank]
+    CohereRerankOperator(
+        task_id="rerank_documents",
+        query="What is the capital of the United States?",
+        documents=[
+            "Carson City is the capital city of Nevada.",
+            "Washington, D.C. is the capital of the United States.",
+            "The capital city of France is Paris.",
+        ],
+        top_n=2,
+    )
+    # [END howto_operator_cohere_rerank]
+
+
+from tests_common.test_utils.system_tests import get_test_run
+
+test_run = get_test_run(dag)

--- a/providers/cohere/tests/unit/cohere/hooks/test_cohere.py
+++ b/providers/cohere/tests/unit/cohere/hooks/test_cohere.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from airflow.models import Connection
 from airflow.providers.cohere.hooks.cohere import (
@@ -44,3 +44,33 @@ class TestCohereHook:
             hook = CohereHook(timeout=timeout)
             _ = hook.get_conn()
             client.assert_called_once_with(api_key=api_key, timeout=timeout, base_url=base_url)
+
+    @patch.object(CohereHook, "get_conn")
+    def test_rerank(self, mock_get_conn):
+        response = MagicMock()
+        response.model_dump.return_value = {
+            "id": "rerank-id",
+            "results": [{"index": 1, "relevance_score": 0.9}],
+        }
+        mock_get_conn.return_value.rerank.return_value = response
+        request_options = {"timeout_in_seconds": 10}
+        hook = CohereHook(request_options=request_options)
+
+        result = hook.rerank(
+            query="Where is the capital?",
+            documents=["first", "second"],
+            model="rerank-v3.5",
+            top_n=1,
+            max_tokens_per_doc=512,
+        )
+
+        mock_get_conn.return_value.rerank.assert_called_once_with(
+            query="Where is the capital?",
+            documents=["first", "second"],
+            model="rerank-v3.5",
+            top_n=1,
+            max_tokens_per_doc=512,
+            request_options=request_options,
+        )
+        response.model_dump.assert_called_once_with(mode="json")
+        assert result == {"id": "rerank-id", "results": [{"index": 1, "relevance_score": 0.9}]}

--- a/providers/cohere/tests/unit/cohere/hooks/test_cohere.py
+++ b/providers/cohere/tests/unit/cohere/hooks/test_cohere.py
@@ -45,9 +45,9 @@ class TestCohereHook:
             _ = hook.get_conn()
             client.assert_called_once_with(api_key=api_key, timeout=timeout, base_url=base_url)
 
-    @patch.object(CohereHook, "get_conn")
+    @patch.object(CohereHook, "get_conn", autospec=True)
     def test_rerank(self, mock_get_conn):
-        response = MagicMock()
+        response = MagicMock(spec=["model_dump"])
         response.model_dump.return_value = {
             "id": "rerank-id",
             "results": [{"index": 1, "relevance_score": 0.9}],
@@ -74,3 +74,20 @@ class TestCohereHook:
         )
         response.model_dump.assert_called_once_with(mode="json")
         assert result == {"id": "rerank-id", "results": [{"index": 1, "relevance_score": 0.9}]}
+
+    @patch.object(CohereHook, "get_conn", autospec=True)
+    def test_rerank_uses_default_model_and_omits_unset_limits(self, mock_get_conn):
+        response = MagicMock(spec=["model_dump"])
+        response.model_dump.return_value = {"results": []}
+        mock_get_conn.return_value.rerank.return_value = response
+        hook = CohereHook()
+
+        result = hook.rerank(query="Where is the capital?", documents=["first", "second"])
+
+        mock_get_conn.return_value.rerank.assert_called_once_with(
+            query="Where is the capital?",
+            documents=["first", "second"],
+            model="rerank-v3.5",
+            request_options=None,
+        )
+        assert result == {"results": []}

--- a/providers/cohere/tests/unit/cohere/operators/test_rerank.py
+++ b/providers/cohere/tests/unit/cohere/operators/test_rerank.py
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from unittest import mock
+
+from airflow.providers.cohere.operators.rerank import CohereRerankOperator
+
+
+@mock.patch("airflow.providers.cohere.operators.rerank.CohereRerankOperator.hook")
+def test_execute(mock_hook):
+    expected = {"id": "rerank-id", "results": [{"index": 1, "relevance_score": 0.9}]}
+    mock_hook.rerank.return_value = expected
+    documents = ["first", "second"]
+    operator = CohereRerankOperator(
+        task_id="rerank",
+        query="Where is the capital?",
+        documents=documents,
+        top_n=1,
+        max_tokens_per_doc=512,
+    )
+
+    result = operator.execute(context={})
+
+    mock_hook.rerank.assert_called_once_with(
+        query="Where is the capital?",
+        documents=documents,
+        top_n=1,
+        max_tokens_per_doc=512,
+    )
+    assert result == expected

--- a/providers/cohere/tests/unit/cohere/operators/test_rerank.py
+++ b/providers/cohere/tests/unit/cohere/operators/test_rerank.py
@@ -19,20 +19,24 @@ from __future__ import annotations
 
 from unittest import mock
 
+from airflow.providers.cohere.hooks.cohere import CohereHook
 from airflow.providers.cohere.operators.rerank import CohereRerankOperator
 
 
-@mock.patch("airflow.providers.cohere.operators.rerank.CohereRerankOperator.hook")
-def test_execute(mock_hook):
+@mock.patch.object(CohereRerankOperator, "hook", new_callable=mock.PropertyMock)
+def test_execute_coerces_templated_limits_and_forwards_model(mock_hook_property):
     expected = {"id": "rerank-id", "results": [{"index": 1, "relevance_score": 0.9}]}
+    mock_hook = mock.create_autospec(CohereHook, instance=True)
+    mock_hook_property.return_value = mock_hook
     mock_hook.rerank.return_value = expected
     documents = ["first", "second"]
     operator = CohereRerankOperator(
         task_id="rerank",
         query="Where is the capital?",
         documents=documents,
-        top_n=1,
-        max_tokens_per_doc=512,
+        model="rerank-v3.5",
+        top_n="1",
+        max_tokens_per_doc="512",
     )
 
     result = operator.execute(context={})
@@ -40,7 +44,43 @@ def test_execute(mock_hook):
     mock_hook.rerank.assert_called_once_with(
         query="Where is the capital?",
         documents=documents,
+        model="rerank-v3.5",
         top_n=1,
         max_tokens_per_doc=512,
     )
     assert result == expected
+
+
+@mock.patch.object(CohereRerankOperator, "hook", new_callable=mock.PropertyMock)
+def test_execute_omits_unset_optional_arguments(mock_hook_property):
+    mock_hook = mock.create_autospec(CohereHook, instance=True)
+    mock_hook_property.return_value = mock_hook
+    operator = CohereRerankOperator(
+        task_id="rerank",
+        query="Where is the capital?",
+        documents=["first", "second"],
+    )
+
+    operator.execute(context={})
+
+    mock_hook.rerank.assert_called_once_with(query="Where is the capital?", documents=["first", "second"])
+
+
+@mock.patch("airflow.providers.cohere.operators.rerank.CohereHook", autospec=True)
+def test_hook_uses_operator_connection_options(mock_hook_class):
+    request_options = {"timeout_in_seconds": 10}
+    operator = CohereRerankOperator(
+        task_id="rerank",
+        query="Where is the capital?",
+        documents=["first", "second"],
+        conn_id="cohere_custom",
+        timeout=30,
+        request_options=request_options,
+    )
+
+    assert operator.hook == mock_hook_class.return_value
+    mock_hook_class.assert_called_once_with(
+        conn_id="cohere_custom",
+        timeout=30,
+        request_options=request_options,
+    )


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
Why
---

Cohere provider only supports embedding and does not provide an operator for the Rerank API.

What
---

- Add `CohereHook.rerank` to rank documents by relevance to a query.
- Add `CohereRerankOperator` with `top_n` and `max_tokens_per_doc` support.
- Return an XCom-serializable dictionary containing ranked indexes and relevance scores.
- Add unit tests, documentation, and an example Dag.

Test
---

Use the testing Dag below with a Cohere connection (Azure).

```python
from __future__ import annotations

import logging
from datetime import datetime, timezone
from typing import Any

from airflow.providers.cohere.operators.rerank import CohereRerankOperator
from airflow.sdk import dag, task

log = logging.getLogger(__name__)


@dag(
    dag_id="test_azure_cohere_rerank",
    schedule=None,
    start_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
    catchup=False,
    tags=["cohere", "azure", "rerank", "test"],
)
def test_azure_cohere_rerank():
    reranked = CohereRerankOperator(
        task_id="rerank_documents",
        conn_id="cohere_azure",
        query="What is the capital of the United States?",
        documents=[
            "Carson City is the capital city of Nevada.",
            "Washington, D.C. is the capital of the United States.",
            "The capital city of France is Paris.",
        ],
        top_n=2,
    )

    @task
    def verify_results(response: dict[str, Any]) -> None:
        results = response.get("results")
        if not results:
            raise ValueError("Cohere returned no reranking results")
        first_result = results[0]
        if "index" not in first_result or "relevance_score" not in first_result:
            raise ValueError("Cohere reranking result is missing its index or relevance score")
        log.info("Highest-ranked document: %s", first_result)

    verify_results(reranked.output)


test_azure_cohere_rerank()
```

log
```
::group::Log message source details
/root/airflow/logs/dag_id=test_azure_cohere_rerank/run_id=manual__2026-09-04T06:59:03.159000+00:00/task_id=rerank_documents/attempt=1.log
::endgroup::
[2026-09-04T06:59:04.172411Z] INFO - ::group::Pre Execute
Task Identity ti_id=01a06b36-b784-737c-a285-3fa0673a58dc dag_id=test_azure_cohere_rerank task_id=rerank_documents run_id=manual__2026-09-04T06:59:03.159000+00:00 try_number=1 map_index=-1
[2026-09-04T06:59:04.208824Z] INFO - DAG bundles loaded: dags-folder
[2026-09-04T06:59:04.209832Z] INFO - Filling up the DagBag from /files/dags/test_azure_cohere_rerank.py
[2026-09-04T06:59:04.284956Z] INFO - Worker startup parse complete bundle_name=dags-folder  bundle_version=null  dag_file=test_azure_cohere_rerank.py  bundle_prepare_ms=2  dag_file_parse_ms=75 
[2026-09-04T06:59:04.312538Z] INFO - ::endgroup::
[2026-09-04T06:59:08.422692Z] INFO - ::group::Post Execute
[2026-09-04T06:59:08.423119Z] INFO - Pushing xcom ti=RuntimeTaskInstance(id=UUID('01a06b36-b784-737c-a285-3fa0673a58dc'), task_id='rerank_documents', dag_id='test_azure_cohere_rerank', run_id='manual__2026-09-04T06:59:03.159000+00:00', try_number=1, dag_version_id=UUID('01a06b31-96de-780b-9344-11512671e374'), map_index=-1, hostname='bed06d3cd41b', context_carrier={'traceparent': '00-398c0a86f4882365defcedb4de9cea71-e1df67c087d2aa62-00'}, queue='default', task=<Task(CohereRerankOperator): rerank_documents>, bundle_instance=LocalDagBundle(name=dags-folder), max_tries=0, start_date=datetime.datetime(2026, 9, 4, 6, 59, 4, 178740, tzinfo=datetime.timezone.utc), end_date=None, state=<TaskInstanceState.RUNNING: 'running'>, is_mapped=False, rendered_map_index=None, sentry_integration='') 
[2026-09-04T06:59:08.479633Z] INFO - ::endgroup::


::group::Log message source details
/root/airflow/logs/dag_id=test_azure_cohere_rerank/run_id=manual__2026-09-04T06:59:03.159000+00:00/task_id=verify_results/attempt=1.log
::endgroup::
[2026-09-04T06:59:09.077249Z] INFO - ::group::Pre Execute
Task Identity ti_id=01a06b36-b785-7dde-b2c0-3e3fa1256d3c dag_id=test_azure_cohere_rerank task_id=verify_results run_id=manual__2026-09-04T06:59:03.159000+00:00 try_number=1 map_index=-1
[2026-09-04T06:59:09.088840Z] INFO - DAG bundles loaded: dags-folder
[2026-09-04T06:59:09.089513Z] INFO - Filling up the DagBag from /files/dags/test_azure_cohere_rerank.py
[2026-09-04T06:59:09.165990Z] INFO - Worker startup parse complete bundle_name=dags-folder  bundle_version=null  dag_file=test_azure_cohere_rerank.py  bundle_prepare_ms=1  dag_file_parse_ms=76 
[2026-09-04T06:59:09.190519Z] INFO - ::endgroup::
[2026-09-04T06:59:09.191773Z] INFO - Highest-ranked document: {'index': 1, 'relevance_score': 0.9446076}
[2026-09-04T06:59:09.191919Z] INFO - Done. Returned value was: None
[2026-09-04T06:59:09.192023Z] INFO - ::group::Post Execute
[2026-09-04T06:59:09.200257Z] INFO - ::endgroup::
```


---
---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (GPT 5.6 sol)


Generated-by: [GPT 5.6 sol] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
