### PR TITLE
Fix Keycloak auth manager rejecting bearer tokens on Airflow 3.3+

### DIFF
--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
@@ -148,12 +148,12 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         )
 
     def serialize_user(self, user: KeycloakAuthManagerUser) -> dict[str, Any]:
-        if AIRFLOW_V_3_3_PLUS:
-            # Omit Keycloak JWTs from claims, they are stored in separate cookies
-            return {
-                "user_id": user.get_id(),
-                "name": user.get_name(),
-            }
+        # The Keycloak JWTs are carried in the claims. The browser login flow stores them
+        # in separate cookies instead, because a cookie holding both the Airflow JWT and
+        # the Keycloak ones can exceed the ~4 KB cookie size limit, and mints its Airflow
+        # JWT from a user without them. Callers authenticating with an ``Authorization``
+        # header are not subject to that limit and need the tokens in the claims: it is
+        # the only place a non-browser caller can carry them.
         return {
             "user_id": user.get_id(),
             "name": user.get_name(),
@@ -185,9 +185,12 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
                 raise InvalidTokenError("Keycloak access token does not belong to this Airflow session")
             user.access_token = access_token
             user.refresh_token = refresh_token
-            return user
-        # Skip refreshing JWT if Keycloak JWTs are not included.
-        return None
+        # No Keycloak cookies on the request: the caller authenticated with an
+        # ``Authorization`` header rather than a browser session, and its tokens come
+        # from the claims, which the Airflow JWT signature already covers. The user is
+        # authenticated either way; ``refresh_user`` decides separately whether the
+        # session can be refreshed.
+        return user
 
     def get_url_login(self, **kwargs) -> str:
         base_url = conf.get("api", "base_url", fallback="/")

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/login.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/login.py
@@ -125,7 +125,16 @@ def login_callback(request: Request):
         access_token=tokens["access_token"],
         refresh_token=tokens["refresh_token"],
     )
-    token = get_auth_manager().generate_jwt(user)
+    if AIRFLOW_V_3_3_PLUS:
+        # The Keycloak tokens are set as their own cookies below. Cookies are capped at
+        # roughly 4 KB and Keycloak access tokens can be large enough that carrying them
+        # in the Airflow JWT cookie as well exceeds it, which logs the user out.
+        jwt_user = KeycloakAuthManagerUser(
+            user_id=user.get_id(), name=user.get_name(), access_token="", refresh_token=None
+        )
+    else:
+        jwt_user = user
+    token = get_auth_manager().generate_jwt(jwt_user)
     request.state.jwt_token_issued = True
 
     response = RedirectResponse(url=conf.get("api", "base_url", fallback="/"), status_code=303)

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/routes/test_login.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/routes/test_login.py
@@ -73,8 +73,13 @@ class TestLoginRouter:
         user = mock_auth_manager.generate_jwt.call_args[0][0]
         assert user.get_id() == "sub"
         assert user.get_name() == "preferred_username"
-        assert user.access_token == "access_token"
-        assert user.refresh_token == "refresh_token"
+        if AIRFLOW_V_3_3_PLUS:
+            # The tokens go in their own cookies below, keeping the JWT cookie small.
+            assert user.access_token == ""
+            assert user.refresh_token is None
+        else:
+            assert user.access_token == "access_token"
+            assert user.refresh_token == "refresh_token"
         assert response.status_code == 303
         assert "location" in response.headers
         assert "_token" in response.cookies

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
@@ -198,15 +198,38 @@ class TestKeycloakAuthManager:
                 user_id="user_id", name="name", access_token="access_token", refresh_token="refresh_token"
             )
         )
-        if AIRFLOW_V_3_3_PLUS:
-            assert result == {"user_id": "user_id", "name": "name"}
-        else:
-            assert result == {
-                "user_id": "user_id",
-                "name": "name",
-                "access_token": "access_token",
-                "refresh_token": "refresh_token",
-            }
+        assert result == {
+            "user_id": "user_id",
+            "name": "name",
+            "access_token": "access_token",
+            "refresh_token": "refresh_token",
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_user_from_token_round_trip_without_cookies(self, auth_manager):
+        """A token minted by ``POST /auth/token`` must authenticate a bearer request.
+
+        The bearer path calls ``get_user_from_token()`` with the Airflow JWT alone -- no
+        cookies exist for a non-browser caller -- so the Keycloak access token has to
+        survive the trip through the auth manager's own serializer.
+        """
+        access_token = keycloak_token("user_id")
+        claims = auth_manager.serialize_user(
+            KeycloakAuthManagerUser(
+                user_id="user_id",
+                name="name",
+                access_token=access_token,
+                refresh_token=None,
+            )
+        )
+        mock_get_user_from_token = AsyncMock(return_value=auth_manager.deserialize_user(claims))
+        with patch.object(BaseAuthManager, "get_user_from_token", mock_get_user_from_token):
+            user = await auth_manager.get_user_from_token("token")
+
+        assert user is not None
+        assert user.get_id() == "user_id"
+        assert user.access_token == access_token
+        assert user.refresh_token is None
 
     @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="Uses KeycloakJWTMiddleware and separate cookies")
     @pytest.mark.asyncio
@@ -257,10 +280,17 @@ class TestKeycloakAuthManager:
 
     @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="Uses KeycloakJWTMiddleware and separate cookies")
     @pytest.mark.asyncio
-    async def test_get_user_from_token_keycloak_jwts_missing(self, auth_manager):
+    async def test_get_user_from_token_keeps_user_when_cookies_missing(self, auth_manager):
+        """Absent Keycloak cookies must not invalidate an otherwise valid session.
+
+        A bearer caller never has those cookies, so discarding the user here returned
+        ``None`` into ``_is_authorized``, which unconditionally reads
+        ``user.access_token`` and raised ``AttributeError`` -> HTTP 500.
+        """
+        access_token = keycloak_token("user_id")
         mock_get_user_from_token = AsyncMock(
             return_value=KeycloakAuthManagerUser(
-                user_id="user_id", name="name", access_token="", refresh_token=None
+                user_id="user_id", name="name", access_token=access_token, refresh_token=None
             )
         )
         with (
@@ -270,7 +300,11 @@ class TestKeycloakAuthManager:
                 mock_get_user_from_token,
             ),
         ):
-            assert await auth_manager.get_user_from_token("token") is None
+            user = await auth_manager.get_user_from_token("token")
+
+        assert user is not None
+        assert user.get_id() == "user_id"
+        assert user.access_token == access_token
 
     @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="Uses KeycloakJWTMiddleware and separate cookies")
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes: #72351

## What

On Airflow 3.3+ with `apache-airflow-providers-keycloak>=0.9.0`, a token obtained from `POST /auth/token` no longer authenticates when presented as `Authorization: Bearer <token>`. The request fails with HTTP 500:

File ".../keycloak/auth_manager/keycloak_auth_manager.py", line 471, in _is_authorized
headers=self._get_headers(user.access_token),
^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'access_token'


Downgrading only the provider to `0.8.2`, with the same core version and the same Keycloak client configuration, resolves it.

## Why it happens

Two changes interact:

1. `serialize_user()` omits the Keycloak tokens from the Airflow JWT claims on 3.3+, because they are stored in dedicated cookies. `deserialize_user()` correspondingly falls back to `access_token=token.get("access_token", "")`.
2. `get_user_from_token()` returns `None` when it is called without an `access_token` argument, on the assumption that the caller is a browser session whose Keycloak cookies are missing.

The cookie split is a browser constraint: cookies are capped at roughly 4 KB and Keycloak access tokens are large enough that a cookie carrying both can exceed it (#61771). But it was applied to token minting in general rather than to the cookie path specifically, and `POST /auth/token` also mints its JWT through `generate_jwt()` -> `serialize_user()`.

The result is that a non-browser caller has nowhere to carry the Keycloak access token: not in the claims, because they are stripped, and not in cookies, because it has none. `get_user()` resolves the user and then discards it, `None` propagates into `_is_authorized()`, and the unconditional `user.access_token` raises.

Note that simply returning the user instead of `None` is not sufficient — the user's `access_token` would be `""`, `_is_authorized()` would send `Authorization: Bearer ` to the UMA token endpoint, and Keycloak would answer 401. The claims side has to be fixed too.

## What this changes

- `serialize_user()` keeps the Keycloak tokens in the claims on all versions, as it did before 3.3. The claims are covered by the Airflow JWT signature, so this is the one place a non-browser caller can carry them safely.
- `login_callback()` mints its JWT from a user without the Keycloak tokens on 3.3+, so the cookie stays small. The size limit is enforced where the cookies are actually set, rather than for every token the auth manager issues.
- `get_user_from_token()` no longer discards a validly resolved user when no cookie tokens were supplied. When they are supplied, the existing subject-binding check and the assignment are unchanged.

The `return None` branch was already unreachable from the browser path: `KeycloakJWTMiddleware._refresh_user()` returns early without a `_token` cookie and raises 401 without an `_access_token` cookie, so it never calls `get_user_from_token()` without an access token. The branch only ever fired for header-authenticated callers.

`refresh_user()` already returns `None` when the user has no refresh token, so the client-credentials service-account path (RFC 6749 §4.4.3, no refresh token issued) is unaffected — it is still not refreshable, it is just no longer unauthenticated.

## Tests

- `test_get_user_from_token_round_trip_without_cookies` — round-trips a user through the auth manager's own serializer, the way `generate_jwt()` does when `/auth/token` mints a token, then resolves it the way the bearer path does, with no cookies. This is the regression test for the issue.
- `test_get_user_from_token_keeps_user_when_cookies_missing` — replaces the previous test asserting `None`.
- `test_serialize_user` and `test_login_callback` updated for the moved responsibility.

I wasn't able to run the suite locally (Windows — the `_shared` symlinks don't survive checkout), so I'm relying on CI for verification.

## Backwards compatibility

Browser sessions are unchanged: the JWT cookie stays token-free and the middleware continues to attach the tokens from the `_access_token` / `_refresh_token` cookies, including the subject-binding check. Airflow < 3.3 behaviour is unchanged. Tokens already issued to bearer clients before this change do not gain claims retroactively and must be re-minted, which the existing expiry handling covers.

##### Was generative AI tooling used to co-author this PR?

Yes. I used Claude to help investigate the root cause and write this description. I reviewed the change and am responsible for its correctness.
