### PR TITLE
Flag deprecated expose_config=non-sensitive-only in config lint

### DIFF
--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -657,6 +657,13 @@ CONFIGS_CHANGES = [
         config=ConfigParameter("api", "page_size"),
         renamed_to=ConfigParameter("api", "fallback_page_limit"),
     ),
+    ConfigChange(
+        config=ConfigParameter("api", "expose_config"),
+        was_removed=False,
+        is_invalid_if="non-sensitive-only",
+        suggestion="This value is deprecated and treated as `True`. Set `expose_config` to `True` instead; "
+        "sensitive configuration values are always masked.",
+    ),
     # scheduler
     ConfigChange(
         config=ConfigParameter("scheduler", "dependency_detector"),

--- a/airflow-core/tests/unit/cli/commands/test_config_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_config_command.py
@@ -532,6 +532,22 @@ class TestConfigLint:
         assert "Invalid value" not in normalized_output
 
     @pytest.mark.parametrize(
+        ("expose_config", "expect_issue"),
+        [
+            pytest.param("non-sensitive-only", True, id="deprecated-value"),
+            pytest.param("True", False, id="boolean-value"),
+        ],
+    )
+    def test_lint_detects_deprecated_expose_config_value(self, expose_config, expect_issue, stdout_capture):
+        with conf_vars({("api", "expose_config"): expose_config}), stdout_capture as temp_stdout:
+            config_command.lint_config(cli_parser.get_parser().parse_args(["config", "lint"]))
+
+        normalized_output = re.sub(r"\s+", " ", temp_stdout.getvalue().strip())
+        expected_message = "Invalid value `non-sensitive-only` set for `expose_config` configuration parameter in `api` section."
+
+        assert (expected_message in normalized_output) is expect_issue
+
+    @pytest.mark.parametrize(
         ("remove_if_equals", "config_value", "expect_issue"),
         [
             pytest.param("removed_value", "removed_value", True, id="match"),

--- a/airflow-ctl/src/airflowctl/ctl/commands/config_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/config_command.py
@@ -259,6 +259,13 @@ CONFIGS_CHANGES = [
         config=ConfigParameter("api", "auth_backends"),
         renamed_to=ConfigParameter("fab", "auth_backends"),
     ),
+    ConfigChange(
+        config=ConfigParameter("api", "expose_config"),
+        was_removed=False,
+        is_invalid_if="non-sensitive-only",
+        suggestion="This value is deprecated and treated as `True`. Set `expose_config` to `True` instead; "
+        "sensitive configuration values are always masked.",
+    ),
     # logging
     ConfigChange(
         config=ConfigParameter("logging", "enable_task_context_logger"),

--- a/airflow-ctl/tests/airflow_ctl/ctl/commands/test_config_command.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/commands/test_config_command.py
@@ -384,6 +384,43 @@ class TestCliConfigCommands:
             in calls[1]
         )
 
+    @pytest.mark.parametrize(
+        ("expose_config", "expect_issue"),
+        [
+            pytest.param("non-sensitive-only", True, id="deprecated-value"),
+            pytest.param("True", False, id="boolean-value"),
+        ],
+    )
+    @patch("rich.print")
+    def test_lint_detects_deprecated_expose_config_value(
+        self, mock_rich_print, expose_config, expect_issue, api_client_maker
+    ):
+        response_config = Config(
+            sections=[
+                ConfigSection(
+                    name="api",
+                    options=[ConfigOption(key="expose_config", value=expose_config)],
+                )
+            ]
+        )
+
+        api_client = api_client_maker(
+            path="/api/v2/config",
+            response_json=response_config.model_dump(),
+            expected_http_status_code=200,
+            kind=ClientKind.CLI,
+        )
+
+        config_command.lint(
+            self.parser.parse_args(["config", "lint"]),
+            api_client=api_client,
+        )
+
+        calls = [call[0][0] for call in mock_rich_print.call_args_list]
+        expected_message = "Invalid value `non-sensitive-only` set for `expose_config` configuration parameter in `api` section."
+
+        assert any(expected_message in call for call in calls) is expect_issue
+
     @patch("airflowctl.api.client.Credentials.load")
     @patch.dict(os.environ, {"AIRFLOW_CLI_TOKEN": "TEST_TOKEN"})
     @patch.dict(os.environ, {"AIRFLOW_CLI_ENVIRONMENT": "TEST_CONFIG"})


### PR DESCRIPTION
## Why

- `[api] expose_config = non-sensitive-only` was deprecated in #59880 (3.2.0), but the only signal is a `DeprecationWarning` that the api-server emits once per process while serving `GET /config`.
- On a config file that still carries `non-sensitive-only`, `airflow config lint` and `airflowctl config lint`  report "No issues found in your airflow.cfg. It is ready for Airflow 3!".


## How

- Add a value-level `ConfigChange` rule (`was_removed=False`, `is_invalid_if="non-sensitive-only"`) to both `CONFIGS_CHANGES` lists, following the existing rule.

## Verification

- Unit test
  - `uv run --frozen --project airflow-core pytest airflow-core/tests/unit/cli/commands/test_config_command.py`
  - `uv run --frozen --project airflow-ctl pytest airflow-ctl/tests/airflow_ctl/ctl/commands/test_config_command.py`
- Integration test:

```
export AIRFLOW_HOME=/tmp/airflow-lint && mkdir -p $AIRFLOW_HOME
.venv/bin/airflow config lint --section api
sed -i '' 's/^expose_config = .*/expose_config = non-sensitive-only/' $AIRFLOW_HOME/airflow.cfg && grep -n '^expose_config' $AIRFLOW_HOME/airflow.cfg
.venv/bin/airflow config lint
```

On main branch, it shows `No issues found in your airflow.cfg. It is ready for Airflow 3!`. In this branch, it shows:

```
Found issues in your airflow.cfg:
  - Invalid value `non-sensitive-only` set for `expose_config` configuration parameter in `api` section. This value is deprecated and treated as
`True`. Set `expose_config` to `True` instead; sensitive configuration values are always masked.

Please update your configuration file accordingly.
```
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
