### PR TITLE
Do not forward an empty ca_certs to the OpenSearch log client

### DIFF
--- a/providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py
+++ b/providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py
@@ -186,6 +186,11 @@ def _ensure_ti(ti: TaskInstanceKey | TaskInstance, session) -> TaskInstance:
 def get_os_kwargs_from_config() -> dict[str, Any]:
     open_search_config = conf.getsection("opensearch_configs")
     kwargs_dict = {key: value for key, value in open_search_config.items()} if open_search_config else {}
+    # ``ca_certs`` defaults to an empty string, which means "not configured". opensearch-py only uses its
+    # default CA bundle when the argument is left out entirely. Passing an empty string instead makes it
+    # raise ImproperlyConfigured when both ``use_ssl`` and ``verify_certs`` are enabled.
+    if not kwargs_dict.get("ca_certs"):
+        kwargs_dict.pop("ca_certs", None)
     return kwargs_dict
 
 

--- a/providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py
+++ b/providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py
@@ -625,6 +625,29 @@ class TestTaskHandlerHelpers:
             assert "http_compress" in args_from_config
             assert "self" not in args_from_config
 
+    @conf_vars(
+        {
+            ("opensearch_configs", "use_ssl"): "True",
+            ("opensearch_configs", "verify_certs"): "True",
+            ("opensearch_configs", "ca_certs"): "",
+        }
+    )
+    def test_empty_ca_certs_is_not_forwarded_to_client(self):
+        """The provider default for ``ca_certs`` is an empty string, which opensearch-py treats as
+        "no root certificates" rather than "use certifi" once TLS verification is enabled."""
+        from airflow.providers.opensearch.log.os_task_handler import _create_opensearch_client
+
+        os_kwargs = get_os_kwargs_from_config()
+
+        assert "ca_certs" not in os_kwargs
+        # Raises ImproperlyConfigured("Root certificates are missing ...") if ca_certs="" is forwarded.
+        client = _create_opensearch_client("localhost", 9200, "admin", "admin", os_kwargs)
+        assert isinstance(client, opensearchpy.OpenSearch)
+
+    @conf_vars({("opensearch_configs", "ca_certs"): "/etc/ssl/certs/ca.pem"})
+    def test_configured_ca_certs_is_forwarded_to_client(self):
+        assert get_os_kwargs_from_config()["ca_certs"] == "/etc/ssl/certs/ca.pem"
+
 
 class TestOpensearchRemoteLogIO:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Why

- `[opensearch_configs] ca_certs` defaults to an empty string in `provider.yaml`, and `get_os_kwargs_from_config()` forwards the whole section to `OpenSearch(...)`.
- opensearch-py only falls back to `certifi` when `ca_certs` is absent. With `use_ssl` and `verify_certs` enabled, an empty string makes it raise `ImproperlyConfigured("Root certificates are missing ...")`.

## How

- `get_os_kwargs_from_config()` drops `ca_certs` when it is empty, so opensearch-py falls back to certifi. It still forwards a configured path unchanged.

## Verification

- Unit test: `uv run --project opensearch pytest providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py`
- Integration test:

1. Setup

```sh
export AIRFLOW_HOME=/tmp/airflow-test-opensearch
mkdir -p $AIRFLOW_HOME
```

2. Start opensearch

```sh
docker run -d --name os-b0047 -p 9200:9200 -e discovery.type=single-node -e "OPENSEARCH_INITIAL_ADMIN_PASSWORD=Str0ng-Pass" -e "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" opensearchproject/opensearch:2
```

```sh
ngrok http https://localhost:9200
```

3. Add airflow.cfg

```sh
cat > $AIRFLOW_HOME/airflow.cfg <<'EOF'
[core]
load_examples = False

[logging]
remote_logging = True
delete_local_logs = False

[opensearch]
host = https://<host>
port = 443
username = admin
password = B0047-Str0ng!Pass
write_to_os = True
json_format = True
write_stdout = False

[opensearch_configs]
http_compress = False
use_ssl = True
verify_certs = True
ssl_assert_hostname = False
ssl_show_warn = False
ca_certs =

[api_auth]
jwt_secret = demo-test
EOF
```

4. Run `airflow version`

On main branch, it shows

```
ImportError: Unable to load logging config from airflow.config_templates.airflow_local_settings.DEFAULT_LOGGING_CONFIG due to: ImproperlyConfigured:Root certificates are missing for certificate validation. Either pass them in using the ca_certs parameter or install certifi to use it automatically.
```

In this branch, it can show the version without error.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
