### PR TITLE
Skip legacy models when selecting a Bedrock inference profile

### DIFF
--- a/providers/amazon/tests/system/amazon/aws/utils/bedrock.py
+++ b/providers/amazon/tests/system/amazon/aws/utils/bedrock.py
@@ -26,6 +26,11 @@ except ImportError:
     from airflow.decorators import task  # type: ignore[attr-defined, no-redef]
 
 
+def _foundation_model_id(model_arn: str) -> str:
+    """Return the model ID part of a foundation model ARN, which is identical in every region."""
+    return model_arn.rpartition("/")[2]
+
+
 @task
 def get_text_inference_profile_arn() -> str:
     """
@@ -37,11 +42,27 @@ def get_text_inference_profile_arn() -> str:
     from airflow.providers.amazon.aws.hooks.bedrock import BedrockHook
 
     client = BedrockHook().conn
+
+    # Bedrock rejects a model its provider marked as legacy, so a legacy model can not be relied on here.
+    # The inference profile summaries do not carry the lifecycle status, only the foundation models a
+    # profile resolves to do.
+    legacy_model_ids = {
+        model["modelId"]
+        for model in client.list_foundation_models()["modelSummaries"]
+        if model.get("modelLifecycle", {}).get("status") == "LEGACY"
+    }
+    log.info("Legacy model IDs: %s", sorted(legacy_model_ids))
+
     profiles = client.list_inference_profiles(typeEquals="SYSTEM_DEFINED")["inferenceProfileSummaries"]
     arns = [
         profile["inferenceProfileArn"]
         for profile in profiles
-        if profile.get("status") == "ACTIVE" and profile["inferenceProfileId"].startswith("global.anthropic.")
+        if profile.get("status") == "ACTIVE"
+        and profile["inferenceProfileId"].startswith("global.anthropic.")
+        and not any(
+            _foundation_model_id(model["modelArn"]) in legacy_model_ids
+            for model in profile.get("models", [])
+        )
     ]
     log.info("Valid text inference profile ARNs: %s", arns)
 
@@ -50,4 +71,4 @@ def get_text_inference_profile_arn() -> str:
         if "sonnet" in arn:
             log.info("Selected inference profile ARN: %s", arn)
             return arn
-    raise RuntimeError("No valid inference profiles found")
+    raise RuntimeError(f"No valid inference profiles found. Non legacy candidates were: {arns}")

--- a/providers/amazon/tests/system/amazon/aws/utils/bedrock.py
+++ b/providers/amazon/tests/system/amazon/aws/utils/bedrock.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import logging
+import re
 
 log = logging.getLogger(__name__)
 
@@ -31,6 +32,16 @@ def _foundation_model_id(model_arn: str) -> str:
     return model_arn.rpartition("/")[2]
 
 
+def _release_date(inference_profile_id: str) -> str:
+    """
+    Return the ``YYYYMMDD`` release date model providers embed in their version, e.g.
+    ``global.anthropic.claude-sonnet-4-5-20250929-v1:0``. An ID without one sorts last, so an
+    unrecognised naming scheme is treated as the newest rather than silently preferred.
+    """
+    match = re.search(r"\d{8}", inference_profile_id)
+    return match.group() if match else "99999999"
+
+
 @task
 def get_text_inference_profile_arn() -> str:
     """
@@ -43,32 +54,36 @@ def get_text_inference_profile_arn() -> str:
 
     client = BedrockHook().conn
 
-    # Bedrock rejects a model its provider marked as legacy, so a legacy model can not be relied on here.
-    # The inference profile summaries do not carry the lifecycle status, only the foundation models a
-    # profile resolves to do.
-    legacy_model_ids = {
+    # Bedrock only accepts a model whose lifecycle status is ACTIVE, so requiring that status keeps this
+    # working if a provider ever reports something other than today's ACTIVE/LEGACY pair. The inference
+    # profile summaries do not carry the lifecycle status, only the foundation models a profile resolves to.
+    active_model_ids = {
         model["modelId"]
         for model in client.list_foundation_models()["modelSummaries"]
-        if model.get("modelLifecycle", {}).get("status") == "LEGACY"
+        if model.get("modelLifecycle", {}).get("status") == "ACTIVE"
     }
-    log.info("Legacy model IDs: %s", sorted(legacy_model_ids))
 
     profiles = client.list_inference_profiles(typeEquals="SYSTEM_DEFINED")["inferenceProfileSummaries"]
-    arns = [
-        profile["inferenceProfileArn"]
-        for profile in profiles
-        if profile.get("status") == "ACTIVE"
-        and profile["inferenceProfileId"].startswith("global.anthropic.")
-        and not any(
-            _foundation_model_id(model["modelArn"]) in legacy_model_ids
-            for model in profile.get("models", [])
-        )
-    ]
-    log.info("Valid text inference profile ARNs: %s", arns)
+    # Oldest release first, so a run picks a mature model rather than a fresh one that batch inference or
+    # RAG may not support yet, and picks the same one on every run.
+    candidates = sorted(
+        (
+            profile
+            for profile in profiles
+            if profile.get("status") == "ACTIVE"
+            and profile["inferenceProfileId"].startswith("global.anthropic.")
+            and all(
+                _foundation_model_id(model["modelArn"]) in active_model_ids for model in profile["models"]
+            )
+        ),
+        key=lambda profile: (_release_date(profile["inferenceProfileId"]), profile["inferenceProfileId"]),
+    )
+    profile_ids = [profile["inferenceProfileId"] for profile in candidates]
+    log.info("Valid text inference profiles, oldest first: %s", profile_ids)
 
-    for arn in arns:
+    for profile in candidates:
         # Haiku has some version dependency issues: RAG only supports 3.5 but batch only supports 4.5
-        if "sonnet" in arn:
-            log.info("Selected inference profile ARN: %s", arn)
-            return arn
-    raise RuntimeError(f"No valid inference profiles found. Non legacy candidates were: {arns}")
+        if "sonnet" in profile["inferenceProfileId"]:
+            log.info("Selected inference profile ARN: %s", profile["inferenceProfileArn"])
+            return profile["inferenceProfileArn"]
+    raise RuntimeError(f"No valid inference profiles found. Active candidates were: {profile_ids}")


### PR DESCRIPTION
`get_text_inference_profile_arn()` returns the first "sonnet" inference profile in `list_inference_profiles` order. That order is not stable, and when it changed the helper started returning a profile backed by a model its provider had marked as legacy. Bedrock then rejects the request:

    ValidationException: This Model is marked by provider as Legacy and you
    have not been actively using the model in the last 30 days. Please upgrade
    to an active model on Amazon Bedrock.

The inference profile summaries do not expose a lifecycle status, so look the legacy models up with `list_foundation_models` and skip any profile that resolves to one of them. Foundation model IDs are compared rather than ARNs because a global profile resolves to the same model in several regions.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
