### PR TITLE
Declare allow_driver_in_extra in the ODBC provider configuration metadata

### DIFF
--- a/providers/odbc/docs/configurations-ref.rst
+++ b/providers/odbc/docs/configurations-ref.rst
@@ -1,0 +1,19 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+.. include:: /../../../devel-common/src/sphinx_exts/includes/providers-configurations-ref.rst
+.. include:: /../../../devel-common/src/sphinx_exts/includes/sections-and-options.rst

--- a/providers/odbc/docs/connections/odbc.rst
+++ b/providers/odbc/docs/connections/odbc.rst
@@ -73,7 +73,7 @@ Extra (optional)
           this config from env vars, use ``AIRFLOW__PROVIDERS_ODBC__ALLOW_DRIVER_IN_EXTRA=true``.
 
     .. note::
-        If setting ``allow_driver_extra`` to True, this allows users to set the driver via the Airflow Connection's
+        If setting ``allow_driver_in_extra`` to True, this allows users to set the driver via the Airflow Connection's
         ``extra`` field.  By default this is not allowed.  If enabling this functionality, you should make sure
         that you trust the users who can edit connections in the UI to not use it maliciously.
 

--- a/providers/odbc/docs/index.rst
+++ b/providers/odbc/docs/index.rst
@@ -34,6 +34,7 @@
     :maxdepth: 1
     :caption: Guides
 
+    Configuration <configurations-ref>
     Connection types <connections/odbc>
     Operators <operators>
 

--- a/providers/odbc/provider.yaml
+++ b/providers/odbc/provider.yaml
@@ -90,3 +90,17 @@ connection-types:
   - hook-class-name: airflow.providers.odbc.hooks.odbc.OdbcHook
     hook-name: "ODBC"
     connection-type: odbc
+
+config:
+  providers.odbc:
+    description: This section applies for the ODBC provider and connection type.
+    options:
+      allow_driver_in_extra:
+        description: |
+          Whether to allow using ``driver`` set in the connection's ``extra`` field. If set to False,
+          ``driver`` will be ignored. If enabling this functionality, you should make sure that you
+          trust the users who can edit connections to not use it maliciously.
+        version_added: "4.0.0"
+        type: boolean
+        example: ~
+        default: "False"

--- a/providers/odbc/src/airflow/providers/odbc/get_provider_info.py
+++ b/providers/odbc/src/airflow/providers/odbc/get_provider_info.py
@@ -43,4 +43,18 @@ def get_provider_info():
                 "connection-type": "odbc",
             }
         ],
+        "config": {
+            "providers.odbc": {
+                "description": "This section applies for the ODBC provider and connection type.",
+                "options": {
+                    "allow_driver_in_extra": {
+                        "description": "Whether to allow using ``driver`` set in the connection's ``extra`` field. If set to False,\n``driver`` will be ignored. If enabling this functionality, you should make sure that you\ntrust the users who can edit connections to not use it maliciously.\n",
+                        "version_added": "4.0.0",
+                        "type": "boolean",
+                        "example": None,
+                        "default": "False",
+                    }
+                },
+            }
+        },
     }

--- a/providers/odbc/tests/unit/odbc/hooks/test_odbc.py
+++ b/providers/odbc/tests/unit/odbc/hooks/test_odbc.py
@@ -236,6 +236,22 @@ class TestOdbcHook:
         )
         assert hook.driver == "Blah driver"
 
+    def test_allow_driver_in_extra_is_declared_in_provider_config(self):
+        """
+        The hook reads ``[providers.odbc] allow_driver_in_extra``. The option has to be declared in
+        ``provider.yaml`` so that ``airflow config list`` and the configuration reference know about it.
+        """
+        from airflow.providers.odbc.get_provider_info import get_provider_info
+
+        option = get_provider_info()["config"]["providers.odbc"]["options"]["allow_driver_in_extra"]
+        assert option["type"] == "boolean"
+        assert option["default"] == "False"
+
+    def test_allow_driver_in_extra_default_is_resolved_without_fallback(self):
+        from airflow.providers.common.compat.sdk import conf
+
+        assert conf.getboolean("providers.odbc", "allow_driver_in_extra") is False
+
     def test_default_driver_set(self):
         with patch.object(OdbcHook, "default_driver", "Blah driver"):
             hook = mock_db_hook(OdbcHook)


### PR DESCRIPTION
## Why

- #31754 (odbc 4.0.0) added the `[providers.odbc] allow_driver_in_extra` option, but `provider.yaml` could not declare configuration at the time (that came later in #32629), so the option was never declared in the provider metadata.
- As a result, `airflow config list --section providers.odbc` prints nothing and the provider has no Configuration Reference page, while `airflow config get-value` does return the value (#40405).

## How

- Add a `config:` block to `providers/odbc/provider.yaml`.

## Verification

- Unit test: `uv run --no-sync pytest providers/odbc/tests/unit/odbc/hooks/test_odbc.py`
- Integration test:
  - main branch
  ```
  > uv run --no-sync airflow config list --section providers.odbc
  <empty>
  > uv run --no-sync airflow config get-value providers.odbc allow_driver_in_extra
  <empty>
  > AIRFLOW__PROVIDERS_ODBC__ALLOW_DRIVER_IN_EXTRA=True AIRFLOW_HOME=$(mktemp -d) uv run --no-sync airflow config get-value providers.odbc allow_driver_in_extra
  <empty>
  ```
  - This branch
  ```
  > uv run --no-sync airflow config list --section providers.odbc
  [providers.odbc]
  # allow_driver_in_extra =
  > uv run --no-sync airflow config get-value providers.odbc allow_driver_in_extra
  False
  > AIRFLOW__PROVIDERS_ODBC__ALLOW_DRIVER_IN_EXTRA=True AIRFLOW_HOME=$(mktemp -d) uv run --no-sync airflow config get-value providers.odbc allow_driver_in_extra
  True
  ```
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
