### PR TITLE
Fix Dag processing duration metric units

### DIFF
--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -1793,7 +1793,7 @@ def process_parse_results(
         normalized_bundle = normalize_name_for_stats(bundle_name)
         stats.timing(
             "dag_processing.last_duration",
-            stat.last_duration,
+            timedelta(seconds=stat.last_duration),
             tags=prune_dict(
                 {"bundle_name": normalized_bundle, "file_name": file_name, "team_name": team_name}
             ),

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -1861,7 +1861,7 @@ class TestDagFileProcessorManager:
         last_runtime = manager._file_stats[file_info].last_duration
         statsd_timing_mock.assert_any_call(
             "dag_processing.last_duration",
-            last_runtime,
+            timedelta(seconds=last_runtime),
             tags={"bundle_name": bundle_name, "file_name": dag_filename[:-3]},
         )
 
@@ -3851,7 +3851,7 @@ class TestMultiTeamMetrics:
 
         mock_timing.assert_called_once_with(
             "dag_processing.last_duration",
-            1.5,
+            timedelta(seconds=1.5),
             tags={"bundle_name": "testing", "file_name": "dag", "team_name": "team_alpha"},
         )
 
@@ -3873,7 +3873,7 @@ class TestMultiTeamMetrics:
 
         mock_timing.assert_called_once_with(
             "dag_processing.last_duration",
-            1.5,
+            timedelta(seconds=1.5),
             tags={"bundle_name": "testing", "file_name": "dag"},
         )
 


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Why

`dag_processing.last_duration` is measured in seconds, but numeric values passed to `stats.timing()` are interpreted as milliseconds.

## What

Pass the duration as a `timedelta` at the metric emission boundary so StatsD, DogStatsD, and OpenTelemetry convert it to milliseconds correctly. `DagFileStat.last_duration` remains in seconds, and the existing metric name, tags, and emission timing are unchanged.

The metric registry already documents this metric in milliseconds, so no documentation change is needed.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (GPT 5.6 sol)

Generated-by: [GPT 5.6 sol] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
