### PR TITLE
Let BashOperator push multiple XComs, including on failure

### DIFF
--- a/providers/standard/docs/operators/bash.rst
+++ b/providers/standard/docs/operators/bash.rst
@@ -276,6 +276,64 @@ resolves to ``{"dag_folder": ..., "file_count": ...}``.
     ``jq -nc --arg uri "$uri" '{uri: $uri}'`` (note that ``jq`` is not installed in every image).
 
 
+XCom directory
+--------------
+
+``output_processor`` and ``multiple_outputs`` both work by parsing captured stdout, so they
+inherit its limits: only the last line is captured, and it must all fit on one line. The XCom
+directory sidesteps both. Instead of parsing output, the ``BashOperator`` hands the script a
+directory -- ``$AIRFLOW_XCOM_DIR`` -- and reads back whatever the script wrote there once the
+command finishes.
+
+Two rules govern what ends up as an XCom:
+
+* A **file's name is the XCom key**. Its content, decoded and with a single trailing newline
+  stripped, becomes the value.
+* A file named with a **``.json`` suffix** has its content parsed with ``json.loads``; the key
+  is the filename without the suffix.
+
+Subdirectories under ``$AIRFLOW_XCOM_DIR`` are not supported; put structured or nested values in
+a ``.json`` file instead (or use ``xcom push --json``).
+
+You can write directly into the directory, or use the ``xcom push`` helper command that the
+operator puts on ``PATH`` (unless ``xcom_helper_name`` is set to ``None``):
+
+.. exampleinclude:: /../src/airflow/providers/standard/example_dags/example_bash_operator.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_bash_xcom_dir]
+    :end-before: [END howto_operator_bash_xcom_dir]
+
+.. code-block:: bash
+
+    # Equivalent to the helper: a plain redirect, since the filename is the key.
+    echo "42" > "$AIRFLOW_XCOM_DIR/row_count"
+
+    # The helper also accepts a value on stdin, which is convenient for large or multiline output.
+    generate_report | xcom push report
+
+    # --json parses the value before storing it, same as writing a ".json" file directly.
+    xcom push --json summary '{"rows": 42, "errors": 0}'
+
+.. important::
+
+    Values written this way are **strings** unless you use ``.json`` -- ``xcom push row_count
+    42`` pushes the string ``"42"``, not the integer ``42``. Use ``xcom push --json`` or a
+    ``.json`` file when you need a non-string type.
+
+.. note::
+
+    Entries are pushed from a ``finally`` block, so they are pushed whether the command
+    succeeds, fails, or is skipped -- this is the point of the mechanism, and it is what lets a
+    failing task still hand diagnostic data to a downstream task or the UI. The one thing it
+    cannot cover is the task process itself being killed (for example, ``SIGKILL``): that
+    prevents the ``finally`` block from running, so nothing is pushed. This covers command
+    failure, not worker death.
+
+If the script writes a ``return_value`` entry (a plain file or a ``return_value.json`` file) and
+the command succeeds, that value is returned from the task instead of the last line of stdout,
+so it becomes the task's XCom return value as usual.
+
 Executing commands from files
 -----------------------------
 Both the ``BashOperator`` and ``@task.bash`` TaskFlow decorator enables you to execute Bash commands stored

--- a/providers/standard/docs/operators/bash.rst
+++ b/providers/standard/docs/operators/bash.rst
@@ -298,11 +298,25 @@ a ``.json`` file instead (or use ``xcom push --json``).
 You can write directly into the directory, or use the ``xcom push`` helper command that the
 operator puts on ``PATH`` (unless ``xcom_helper_name`` is set to ``None``):
 
-.. exampleinclude:: /../src/airflow/providers/standard/example_dags/example_bash_operator.py
-    :language: python
-    :dedent: 4
-    :start-after: [START howto_operator_bash_xcom_dir]
-    :end-before: [END howto_operator_bash_xcom_dir]
+.. tab-set::
+
+    .. tab-item:: @task.bash
+        :sync: taskflow
+
+        .. exampleinclude:: /../src/airflow/providers/standard/example_dags/example_bash_decorator.py
+            :language: python
+            :dedent: 4
+            :start-after: [START howto_decorator_bash_xcom_dir]
+            :end-before: [END howto_decorator_bash_xcom_dir]
+
+    .. tab-item:: BashOperator
+        :sync: operator
+
+        .. exampleinclude:: /../src/airflow/providers/standard/example_dags/example_bash_operator.py
+            :language: python
+            :dedent: 4
+            :start-after: [START howto_operator_bash_xcom_dir]
+            :end-before: [END howto_operator_bash_xcom_dir]
 
 .. code-block:: bash
 

--- a/providers/standard/src/airflow/providers/standard/example_dags/example_bash_decorator.py
+++ b/providers/standard/src/airflow/providers/standard/example_dags/example_bash_decorator.py
@@ -138,6 +138,27 @@ def example_bash_decorator():
     show_dag_folder_stats(folder=dag_stats["dag_folder"], count=dag_stats["file_count"])
     # [END howto_decorator_bash_multiple_outputs]
 
+    # [START howto_decorator_bash_xcom_dir]
+    @task.bash
+    def write_multiple_xcoms() -> str:
+        # The filename is the XCom key, so no value needs quoting or escaping.
+        return """
+            set -e
+            echo "42" > "$AIRFLOW_XCOM_DIR/row_count"
+            xcom push --json summary '{"rows": 42, "errors": 0}'
+        """
+
+    @task.bash
+    def read_multiple_xcoms(row_count: str, summary: dict) -> str:
+        return f'echo "row_count={row_count} errors={summary["errors"]}"'
+
+    write_multiple_xcoms_task = write_multiple_xcoms()
+    read_multiple_xcoms(
+        row_count=write_multiple_xcoms_task["row_count"],
+        summary=write_multiple_xcoms_task["summary"],
+    )
+    # [END howto_decorator_bash_xcom_dir]
+
     chain(run_me_loop, run_this)
     chain([also_this, also_this_again, this_skips, run_this], run_this_last)
 

--- a/providers/standard/src/airflow/providers/standard/example_dags/example_bash_operator.py
+++ b/providers/standard/src/airflow/providers/standard/example_dags/example_bash_operator.py
@@ -48,6 +48,7 @@ with DAG(
     - Executing simple bash commands
     - Creating task dependencies, including loops and templated commands
     - Pushing several named XComs from one task with `multiple_outputs`
+    - Pushing several named XComs, resilient to task failure, via the XCom directory
 
     This example is intended for beginners who want to understand how Airflow
     interacts with system-level commands using bash.
@@ -105,6 +106,26 @@ with DAG(
     )
     # [END howto_operator_bash_multiple_outputs]
     describe_dag_folder >> show_dag_folder_stats >> run_this_last
+
+    # [START howto_operator_bash_xcom_dir]
+    write_multiple_xcoms = BashOperator(
+        task_id="write_multiple_xcoms",
+        bash_command="""
+            set -e
+            echo "42" > "$AIRFLOW_XCOM_DIR/row_count"
+            xcom push --json summary '{"rows": 42, "errors": 0}'
+        """,
+    )
+
+    read_multiple_xcoms = BashOperator(
+        task_id="read_multiple_xcoms",
+        bash_command=(
+            "echo \"row_count={{ ti.xcom_pull(task_ids='write_multiple_xcoms', key='row_count') }}"
+            " summary={{ ti.xcom_pull(task_ids='write_multiple_xcoms', key='summary') }}\""
+        ),
+    )
+    # [END howto_operator_bash_xcom_dir]
+    write_multiple_xcoms >> read_multiple_xcoms >> run_this_last
 
 # [START howto_operator_bash_skip]
 this_will_skip = BashOperator(

--- a/providers/standard/src/airflow/providers/standard/operators/bash.py
+++ b/providers/standard/src/airflow/providers/standard/operators/bash.py
@@ -17,11 +17,14 @@
 # under the License.
 from __future__ import annotations
 
+import contextlib
+import json
 import os
 import shutil
 import tempfile
-from collections.abc import Callable, Container, Sequence
+from collections.abc import Callable, Container, Iterator, Sequence
 from functools import cached_property
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from airflow.providers.common.compat.sdk import (
@@ -36,6 +39,21 @@ if TYPE_CHECKING:
     from airflow.providers.common.compat.sdk import Context
     from airflow.providers.standard.version_compat import ArgNotSet
 
+# POSIX sh, no bashisms: this shim runs inside whatever shell the user's bash_command uses to
+# invoke it, which is not necessarily bash (e.g. a script that re-execs into sh).
+_XCOM_HELPER_SHIM = """#!/bin/sh
+set -e
+[ "$1" = push ] || { echo "usage: xcom push [--json] <key> [value]" >&2; exit 2; }
+shift
+ext=""
+[ "$1" = --json ] && { ext=.json; shift; }
+key=$1
+case "$key" in ""|.|..|*/*) echo "xcom: invalid key '$key'" >&2; exit 2 ;; esac
+shift
+target=$AIRFLOW_XCOM_DIR/$key$ext
+if [ $# -gt 0 ]; then printf '%s' "$1" > "$target"; else cat > "$target"; fi
+"""
+
 
 class BashOperator(BaseOperator):
     r"""
@@ -46,7 +64,13 @@ class BashOperator(BaseOperator):
         :ref:`howto/operator:BashOperator`
 
     If BaseOperator.do_xcom_push is True, the last line written to stdout
-    will also be pushed to an XCom when the bash command completes
+    will also be pushed to an XCom when the bash command completes.
+
+    Additionally, when ``do_xcom_push`` is True, the operator exposes an ``$AIRFLOW_XCOM_DIR``
+    directory (and, unless ``xcom_helper_name`` is ``None``, an ``xcom push`` helper command on
+    ``PATH``) that the script can use to push multiple, named XComs -- one file per XCom -- and
+    those are pushed whether the command succeeds, fails, or is skipped. See
+    :ref:`howto/operator:BashOperator` for details.
 
     :param bash_command: The command, set of commands or reference to a
         Bash script (must be '.sh' or '.bash') to be executed. (templated)
@@ -71,6 +95,11 @@ class BashOperator(BaseOperator):
         template) into a new temporary file in this directory.
     :param output_processor: Function to further process the output of the bash script
         (default is lambda output: output).
+    :param xcom_helper_name: Name of an ``xcom push`` helper command installed on ``PATH`` for the
+        bash command (default ``"xcom"``). Set to ``None`` to skip installing the helper; the
+        ``$AIRFLOW_XCOM_DIR`` directory is still made available either way.
+    :param max_xcom_file_size: Maximum size, in bytes, of a single file under
+        ``$AIRFLOW_XCOM_DIR`` that will be read and pushed as an XCom.
 
     Airflow will evaluate the exit code of the Bash command. In general, a non-zero exit code will result in
     task failure and zero will result in task success.
@@ -145,6 +174,10 @@ class BashOperator(BaseOperator):
     .. versionadded:: 2.10.0
        The `output_processor` parameter.
 
+    .. versionadded:: NEXT
+       The ``xcom_helper_name`` and ``max_xcom_file_size`` parameters, and the
+       ``$AIRFLOW_XCOM_DIR`` XCom directory mechanism.
+
     """
 
     template_fields: Sequence[str] = ("bash_command", "env", "cwd")
@@ -162,6 +195,8 @@ class BashOperator(BaseOperator):
         skip_on_exit_code: int | Container[int] | None = 99,
         cwd: str | None = None,
         output_processor: Callable[[str], Any] = lambda result: result,
+        xcom_helper_name: str | None = "xcom",
+        max_xcom_file_size: int = 1_048_576,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -178,6 +213,8 @@ class BashOperator(BaseOperator):
         self.cwd = cwd
         self.append_env = append_env
         self.output_processor = output_processor
+        self.xcom_helper_name = xcom_helper_name
+        self.max_xcom_file_size = max_xcom_file_size
         self._is_inline_cmd: bool | None = None
 
     @cached_property
@@ -214,18 +251,48 @@ class BashOperator(BaseOperator):
         env = self.get_env(context)
 
         self._is_inline_cmd = self._is_inline_command(bash_command=cast("str", self.bash_command))
-        if self._is_inline_cmd:
-            result = self._run_inline_command(bash_path=bash_path, env=env)
-        else:
-            result = self._run_rendered_script_file(bash_path=bash_path, env=env)
 
-        if result.exit_code in self.skip_on_exit_code:
-            raise AirflowSkipException(f"Bash command returned exit code {result.exit_code}. Skipping.")
-        if result.exit_code != 0:
-            raise AirflowException(
-                f"Bash command failed. The command returned a non-zero exit code {result.exit_code}."
-            )
+        pushed_xcoms: dict[str, Any] = {}
+        with contextlib.ExitStack() as stack:
+            xcom_dir: Path | None = None
+            if self.do_xcom_push:
+                xcom_dir, bin_dir = stack.enter_context(self._xcom_workspace())
+                # get_env() returns self.env itself when append_env is False, so copy before
+                # adding per-run vars -- otherwise these temp paths leak into the operator's
+                # own env attribute and survive into later runs.
+                env = dict(env)
+                env["AIRFLOW_XCOM_DIR"] = os.fspath(xcom_dir)
+                if bin_dir is not None:
+                    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH') or os.defpath}"
 
+            exception_in_flight = False
+            try:
+                if self._is_inline_cmd:
+                    result = self._run_inline_command(bash_path=bash_path, env=env)
+                else:
+                    result = self._run_rendered_script_file(bash_path=bash_path, env=env)
+
+                if result.exit_code in self.skip_on_exit_code:
+                    raise AirflowSkipException(
+                        f"Bash command returned exit code {result.exit_code}. Skipping."
+                    )
+                if result.exit_code != 0:
+                    raise AirflowException(
+                        f"Bash command failed. The command returned a non-zero exit code {result.exit_code}."
+                    )
+            except BaseException:
+                exception_in_flight = True
+                raise
+            finally:
+                # Collecting here (rather than after the exit-code checks above) means XComs are
+                # pushed whether the command succeeded, failed, or was skipped.
+                if xcom_dir is not None:
+                    pushed_xcoms = self._collect_and_push_xcom(
+                        context=context, xcom_dir=xcom_dir, exception_in_flight=exception_in_flight
+                    )
+
+        if "return_value" in pushed_xcoms:
+            return pushed_xcoms["return_value"]
         return self.output_processor(result.output)
 
     def _run_inline_command(self, bash_path: str, env: dict) -> SubprocessResult:
@@ -260,6 +327,96 @@ class BashOperator(BaseOperator):
     def _is_inline_command(cls, bash_command: str) -> bool:
         """Return True if the bash command is an inline string. False if it's a bash script file."""
         return not bash_command.endswith(tuple(cls.template_ext))
+
+    @contextlib.contextmanager
+    def _xcom_workspace(self) -> Iterator[tuple[Path, Path | None]]:
+        """
+        Create the ``$AIRFLOW_XCOM_DIR`` workspace for a single run.
+
+        Kept separate from the ``working_directory()`` script cwd tempdir so a rendered ``.sh``
+        file can never collide with an XCom key.
+        """
+        with tempfile.TemporaryDirectory(prefix="airflow-bash-xcom-") as workspace:
+            xcom_dir = Path(workspace) / "xcom"
+            xcom_dir.mkdir()
+            bin_dir: Path | None = None
+            if self.xcom_helper_name:
+                bin_dir = Path(workspace) / "bin"
+                bin_dir.mkdir()
+                helper_path = bin_dir / self.xcom_helper_name
+                helper_path.write_text(_XCOM_HELPER_SHIM)
+                helper_path.chmod(0o755)
+            yield xcom_dir, bin_dir
+
+    def _read_xcom_file(self, path: Path) -> tuple[str | None, Any, str | None]:
+        """Read one file under ``$AIRFLOW_XCOM_DIR`` and return ``(key, value, error)``."""
+        size = path.stat().st_size
+        if size > self.max_xcom_file_size:
+            return (
+                None,
+                None,
+                f"XCom file {path} is {size} bytes, exceeding max_xcom_file_size "
+                f"({self.max_xcom_file_size} bytes); it was not pushed.",
+            )
+        text = path.read_bytes().decode(self.output_encoding)
+        value = text[:-1] if text.endswith("\n") else text
+        if path.suffix != ".json":
+            return path.name, value, None
+        try:
+            return path.stem, json.loads(text), None
+        except json.JSONDecodeError as exc:
+            # Keep the ".json" suffix on the key so downstream consumers can tell this value
+            # was not parsed, and never silently drop the diagnostic content.
+            return (
+                path.name,
+                value,
+                f"XCom file {path} contains invalid JSON ({exc}); the raw content was pushed "
+                f"under {path.name!r} instead.",
+            )
+
+    def _read_xcom_dir(self, xcom_dir: Path, errors: list[str]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for entry in sorted(os.scandir(xcom_dir), key=lambda e: e.name):
+            # is_symlink() is checked first because is_dir()/is_file() follow symlinks.
+            if entry.is_symlink() or not (entry.is_dir() or entry.is_file()):
+                errors.append(
+                    f"XCom directory entry {entry.path!r} is not a regular file; it was not pushed."
+                )
+                continue
+            if entry.is_dir():
+                errors.append(
+                    f"XCom directory entry {entry.path!r} is a subdirectory; subdirectories are not "
+                    "supported. Use a '.json' file (or `xcom push --json`) for structured values."
+                )
+                continue
+            key, value, error = self._read_xcom_file(Path(entry.path))
+            if error is not None:
+                errors.append(error)
+            if key is not None:
+                result[key] = value
+        return result
+
+    def _collect_and_push_xcom(
+        self, context: Context, xcom_dir: Path, exception_in_flight: bool
+    ) -> dict[str, Any]:
+        """
+        Read ``$AIRFLOW_XCOM_DIR`` and push every entry found in it.
+
+        Called from a ``finally`` block, so collection errors are gathered rather than raised
+        inline, and are downgraded to a warning when the command already failed or skipped --
+        an original Bash failure must never be masked by a bad XCom file.
+        """
+        errors: list[str] = []
+        entries = self._read_xcom_dir(xcom_dir, errors=errors)
+        for key, value in entries.items():
+            context["ti"].xcom_push(key=key, value=value)
+        if errors:
+            message = "; ".join(errors)
+            if exception_in_flight:
+                self.log.warning("Errors while collecting the XCom directory: %s", message)
+            else:
+                raise ValueError(f"Errors while collecting the XCom directory: {message}")
+        return entries
 
     def on_kill(self) -> None:
         self.subprocess_hook.send_sigterm()

--- a/providers/standard/tests/unit/standard/decorators/test_bash.py
+++ b/providers/standard/tests/unit/standard/decorators/test_bash.py
@@ -503,6 +503,47 @@ class TestBashDecorator:
             "uri": "s3://bucket/out",
         }
 
+    def test_xcom_dir_pushes_one_xcom_per_file(self, session):
+        """Files written into $AIRFLOW_XCOM_DIR each become their own XCom."""
+        with self.dag_maker:
+
+            @task.bash
+            def bash():
+                return """
+                    set -e
+                    printf 'a b "c"' > "$AIRFLOW_XCOM_DIR/message"
+                    xcom push --json summary '{"rows": 42}'
+                """
+
+            bash_task = bash()
+
+        ti, _ = self.execute_task(bash_task)
+
+        assert ti.xcom_pull(task_ids=ti.task_id, key="message", session=session) == 'a b "c"'
+        assert ti.xcom_pull(task_ids=ti.task_id, key="summary", session=session) == {"rows": 42}
+
+    def test_xcom_dir_pushes_when_the_command_fails(self, session):
+        """A failing @task.bash still hands its XCom directory entries to downstream tasks."""
+        with self.dag_maker:
+
+            @task.bash
+            def bash():
+                return """
+                    xcom push stage "loading"
+                    exit 1
+                """
+
+            bash_task = bash()
+
+        dag_run = self.dag_maker.create_dagrun(
+            run_id=f"bash_deco_xcom_fail_{DEFAULT_DATE.date()}", session=session
+        )
+        ti = dag_run.get_task_instance(bash_task.operator.task_id, session=session)
+        with pytest.raises(AirflowException):
+            bash_task.operator.execute(context={"ti": ti, "ds": DEFAULT_DATE.isoformat()[:10]})
+
+        assert ti.xcom_pull(task_ids=ti.task_id, key="stage", session=session) == "loading"
+
     @pytest.mark.parametrize(
         argnames=("return_val", "expected"),
         argvalues=[

--- a/providers/standard/tests/unit/standard/decorators/test_bash.py
+++ b/providers/standard/tests/unit/standard/decorators/test_bash.py
@@ -503,6 +503,9 @@ class TestBashDecorator:
             "uri": "s3://bucket/out",
         }
 
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_0_PLUS, reason="@task.bash only resolves to the provider's BashOperator on 3.0+"
+    )
     def test_xcom_dir_pushes_one_xcom_per_file(self, session):
         """Files written into $AIRFLOW_XCOM_DIR each become their own XCom."""
         with self.dag_maker:
@@ -522,6 +525,9 @@ class TestBashDecorator:
         assert ti.xcom_pull(task_ids=ti.task_id, key="message", session=session) == 'a b "c"'
         assert ti.xcom_pull(task_ids=ti.task_id, key="summary", session=session) == {"rows": 42}
 
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_0_PLUS, reason="@task.bash only resolves to the provider's BashOperator on 3.0+"
+    )
     def test_xcom_dir_pushes_when_the_command_fails(self, session):
         """A failing @task.bash still hands its XCom directory entries to downstream tasks."""
         with self.dag_maker:

--- a/providers/standard/tests/unit/standard/operators/test_bash.py
+++ b/providers/standard/tests/unit/standard/operators/test_bash.py
@@ -324,3 +324,198 @@ class TestBashOperator:
         task = ti.render_templates(context=context)
         result = task.execute(context=context)
         assert result == "test_templated_fields_task"
+
+
+def _pushed_xcoms(context) -> dict[str, object]:
+    """Turn ``context["ti"].xcom_push`` calls into a plain ``{key: value}`` dict."""
+    return {call.kwargs["key"]: call.kwargs["value"] for call in context["ti"].xcom_push.call_args_list}
+
+
+class TestBashOperatorXComDir:
+    def test_plain_file_strips_one_trailing_newline(self, context):
+        op = BashOperator(task_id="abc", bash_command="printf 'a\\n\\n' > \"$AIRFLOW_XCOM_DIR/k\"")
+        op.execute(context)
+        assert _pushed_xcoms(context) == {"k": "a\n"}
+
+    @pytest.mark.parametrize(
+        ("json_payload", "expected"),
+        [
+            ('{"a": 1}', {"a": 1}),
+            ("[1, 2, 3]", [1, 2, 3]),
+            ("42", 42),
+        ],
+    )
+    def test_json_file_is_parsed_under_stem_key(self, json_payload, expected, context):
+        op = BashOperator(
+            task_id="abc",
+            bash_command=f"printf '{json_payload}' > \"$AIRFLOW_XCOM_DIR/d.json\"",
+        )
+        op.execute(context)
+        assert _pushed_xcoms(context) == {"d": expected}
+
+    def test_value_with_quotes_and_newlines_survives_verbatim(self, context):
+        op = BashOperator(
+            task_id="abc",
+            bash_command=(
+                "cat <<'XCOM_EOF' > \"$AIRFLOW_XCOM_DIR/k\"\n"
+                "line one\n"
+                "line two with 'single' and \"double\" quotes\n"
+                "last line\n"
+                "XCOM_EOF\n"
+            ),
+        )
+        op.execute(context)
+        assert _pushed_xcoms(context) == {
+            "k": "line one\nline two with 'single' and \"double\" quotes\nlast line"
+        }
+
+    def test_non_zero_exit_still_pushes_and_raises(self, context):
+        op = BashOperator(task_id="abc", bash_command='printf x > "$AIRFLOW_XCOM_DIR/k"; exit 7')
+        with pytest.raises(AirflowException):
+            op.execute(context)
+        assert _pushed_xcoms(context) == {"k": "x"}
+
+    def test_skip_exit_code_still_pushes_and_raises(self, context):
+        op = BashOperator(task_id="abc", bash_command='printf x > "$AIRFLOW_XCOM_DIR/k"; exit 99')
+        with pytest.raises(AirflowSkipException):
+            op.execute(context)
+        assert _pushed_xcoms(context) == {"k": "x"}
+
+    def test_shim_push_with_inline_value(self, context):
+        op = BashOperator(task_id="abc", bash_command="xcom push k v")
+        op.execute(context)
+        assert _pushed_xcoms(context) == {"k": "v"}
+
+    def test_shim_push_reads_value_from_stdin(self, context):
+        op = BashOperator(task_id="abc", bash_command="printf hello | xcom push k")
+        op.execute(context)
+        assert _pushed_xcoms(context) == {"k": "hello"}
+
+    def test_shim_push_json_flag(self, context):
+        op = BashOperator(task_id="abc", bash_command="xcom push --json k '{\"a\": 1}'")
+        op.execute(context)
+        assert _pushed_xcoms(context) == {"k": {"a": 1}}
+
+    @pytest.mark.parametrize("bad_key", ["/abs", "../x", "", "a/b"])
+    def test_shim_rejects_invalid_keys(self, bad_key, context):
+        op = BashOperator(task_id="abc", bash_command=f'xcom push "{bad_key}" v')
+        with pytest.raises(AirflowException):
+            op.execute(context)
+
+    def test_malformed_json_on_success_path_raises_value_error(self, context):
+        op = BashOperator(
+            task_id="abc", bash_command="printf '{not json' > \"$AIRFLOW_XCOM_DIR/config.json\""
+        )
+        with pytest.raises(ValueError, match="config.json"):
+            op.execute(context)
+        assert _pushed_xcoms(context) == {"config.json": "{not json"}
+
+    def test_malformed_json_on_failure_path_keeps_original_exception(self, context):
+        op = BashOperator(
+            task_id="abc",
+            bash_command="printf '{not json' > \"$AIRFLOW_XCOM_DIR/config.json\"; exit 3",
+        )
+        with pytest.raises(AirflowException) as exc_info:
+            op.execute(context)
+        assert not isinstance(exc_info.value, ValueError)
+        assert "exit code 3" in str(exc_info.value)
+        assert _pushed_xcoms(context) == {"config.json": "{not json"}
+
+    def test_file_over_max_size_is_not_pushed_and_raises(self, context):
+        op = BashOperator(
+            task_id="abc",
+            bash_command='printf "abcdefgh" > "$AIRFLOW_XCOM_DIR/big"',
+            max_xcom_file_size=5,
+        )
+        with pytest.raises(ValueError, match="max_xcom_file_size"):
+            op.execute(context)
+        assert _pushed_xcoms(context) == {}
+
+    @pytest.mark.parametrize("dirname", ["stats", "stats.json"])
+    def test_subdirectory_is_an_error(self, dirname, context):
+        op = BashOperator(
+            task_id="abc",
+            bash_command=(
+                f'mkdir -p "$AIRFLOW_XCOM_DIR/{dirname}"; printf v > "$AIRFLOW_XCOM_DIR/{dirname}/x"'
+            ),
+        )
+        with pytest.raises(ValueError, match=r"\.json"):
+            op.execute(context)
+        pushed = _pushed_xcoms(context)
+        assert dirname not in pushed
+
+    def test_subdirectory_error_does_not_mask_command_failure(self, context):
+        op = BashOperator(
+            task_id="abc",
+            bash_command=('mkdir -p "$AIRFLOW_XCOM_DIR/stats"; printf v > "$AIRFLOW_XCOM_DIR/k"; exit 3'),
+        )
+        with pytest.raises(AirflowException) as exc_info:
+            op.execute(context)
+        assert not isinstance(exc_info.value, ValueError)
+        assert "exit code 3" in str(exc_info.value)
+        assert _pushed_xcoms(context) == {"k": "v"}
+
+    def test_symlink_is_an_error(self, context):
+        op = BashOperator(
+            task_id="abc",
+            bash_command=('printf v > "$AIRFLOW_XCOM_DIR/real"; ln -s real "$AIRFLOW_XCOM_DIR/link"'),
+        )
+        with pytest.raises(ValueError, match="not a regular file"):
+            op.execute(context)
+        assert _pushed_xcoms(context) == {"real": "v"}
+
+    def test_do_xcom_push_false_disables_the_mechanism(self, context):
+        op = BashOperator(
+            task_id="abc",
+            bash_command='[ -z "$AIRFLOW_XCOM_DIR" ] && exit 0 || exit 1',
+            do_xcom_push=False,
+        )
+        op.execute(context)
+        context["ti"].xcom_push.assert_not_called()
+
+    def test_xcom_helper_name_none_removes_helper_but_keeps_dir(self, context):
+        op = BashOperator(
+            task_id="abc",
+            bash_command=('command -v xcom >/dev/null 2>&1 && exit 1; printf v > "$AIRFLOW_XCOM_DIR/k"'),
+            xcom_helper_name=None,
+        )
+        op.execute(context)
+        assert _pushed_xcoms(context) == {"k": "v"}
+
+    def test_return_value_file_overrides_stdout_last_line(self, context):
+        op = BashOperator(
+            task_id="abc",
+            bash_command='printf rv > "$AIRFLOW_XCOM_DIR/return_value"; echo "last line"',
+        )
+        result = op.execute(context)
+        assert result == "rv"
+
+    def test_no_return_value_entry_keeps_stdout_last_line(self, context):
+        op = BashOperator(task_id="abc", bash_command='echo "last line"')
+        result = op.execute(context)
+        assert result == "last line"
+
+    def test_execute_does_not_mutate_the_operators_env(self, context):
+        user_env = {"var": "value"}
+        op = BashOperator(
+            task_id="abc",
+            bash_command='echo "$var" > "$AIRFLOW_XCOM_DIR/seen"',
+            env=user_env,
+            append_env=False,
+        )
+        op.execute(context)
+
+        assert _pushed_xcoms(context) == {"seen": "value"}
+        assert "AIRFLOW_XCOM_DIR" not in op.env
+        assert "PATH" not in op.env
+        assert user_env["var"] == "value"
+
+    def test_helper_found_via_defpath_fallback_when_env_has_no_path(self, context):
+        op = BashOperator(
+            task_id="abc",
+            bash_command="command -v xcom >/dev/null 2>&1 || exit 1; xcom push k v",
+            env={"FOO": "bar"},
+            append_env=False,
+        )
+        op.execute(context)
+        assert _pushed_xcoms(context) == {"k": "v"}


### PR DESCRIPTION
A Bash task can only produce one XCom today: the last line written to stdout. Anything richer means serialising to JSON on a single line and parsing it back with `output_processor`, which drags shell authors into quote-escaping for even simple key/value pairs. The `KubernetesPodOperator` sidecar has the same JSON contract, and every example of it in this repo writes a JSON *literal* rather than a shell variable — which is telling.

Separately, the task runner only pushes XCom on the success path (`_push_xcom_if_needed`), so a failing command cannot hand any diagnostic data to downstream tasks or to the UI — precisely when that data is most wanted.

### What this adds

When `do_xcom_push` is set, `BashOperator` exposes a directory as `$AIRFLOW_XCOM_DIR` plus an `xcom push` helper on `PATH`, and reads the directory back in a `finally` block — so entries are pushed whether the command succeeded, failed, or skipped.

Two rules govern what becomes an XCom:

* a **file's name is the key**, and its content (one trailing newline stripped) is the value;
* a **`.json` suffix** parses the content and drops the suffix from the key.

```bash
echo "$rows" > "$AIRFLOW_XCOM_DIR/row_count"   # no escaping, whatever $rows contains
generate_report | xcom push report             # stdin, for large or multiline values
xcom push --json summary '{"rows": 42}'        # same as writing summary.json
```

Because the filename carries the key, there is no format to escape — the value can contain quotes, spaces, or newlines and still round-trips. The helper is sugar over the documented directory contract, so scripts that reset `PATH` or exec into a container can just redirect into `$AIRFLOW_XCOM_DIR`.

If the script writes a `return_value` entry and the command succeeds, that value is returned from `execute()` rather than the stdout last line, so it flows through the runner's normal return-value push and composes with `multiple_outputs=True`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)