### PR TITLE
Skip common.ai provider from Airflow 3.0-3.2 CI compatibility tests

### DIFF
--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -874,22 +874,25 @@ PROVIDERS_COMPATIBILITY_TESTS_MATRIX: list[dict[str, str | list[str]]] = [
         "remove-providers": "anthropic common.messaging common.dataquality edge3 fab git keycloak informatica common.ai opensearch",
         "run-unit-tests": "true",
     },
+    # common.ai supports Airflow >= 3.0, but the constraint files these jobs install with pin
+    # pydantic, opentelemetry-api or pydantic-ai-slim itself below its pydantic-ai-slim>=2.0.0
+    # floor - the provider ends up mismatched and its tests fail on import, so skip it there.
     {
         "python-version": "3.10",
         "airflow-version": "3.0.6",
-        "remove-providers": "",
+        "remove-providers": "common.ai",
         "run-unit-tests": "true",
     },
     {
         "python-version": "3.10",
         "airflow-version": "3.1.8",
-        "remove-providers": "",
+        "remove-providers": "common.ai",
         "run-unit-tests": "true",
     },
     {
         "python-version": "3.10",
         "airflow-version": "3.2.2",
-        "remove-providers": "",
+        "remove-providers": "common.ai",
         "run-unit-tests": "true",
     },
     {


### PR DESCRIPTION
## Summary

`Compat 3.0.6`, `Compat 3.1.8`, and `Compat 3.2.2` have been failing on main since 2026-09-04, all in `providers/common/ai`:

- `cannot import name 'EventSource' from 'httpx2'`
- `FastMCP client support is not installed`

The issue is caused by the old frozen constraints used by these jobs. `common.ai` requires `pydantic-ai-slim>=2.0.0`, but the 3.0-3.2 constraint sets pin incompatible dependency versions. Installing today's provider wheels with `--providers-skip-constraints` therefore creates a mixed environment that fails when the provider is imported.

`Compat 3.3.1` passes, and `2.11.1` already skips this provider.

We should not raise the provider's `apache-airflow` floor: Airflow 3.0-3.2 do not impose upper bounds on the relevant dependencies, so `common.ai` still supports those releases outside the frozen constraints.

The prov:LowestDeps failures in the same canary are an unrelated ibm.mq pre-extras download flake, addressed separately in #71544.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
