### PR TITLE
Make Helm chart version optional in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-airflow_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1-airflow_bug_report.yml
@@ -258,8 +258,6 @@ body:
         - "1.0.0"
         - "main (development)"
       default: 0
-    validations:
-      required: true
   - type: input
     attributes:
       label: Kubernetes Version


### PR DESCRIPTION
Bug reports unrelated to the Helm chart currently require reporters to select a chart version, usually `Not Applicable`. Making the field optional removes an unnecessary step while preserving the issue category, Airflow version, reproduction details, and Code of Conduct as required fields.

The existing `Not Applicable` default remains available for reporters using the Helm chart.

closes: #55840

Testing:

- `prek run yamllint --files .github/ISSUE_TEMPLATE/1-airflow_bug_report.yml`
- `prek run check-airflow-bug-report-template --files .github/ISSUE_TEMPLATE/1-airflow_bug_report.yml`
- `codespell .github/ISSUE_TEMPLATE/1-airflow_bug_report.yml`
- Manual-stage static checks

No runtime tests are needed because this only changes GitHub Issue Form validation.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — OpenAI Codex (GPT-5)

Generated-by: OpenAI Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---
Drafted-by: OpenAI Codex (GPT-5) (no human review before posting)
