### PR TITLE
Fix XCom sidecar helper mutating the caller's pod volumes

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/xcom_sidecar.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/xcom_sidecar.py
@@ -62,10 +62,10 @@ def add_xcom_sidecar(
 ) -> k8s.V1Pod:
     """Add sidecar."""
     pod_cp = copy.deepcopy(pod)
-    pod_cp.spec.volumes = pod.spec.volumes or []
-    pod_cp.spec.volumes.insert(0, PodDefaults.VOLUME)
+    pod_cp.spec.volumes = pod_cp.spec.volumes or []
+    pod_cp.spec.volumes.insert(0, copy.deepcopy(PodDefaults.VOLUME))
     pod_cp.spec.containers[0].volume_mounts = pod_cp.spec.containers[0].volume_mounts or []
-    pod_cp.spec.containers[0].volume_mounts.insert(0, PodDefaults.VOLUME_MOUNT)
+    pod_cp.spec.containers[0].volume_mounts.insert(0, copy.deepcopy(PodDefaults.VOLUME_MOUNT))
     sidecar = copy.deepcopy(PodDefaults.SIDECAR_CONTAINER)
     sidecar.image = sidecar_container_image or PodDefaults.SIDECAR_CONTAINER.image
     if sidecar_container_resources:

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_xcom_sidecar.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_xcom_sidecar.py
@@ -69,3 +69,20 @@ def test_add_xcom_sidecar_empty_security_context():
 def test_add_xcom_sidecar_does_not_mutate_shared_default():
     add_xcom_sidecar(_base_pod(), sidecar_container_security_context={"readOnlyRootFilesystem": True})
     assert PodDefaults.SIDECAR_CONTAINER.security_context is None
+
+
+def test_add_xcom_sidecar_does_not_mutate_input_pod_volumes():
+    pod = _base_pod()
+    pod.spec.volumes = [k8s.V1Volume(name="data", empty_dir=k8s.V1EmptyDirVolumeSource())]
+
+    result = add_xcom_sidecar(pod)
+
+    assert [v.name for v in pod.spec.volumes] == ["data"]
+    assert [v.name for v in result.spec.volumes] == ["xcom", "data"]
+
+
+def test_add_xcom_sidecar_copies_default_volume_and_mount():
+    result = add_xcom_sidecar(_base_pod())
+
+    assert result.spec.volumes[0] is not PodDefaults.VOLUME
+    assert result.spec.containers[0].volume_mounts[0] is not PodDefaults.VOLUME_MOUNT


### PR DESCRIPTION
## Why

`add_xcom_sidecar` deep-copies the input pod so the caller's object stays untouched, but it then re-pointed the copy's `spec.volumes` at the **original** pod's volume list before inserting the `xcom` volume. Any caller that reuses the same pod object (custom operators or subclasses calling `build_pod_request_obj` more than once, or direct users of the helper) accumulated one extra `xcom` volume per call. Kubernetes requires volume names to be unique, so the API rejects the second pod as a duplicate. `KubernetesPodOperator` itself was only shielded because `reconcile_pods` happens to deep-copy first.

The helper also inserted the module-level `PodDefaults.VOLUME` and `PodDefaults.VOLUME_MOUNT` instances directly, so mutating them on one pod silently changed every other pod built by the helper, as well as the defaults themselves.

## What

- `providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/xcom_sidecar.py`: assign `pod_cp.spec.volumes` from the copy instead of the original pod, and insert deep copies of `PodDefaults.VOLUME` and `PodDefaults.VOLUME_MOUNT`.
- `providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_xcom_sidecar.py`: add two regression tests. One asserts the caller's pod keeps its original volume list while the returned copy gains the `xcom` volume. The other asserts the inserted volume and mount are not the shared default instances. Both fail on `main` and pass with this change.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5.1)