### PR TITLE
Fix lineage entities sharing mutable defaults across instances

### DIFF
--- a/providers/common/compat/src/airflow/providers/common/compat/lineage/entities.py
+++ b/providers/common/compat/src/airflow/providers/common/compat/lineage/entities.py
@@ -61,7 +61,7 @@ class Column:
     name: str = attr.ib()
     description: str | None = None
     data_type: str = attr.ib()
-    tags: list[Tag] = []
+    tags: list[Tag] = attr.Factory(list)
 
     template_fields: ClassVar = ("name", "description", "data_type", "tags")
 
@@ -83,11 +83,11 @@ class Table:
     database: str = attr.ib()
     cluster: str = attr.ib()
     name: str = attr.ib()
-    tags: list[Tag] = []
+    tags: list[Tag] = attr.Factory(list)
     description: str | None = None
-    columns: list[Column] = []
-    owners: list[User] = []
-    extra: dict[str, Any] = {}
+    columns: list[Column] = attr.Factory(list)
+    owners: list[User] = attr.Factory(list)
+    extra: dict[str, Any] = attr.Factory(dict)
     type_hint: str | None = None
 
     template_fields: ClassVar = (

--- a/providers/common/compat/tests/unit/common/compat/lineage/test_entities.py
+++ b/providers/common/compat/tests/unit/common/compat/lineage/test_entities.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from airflow.providers.common.compat.lineage.entities import Column, Table, Tag, User
+
+
+class TestMutableDefaultsAreNotShared:
+    """Each instance must get its own container; a bare ``= []`` default is shared class-wide."""
+
+    def test_column_tags_are_isolated_between_instances(self):
+        first = Column(name="a", data_type="INT")
+        second = Column(name="b", data_type="INT")
+
+        first.tags.append(Tag(tag_name="pii"))
+
+        assert first.tags == [Tag(tag_name="pii")]
+        assert second.tags == []
+        assert first.tags is not second.tags
+
+    def test_table_containers_are_isolated_between_instances(self):
+        first = Table(database="db", cluster="cluster", name="first")
+        second = Table(database="db", cluster="cluster", name="second")
+
+        first.tags.append(Tag(tag_name="pii"))
+        first.columns.append(Column(name="id", data_type="INT"))
+        first.owners.append(User(email="owner@example.com"))
+        first.extra["source"] = "warehouse"
+
+        assert second.tags == []
+        assert second.columns == []
+        assert second.owners == []
+        assert second.extra == {}


### PR DESCRIPTION
The attrs entities in `airflow.providers.common.compat.lineage.entities` declare bare mutable defaults (`tags: list[Tag] = []`, `extra: dict[str, Any] = {}`). With `@attr.s(auto_attribs=True)` such a default is evaluated once and shared class-wide, so mutating one instance silently mutates every other instance:

```python
t1 = Table(database="db", cluster="c", name="t1")
t2 = Table(database="db", cluster="c", name="t2")
t1.tags.append(Tag(tag_name="pii"))
t2.tags  # [Tag(tag_name='pii')] — polluted
t1.tags is t2.tags  # True
```

This affects `Table.tags` / `columns` / `owners` / `extra` and `Column.tags`, i.e. lineage metadata can leak between unrelated entities whenever more than one is constructed. Found while writing the missing test module for this file (#72506).

The fix switches the five defaults to `attr.Factory(list)` / `attr.Factory(dict)`. Regression tests assert per-instance isolation and fail on the previous code.

Note: #72506 (in flight) adds broader coverage for the same module in the same test file; whichever lands second will be rebased.

related: #35442

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)