### PR TITLE
Fix airflow connections test returning success exit code on failure

### DIFF
--- a/airflow-core/src/airflow/cli/commands/connection_command.py
+++ b/airflow-core/src/airflow/cli/commands/connection_command.py
@@ -469,3 +469,4 @@ def connections_test(args) -> None:
         console.print("[bold green]\nConnection success!\n")
     else:
         console.print(f"[bold][red]\nConnection failed![/bold]\n{message}\n")
+        raise SystemExit(1)

--- a/airflow-core/tests/unit/cli/commands/test_connection_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_connection_command.py
@@ -1107,9 +1107,10 @@ class TestCliTestConnections:
         mock_test_conn = mocker.patch("airflow.providers.http.hooks.http.HttpHook.test_connection")
         conn_id = "http_default"
         mock_test_conn.return_value = False, "Failed."
-        with stdout_capture as stdout:
+        with stdout_capture as stdout, pytest.raises(SystemExit) as exc_info:
             connection_command.connections_test(self.parser.parse_args(["connections", "test", conn_id]))
-            assert "Connection failed!\nFailed.\n\n" in stdout.getvalue()
+        assert exc_info.value.code == 1
+        assert "Connection failed!\nFailed.\n\n" in stdout.getvalue()
 
     def test_cli_connections_test_missing_conn(self, mocker, stdout_capture):
         mocker.patch.dict(os.environ, {"AIRFLOW__CORE__TEST_CONNECTION": "Enabled"})


### PR DESCRIPTION
### Sumarry

`airflow connections test <conn_id>` prints "Connection failed!" but always returns exit code 0, because the failure branch in `connections_test` (`airflow-core/src/airflow/cli/commands/connection_command.py`) only prints
the error message without raising `SystemExit(1)`. The other two failure paths in the same function (test-connection disabled, connection not found) already `raise SystemExit(1)`, so this was an inconsistency rather than intentional behavior.

Any script that runs this command and checks `$?` (e.g. a deployment pre-flight check or a custom health check a deployment team wrote around this CLI) will treat a failed connection test as a success.

### Change

This PR adds `raise SystemExit(1)` to the failure branch and updates `test_cli_connections_test_fail` to assert the exit code.
