### PR TITLE
Stop ExternalTaskSensor waiting for missing Dags on Airflow 3.2+

### DIFF
--- a/providers/standard/src/airflow/providers/standard/sensors/external_task.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/external_task.py
@@ -21,6 +21,7 @@ import os
 import typing
 import warnings
 from collections.abc import Callable, Collection, Iterable, Sequence
+from http import HTTPStatus
 from typing import TYPE_CHECKING, ClassVar
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
@@ -64,6 +65,7 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from airflow.providers.common.compat.sdk import Context, TaskInstanceKey
+    from airflow.sdk.types import RuntimeTaskInstanceProtocol
 
 
 class ExternalDagLink(BaseOperatorLink):
@@ -168,9 +170,13 @@ class ExternalTaskSensor(BaseSensorOperator):
         Either execution_delta or execution_date_fn can be passed to ExternalTaskSensor,
         but not both.
     :param check_existence: Set to `True` to check if the external task exists (when
-        external_task_id is not None) or check if the DAG to wait for exists (when
+        external_task_id is not None) or check if the Dag to wait for exists (when
         external_task_id is None), and immediately cease waiting if the external task
-        or DAG does not exist (default value: False).
+        or Dag does not exist (default value: False).
+        On Airflow 3 a worker has no database access, so only the existence of the
+        external Dag is checked through the execution API. Task and task group
+        existence is not checked, and nothing is checked before Airflow 3.2, whose
+        execution API is the first to be able to look up a Dag.
     :param poke_interval: polling period in seconds to check for the status
     :param poll_interval: (DEPRECATED) use ``poke_interval`` instead
     :param deferrable: Run sensor in deferrable mode
@@ -351,8 +357,10 @@ class ExternalTaskSensor(BaseSensorOperator):
     def _poke_af3(self, context: Context, dttm_filter: Sequence[datetime.datetime]) -> bool:
         from airflow.providers.standard.utils.sensor_helper import _get_count_by_matched_states
 
-        self._has_checked_existence = True
         ti = context["ti"]
+
+        if self.check_existence and not self._has_checked_existence:
+            self._check_for_existence_af3(ti)
 
         def _get_count(states: list[str]) -> int:
             if self.external_task_ids:
@@ -474,6 +482,9 @@ class ExternalTaskSensor(BaseSensorOperator):
 
             dttm_filter = self._get_dttm_filter(context)
             if AIRFLOW_V_3_0_PLUS:
+                if self.check_existence and not self._has_checked_existence:
+                    self._check_for_existence_af3(context["ti"])
+
                 self.defer(
                     timeout=datetime.timedelta(seconds=timeout_value) if timeout_value else None,
                     trigger=WorkflowTrigger(
@@ -540,6 +551,44 @@ class ExternalTaskSensor(BaseSensorOperator):
                 "Error occurred while trying to retrieve task status. Please, check the "
                 "name of executed task and Dag."
             )
+
+    def _check_for_existence_af3(self, ti: RuntimeTaskInstanceProtocol) -> None:
+        """
+        Check that the external Dag exists through the execution API.
+
+        A worker has no database access on Airflow 3, so unlike `_check_for_existence` this
+        can only check what the execution API exposes, which is whether the Dag is
+        registered. Task and task group existence cannot be checked.
+
+        :param ti: the task instance running this sensor, used to reach the execution API
+        """
+        if not AIRFLOW_V_3_2_PLUS:
+            self.log.warning(
+                "External Dag existence cannot be checked on this Airflow version",
+                dag_id=self.external_dag_id,
+                required_airflow_version="3.2",
+            )
+            self._has_checked_existence = True
+            return
+
+        from airflow.sdk.exceptions import AirflowRuntimeError
+
+        try:
+            ti.get_dag(self.external_dag_id)
+        except AirflowRuntimeError as e:
+            if (e.error.detail or {}).get("status_code") == HTTPStatus.NOT_FOUND:
+                raise ExternalDagNotFoundError(
+                    f"The external Dag {self.external_dag_id} does not exist."
+                ) from None
+            raise
+
+        if self.external_task_ids or self.external_task_group_id:
+            self.log.warning(
+                "Task and task group existence cannot be checked on Airflow 3",
+                dag_id=self.external_dag_id,
+            )
+
+        self._has_checked_existence = True
 
     def _check_for_existence(self, session: Session) -> None:
         dag_to_wait = DagModel.get_current(self.external_dag_id, session=session)

--- a/providers/standard/src/airflow/providers/standard/sensors/external_task.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/external_task.py
@@ -582,6 +582,8 @@ class ExternalTaskSensor(BaseSensorOperator):
                 ) from None
             raise
 
+        # Task and task-group checks need Dag-version-aware API support;
+        # tracked at https://github.com/apache/airflow/issues/72514
         if self.external_task_ids or self.external_task_group_id:
             self.log.warning(
                 "Task and task group existence cannot be checked on Airflow 3",

--- a/providers/standard/tests/unit/standard/sensors/test_external_task_sensor.py
+++ b/providers/standard/tests/unit/standard/sensors/test_external_task_sensor.py
@@ -1185,6 +1185,19 @@ exit 0
         assert op._handle_execution_date_fn(context) == DEFAULT_DATE
 
 
+def _api_server_error(status_code: int):
+    """Build the error a task gets back when an execution API call fails."""
+    from airflow.sdk.exceptions import AirflowRuntimeError, ErrorType
+    from airflow.sdk.execution_time.comms import ErrorResponse
+
+    return AirflowRuntimeError(
+        ErrorResponse(
+            error=ErrorType.API_SERVER_ERROR,
+            detail={"status_code": status_code, "message": f"Server returned {status_code}"},
+        )
+    )
+
+
 @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Different test for AF 2")
 @pytest.mark.usefixtures("testing_dag_bundle")
 class TestExternalTaskSensorV3:
@@ -1444,6 +1457,105 @@ class TestExternalTaskSensorV3:
         assert exc.value.trigger.external_dag_id == "test_dag_parent"
         assert exc.value.trigger.external_task_ids == ["test_task"]
         assert exc.value.trigger.logical_dates == [DEFAULT_DATE]
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Dag lookup requires Airflow 3.2+")
+    @pytest.mark.execution_timeout(10)
+    def test_check_existence_dag_not_found(self, dag_maker):
+        """The sensor fails fast when the external Dag is not registered."""
+        with dag_maker("test_dag_child"):
+            op = ExternalTaskSensor(
+                task_id="test_external_task_sensor_check",
+                external_dag_id="non_existing_dag",
+                external_task_id=None,
+                check_existence=True,
+            )
+
+        self.context["ti"].get_dag.side_effect = _api_server_error(404)
+
+        with pytest.raises(ExternalDagNotFoundError, match="non_existing_dag"):
+            op.execute(context=self.context)
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Dag lookup requires Airflow 3.2+")
+    @pytest.mark.execution_timeout(10)
+    def test_check_existence_dag_not_found_deferrable(self, dag_maker):
+        """A deferrable sensor fails fast too, rather than deferring on a missing Dag."""
+        with dag_maker("test_dag_child"):
+            op = ExternalTaskSensor(
+                task_id="test_external_task_sensor_check",
+                external_dag_id="non_existing_dag",
+                external_task_id=None,
+                deferrable=True,
+                check_existence=True,
+            )
+
+        self.context["ti"].get_dag.side_effect = _api_server_error(404)
+
+        with pytest.raises(ExternalDagNotFoundError, match="non_existing_dag"):
+            op.execute(context=self.context)
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Dag lookup requires Airflow 3.2+")
+    @pytest.mark.execution_timeout(10)
+    def test_check_existence_checked_only_once(self, dag_maker, caplog):
+        """An existing Dag is looked up on the first poke only."""
+        with dag_maker("test_dag_child"):
+            op = ExternalTaskSensor(
+                task_id="test_external_task_sensor_check",
+                external_dag_id="test_dag_parent",
+                external_task_id="test_task",
+                check_existence=True,
+            )
+
+        assert op.poke(self.context) is False
+        assert op.poke(self.context) is False
+
+        self.context["ti"].get_dag.assert_called_once_with("test_dag_parent")
+        assert {
+            "event": "Task and task group existence cannot be checked on Airflow 3",
+            "dag_id": "test_dag_parent",
+            "log_level": "warning",
+        } in caplog
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Dag lookup requires Airflow 3.2+")
+    @pytest.mark.execution_timeout(10)
+    def test_check_existence_other_error_is_not_swallowed(self, dag_maker):
+        """Errors other than a missing Dag keep their own type."""
+        from airflow.sdk.exceptions import AirflowRuntimeError
+
+        with dag_maker("test_dag_child"):
+            op = ExternalTaskSensor(
+                task_id="test_external_task_sensor_check",
+                external_dag_id="test_dag_parent",
+                external_task_id=None,
+                check_existence=True,
+            )
+
+        self.context["ti"].get_dag.side_effect = _api_server_error(500)
+
+        with pytest.raises(AirflowRuntimeError):
+            op.poke(self.context)
+
+    @mock.patch("airflow.providers.standard.sensors.external_task.AIRFLOW_V_3_2_PLUS", False)
+    @pytest.mark.execution_timeout(10)
+    def test_check_existence_skipped_before_3_2(self, dag_maker, caplog):
+        """Before Airflow 3.2 there is no execution API to look up a Dag."""
+        with dag_maker("test_dag_child"):
+            op = ExternalTaskSensor(
+                task_id="test_external_task_sensor_check",
+                external_dag_id="test_dag_parent",
+                external_task_id=None,
+                check_existence=True,
+            )
+
+        with caplog.at_level(logging.WARNING):
+            assert op.poke(self.context) is False
+
+        self.context["ti"].get_dag.assert_not_called()
+        assert {
+            "event": "External Dag existence cannot be checked on this Airflow version",
+            "dag_id": "test_dag_parent",
+            "required_airflow_version": "3.2",
+            "log_level": "warning",
+        } in caplog
 
     def test_poke_interval_set_on_init(self):
         """Test that poke_interval is set on init and the deprecated poll_interval attribute mirrors it."""


### PR DESCRIPTION
`ExternalTaskSensor(check_existence=True)` is supposed to fail immediately when the external Dag does not exist. On Airflow 3 **it does not check at all**.  When `external_dag_id` refers to a Dag that does not exist, the sensor waits until its timeout instead of reporting the problem immediately.

The same thing happens when waiting is handed off to the triggerer (`deferrable=True`): the wait starts without a check.

Note:

* Airflow 2 is not affected.
* This only changes behavior for sensors with `check_existence=True`.

<details>
<summary> Where it happens </summary>

In `providers/standard/src/airflow/providers/standard/sensors/external_task.py`:

```python
def _poke_af3(self, context: Context, dttm_filter: Sequence[datetime.datetime]) -> bool:
    from airflow.providers.standard.utils.sensor_helper import _get_count_by_matched_states

    self._has_checked_existence = True  # set here, then never read again
    ti = context["ti"]
```

`_has_checked_existence` is meant to stop the same check from being repeated. In the Airflow 3 code it is set before any check has happened.

The check itself is behind this condition:

```python
if self.check_existence and not self._has_checked_existence:
    self._check_for_existence(session=session)
```

Both copies of the condition are in Airflow 2-only code, so Airflow 3 never calls `_check_for_existence`.

</details>

<details>
<summary> How it got here </summary>

The existing check reads the metadata database and the Dag file. An Airflow 3 worker has access to neither, so it cannot use that implementation.

- #48651 (`6775bf7bae`) split the sensor into Airflow 2 and Airflow 3 implementations. The status checks were moved to the new Airflow 3 implementation, but the existence check was not.
- #64394 (`ce88001bb2`) later fixed `check_existence` when `deferrable=True`, but only for Airflow 2. The Airflow 3 code still starts waiting without checking.

The missing piece was a way for a worker to ask whether a Dag exists. #56955 added that to the execution API in Airflow 3.2.

#67832 explored a broader check for individual tasks and task groups. It was closed because the answer depends on the Dag version used by a particular run. This PR does not add a new API. It uses the existing Dag lookup only to answer whether the external Dag itself exists.

</details>

What this PR does:

- `external_task.py`: on Airflow 3.2 and later, asks the execution API whether the external Dag exists before the sensor starts waiting. A missing Dag raises `ExternalDagNotFoundError`; other API errors are left unchanged.
- `external_task.py`: applies the check whether the sensor waits itself or hands the wait to the triggerer, and documents the limits below.
- `test_external_task_sensor.py`: covers both ways of waiting, repeated checks, unexpected API errors, and older Airflow 3 versions.

What this PR does not fix:

- On Airflow 3, `external_task_ids` and `external_task_group_id` are still not checked. The external Dag is checked, but the execution API cannot say whether a task exists in the Dag version used by a particular run. When an external task or task group is configured, the sensor now warns that only the external Dag was checked. The full task and task-group check is not part of this PR.
- Airflow 3.0 and 3.1 cannot perform the Dag check because the required execution API was added in Airflow 3.2. They also log a warning and keep the existing behavior.

related: #72514

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes, Codex (GPT-5)

Used to trace the regression through the history above, check what an Airflow 3 worker can ask the execution API, and review the implementation and tests.