### PR TITLE
Keep provider_config_fallback_defaults.cfg in sync with provider.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1148,6 +1148,18 @@ repos:
         pass_filenames: false
         require_serial: true
         additional_dependencies: ['packaging>=25', 'pyyaml', 'tomli>=2.0.1', 'rich>=13.6.0']
+      - id: check-provider-config-fallback-defaults
+        name: Check provider_config_fallback_defaults.cfg is in sync with provider.yaml files
+        language: python
+        entry: ./scripts/ci/prek/check_provider_config_fallback_defaults.py
+        files: >
+          (?x)
+          ^airflow-core/src/airflow/config_templates/provider_config_fallback_defaults\.cfg$|
+          ^providers/.*/provider\.yaml$|
+          ^scripts/ci/prek/check_provider_config_fallback_defaults\.py$
+        pass_filenames: false
+        require_serial: true
+        additional_dependencies: ['pyyaml', 'rich>=13.6.0']
       - id: check-dependency-lower-bounds
         name: Check that dependencies in pyproject.toml have lower bounds
         language: python

--- a/airflow-core/docs/cli-and-env-variables-ref.rst
+++ b/airflow-core/docs/cli-and-env-variables-ref.rst
@@ -80,7 +80,6 @@ Environment Variables
 * ``broker_url`` in ``[celery]`` section
 * ``flower_basic_auth`` in ``[celery]`` section
 * ``result_backend`` in ``[celery]`` section
-* ``password`` in ``[atlas]`` section
 * ``smtp_password`` in ``[smtp]`` section
 * ``secret_key`` in ``[api]`` section
 

--- a/airflow-core/docs/howto/set-config.rst
+++ b/airflow-core/docs/howto/set-config.rst
@@ -103,7 +103,6 @@ The following config options support this ``_cmd`` and ``_secret`` version:
 * ``broker_url`` in ``[celery]`` section
 * ``flower_basic_auth`` in ``[celery]`` section
 * ``result_backend`` in ``[celery]`` section
-* ``password`` in ``[atlas]`` section
 * ``smtp_password`` in ``[smtp]`` section
 * ``secret_key`` in ``[api]`` section
 * ``jwt_secret`` in ``[api_auth]`` section

--- a/airflow-core/src/airflow/config_templates/provider_config_fallback_defaults.cfg
+++ b/airflow-core/src/airflow/config_templates/provider_config_fallback_defaults.cfg
@@ -32,13 +32,6 @@
 # You've been warned!
 #
 
-[atlas]
-sasl_enabled = False
-host =
-port = 21000
-username =
-password =
-
 [hive]
 default_hive_mapred_queue =
 
@@ -69,7 +62,6 @@ pool = prefork
 operation_timeout = 1.0
 task_track_started = True
 task_publish_max_retries = 3
-worker_precheck = False
 
 [elasticsearch]
 host =
@@ -86,7 +78,7 @@ write_to_es = False
 target_index = airflow-logs
 
 [elasticsearch_configs]
-use_ssl = False
+http_compress = False
 verify_certs = True
 
 [opensearch]
@@ -132,5 +124,4 @@ tcp_keep_idle = 120
 tcp_keep_intvl = 30
 tcp_keep_cnt = 6
 verify_ssl = True
-worker_pods_queued_check_interval = 60
 ssl_ca_cert =

--- a/devel-common/src/tests_common/test_utils/config.py
+++ b/devel-common/src/tests_common/test_utils/config.py
@@ -45,7 +45,7 @@ PROVIDER_METADATA_CONFIG_OPTIONS: list[tuple[str, str, str]] = [
 CFG_FALLBACK_CONFIG_OPTIONS: list[tuple[str, str, str]] = [
     ("celery", "flower_host", "0.0.0.0"),
     ("celery", "pool", "prefork"),
-    ("celery", "worker_precheck", "False"),
+    ("celery", "worker_prefetch_multiplier", "1"),
     ("kubernetes_executor", "in_cluster", "True"),
     ("kubernetes_executor", "verify_ssl", "True"),
     ("elasticsearch", "end_of_log_mark", "end_of_log"),

--- a/scripts/ci/prek/check_provider_config_fallback_defaults.py
+++ b/scripts/ci/prek/check_provider_config_fallback_defaults.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# /// script
+# requires-python = ">=3.10,<3.11"
+# dependencies = [
+#   "pyyaml",
+#   "rich>=13.6.0",
+# ]
+# ///
+"""
+Check that ``provider_config_fallback_defaults.cfg`` only carries options providers still declare.
+
+``airflow-core/src/airflow/config_templates/provider_config_fallback_defaults.cfg`` is a hand-maintained
+subset of provider configuration: the defaults core may need while provider modules are being imported,
+before the providers' own configuration has been loaded. Everything in it is merged into ``conf`` as if
+the provider had declared it (``has_option``, ``as_dict``, ``airflow config list``), so an entry that no
+``provider.yaml`` declares any more keeps a removed option alive indefinitely.
+
+This check enforces the "cfg is a subset of provider.yaml" direction only: every ``(section, option)``
+in the cfg must be declared in the ``config`` section of some ``providers/**/provider.yaml`` with the
+same default.
+"""
+
+from __future__ import annotations
+
+import sys
+from configparser import ConfigParser
+from pathlib import Path
+from typing import TYPE_CHECKING, NamedTuple
+
+import yaml
+from common_prek_utils import (
+    AIRFLOW_CORE_SOURCES_PATH,
+    AIRFLOW_ROOT_PATH,
+    console,
+    get_all_provider_yaml_files,
+)
+from rich.markup import escape
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+FALLBACK_CFG_PATH = (
+    AIRFLOW_CORE_SOURCES_PATH / "airflow" / "config_templates" / "provider_config_fallback_defaults.cfg"
+)
+
+# Options whose cfg default intentionally differs from the provider.yaml default.
+# (section, option, provider.yaml default, cfg default)
+#
+# Keep in sync with PROVIDER_METADATA_OVERRIDES_CFG_FALLBACK in
+# devel-common/src/tests_common/test_utils/config.py - the unit test in
+# scripts/tests/ci/prek/test_check_provider_config_fallback_defaults.py fails when the two lists differ.
+PROVIDER_METADATA_OVERRIDES_CFG_FALLBACK: list[tuple[str, str, str, str]] = [
+    (
+        "celery",
+        "celery_app_name",
+        "airflow.providers.celery.executors.celery_executor",
+        "airflow.executors.celery_executor",
+    ),
+]
+
+
+class ProviderOption(NamedTuple):
+    """Default declared for a config option in a provider.yaml (``None`` when declared as ``~``)."""
+
+    default: str | None
+    provider_yaml: Path
+
+
+def load_fallback_cfg(cfg_path: Path) -> dict[str, dict[str, str]]:
+    """Return ``{section: {option: value}}`` for the fallback cfg, lower-cased and without interpolation."""
+    parser = ConfigParser(interpolation=None)
+    parser.read_string(cfg_path.read_text(), source=str(cfg_path))
+    return {
+        section.lower(): {option.lower(): value for option, value in parser.items(section)}
+        for section in parser.sections()
+    }
+
+
+def load_provider_config_options(
+    provider_yaml_files: Iterable[Path],
+) -> dict[tuple[str, str], ProviderOption]:
+    """Return ``{(section, option): ProviderOption}`` for every config option the given provider.yaml files declare."""
+    loader = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
+    options: dict[tuple[str, str], ProviderOption] = {}
+    for provider_yaml in sorted(provider_yaml_files):
+        provider_info = yaml.load(provider_yaml.read_text(), Loader=loader)
+        for section, section_content in (provider_info.get("config") or {}).items():
+            for option, option_content in ((section_content or {}).get("options") or {}).items():
+                default = (option_content or {}).get("default")
+                options[(section.lower(), option.lower())] = ProviderOption(
+                    default=None if default is None else str(default),
+                    provider_yaml=provider_yaml,
+                )
+    return options
+
+
+def _display_path(path: Path) -> str:
+    try:
+        return path.relative_to(AIRFLOW_ROOT_PATH).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def find_drift(
+    cfg: dict[str, dict[str, str]],
+    provider_options: dict[tuple[str, str], ProviderOption],
+    overrides: Iterable[tuple[str, str, str, str]] = PROVIDER_METADATA_OVERRIDES_CFG_FALLBACK,
+) -> list[str]:
+    """
+    Return one message per cfg entry that no provider.yaml declares, or declares with a different default.
+
+    Sections that no provider.yaml declares at all are reported once, not once per option.
+    """
+    provider_sections = {section for section, _ in provider_options}
+    intentional = {
+        (section, option): (metadata_default, cfg_default)
+        for section, option, metadata_default, cfg_default in overrides
+    }
+    errors: list[str] = []
+    for section, options in cfg.items():
+        if section not in provider_sections:
+            errors.append(
+                f"[{section}]: no provider.yaml declares this section any more - remove the whole section"
+            )
+            continue
+        for option, cfg_value in options.items():
+            declared = provider_options.get((section, option))
+            if declared is None:
+                errors.append(
+                    f"[{section}] {option}: no provider.yaml declares this option any more - remove it"
+                )
+                continue
+            expected = intentional.get((section, option))
+            if expected is not None:
+                metadata_default, cfg_default = expected
+                if declared.default != metadata_default or cfg_value != cfg_default:
+                    errors.append(
+                        f"[{section}] {option}: intentional override is out of date - "
+                        f"{_display_path(declared.provider_yaml)} declares {declared.default!r}, "
+                        f"the cfg has {cfg_value!r}, but PROVIDER_METADATA_OVERRIDES_CFG_FALLBACK "
+                        f"expects ({metadata_default!r}, {cfg_default!r})"
+                    )
+                continue
+            if declared.default is None:
+                errors.append(
+                    f"[{section}] {option} = {cfg_value!r}: "
+                    f"{_display_path(declared.provider_yaml)} declares no default for it"
+                )
+            elif declared.default != cfg_value:
+                errors.append(
+                    f"[{section}] {option} = {cfg_value!r}: "
+                    f"{_display_path(declared.provider_yaml)} declares default {declared.default!r}"
+                )
+    return errors
+
+
+def main() -> int:
+    cfg = load_fallback_cfg(FALLBACK_CFG_PATH)
+    provider_options = load_provider_config_options(get_all_provider_yaml_files())
+    errors = find_drift(cfg, provider_options)
+    if errors:
+        console.print(
+            f"\n[red]{_display_path(FALLBACK_CFG_PATH)} is out of sync with provider.yaml files![/]\n"
+        )
+        for error in errors:
+            # Section names look like Rich markup tags, so escape them before printing.
+            console.print(f"  - {escape(error)}")
+        console.print(
+            "\n[yellow]Every option in the fallback cfg must be declared in some providers/**/provider.yaml "
+            "with the same default. If a provider dropped or renamed an option, drop it from the cfg too. "
+            "If a default has to differ on purpose, add it to PROVIDER_METADATA_OVERRIDES_CFG_FALLBACK both "
+            "in this script and in devel-common/src/tests_common/test_utils/config.py.[/]\n"
+        )
+        return 1
+    checked = sum(len(options) for options in cfg.values())
+    console.print(
+        f"[green]All {checked} fallback defaults in {len(cfg)} sections are declared "
+        "in provider.yaml files with matching defaults.[/]"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/ci/prek/test_check_provider_config_fallback_defaults.py
+++ b/scripts/tests/ci/prek/test_check_provider_config_fallback_defaults.py
@@ -1,0 +1,227 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import re
+import textwrap
+from pathlib import Path
+
+import check_provider_config_fallback_defaults as hook
+import pytest
+import yaml
+from check_provider_config_fallback_defaults import (
+    FALLBACK_CFG_PATH,
+    PROVIDER_METADATA_OVERRIDES_CFG_FALLBACK,
+    ProviderOption,
+    find_drift,
+    load_fallback_cfg,
+    load_provider_config_options,
+)
+from common_prek_utils import get_all_provider_yaml_files
+
+CELERY_YAML = Path("providers/celery/provider.yaml")
+CNCF_YAML = Path("providers/cncf/kubernetes/provider.yaml")
+
+
+def _write_cfg(tmp_path: Path, content: str) -> Path:
+    path = tmp_path / "provider_config_fallback_defaults.cfg"
+    path.write_text(textwrap.dedent(content))
+    return path
+
+
+def _write_provider_yaml(tmp_path: Path, provider_id: str, config: dict) -> Path:
+    path = tmp_path / "providers" / provider_id / "provider.yaml"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        yaml.dump(
+            {"package-name": f"apache-airflow-providers-{provider_id}", "state": "ready", "config": config}
+        )
+    )
+    return path
+
+
+def _declared(provider_yaml: Path, **defaults: str | None) -> dict[tuple[str, str], ProviderOption]:
+    """Build ``{("celery", option): ProviderOption}`` for the given ``option=default`` pairs."""
+    return {
+        ("celery", option): ProviderOption(default, provider_yaml) for option, default in defaults.items()
+    }
+
+
+class TestLoadFallbackCfg:
+    def test_lower_cases_sections_and_options_and_keeps_empty_values(self, tmp_path):
+        cfg_path = _write_cfg(
+            tmp_path,
+            """
+            [Celery]
+            Pool = prefork
+            flower_url_prefix =
+
+            [elasticsearch]
+            log_id_template = {dag_id}-{task_id}-{run_id}-{map_index}-{try_number}
+            """,
+        )
+        assert load_fallback_cfg(cfg_path) == {
+            "celery": {"pool": "prefork", "flower_url_prefix": ""},
+            "elasticsearch": {"log_id_template": "{dag_id}-{task_id}-{run_id}-{map_index}-{try_number}"},
+        }
+
+    def test_percent_signs_are_not_interpolated(self, tmp_path):
+        cfg_path = _write_cfg(tmp_path, "[logging]\nfmt = %(asctime)s\n")
+        assert load_fallback_cfg(cfg_path) == {"logging": {"fmt": "%(asctime)s"}}
+
+
+class TestLoadProviderConfigOptions:
+    def test_collects_defaults_across_files(self, tmp_path):
+        celery_yaml = _write_provider_yaml(
+            tmp_path,
+            "celery",
+            {
+                "celery": {"options": {"pool": {"default": "prefork"}, "result_backend": {"default": None}}},
+                "celery_kubernetes_executor": {"options": {"kubernetes_queue": {"default": "kubernetes"}}},
+            },
+        )
+        cncf_yaml = _write_provider_yaml(
+            tmp_path,
+            "cncf/kubernetes",
+            {"kubernetes_executor": {"options": {"tcp_keep_idle": {"default": 120}}}},
+        )
+        assert load_provider_config_options([celery_yaml, cncf_yaml]) == {
+            ("celery", "pool"): ProviderOption("prefork", celery_yaml),
+            ("celery", "result_backend"): ProviderOption(None, celery_yaml),
+            ("celery_kubernetes_executor", "kubernetes_queue"): ProviderOption("kubernetes", celery_yaml),
+            ("kubernetes_executor", "tcp_keep_idle"): ProviderOption("120", cncf_yaml),
+        }
+
+    def test_provider_without_config_is_ignored(self, tmp_path):
+        path = tmp_path / "provider.yaml"
+        path.write_text(yaml.dump({"package-name": "apache-airflow-providers-sqlite"}))
+        assert load_provider_config_options([path]) == {}
+
+
+class TestFindDrift:
+    def test_in_sync_cfg_has_no_errors(self):
+        cfg = {"celery": {"pool": "prefork", "flower_url_prefix": ""}}
+        assert find_drift(cfg, _declared(CELERY_YAML, pool="prefork", flower_url_prefix="")) == []
+
+    def test_section_nobody_declares_is_reported_once(self):
+        cfg = {"atlas": {"host": "", "port": "21000"}, "celery": {"pool": "prefork"}}
+        errors = find_drift(cfg, _declared(CELERY_YAML, pool="prefork"))
+        assert len(errors) == 1
+        assert errors[0].startswith("[atlas]:")
+        assert "remove the whole section" in errors[0]
+
+    def test_option_nobody_declares_is_reported(self):
+        cfg = {"celery": {"pool": "prefork", "worker_precheck": "False"}}
+        errors = find_drift(cfg, _declared(CELERY_YAML, pool="prefork"))
+        assert errors == [
+            "[celery] worker_precheck: no provider.yaml declares this option any more - remove it"
+        ]
+
+    def test_different_default_is_reported_with_both_values(self):
+        cfg = {"celery": {"worker_concurrency": "16"}}
+        errors = find_drift(cfg, _declared(CELERY_YAML, worker_concurrency="32"))
+        assert errors == [
+            "[celery] worker_concurrency = '16': providers/celery/provider.yaml declares default '32'"
+        ]
+
+    def test_provider_declaring_no_default_is_reported(self):
+        cfg = {"celery": {"result_backend": ""}}
+        errors = find_drift(cfg, _declared(CELERY_YAML, result_backend=None))
+        assert errors == [
+            "[celery] result_backend = '': providers/celery/provider.yaml declares no default for it"
+        ]
+
+    def test_intentional_override_is_accepted(self):
+        cfg = {"celery": {"celery_app_name": "old.module"}}
+        declared = _declared(CELERY_YAML, celery_app_name="new.module")
+        overrides = [("celery", "celery_app_name", "new.module", "old.module")]
+        assert find_drift(cfg, declared, overrides) == []
+
+    @pytest.mark.parametrize(
+        ("provider_default", "cfg_value"),
+        [
+            pytest.param("renamed.module", "old.module", id="provider-default-changed"),
+            pytest.param("new.module", "edited.module", id="cfg-value-changed"),
+        ],
+    )
+    def test_stale_intentional_override_is_reported(self, provider_default, cfg_value):
+        cfg = {"celery": {"celery_app_name": cfg_value}}
+        declared = _declared(CELERY_YAML, celery_app_name=provider_default)
+        overrides = [("celery", "celery_app_name", "new.module", "old.module")]
+        errors = find_drift(cfg, declared, overrides)
+        assert len(errors) == 1
+        assert "intentional override is out of date" in errors[0]
+        assert "PROVIDER_METADATA_OVERRIDES_CFG_FALLBACK" in errors[0]
+
+    def test_intentional_override_does_not_resurrect_removed_option(self):
+        cfg = {"celery": {"celery_app_name": "old.module"}}
+        overrides = [("celery", "celery_app_name", "new.module", "old.module")]
+        errors = find_drift(cfg, _declared(CELERY_YAML, pool="prefork"), overrides)
+        assert errors == [
+            "[celery] celery_app_name: no provider.yaml declares this option any more - remove it"
+        ]
+
+    def test_all_problems_are_reported_together(self):
+        cfg = {
+            "atlas": {"host": ""},
+            "celery": {"pool": "prefork", "worker_precheck": "False", "worker_concurrency": "16"},
+        }
+        declared = _declared(CELERY_YAML, pool="prefork", worker_concurrency="32")
+        errors = find_drift(cfg, declared)
+        assert [error.split(":")[0] for error in errors] == [
+            "[atlas]",
+            "[celery] worker_precheck",
+            "[celery] worker_concurrency = '16'",
+        ]
+
+
+class TestMain:
+    def _run_main(self, monkeypatch, tmp_path, cfg_content: str, config: dict) -> int:
+        cfg_path = _write_cfg(tmp_path, cfg_content)
+        provider_yaml = _write_provider_yaml(tmp_path, "celery", config)
+        monkeypatch.setattr(hook, "FALLBACK_CFG_PATH", cfg_path)
+        monkeypatch.setattr(hook, "get_all_provider_yaml_files", lambda: [provider_yaml])
+        return hook.main()
+
+    def test_returns_zero_when_in_sync(self, monkeypatch, tmp_path):
+        config = {"celery": {"options": {"pool": {"default": "prefork"}}}}
+        assert self._run_main(monkeypatch, tmp_path, "[celery]\npool = prefork\n", config) == 0
+
+    def test_returns_one_on_drift(self, monkeypatch, tmp_path, capsys):
+        config = {"celery": {"options": {"pool": {"default": "prefork"}}}}
+        assert (
+            self._run_main(
+                monkeypatch, tmp_path, "[celery]\npool = prefork\nworker_precheck = False\n", config
+            )
+            == 1
+        )
+        plain_output = re.sub(r"\x1b\[[0-9;]*m", "", capsys.readouterr().out)
+        assert "[celery] worker_precheck: no provider.yaml declares this option any more" in plain_output
+
+
+class TestRepositoryState:
+    def test_fallback_cfg_is_in_sync_with_provider_yaml_files(self):
+        cfg = load_fallback_cfg(FALLBACK_CFG_PATH)
+        provider_options = load_provider_config_options(get_all_provider_yaml_files())
+        assert find_drift(cfg, provider_options) == []
+
+    def test_intentional_overrides_match_tests_common(self):
+        from tests_common.test_utils.config import (
+            PROVIDER_METADATA_OVERRIDES_CFG_FALLBACK as TESTS_COMMON_OVERRIDES,
+        )
+
+        assert sorted(PROVIDER_METADATA_OVERRIDES_CFG_FALLBACK) == sorted(TESTS_COMMON_OVERRIDES)


### PR DESCRIPTION
## Why

- `airflow-core/src/airflow/config_templates/provider_config_fallback_defaults.cfg` is a hand-copied subset of provider config defaults. Core needs it while provider modules are being imported, before provider metadata is loaded. Nothing checks it against `provider.yaml`. Every entry in it is merged into `configuration_description`, so a stale entry keeps showing up in `airflow config list`.
- `[atlas]`: #32776 removed the section from core config.
- `[celery] worker_precheck`: #47320 removed it from the celery provider.
- `[kubernetes_executor] worker_pods_queued_check_interval`: #45184 removed it from the cncf.kubernetes provider.
- `[elasticsearch_configs] use_ssl`: #33135 replaced `use_ssl` with `http_compress`.

## How

- Remove the `[atlas]` section, `worker_precheck` and `worker_pods_queued_check_interval`; replace `use_ssl` with `http_compress = False` in `[elasticsearch_configs]`.
- Drop the two docs lines that list `password` in `[atlas]` as `_cmd` / `_secret` capable.
- Replace the `worker_precheck` row in `CFG_FALLBACK_CONFIG_OPTIONS` (devel-common test data) with `worker_prefetch_multiplier`.
- Add the `check-provider-config-fallback-defaults` prek hook : every `(section, option)` in the cfg must be declared in some `providers/**/provider.yaml` with the same default. It runs whenever the cfg or a `provider.yaml` changes, and only checks that the cfg is a subset of `provider.yaml`.

## Verification

- `uv run --project scripts pytest scripts/tests/ci/prek/test_check_provider_config_fallback_defaults.py`
- `uv run --no-sync pytest airflow-core/tests/unit/core/test_configuration.py`
- `cd task-sdk && uv run --no-sync pytest tests/task_sdk/test_configuration.py`

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
