### PR TITLE
Warn when a deadline alert cannot be scheduled for a Dag run

### DIFF
--- a/airflow-core/src/airflow/serialization/definitions/dag.py
+++ b/airflow-core/src/airflow/serialization/definitions/dag.py
@@ -789,6 +789,15 @@ class SerializedDAG:
                         "deadline_alerts.deadline_created",
                         tags=prune_dict({"dag_id": self.dag_id, "team_name": team_name}),
                     )
+                else:
+                    # A reference returns None when the Dag run attribute it reads is unset (e.g.
+                    # logical_date on a run triggered without one); without this the alert never fires.
+                    log.warning(
+                        "deadline alert skipped, reference produced no deadline time",
+                        dag_id=self.dag_id,
+                        run_id=orm_dagrun.run_id,
+                        reference=type(deserialized_deadline_alert.reference).__name__,
+                    )
 
     @provide_session
     def set_task_instance_state(

--- a/airflow-core/tests/unit/models/test_dag.py
+++ b/airflow-core/tests/unit/models/test_dag.py
@@ -2448,6 +2448,39 @@ my_postgres_conn:
         assert len(dr.deadlines) == 1
         assert dr.deadlines[0].deadline_time == getattr(dr, reference_column, DEFAULT_DATE) + interval
 
+    @pytest.mark.need_serialized_dag
+    def test_dagrun_deadline_skipped_when_reference_has_no_value(self, testing_dag_bundle, session, caplog):
+        dag = DAG(
+            dag_id="test_deadline_without_logical_date",
+            schedule=None,
+            deadline=DeadlineAlert(
+                reference=DeadlineReference.DAGRUN_LOGICAL_DATE,
+                interval=datetime.timedelta(hours=1),
+                callback=AsyncCallback(empty_callback_for_deadline),
+            ),
+        )
+
+        scheduler_dag = sync_dag_to_db(dag, session=session)
+
+        dr = scheduler_dag.create_dagrun(
+            run_id="test_dagrun_deadline_without_logical_date",
+            run_type=DagRunType.MANUAL,
+            state=State.QUEUED,
+            logical_date=None,
+            run_after=TEST_DATE,
+            triggered_by=DagRunTriggeredByType.TEST,
+        )
+        session.flush()
+        dr = session.merge(dr)
+
+        assert dr.deadlines == []
+        assert {
+            "event": "deadline alert skipped, reference produced no deadline time",
+            "dag_id": "test_deadline_without_logical_date",
+            "run_id": "test_dagrun_deadline_without_logical_date",
+            "reference": "DagRunLogicalDateDeadline",
+        } in caplog
+
     def test_dag_with_multiple_deadlines(self, testing_dag_bundle, session):
         """Test that a Dag with multiple deadlines stores all deadlines and persists on re-serialization."""
         deadlines = [


### PR DESCRIPTION
A DAGRUN deadline reference evaluates to None whenever the Dag run attribute it reads is unset -- `logical_date` is NULL on runs triggered without one, such as `airflow dags trigger` without `-l` or a run created from another Dag's asset output. The caller then created no Deadline row and logged nothing at all, so the alert simply never fired and an operator had no way to discover why.

The only trace was a warning from a lower layer claiming the Dag run could not be found, which is actively misleading: the run exists, it just has no value for the column the reference reads.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
