### PR TITLE
Show the test type description in provider CI compatibility job names

### DIFF
--- a/.github/workflows/test-providers.yml
+++ b/.github/workflows/test-providers.yml
@@ -178,7 +178,7 @@ jobs:
   providers-compatibility-tests-matrix:
     timeout-minutes: 80
     # yamllint disable rule:line-length
-    name: Compat ${{ matrix.compat.airflow-version }}:P${{ matrix.compat.python-version }}:${{ matrix.compat.test-types.description }}
+    name: Compat ${{ matrix.compat.airflow-version }}:P${{ matrix.compat.python-version }}:${{ matrix.test-types.description }}
     runs-on: ${{ fromJSON(inputs.runners) }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

The compatibility job name is trying to get the test type description from `matrix.compat`, but the description actually belongs to the separate `matrix.test-types` axis.

For example, the matrix has values like:

```text
compat:     3.0.6
python:     3.10
test-types: Provider unit tests
```

The job name currently looks for the test type under `compat`, so it produces:

```text
Compat 3.0.6:P3.10:
```

The trailing `:` is left empty because `compat` does not contain the test type description.

The test step in the same job already gets the description from `test-types` correctly. This change makes the job name use the same source, so it will show the test type as well.


---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)