### PR TITLE
Pass verify and botocore_config to GlueJobCompleteTrigger

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/glue.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/glue.py
@@ -367,6 +367,8 @@ class GlueJobOperator(ResumableJobMixin, AwsBaseOperator[GlueJobHook]):
                     waiter_delay=self.waiter_delay,
                     waiter_max_attempts=self.waiter_max_attempts,
                     region_name=self.region_name,
+                    verify=self.verify,
+                    botocore_config=self.botocore_config,
                 ),
                 method_name="execute_complete",
             )

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/glue.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/glue.py
@@ -105,6 +105,8 @@ class GlueJobSensor(AwsBaseSensor[GlueJobHook]):
                     waiter_delay=int(self.poke_interval),
                     waiter_max_attempts=self.max_retries,
                     region_name=self.region_name,
+                    verify=self.verify,
+                    botocore_config=self.botocore_config,
                 ),
                 method_name="execute_complete",
             )

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_glue.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_glue.py
@@ -184,6 +184,35 @@ class TestGlueJobOperator:
         assert defer.value.trigger.attempts == 75
         assert defer.value.trigger.aws_conn_id == "aws_default"
 
+    @mock.patch.object(GlueJobHook, "initialize_job")
+    @mock.patch.object(GlueJobHook, "get_conn")
+    def test_execute_deferrable_forwards_hook_config_to_trigger(self, _, mock_initialize_job):
+        """The deferred half must reach AWS with the same hook settings as the synchronous half."""
+        botocore_config = {"read_timeout": 42}
+        glue = GlueJobOperator(
+            durable=False,
+            task_id=TASK_ID,
+            job_name=JOB_NAME,
+            script_location="s3://folder/file",
+            aws_conn_id="aws_default",
+            region_name="us-west-2",
+            verify=False,
+            botocore_config=botocore_config,
+            s3_bucket="some_bucket",
+            iam_role_name="my_test_role",
+            deferrable=True,
+        )
+        mock_initialize_job.return_value = {"JobRunState": "RUNNING", "JobRunId": JOB_RUN_ID}
+
+        with pytest.raises(TaskDeferred) as defer:
+            glue.execute(mock.MagicMock())
+
+        # assert on the serialized payload: that is what actually reaches the triggerer
+        _, serialized = defer.value.trigger.serialize()
+        assert serialized["region_name"] == "us-west-2"
+        assert serialized["verify"] is False
+        assert serialized["botocore_config"] == botocore_config
+
     @mock.patch.object(GlueJobHook, "conn", new_callable=mock.PropertyMock)
     @mock.patch.object(GlueJobHook, "initialize_job")
     @mock.patch.object(GlueJobHook, "get_conn")

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_glue.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_glue.py
@@ -167,6 +167,31 @@ class TestGlueJobSensor:
         with pytest.raises(TaskDeferred):
             sensor.execute({})
 
+    def test_deferrable_execute_forwards_hook_config_to_trigger(self):
+        """The deferred half must reach AWS with the same hook settings as the synchronous half."""
+        botocore_config = {"read_timeout": 42}
+        sensor = GlueJobSensor(
+            task_id="test_glue_job_sensor",
+            job_name="job_name",
+            run_id="job_run_id",
+            aws_conn_id="aws_default",
+            region_name="us-west-2",
+            verify=False,
+            botocore_config=botocore_config,
+            deferrable=True,
+            poke_interval=1,
+            timeout=5,
+        )
+
+        with pytest.raises(TaskDeferred) as defer:
+            sensor.execute({})
+
+        # assert on the serialized payload: that is what actually reaches the triggerer
+        _, serialized = defer.value.trigger.serialize()
+        assert serialized["region_name"] == "us-west-2"
+        assert serialized["verify"] is False
+        assert serialized["botocore_config"] == botocore_config
+
     @mock.patch.object(GlueJobSensor, "defer")
     def test_default_timeout(self, mock_defer):
         mock_defer.side_effect = TaskDeferred(trigger=mock.Mock(), method_name="execute_complete")


### PR DESCRIPTION
Part of #72144. Covers the two "Shape A" call sites from that issue's table.

`GlueJobOperator` and `GlueJobSensor` are `AwsBaseOperator` / `AwsBaseSensor` subclasses, so they always carry `region_name`, `verify` and `botocore_config`. Both forward only `region_name` when they defer, so the triggerer rebuilds its hook with default SSL verification and default botocore timeouts/retries. A deployment that sets `verify=False`, points `verify` at a private CA bundle, or tunes `botocore_config` gets those settings on the synchronous path and silently loses them the moment the task defers.

`GlueJobCompleteTrigger` already accepts all three parameters, and its `hook()` already forwards all three into `GlueJobHook`, so this is a call-site-only fix and is complete end to end as it stands. It does not depend on #72171.

related: #72144

### Tests

One regression test per call site. Both assert on `trigger.serialize()[1]` rather than on trigger attributes, since the serialized payload is what actually reaches the triggerer process. `verify=False` is used deliberately, as a falsy value is the one most likely to be dropped by mistake.

Verified both tests fail without the source change (`KeyError: 'verify'`) and pass with it. Full Glue operator/sensor/trigger suites pass (141 passed).

### A possible correction to the ECS rows in #72144

While tracing this I think the issue's table may be slightly off for ECS. It lists `EcsCreateClusterOperator` and `EcsDeleteClusterOperator` under "trigger takes `**kwargs`; operator-side fix only", but `ClusterActiveTrigger.hook()` and `ClusterInactiveTrigger.hook()` are:

```python
def hook(self) -> AwsGenericHook:
    return EcsHook(aws_conn_id=self.aws_conn_id, region_name=self.region_name)
```

The `**kwargs` do reach `AwsBaseWaiterTrigger`, so the two parameters would serialize correctly, but the bespoke `hook()` builds the hook without them. An operator-side-only change there would look correct and serialize correctly while still polling with default `verify` / `botocore_config`. Those two sites look like they also need their `hook()` widened, or need #72171 to land first. Happy to open a separate issue if that's useful.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)