### PR TITLE
Add EKS operator for commands in existing Pods

### DIFF
--- a/providers/amazon/docs/operators/eks.rst
+++ b/providers/amazon/docs/operators/eks.rst
@@ -213,9 +213,9 @@ Execute a command in an existing Pod on Amazon EKS
 To execute a command in a running container without managing the Pod lifecycle, use
 :class:`~airflow.providers.amazon.aws.operators.eks.EksPodExecOperator`.
 The Pod must already exist and be running. The operator streams command output, waits for the exit code,
-and leaves the Pod unchanged.
-The AWS identity must be authorized to access the EKS cluster, and Kubernetes RBAC must allow
-``get`` on ``pods`` and ``create`` and ``get`` on ``pods/exec``.
+and does not create, restart, or delete the Pod.
+The AWS identity must have permission to call ``eks:DescribeCluster`` and be authorized to access the
+EKS cluster. Kubernetes RBAC must allow ``get`` on ``pods`` and ``pods/exec``.
 See :class:`~airflow.providers.cncf.kubernetes.operators.pod_exec.KubernetesPodExecOperator`
 for command, output, XCom, and retry behavior.
 

--- a/providers/amazon/docs/operators/eks.rst
+++ b/providers/amazon/docs/operators/eks.rst
@@ -205,6 +205,26 @@ Note: An Amazon EKS Cluster with underlying compute infrastructure is required.
     :start-after: [START howto_operator_eks_pod_operator]
     :end-before: [END howto_operator_eks_pod_operator]
 
+.. _howto/operator:EksPodExecOperator:
+
+Execute a command in an existing Pod on Amazon EKS
+==================================================
+
+To execute a command in a running container without managing the Pod lifecycle, use
+:class:`~airflow.providers.amazon.aws.operators.eks.EksPodExecOperator`.
+The Pod must already exist and be running. The operator streams command output, waits for the exit code,
+and leaves the Pod unchanged.
+The AWS identity must be authorized to access the EKS cluster, and Kubernetes RBAC must allow
+``get`` on ``pods`` and ``create`` and ``get`` on ``pods/exec``.
+See :class:`~airflow.providers.cncf.kubernetes.operators.pod_exec.KubernetesPodExecOperator`
+for command, output, XCom, and retry behavior.
+
+.. exampleinclude:: /../../amazon/tests/system/amazon/aws/example_eks_with_nodegroups.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_eks_pod_exec]
+    :end-before: [END howto_operator_eks_pod_exec]
+
 Sensors
 -------
 

--- a/providers/amazon/docs/operators/eks.rst
+++ b/providers/amazon/docs/operators/eks.rst
@@ -212,10 +212,13 @@ Execute a command in an existing Pod on Amazon EKS
 
 To execute a command in a running container without managing the Pod lifecycle, use
 :class:`~airflow.providers.amazon.aws.operators.eks.EksPodExecOperator`.
+
 The Pod must already exist and be running. The operator streams command output, waits for the exit code,
 and does not create, restart, or delete the Pod.
+
 The AWS identity must have permission to call ``eks:DescribeCluster`` and be authorized to access the
 EKS cluster. Kubernetes RBAC must allow ``get`` on ``pods`` and ``pods/exec``.
+
 See :class:`~airflow.providers.cncf.kubernetes.operators.pod_exec.KubernetesPodExecOperator`
 for command, output, XCom, and retry behavior.
 

--- a/providers/amazon/pyproject.toml
+++ b/providers/amazon/pyproject.toml
@@ -92,7 +92,7 @@ dependencies = [
     "aiobotocore>=3.0.0",
 ]
 "cncf.kubernetes" = [
-    "apache-airflow-providers-cncf-kubernetes>=7.2.0",
+    "apache-airflow-providers-cncf-kubernetes>=7.2.0",  # use next version
 ]
 "s3fs" = [
     "s3fs>=2023.10.0",

--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/eks.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/eks.py
@@ -105,10 +105,8 @@ COMMAND = """
                 exit "$status"
             fi
 
-            # Use pure bash below to parse so that it's posix compliant
-            # Only the token line should be on stdout (stderr captured above)
-
-            last_line=${{output##*$'\\n'}}  # strip everything up to the last newline
+            # Keep only the token line even if a dependency logs to stdout.
+            last_line=$(printf '%s\\n' "$output" | tail -n 1)
 
             timestamp=${{last_line#expirationTimestamp: }}  # drop the label
             timestamp=${{timestamp%%,*}}  # keep up to the first comma

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
@@ -47,8 +47,9 @@ from airflow.providers.amazon.aws.utils import (
     build_resource_in_use_retry_args,
     validate_execute_complete_event,
 )
-from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
+from airflow.providers.amazon.aws.utils.mixins import AwsHookParams, aws_template_fields
 from airflow.providers.amazon.aws.utils.waiter_with_logging import wait
+from airflow.providers.cncf.kubernetes.operators.pod_exec import KubernetesPodExecOperator
 from airflow.providers.cncf.kubernetes.utils.pod_manager import OnFinishAction
 from airflow.providers.common.compat.sdk import AirflowException, conf
 
@@ -1348,3 +1349,105 @@ class EksPodOperator(KubernetesPodOperator):
                 self.log.exception("Failed to refresh AWS credentials.")
                 raise
         super()._refresh_cached_properties()
+
+
+class EksPodExecOperator(KubernetesPodExecOperator):
+    """
+    Execute a command in a running container of an existing Pod on Amazon EKS.
+
+    The operator authenticates with Amazon EKS and delegates command execution to
+    :class:`~airflow.providers.cncf.kubernetes.operators.pod_exec.KubernetesPodExecOperator`.
+    It does not create, restart, or delete the target Pod.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:EksPodExecOperator`
+
+    :param cluster_name: The name of the Amazon EKS Cluster containing the Pod. (templated)
+    :param pod_name: Name of the existing Kubernetes Pod. (templated)
+    :param command: Command and arguments to execute in the container. (templated)
+    :param namespace: Namespace containing the Pod. Defaults to ``default``. (templated)
+    :param container_name: Name of the container in which to execute the command. When omitted, the
+        ``kubectl.kubernetes.io/default-container`` annotation or the first container is used. (templated)
+    :param aws_conn_id: The Airflow connection used for AWS credentials. (templated)
+        If this is ``None`` or empty, the default boto3 credential strategy is used.
+    :param region_name: AWS region containing the Amazon EKS Cluster. (templated)
+        If this is ``None`` or empty, the default boto3 region strategy is used.
+    :param verify: Whether to verify SSL certificates, or the path to a CA bundle. (templated)
+    :param botocore_config: Configuration dictionary for the botocore client.
+    :param do_xcom_push: Return standard output through XCom when ``True``. Defaults to ``False``.
+    :param max_xcom_output_size: Maximum UTF-8 byte size retained for XCom. Defaults to 49,344 bytes.
+    """
+
+    template_fields: Sequence[str] = aws_template_fields(
+        "cluster_name",
+        *(
+            field
+            for field in KubernetesPodExecOperator.template_fields
+            if field not in {"cluster_context", "config_file", "kubernetes_conn_id"}
+        ),
+    )
+
+    def __init__(
+        self,
+        *,
+        cluster_name: str,
+        pod_name: str,
+        command: Sequence[str],
+        namespace: str = DEFAULT_NAMESPACE_NAME,
+        container_name: str | None = None,
+        aws_conn_id: str | None = DEFAULT_CONN_ID,
+        region_name: str | None = None,
+        verify: bool | str | None = None,
+        botocore_config: dict | None = None,
+        **kwargs,
+    ) -> None:
+        hook_params = AwsHookParams.from_constructor(
+            aws_conn_id, region_name, verify, botocore_config, additional_params=kwargs
+        )
+        super().__init__(
+            pod_name=pod_name,
+            command=command,
+            namespace=namespace,
+            container_name=container_name,
+            kubernetes_conn_id=None,
+            in_cluster=False,
+            cluster_context=None,
+            config_file=None,
+            **kwargs,
+        )
+        self.cluster_name = cluster_name
+        self.aws_conn_id = hook_params.aws_conn_id
+        self.region_name = hook_params.region_name
+        self.verify = hook_params.verify
+        self.botocore_config = hook_params.botocore_config
+
+    def execute(self, context: Context) -> str | None:
+        eks_hook = EksHook(
+            aws_conn_id=self.aws_conn_id,
+            region_name=self.region_name,
+            verify=self.verify,
+            config=self.botocore_config,
+        )
+        credentials = eks_hook.get_session().get_credentials()
+        if credentials is None:
+            raise RuntimeError(
+                "Unable to retrieve AWS credentials. Credentials may have expired or not been configured. "
+                "Please check your AWS connection configuration."
+            )
+        frozen_credentials = credentials.get_frozen_credentials()
+        with eks_hook._secure_credential_context(
+            frozen_credentials.access_key,
+            frozen_credentials.secret_key,
+            frozen_credentials.token,
+        ) as credentials_file:
+            with eks_hook.generate_config_file(
+                eks_cluster_name=self.cluster_name,
+                pod_namespace=self.namespace,
+                credentials_file=credentials_file,
+            ) as config_file:
+                self.config_file = config_file
+                try:
+                    return super().execute(context)
+                finally:
+                    self.config_file = None

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
@@ -1368,13 +1368,18 @@ class EksPodExecOperator(KubernetesPodExecOperator):
     :param command: Command and arguments to execute in the container. (templated)
     :param namespace: Namespace containing the Pod. Defaults to ``default``. (templated)
     :param container_name: Name of the container in which to execute the command. When omitted, the
-        ``kubectl.kubernetes.io/default-container`` annotation or the first container is used. (templated)
+        ``kubectl.kubernetes.io/default-container`` annotation or the first container is used.
+        Defaults to ``None``. (templated)
     :param aws_conn_id: The Airflow connection used for AWS credentials. (templated)
-        If this is ``None`` or empty, the default boto3 credential strategy is used.
+        Defaults to ``aws_default``. If this is ``None`` or empty, the default boto3 credential
+        strategy is used without an Airflow connection lookup.
     :param region_name: AWS region containing the Amazon EKS Cluster. (templated)
-        If this is ``None`` or empty, the default boto3 region strategy is used.
-    :param verify: Whether to verify SSL certificates, or the path to a CA bundle. (templated)
-    :param botocore_config: Configuration dictionary for the botocore client.
+        Defaults to ``None``, which uses the region from the AWS connection when available and
+        otherwise falls back to the default boto3 region strategy.
+    :param verify: Whether to verify SSL certificates, or the path to a CA bundle. Defaults to
+        ``None``, which uses the value from the AWS connection when available. (templated)
+    :param botocore_config: Configuration dictionary for the botocore client. Defaults to ``None``,
+        which uses ``config_kwargs`` from the AWS connection when available.
     :param do_xcom_push: Return standard output through XCom when ``True``. Defaults to ``False``.
     :param max_xcom_output_size: Maximum UTF-8 byte size retained for XCom. Defaults to 49,344 bytes.
     """

--- a/providers/amazon/tests/system/amazon/aws/example_eks_with_nodegroups.py
+++ b/providers/amazon/tests/system/amazon/aws/example_eks_with_nodegroups.py
@@ -26,6 +26,7 @@ from airflow.providers.amazon.aws.operators.eks import (
     EksCreateNodegroupOperator,
     EksDeleteClusterOperator,
     EksDeleteNodegroupOperator,
+    EksPodExecOperator,
     EksPodOperator,
 )
 from airflow.providers.amazon.aws.sensors.eks import EksClusterStateSensor, EksNodegroupStateSensor
@@ -46,10 +47,16 @@ except ImportError:
     # Compatibility for Airflow < 3.1
     from airflow.utils.trigger_rule import TriggerRule  # type: ignore[no-redef,attr-defined]
 
+try:
+    from airflow.providers.standard.operators.bash import BashOperator
+except ImportError:
+    from airflow.operators.bash import BashOperator  # type: ignore[no-redef]
+
 from system.amazon.aws.utils import ENV_ID_KEY, SystemTestContextBuilder
 from system.amazon.aws.utils.k8s import get_describe_pod_operator
 
 DAG_ID = "example_eks_with_nodegroups"
+EXPECTED_EXEC_OUTPUT = "command executed in existing EKS pod"
 
 # Externally fetched variables:
 ROLE_ARN_KEY = "ROLE_ARN"
@@ -76,6 +83,12 @@ def delete_launch_template(template_name: str):
     boto3.client("ec2").delete_launch_template(LaunchTemplateName=template_name)
 
 
+@task
+def verify_exec_output(output: str) -> None:
+    if output != EXPECTED_EXEC_OUTPUT:
+        raise ValueError(f"Unexpected command output: {output!r}")
+
+
 with DAG(
     dag_id=DAG_ID,
     schedule="@once",
@@ -88,6 +101,7 @@ with DAG(
     cluster_name = f"{env_id}-cluster"
     nodegroup_name = f"{env_id}-nodegroup"
     launch_template_name = f"{env_id}-launch-template"
+    exec_pod_name = f"{env_id}-exec-pod"
 
     # [START howto_operator_eks_create_cluster]
     # Create an Amazon EKS Cluster control plane without attaching compute service.
@@ -151,6 +165,46 @@ with DAG(
     # it is cleaned anyway with the cluster later on.
     start_pod.is_delete_operator_pod = False
 
+    create_exec_pod = BashOperator(
+        task_id="create_exec_pod",
+        bash_command="""
+            set -euo pipefail
+            install_aws.sh
+            install_kubectl.sh
+            aws eks update-kubeconfig --name "${CLUSTER_NAME}"
+            kubectl run "${POD_NAME}" --image=busybox:1.38.0 --restart=Never --command -- sleep 3600
+            kubectl wait --for=condition=Ready "pod/${POD_NAME}" --timeout=120s
+        """,
+        env={"CLUSTER_NAME": cluster_name, "POD_NAME": exec_pod_name},
+        append_env=True,
+    )
+
+    # [START howto_operator_eks_pod_exec]
+    run_command = EksPodExecOperator(
+        task_id="run_command_in_existing_pod",
+        cluster_name=cluster_name,
+        pod_name=exec_pod_name,
+        command=["sh", "-c", f"printf '{EXPECTED_EXEC_OUTPUT}'"],
+        do_xcom_push=True,
+    )
+    # [END howto_operator_eks_pod_exec]
+
+    exec_output_is_valid = verify_exec_output(run_command.output)
+
+    delete_exec_pod = BashOperator(
+        task_id="delete_exec_pod",
+        bash_command="""
+            set -euo pipefail
+            install_aws.sh
+            install_kubectl.sh
+            aws eks update-kubeconfig --name "${CLUSTER_NAME}"
+            kubectl delete pod "${POD_NAME}" --ignore-not-found=true --wait=false
+        """,
+        env={"CLUSTER_NAME": cluster_name, "POD_NAME": exec_pod_name},
+        append_env=True,
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+
     describe_pod = get_describe_pod_operator(
         cluster_name, pod_name="{{ ti.xcom_pull(key='pod_name', task_ids='run_pod') }}"
     )
@@ -211,14 +265,30 @@ with DAG(
         # TEST SETUP
         test_context,
         create_launch_template(launch_template_name),
-        # TEST BODY
         create_cluster,
         await_create_cluster,
         create_nodegroup,
         await_create_nodegroup,
+    )
+    chain(
+        # TEST BODY: EksPodOperator
+        await_create_nodegroup,
         start_pod,
-        # TEST TEARDOWN
         describe_pod,
+        await_nodegroup_stable,
+    )
+    chain(
+        # TEST BODY: EksPodExecOperator
+        await_create_nodegroup,
+        create_exec_pod,
+        run_command,
+        exec_output_is_valid,
+        # TEST TEARDOWN
+        delete_exec_pod,
+        await_nodegroup_stable,
+    )
+    chain(
+        # TEST TEARDOWN
         await_nodegroup_stable,
         delete_nodegroup,  # part of the test AND teardown
         await_delete_nodegroup,

--- a/providers/amazon/tests/system/amazon/aws/example_eks_with_nodegroups.py
+++ b/providers/amazon/tests/system/amazon/aws/example_eks_with_nodegroups.py
@@ -16,11 +16,15 @@
 # under the License.
 from __future__ import annotations
 
+import asyncio
+from contextlib import contextmanager
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 import boto3
+from kubernetes.client import V1Container, V1ObjectMeta, V1Pod, V1PodSpec
 
-from airflow.providers.amazon.aws.hooks.eks import ClusterStates, NodegroupStates
+from airflow.providers.amazon.aws.hooks.eks import ClusterStates, EksHook, NodegroupStates
 from airflow.providers.amazon.aws.operators.eks import (
     EksCreateClusterOperator,
     EksCreateNodegroupOperator,
@@ -30,6 +34,8 @@ from airflow.providers.amazon.aws.operators.eks import (
     EksPodOperator,
 )
 from airflow.providers.amazon.aws.sensors.eks import EksClusterStateSensor, EksNodegroupStateSensor
+from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
+from airflow.providers.cncf.kubernetes.utils.pod_manager import PodManager
 
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
@@ -47,13 +53,13 @@ except ImportError:
     # Compatibility for Airflow < 3.1
     from airflow.utils.trigger_rule import TriggerRule  # type: ignore[no-redef,attr-defined]
 
-try:
-    from airflow.providers.standard.operators.bash import BashOperator
-except ImportError:
-    from airflow.operators.bash import BashOperator  # type: ignore[no-redef]
-
 from system.amazon.aws.utils import ENV_ID_KEY, SystemTestContextBuilder
 from system.amazon.aws.utils.k8s import get_describe_pod_operator
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from kubernetes.client import CoreV1Api
 
 DAG_ID = "example_eks_with_nodegroups"
 EXPECTED_EXEC_OUTPUT = "command executed in existing EKS pod"
@@ -81,6 +87,44 @@ def create_launch_template(template_name: str):
 @task(trigger_rule=TriggerRule.ALL_DONE)
 def delete_launch_template(template_name: str):
     boto3.client("ec2").delete_launch_template(LaunchTemplateName=template_name)
+
+
+@contextmanager
+def get_eks_kubernetes_client(cluster_name: str) -> Generator[CoreV1Api, None, None]:
+    eks_hook = EksHook()
+    credentials = eks_hook.get_session().get_credentials()
+    if credentials is None:
+        raise RuntimeError("Unable to retrieve AWS credentials for the EKS system test.")
+    frozen_credentials = credentials.get_frozen_credentials()
+    with eks_hook._secure_credential_context(
+        frozen_credentials.access_key,
+        frozen_credentials.secret_key,
+        frozen_credentials.token,
+    ) as credentials_file:
+        with eks_hook.generate_config_file(cluster_name, "default", credentials_file) as config_file:
+            yield KubernetesHook(kubernetes_conn_id=None, config_file=config_file).core_v1_client
+
+
+@task
+def create_exec_pod(cluster_name: str, pod_name: str) -> None:
+    pod = V1Pod(
+        metadata=V1ObjectMeta(name=pod_name, namespace="default"),
+        spec=V1PodSpec(
+            containers=[V1Container(name="main", image="busybox:1.38.0", command=["sleep", "3600"])],
+            restart_policy="Never",
+        ),
+    )
+    with get_eks_kubernetes_client(cluster_name) as kube_client:
+        pod_manager = PodManager(kube_client=kube_client)
+        created_pod = pod_manager.create_pod(pod)
+        asyncio.run(pod_manager.await_pod_start(created_pod))
+
+
+@task(trigger_rule=TriggerRule.ALL_DONE)
+def delete_exec_pod(cluster_name: str, pod_name: str) -> None:
+    pod = V1Pod(metadata=V1ObjectMeta(name=pod_name, namespace="default"))
+    with get_eks_kubernetes_client(cluster_name) as kube_client:
+        PodManager(kube_client=kube_client).delete_pod(pod)
 
 
 @task
@@ -165,19 +209,7 @@ with DAG(
     # it is cleaned anyway with the cluster later on.
     start_pod.is_delete_operator_pod = False
 
-    create_exec_pod = BashOperator(
-        task_id="create_exec_pod",
-        bash_command="""
-            set -euo pipefail
-            install_aws.sh
-            install_kubectl.sh
-            aws eks update-kubeconfig --name "${CLUSTER_NAME}"
-            kubectl run "${POD_NAME}" --image=busybox:1.38.0 --restart=Never --command -- sleep 3600
-            kubectl wait --for=condition=Ready "pod/${POD_NAME}" --timeout=120s
-        """,
-        env={"CLUSTER_NAME": cluster_name, "POD_NAME": exec_pod_name},
-        append_env=True,
-    )
+    create_exec_pod_task = create_exec_pod(cluster_name, exec_pod_name)
 
     # [START howto_operator_eks_pod_exec]
     run_command = EksPodExecOperator(
@@ -191,19 +223,7 @@ with DAG(
 
     exec_output_is_valid = verify_exec_output(run_command.output)
 
-    delete_exec_pod = BashOperator(
-        task_id="delete_exec_pod",
-        bash_command="""
-            set -euo pipefail
-            install_aws.sh
-            install_kubectl.sh
-            aws eks update-kubeconfig --name "${CLUSTER_NAME}"
-            kubectl delete pod "${POD_NAME}" --ignore-not-found=true --wait=false
-        """,
-        env={"CLUSTER_NAME": cluster_name, "POD_NAME": exec_pod_name},
-        append_env=True,
-        trigger_rule=TriggerRule.ALL_DONE,
-    )
+    delete_exec_pod_task = delete_exec_pod(cluster_name, exec_pod_name)
 
     describe_pod = get_describe_pod_operator(
         cluster_name, pod_name="{{ ti.xcom_pull(key='pod_name', task_ids='run_pod') }}"
@@ -280,11 +300,11 @@ with DAG(
     chain(
         # TEST BODY: EksPodExecOperator
         await_create_nodegroup,
-        create_exec_pod,
+        create_exec_pod_task,
         run_command,
         exec_output_is_valid,
         # TEST TEARDOWN
-        delete_exec_pod,
+        delete_exec_pod_task,
         await_nodegroup_stable,
     )
     chain(

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_eks.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_eks.py
@@ -55,7 +55,7 @@ from moto.eks.models import (
     NODEGROUP_NOT_FOUND_MSG,
 )
 
-from airflow.providers.amazon.aws.hooks.eks import EksHook
+from airflow.providers.amazon.aws.hooks.eks import COMMAND, EksHook
 
 from unit.amazon.aws.utils.eks_test_constants import (
     DEFAULT_CONN_ID,
@@ -1289,8 +1289,6 @@ class TestEksHook:
         assert "2>/dev/null" not in COMMAND
 
     def test_command_template_uses_last_stdout_line_with_posix_shell(self, tmp_path):
-        from airflow.providers.amazon.aws.hooks.eks import COMMAND
-
         credentials_file = tmp_path / "credentials"
         credentials_file.write_text(
             "export AWS_ACCESS_KEY_ID='test-access-key'\nexport AWS_SECRET_ACCESS_KEY='test-secret-key'\n"

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_eks.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_eks.py
@@ -17,6 +17,8 @@
 # under the License.
 from __future__ import annotations
 
+import json
+import subprocess
 import sys
 from copy import deepcopy
 from pathlib import Path
@@ -1285,6 +1287,38 @@ class TestEksHook:
         assert '2>"$stderr_file"' in COMMAND
         assert 'cat "$stderr_file" >&2' in COMMAND
         assert "2>/dev/null" not in COMMAND
+
+    def test_command_template_uses_last_stdout_line_with_posix_shell(self, tmp_path):
+        from airflow.providers.amazon.aws.hooks.eks import COMMAND
+
+        credentials_file = tmp_path / "credentials"
+        credentials_file.write_text(
+            "export AWS_ACCESS_KEY_ID='test-access-key'\nexport AWS_SECRET_ACCESS_KEY='test-secret-key'\n"
+        )
+        token_helper = tmp_path / "token-helper"
+        token_helper.write_text(
+            "#!/bin/sh\n"
+            "printf '%s\\n' '2026-09-04T17:50:59Z [info] Found credentials in environment variables.'\n"
+            "printf '%s\\n' 'expirationTimestamp: 2026-09-04T18:04:59Z, token: test-token'\n"
+        )
+        token_helper.chmod(0o700)
+        command = COMMAND.format(
+            credentials_file=credentials_file,
+            sts_url="https://sts.us-east-1.amazonaws.com",
+            python_executable=token_helper,
+            eks_cluster_name="test-cluster",
+            args="",
+            authentication_api_version="client.authentication.k8s.io/v1",
+        )
+
+        result = subprocess.run(["sh", "-c", command], capture_output=True, text=True, check=True)
+
+        assert json.loads(result.stdout) == {
+            "kind": "ExecCredential",
+            "apiVersion": "client.authentication.k8s.io/v1",
+            "spec": {},
+            "status": {"expirationTimestamp": "2026-09-04T18:04:59Z", "token": "test-token"},
+        }
 
     def test_command_template_does_not_print_token_output_on_error(self):
         """Verify the error path does not echo stdout, which can contain a token."""

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_eks.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_eks.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any, TypedDict
 from unittest import mock
 
@@ -33,6 +34,7 @@ from airflow.providers.amazon.aws.operators.eks import (
     EksDeleteClusterOperator,
     EksDeleteFargateProfileOperator,
     EksDeleteNodegroupOperator,
+    EksPodExecOperator,
     EksPodOperator,
 )
 from airflow.providers.amazon.aws.triggers.eks import (
@@ -1293,3 +1295,123 @@ class TestEksPodOperator:
 
         with pytest.raises(RuntimeError, match="Pod must be created with metadata before deferring"):
             op.invoke_defer_method()
+
+
+class TestEksPodExecOperator:
+    @staticmethod
+    def configure_eks_auth(eks_hook_mock):
+        eks_hook = eks_hook_mock.return_value
+        credentials = eks_hook.get_session.return_value.get_credentials.return_value
+        credentials.get_frozen_credentials.return_value = SimpleNamespace(
+            access_key="test_access_key",
+            secret_key="test_secret_key",
+            token="test_token",
+        )
+        eks_hook._secure_credential_context.return_value.__enter__.return_value = "/tmp/aws-credentials"
+        eks_hook.generate_config_file.return_value.__enter__.return_value = "/tmp/eks-kubeconfig"
+        return eks_hook
+
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.operators.pod_exec.KubernetesPodExecOperator.execute",
+        autospec=True,
+    )
+    @mock.patch("airflow.providers.amazon.aws.operators.eks.EksHook", autospec=True)
+    def test_execute(self, eks_hook_mock, pod_exec_execute_mock):
+        eks_hook = self.configure_eks_auth(eks_hook_mock)
+
+        def execute_with_generated_config(operator, context):
+            assert operator.config_file == "/tmp/eks-kubeconfig"
+            assert operator.kubernetes_conn_id is None
+            assert operator.in_cluster is False
+            assert operator.do_xcom_push is True
+            assert operator.max_xcom_output_size == 1024
+            return "command output"
+
+        pod_exec_execute_mock.side_effect = execute_with_generated_config
+        operator = EksPodExecOperator(
+            task_id="run_command",
+            cluster_name=CLUSTER_NAME,
+            pod_name="existing-pod",
+            namespace="workloads",
+            container_name="worker",
+            command=["dbt", "run"],
+            aws_conn_id="aws_test",
+            region_name="us-east-2",
+            verify=False,
+            botocore_config={"retries": {"max_attempts": 5}},
+            do_xcom_push=True,
+            max_xcom_output_size=1024,
+        )
+
+        result = operator.execute({})
+
+        assert result == "command output"
+        eks_hook_mock.assert_called_once_with(
+            aws_conn_id="aws_test",
+            region_name="us-east-2",
+            verify=False,
+            config={"retries": {"max_attempts": 5}},
+        )
+        eks_hook.get_session.return_value.get_credentials.assert_called_once_with()
+        eks_hook._secure_credential_context.assert_called_once_with(
+            "test_access_key", "test_secret_key", "test_token"
+        )
+        eks_hook.generate_config_file.assert_called_once_with(
+            eks_cluster_name=CLUSTER_NAME,
+            pod_namespace="workloads",
+            credentials_file="/tmp/aws-credentials",
+        )
+        pod_exec_execute_mock.assert_called_once_with(operator, {})
+        assert operator.config_file is None
+
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.operators.pod_exec.KubernetesPodExecOperator.execute",
+        autospec=True,
+    )
+    @mock.patch("airflow.providers.amazon.aws.operators.eks.EksHook", autospec=True)
+    def test_execute_clears_config_file_on_failure(self, eks_hook_mock, pod_exec_execute_mock):
+        self.configure_eks_auth(eks_hook_mock)
+        pod_exec_execute_mock.side_effect = RuntimeError("command failed")
+        operator = EksPodExecOperator(
+            task_id="run_command",
+            cluster_name=CLUSTER_NAME,
+            pod_name="existing-pod",
+            command=["false"],
+        )
+
+        with pytest.raises(RuntimeError, match="command failed"):
+            operator.execute({})
+
+        assert operator.config_file is None
+
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.operators.pod_exec.KubernetesPodExecOperator.execute",
+        autospec=True,
+    )
+    @mock.patch("airflow.providers.amazon.aws.operators.eks.EksHook", autospec=True)
+    def test_execute_rejects_missing_credentials(self, eks_hook_mock, pod_exec_execute_mock):
+        eks_hook = eks_hook_mock.return_value
+        eks_hook.get_session.return_value.get_credentials.return_value = None
+        operator = EksPodExecOperator(
+            task_id="run_command",
+            cluster_name=CLUSTER_NAME,
+            pod_name="existing-pod",
+            command=["true"],
+        )
+
+        with pytest.raises(RuntimeError, match="Unable to retrieve AWS credentials"):
+            operator.execute({})
+
+        eks_hook._secure_credential_context.assert_not_called()
+        eks_hook.generate_config_file.assert_not_called()
+        pod_exec_execute_mock.assert_not_called()
+
+    def test_template_fields(self):
+        operator = EksPodExecOperator(
+            task_id="run_command",
+            cluster_name=CLUSTER_NAME,
+            pod_name="existing-pod",
+            command=["dbt", "run"],
+        )
+
+        validate_template_fields(operator)

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_eks.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_eks.py
@@ -1415,3 +1415,10 @@ class TestEksPodExecOperator:
         )
 
         validate_template_fields(operator)
+        assert "cluster_name" in operator.template_fields
+        assert "pod_name" in operator.template_fields
+        assert "command" in operator.template_fields
+
+        assert "cluster_context" not in operator.template_fields
+        assert "config_file" not in operator.template_fields
+        assert "kubernetes_conn_id" not in operator.template_fields


### PR DESCRIPTION
Add `EksPodExecOperator` so Dags can execute commands in running containers of existing Amazon EKS Pods without Airflow creating, restarting, or deleting them.

This supports long-lived workloads managed by another platform, where Airflow should own the command execution but not the Pod lifecycle. Reusing an already-running Pod also avoids paying its startup cost for every task.

The operator uses the AWS connection to generate a temporary EKS kubeconfig, then delegates command execution, log streaming, exit-code handling, and bounded optional XCom output to `KubernetesPodExecOperator`. This keeps EKS authentication in the Amazon provider while reusing the Kubernetes behavior introduced in #71244.

The change includes unit coverage, documentation, and an EKS system-test path that creates and deletes the external Pod outside the operator.

The live test also exposed an existing shell-portability issue in the EKS kubeconfig credential parser. The regression fix protects both `EksPodOperator` and `EksPodExecOperator` when credential discovery writes an informational line before the token output.

Testing:

- `breeze run --skip-image-upgrade-check pytest providers/amazon/tests/unit/amazon/aws/operators/test_eks.py -q --tb=short` (`66 passed`)
- `breeze run --skip-image-upgrade-check pytest providers/amazon/tests/unit/amazon/aws/hooks/test_eks.py::TestEksHook -q` (`7 passed`)
- `breeze run --skip-image-upgrade-check mypy providers/amazon/src/airflow/providers/amazon/aws/hooks/eks.py providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py providers/amazon/tests/system/amazon/aws/example_eks_with_nodegroups.py` (no issues)
- System-test import and collection (`1 test collected`)


- **Live AWS end-to-end system test using** `--forward-credentials`: create the EKS cluster and nodegroup, create an externally managed Pod, execute and validate the command output, delete the Pod, and tear down the AWS resources (`1 passed` in 15:37)

- **Apache Magpie self-review** (`pr-management-code-review`, dry-run): completed with no code-level findings.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)