### PR TITLE
Bump common-compat lower bound for akeyless, hashicorp and smtp

### DIFF
--- a/providers/akeyless/README.rst
+++ b/providers/akeyless/README.rst
@@ -56,7 +56,7 @@ Requirements
 PIP package                                 Version required
 ==========================================  ==================
 ``apache-airflow``                          ``>=2.11.0``
-``apache-airflow-providers-common-compat``  ``>=1.8.0``
+``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``akeyless``                                ``>=5.0.0``
 ==========================================  ==================
 

--- a/providers/akeyless/docs/index.rst
+++ b/providers/akeyless/docs/index.rst
@@ -102,7 +102,7 @@ The minimum Apache Airflow version supported by this provider distribution is ``
 PIP package                                 Version required
 ==========================================  ==================
 ``apache-airflow``                          ``>=2.11.0``
-``apache-airflow-providers-common-compat``  ``>=1.8.0``
+``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``akeyless``                                ``>=5.0.0``
 ==========================================  ==================
 

--- a/providers/akeyless/pyproject.toml
+++ b/providers/akeyless/pyproject.toml
@@ -60,7 +60,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.11.0",
-    "apache-airflow-providers-common-compat>=1.8.0",
+    "apache-airflow-providers-common-compat>=1.12.0",
     "akeyless>=5.0.0",
 ]
 

--- a/providers/hashicorp/README.rst
+++ b/providers/hashicorp/README.rst
@@ -54,7 +54,7 @@ Requirements
 PIP package                                 Version required
 ==========================================  ==================
 ``apache-airflow``                          ``>=2.11.0``
-``apache-airflow-providers-common-compat``  ``>=1.8.0``
+``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``hvac``                                    ``>=1.1.0``
 ==========================================  ==================
 

--- a/providers/hashicorp/docs/index.rst
+++ b/providers/hashicorp/docs/index.rst
@@ -93,7 +93,7 @@ The minimum Apache Airflow version supported by this provider distribution is ``
 PIP package                                 Version required
 ==========================================  ==================
 ``apache-airflow``                          ``>=2.11.0``
-``apache-airflow-providers-common-compat``  ``>=1.8.0``
+``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``hvac``                                    ``>=1.1.0``
 ==========================================  ==================
 

--- a/providers/hashicorp/pyproject.toml
+++ b/providers/hashicorp/pyproject.toml
@@ -60,7 +60,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.11.0",
-    "apache-airflow-providers-common-compat>=1.8.0",
+    "apache-airflow-providers-common-compat>=1.12.0",
     "hvac>=1.1.0",
 ]
 

--- a/providers/smtp/README.rst
+++ b/providers/smtp/README.rst
@@ -54,7 +54,7 @@ Requirements
 PIP package                                 Version required
 ==========================================  ==================
 ``apache-airflow``                          ``>=2.11.0``
-``apache-airflow-providers-common-compat``  ``>=1.10.1``
+``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``aiosmtplib``                              ``>=0.1.6``
 ==========================================  ==================
 

--- a/providers/smtp/docs/index.rst
+++ b/providers/smtp/docs/index.rst
@@ -88,7 +88,7 @@ The minimum Apache Airflow version supported by this provider distribution is ``
 PIP package                                 Version required
 ==========================================  ==================
 ``apache-airflow``                          ``>=2.11.0``
-``apache-airflow-providers-common-compat``  ``>=1.10.1``
+``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``aiosmtplib``                              ``>=0.1.6``
 ==========================================  ==================
 

--- a/providers/smtp/pyproject.toml
+++ b/providers/smtp/pyproject.toml
@@ -60,7 +60,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.11.0",
-    "apache-airflow-providers-common-compat>=1.10.1",
+    "apache-airflow-providers-common-compat>=1.12.0",
     "aiosmtplib>=0.1.6",
 ]
 


### PR DESCRIPTION
## Why

- The `akeyless`, `hashicorp` and `smtp` providers all import `conf` with `from airflow.providers.common.compat.sdk import conf` in

https://github.com/apache/airflow/blob/b3b62fa8cf3c32cb45bb2815385a2af498300754/providers/akeyless/src/airflow/providers/akeyless/secrets/akeyless.py#L28

https://github.com/apache/airflow/blob/b3b62fa8cf3c32cb45bb2815385a2af498300754/providers/hashicorp/src/airflow/providers/hashicorp/secrets/vault.py#L27

https://github.com/apache/airflow/blob/b3b62fa8cf3c32cb45bb2815385a2af498300754/providers/smtp/src/airflow/providers/smtp/notifications/smtp.py#L26

- `common.compat.sdk` only contains `conf` in common-compat 1.12.0 (#59966).
- The three `pyproject.toml` files still declare `apache-airflow-providers-common-compat>=1.8.0` (akeyless, hashicorp) and `>=1.10.1` (smtp).

## How

- Bump `apache-airflow-providers-common-compat` to `>=1.12.0` in the three `pyproject.toml` files.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
