### PR TITLE
Fix flaky airflowctl integration tests by limiting worker concurrency

### DIFF
--- a/airflow-ctl-tests/tests/airflowctl_tests/conftest.py
+++ b/airflow-ctl-tests/tests/airflowctl_tests/conftest.py
@@ -370,6 +370,9 @@ def docker_compose_up(tmp_path_factory):
         f"AIRFLOW_UID={os.getuid()}\n"
         # To enable config operations to work
         "AIRFLOW__API__EXPOSE_CONFIG=true\n"
+        # The single api-server process also serves the Execution API; a burst of task processes
+        # starting at once starves it of CPU on small CI runners and airflowctl calls time out.
+        "AIRFLOW__CELERY__WORKER_CONCURRENCY=2\n"
     )
 
     # Set environment variables for the test


### PR DESCRIPTION
## Why

`test_airflowctl_commands[tasks failed-deps0]` fails now and then with `Read timeout error` after three retries ([example run](https://github.com/apache/airflow/actions/runs/33647995987/job/100325459131)). The compose stack has one api-server process, and with the default Celery concurrency of 16 a trigger of `example_bash_operator` forks more than ten task processes at once. On the 4 vCPU runner the api-server then gets no CPU for 20 to 35 seconds, and any airflowctl command in that window times out.

```mermaid
sequenceDiagram
    participant T as pytest (airflowctl)
    participant A as api-server (1 process)
    participant W as celery worker

    Note over T,W: concurrency 16 (before)
    T->>A: dags trigger + unpause
    W->>W: fork 10+ task processes at once
    Note over A: starved of CPU for 20-35s
    T->>A: tasks failed-deps
    A--xT: 5s read timeout, x3
    T->>T: exit 1 (flaky)

    Note over T,W: concurrency 2 (after)
    T->>A: dags trigger + unpause
    W->>W: fork 2 task processes
    T->>A: tasks failed-deps
    A-->>T: 200
```

## What

Set `AIRFLOW__CELERY__WORKER_CONCURRENCY=2` in the `.env` the test conftest already writes, so tasks start two at a time. Measured locally with all containers pinned to one core plus 6 busy-loop containers, probing `/api/v2/monitor/health` every second:

| Worker concurrency | Max health latency | api-server log gap > 6s | Suite |
|---|---|---|---|
| 16 (default) | 17.0s / 18.5s | yes, 19s | 170 passed |
| 2 | 2.1s / under 1s | no | 170 passed |

I did not get a red run locally, the stall landed on the test's own Dag run polling instead of an airflowctl command. 
**The trade-off is a slower suite**, about **6 seconds** more on my machine (64s to 70s), since tasks now run two at a time. Happy to share the scripts and logs.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5.1)

Generated-by: Claude Code (Fable 5.1) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)