### PR TITLE
Fix KubernetesPodOperator XCom loss when container_logs is a string

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -922,8 +922,11 @@ class KubernetesPodOperator(BaseOperator):
                     container_name_log_prefix_enabled=self.container_name_log_prefix_enabled,
                     log_formatter=self.log_formatter,
                 )
+            followed_containers = (
+                [self.container_logs] if isinstance(self.container_logs, str) else self.container_logs
+            )
             if not self.get_logs or (
-                self.container_logs is not True and self.base_container_name not in self.container_logs
+                followed_containers is not True and self.base_container_name not in followed_containers
             ):
                 self.pod_manager.await_container_completion(
                     pod=pod,

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -2126,6 +2126,28 @@ class TestKubernetesPodOperator:
         # check that we wait for the xcom sidecar to start before extracting XCom
         mock_await_xcom_sidecar.assert_called_once_with(pod=pod)
 
+    @pytest.mark.parametrize(
+        ("container_logs", "should_await_base"),
+        [
+            pytest.param("base", False, id="base-as-string"),
+            pytest.param("base2", True, id="base-is-substring-of-other-container"),
+        ],
+    )
+    @patch(f"{POD_MANAGER_CLASS}.await_container_completion")
+    @patch(f"{POD_MANAGER_CLASS}.fetch_requested_container_logs")
+    def test_string_container_logs_matches_base_container_by_name_not_substring(
+        self, mock_fetch_log, mock_await_container_completion, container_logs, should_await_base
+    ):
+        k = KubernetesPodOperator(task_id="task", get_logs=True, container_logs=container_logs)
+        pod, _ = self.run_pod(k)
+
+        if should_await_base:
+            mock_await_container_completion.assert_called_once_with(
+                pod=pod, container_name="base", polling_time=1
+            )
+        else:
+            mock_await_container_completion.assert_not_called()
+
     @patch(HOOK_CLASS, new=MagicMock)
     @patch(KUB_OP_PATH.format("find_pod"))
     def test_execute_sync_callbacks(self, find_pod_mock):


### PR DESCRIPTION
## Why

`KubernetesPodOperator.await_pod_completion` decides whether it still has to wait for the base container with `self.base_container_name not in self.container_logs`. `container_logs` accepts a single container name as a plain string, and that is also the default (`"base"`), so for string values this is a substring check rather than a membership check. Any name that merely contains the base container name, such as a typo like `"base2"` or a sidecar named `"base-metrics"`, makes the operator believe the base container's logs are being followed and skip `await_container_completion`.

With `do_xcom_push=True` the operator then execs into the XCom sidecar while the base container is still running, reads an empty `return.json`, tears the sidecar down, and the task succeeds with a `None` XCom. Nothing is logged as an error, so downstream tasks silently receive wrong data.

## What

- `providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py`: normalise a string `container_logs` into a single-element list before the membership check in `await_pod_completion`, so the base container is awaited whenever its logs are not actually being followed. Behaviour for `True` and list values is unchanged.
---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5.1)