### PR TITLE
Add environments and trigger named parameters to Databricks operators

### DIFF
--- a/providers/databricks/docs/operators/jobs_create.rst
+++ b/providers/databricks/docs/operators/jobs_create.rst
@@ -48,11 +48,13 @@ Currently the named parameters that ``DatabricksCreateJobsOperator`` supports ar
   - ``tags``
   - ``tasks``
   - ``job_clusters``
+  - ``environments``
   - ``email_notifications``
   - ``webhook_notifications``
   - ``notification_settings``
   - ``timeout_seconds``
   - ``schedule``
+  - ``trigger``
   - ``max_concurrent_runs``
   - ``git_source``
   - ``access_control_list``

--- a/providers/databricks/docs/operators/submit_run.rst
+++ b/providers/databricks/docs/operators/submit_run.rst
@@ -78,6 +78,7 @@ Currently the named parameters that ``DatabricksSubmitRunOperator`` supports are
     - ``new_cluster``
     - ``existing_cluster_id``
     - ``libraries``
+    - ``environments``
     - ``run_name``
     - ``timeout_seconds``
     - ``performance_target``

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
@@ -437,11 +437,16 @@ class DatabricksCreateJobsOperator(BaseOperator):
         Array of objects (JobTaskSettings).
     :param job_clusters: A list of job cluster specifications that can be shared and reused by
         tasks of this job. Array of objects (JobCluster).
+    :param environments: A list of task execution environments that the serverless tasks of this
+        job reference through their ``environment_key``. Array of objects (JobEnvironment).
     :param email_notifications: Object (JobEmailNotifications).
     :param webhook_notifications: Object (WebhookNotifications).
     :param notification_settings: Optional notification settings.
     :param timeout_seconds: An optional timeout applied to each run of this job.
     :param schedule: Object (CronSchedule).
+    :param trigger: A configuration to trigger a run when certain conditions are met, such as a
+        file arriving in an external location, a monitored table being updated, or a periodic
+        interval elapsing. Object (TriggerSettings).
     :param max_concurrent_runs: An optional maximum allowed number of concurrent runs of the job.
     :param git_source: An optional specification for a remote repository containing the notebooks
         used by this job's notebook tasks. Object (GitSource).
@@ -480,11 +485,13 @@ class DatabricksCreateJobsOperator(BaseOperator):
         "tags",
         "tasks",
         "job_clusters",
+        "environments",
         "email_notifications",
         "webhook_notifications",
         "notification_settings",
         "timeout_seconds",
         "schedule",
+        "trigger",
         "max_concurrent_runs",
         "git_source",
         "access_control_list",
@@ -503,11 +510,13 @@ class DatabricksCreateJobsOperator(BaseOperator):
         tags: dict[str, str] | None = None,
         tasks: list[dict] | None = None,
         job_clusters: list[dict] | None = None,
+        environments: list[dict] | None = None,
         email_notifications: dict | None = None,
         webhook_notifications: dict | None = None,
         notification_settings: dict | None = None,
         timeout_seconds: int | None = None,
         schedule: dict | None = None,
+        trigger: dict | None = None,
         max_concurrent_runs: int | None = None,
         git_source: dict | None = None,
         access_control_list: list[dict] | None = None,
@@ -526,11 +535,13 @@ class DatabricksCreateJobsOperator(BaseOperator):
         self.tags = tags
         self.tasks = tasks
         self.job_clusters = job_clusters
+        self.environments = environments
         self.email_notifications = email_notifications
         self.webhook_notifications = webhook_notifications
         self.notification_settings = notification_settings
         self.timeout_seconds = timeout_seconds
         self.schedule = schedule
+        self.trigger = trigger
         self.max_concurrent_runs = max_concurrent_runs
         self.git_source = git_source
         self.access_control_list = access_control_list
@@ -547,11 +558,13 @@ class DatabricksCreateJobsOperator(BaseOperator):
             "tags": self.tags,
             "tasks": self.tasks,
             "job_clusters": self.job_clusters,
+            "environments": self.environments,
             "email_notifications": self.email_notifications,
             "webhook_notifications": self.webhook_notifications,
             "notification_settings": self.notification_settings,
             "timeout_seconds": self.timeout_seconds,
             "schedule": self.schedule,
+            "trigger": self.trigger,
             "max_concurrent_runs": self.max_concurrent_runs,
             "git_source": self.git_source,
             "access_control_list": self.access_control_list,
@@ -673,6 +686,12 @@ class DatabricksSubmitRunOperator(ResumableJobMixin, BaseOperator):
 
         .. seealso::
             https://docs.databricks.com/dev-tools/api/2.0/jobs.html#managedlibrarieslibrary
+    :param environments: A list of task execution environments that the serverless tasks of this
+        run reference through their ``environment_key``. Array of objects (JobEnvironment).
+        This field will be templated.
+
+        .. seealso::
+            https://docs.databricks.com/api/workspace/jobs/submit#environments
     :param run_name: The run name used for this task.
         By default this will be set to the Airflow ``task_id``. This ``task_id`` is a
         required parameter of the superclass ``BaseOperator``.
@@ -752,6 +771,7 @@ class DatabricksSubmitRunOperator(ResumableJobMixin, BaseOperator):
         "new_cluster",
         "existing_cluster_id",
         "libraries",
+        "environments",
         "run_name",
         "timeout_seconds",
         "idempotency_token",
@@ -780,6 +800,7 @@ class DatabricksSubmitRunOperator(ResumableJobMixin, BaseOperator):
         new_cluster: dict[str, object] | None = None,
         existing_cluster_id: str | None = None,
         libraries: list[dict[str, Any]] | None = None,
+        environments: list[dict[str, Any]] | None = None,
         run_name: str | None = None,
         timeout_seconds: int | None = None,
         databricks_conn_id: str = "databricks_default",
@@ -820,6 +841,7 @@ class DatabricksSubmitRunOperator(ResumableJobMixin, BaseOperator):
         self.new_cluster = new_cluster
         self.existing_cluster_id = existing_cluster_id
         self.libraries = libraries
+        self.environments = environments
         self.run_name = run_name
         self.timeout_seconds = timeout_seconds
         self.idempotency_token = idempotency_token
@@ -852,6 +874,7 @@ class DatabricksSubmitRunOperator(ResumableJobMixin, BaseOperator):
             "new_cluster": self.new_cluster,
             "existing_cluster_id": self.existing_cluster_id,
             "libraries": self.libraries,
+            "environments": self.environments,
             "run_name": self.run_name,
             "timeout_seconds": self.timeout_seconds,
             "idempotency_token": self.idempotency_token,

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks.py
@@ -293,6 +293,36 @@ ACCESS_CONTROL_LIST = [
         "permission_level": "CAN_MANAGE",
     }
 ]
+ENVIRONMENTS = [
+    {
+        "environment_key": "serverless_default",
+        "spec": {"environment_version": "3", "dependencies": ["simplejson==3.19.3"]},
+    }
+]
+TRIGGER = {
+    "pause_status": "UNPAUSED",
+    "file_arrival": {"url": "/Volumes/main/default/landing/", "min_time_between_triggers_seconds": 60},
+}
+TEMPLATED_ENVIRONMENTS = [
+    {
+        "environment_key": "serverless_default",
+        "spec": {"environment_version": "3", "dependencies": ["simplejson=={{ ds }}"]},
+    }
+]
+RENDERED_TEMPLATED_ENVIRONMENTS = [
+    {
+        "environment_key": "serverless_default",
+        "spec": {"environment_version": "3", "dependencies": [f"simplejson=={DATE}"]},
+    }
+]
+TEMPLATED_TRIGGER = {
+    "pause_status": "UNPAUSED",
+    "file_arrival": {"url": "/Volumes/main/default/landing/{{ ds }}/"},
+}
+RENDERED_TEMPLATED_TRIGGER = {
+    "pause_status": "UNPAUSED",
+    "file_arrival": {"url": f"/Volumes/main/default/landing/{DATE}/"},
+}
 JOB_PARAMS = [{"name": "param1", "default": "value1"}]
 
 
@@ -452,6 +482,56 @@ class TestDatabricksCreateJobsOperator:
                 "max_concurrent_runs": override_max_concurrent_runs,
                 "git_source": override_git_source,
                 "access_control_list": override_access_control_list,
+            }
+        )
+
+        assert expected == utils.normalise_json_content(op._get_merged_json())
+
+    @pytest.mark.parametrize(
+        "json",
+        [
+            pytest.param(None, id="named-parameters-only"),
+            pytest.param({"environments": [], "trigger": {}}, id="named-parameters-override-json"),
+        ],
+    )
+    def test_init_with_environments_and_trigger_named_parameters(self, json):
+        """
+        Test the initializer merges ``environments`` and ``trigger`` into the create payload.
+        """
+        op = DatabricksCreateJobsOperator(
+            task_id=TASK_ID,
+            json=json,
+            name=JOB_NAME,
+            tasks=TASKS,
+            environments=ENVIRONMENTS,
+            trigger=TRIGGER,
+        )
+        expected = utils.normalise_json_content(
+            {
+                "name": JOB_NAME,
+                "tasks": TASKS,
+                "environments": ENVIRONMENTS,
+                "trigger": TRIGGER,
+            }
+        )
+
+        assert expected == utils.normalise_json_content(op._get_merged_json())
+
+    def test_environments_and_trigger_are_templated(self):
+        dag = DAG("test", schedule=None, start_date=datetime.now())
+        op = DatabricksCreateJobsOperator(
+            dag=dag,
+            task_id=TASK_ID,
+            name=JOB_NAME,
+            environments=TEMPLATED_ENVIRONMENTS,
+            trigger=TEMPLATED_TRIGGER,
+        )
+        op.render_template_fields(context={"ds": DATE})
+        expected = utils.normalise_json_content(
+            {
+                "name": JOB_NAME,
+                "environments": RENDERED_TEMPLATED_ENVIRONMENTS,
+                "trigger": RENDERED_TEMPLATED_TRIGGER,
             }
         )
 
@@ -763,6 +843,43 @@ class TestDatabricksSubmitRunOperator:
                 "new_cluster": NEW_CLUSTER,
                 "notebook_task": NOTEBOOK_TASK,
                 "performance_target": "PERFORMANCE_OPTIMIZED",
+                "run_name": TASK_ID,
+            }
+        )
+
+        assert expected == utils.normalise_json_content(op._get_merged_json())
+
+    @pytest.mark.parametrize(
+        "json",
+        [
+            pytest.param({"notebook_task": NOTEBOOK_TASK}, id="named-parameters-only"),
+            pytest.param(
+                {"notebook_task": NOTEBOOK_TASK, "environments": []},
+                id="named-parameters-override-json",
+            ),
+        ],
+    )
+    def test_init_with_environments_named_parameter(self, json):
+        """
+        Test the initializer merges ``environments`` into the submit payload.
+        """
+        op = DatabricksSubmitRunOperator(task_id=TASK_ID, json=json, environments=ENVIRONMENTS)
+        expected = utils.normalise_json_content(
+            {"notebook_task": NOTEBOOK_TASK, "environments": ENVIRONMENTS, "run_name": TASK_ID}
+        )
+
+        assert expected == utils.normalise_json_content(op._get_merged_json())
+
+    def test_environments_is_templated(self):
+        dag = DAG("test", schedule=None, start_date=datetime.now())
+        op = DatabricksSubmitRunOperator(
+            dag=dag, task_id=TASK_ID, notebook_task=NOTEBOOK_TASK, environments=TEMPLATED_ENVIRONMENTS
+        )
+        op.render_template_fields(context={"ds": DATE})
+        expected = utils.normalise_json_content(
+            {
+                "notebook_task": NOTEBOOK_TASK,
+                "environments": RENDERED_TEMPLATED_ENVIRONMENTS,
                 "run_name": TASK_ID,
             }
         )


### PR DESCRIPTION
`api/2.2/jobs/create` and `api/2.2/jobs/runs/submit` both take a top-level `environments` field, and `create` also takes `trigger`. Neither had a named parameter on the operators, so a job that uses serverless task dependencies or an event-driven trigger had to be hand-written into `json` — and the operator signature, which the docs describe as having "exactly one named parameter for each top level parameter", no longer showed that those fields exist at all.

* `DatabricksCreateJobsOperator`: adds `environments` and `trigger`
* `DatabricksSubmitRunOperator`: adds `environments` (`runs/submit` has no `trigger`; a trigger is job-level)

Both are in `template_fields`, so a rendered value can be built from the Dag context — e.g. a `file_arrival` URL or a pinned dependency version per run — and both follow the existing merge rule, overriding the same key in `json`.

This is reach the payload already had, so the change is discoverability and typing rather than new capability. I checked that first: `normalise_json_content` stringifies ints, and the API accepts `trigger.periodic.interval` as either an int or a string and returns it as an int, so `json=` was never actually blocked here.

Verified against a live workspace, through the operators and the real hook, reading the result back with the CLI rather than the code under test:

* `jobs/create` with `environments` + `trigger` — accepted, and `jobs/get` returns both byte for byte, including `spec.environment_version` and the int-valued `min_time_between_triggers_seconds` / `periodic.interval`. Checked with `trigger.file_arrival` and `trigger.periodic`.
* `runs/submit` with `environments` — accepted. Submitting the same task **without** `environments` is rejected with `Job environment 'serverless_default' used by task probe is not defined in field 'environments'`, which is what shows the field is genuinely consumed by the API and not quietly dropped.
* One fixture note from that run: a `file_arrival.url` must end in `/` and must resolve to a UC volume — a raw `s3://` URL that overlaps an existing volume or table is refused — so the unit-test fixtures use a `/Volumes/...` URL.

All six new unit tests fail without the change. Removing only the two `template_fields` entries, keeping the named parameters, fails exactly the two templating tests and leaves the four merge tests green, so the tests separate the two halves of the change. The provider's unit suite is 929 passed / 12 skipped, and mypy is clean on the changed file.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)