### PR TITLE
Support multi-column sort in the Dags list table

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DataTable/DataTable.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/DataTable.test.tsx
@@ -82,6 +82,39 @@ describe("DataTable", () => {
     expect(screen.getByText("Jane Doe")).toBeInTheDocument();
   });
 
+  it.each([
+    { enableMultiSort: undefined, expected: [{ desc: false, id: "Second" }] },
+    {
+      enableMultiSort: true,
+      expected: [
+        { desc: false, id: "name" },
+        { desc: false, id: "Second" },
+      ],
+    },
+  ])(
+    "shift-click adds a secondary sort only when enableMultiSort=$enableMultiSort",
+    ({ enableMultiSort, expected }) => {
+      const sortOnStateChange = vi.fn();
+
+      render(
+        <DataTable
+          columns={[...columns, { accessorKey: "name", header: "Second", id: "Second" }]}
+          data={data}
+          enableMultiSort={enableMultiSort}
+          initialState={{ pagination, sorting: [{ desc: false, id: "name" }] }}
+          modelName="task"
+          onStateChange={sortOnStateChange}
+          total={2}
+        />,
+        { wrapper: ChakraWrapper },
+      );
+
+      fireEvent.click(screen.getByText("Second", { selector: "button" }), { shiftKey: true });
+
+      expect(sortOnStateChange).toHaveBeenLastCalledWith(expect.objectContaining({ sorting: expected }));
+    },
+  );
+
   it("disables previous page button on first page", () => {
     render(
       <DataTable

--- a/airflow-core/src/airflow/ui/src/components/DataTable/DataTable.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/DataTable.tsx
@@ -47,6 +47,8 @@ type DataTableProps<TData> = {
   readonly columns: Array<MetaColumn<TData>>;
   readonly data: Array<TData>;
   readonly displayMode?: "card" | "table";
+  /** Lets shift-click on a column header add it as a secondary sort; the page must send every sort to its endpoint. */
+  readonly enableMultiSort?: boolean;
   readonly errorMessage?: ReactNode | string;
   /**
    * Controls that change *which* rows the table returns — a `SearchBar`, a `FilterBar`, or both
@@ -110,6 +112,7 @@ export const DataTable = <TData,>({
   columns,
   data,
   displayMode = "table",
+  enableMultiSort = false,
   errorMessage,
   filterActions,
   headingExtra,
@@ -174,6 +177,7 @@ export const DataTable = <TData,>({
     columns,
     data,
     enableHiding: true,
+    enableMultiSort,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     manualPagination: true,

--- a/airflow-core/src/airflow/ui/src/components/DataTable/TableList.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/TableList.tsx
@@ -18,7 +18,7 @@
  */
 import type { ReactNode } from "react";
 
-import { Button, Icon, Table } from "@chakra-ui/react";
+import { Button, Icon, Table, Text } from "@chakra-ui/react";
 import { flexRender, type Table as TanStackTable } from "@tanstack/react-table";
 import { useTranslation } from "react-i18next";
 import { TiArrowSortedDown, TiArrowSortedUp, TiArrowUnsorted } from "react-icons/ti";
@@ -32,6 +32,7 @@ export const TableList = <TData,>({ noRowsMessage, table }: TableListProps<TData
   "use no memo"; // remove if https://github.com/TanStack/table/issues/5567 is resolved
   const { t: translate } = useTranslation("components");
   const { rows } = table.getRowModel();
+  const isMultiSorted = table.getState().sorting.length > 1;
 
   return (
     <Table.Root data-testid="table-list" size="sm" striped>
@@ -76,6 +77,11 @@ export const TableList = <TData,>({ noRowsMessage, table }: TableListProps<TData
                       >
                         {text}
                         {rightIcon}
+                        {isMultiSorted && sort !== false ? (
+                          <Text as="span" data-testid={`sort-index-${column.id}`} fontSize="xs">
+                            {column.getSortIndex() + 1}
+                          </Text>
+                        ) : undefined}
                       </Button>
                     )}
                   </Table.ColumnHeader>

--- a/airflow-core/src/airflow/ui/src/components/DataTable/searchParams.test.ts
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/searchParams.test.ts
@@ -34,6 +34,45 @@ describe("searchParams", () => {
 
       expect(stateToSearchParams(state).toString()).toEqual("limit=20&offset=1&sort=name");
     });
+
+    it("serializes every sort in order", () => {
+      const state: TableState = {
+        pagination: {
+          pageIndex: 0,
+          pageSize: 20,
+        },
+        sorting: [
+          { desc: true, id: "age" },
+          { desc: false, id: "name" },
+        ],
+      };
+
+      expect(stateToSearchParams(state).toString()).toEqual("limit=20&sort=-age&sort=name");
+    });
+
+    it("omits sort only when it matches the default sorting exactly", () => {
+      const defaultState: TableState = {
+        pagination: {
+          pageIndex: 0,
+          pageSize: 20,
+        },
+        sorting: [{ desc: true, id: "age" }],
+      };
+
+      expect(stateToSearchParams(defaultState, defaultState).toString()).toEqual("");
+      expect(
+        stateToSearchParams(
+          {
+            ...defaultState,
+            sorting: [
+              { desc: true, id: "age" },
+              { desc: false, id: "name" },
+            ],
+          },
+          defaultState,
+        ).toString(),
+      ).toEqual("sort=-age&sort=name");
+    });
   });
 
   describe("searchParamsToState", () => {

--- a/airflow-core/src/airflow/ui/src/components/DataTable/searchParams.ts
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/searchParams.ts
@@ -29,6 +29,14 @@ const {
   SORT: SORT_PARAM,
 }: SearchParamsKeysType = SearchParamsKeys;
 
+const isSameSorting = (sorting: SortingState, defaultSorting: SortingState | undefined) =>
+  defaultSorting?.length === sorting.length &&
+  sorting.every((sort, index) => {
+    const defaultSort = defaultSorting[index];
+
+    return defaultSort?.id === sort.id && defaultSort.desc === sort.desc;
+  });
+
 export const stateToSearchParams = (state: TableState, defaultTableState?: TableState): URLSearchParams => {
   const queryParams = new URLSearchParams(globalThis.location.search);
 
@@ -50,16 +58,11 @@ export const stateToSearchParams = (state: TableState, defaultTableState?: Table
     queryParams.delete(CURSOR_PARAM);
   }
 
-  if (state.sorting.length) {
+  queryParams.delete(SORT_PARAM);
+  if (!isSameSorting(state.sorting, defaultTableState?.sorting)) {
     state.sorting.forEach(({ desc, id }) => {
-      if (defaultTableState?.sorting.find((sort) => sort.id === id && sort.desc === desc)) {
-        queryParams.delete(SORT_PARAM, `${desc ? "-" : ""}${id}`);
-      } else {
-        queryParams.set(SORT_PARAM, `${desc ? "-" : ""}${id}`);
-      }
+      queryParams.append(SORT_PARAM, `${desc ? "-" : ""}${id}`);
     });
-  } else {
-    queryParams.delete(SORT_PARAM);
   }
 
   return queryParams;

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.test.tsx
@@ -117,4 +117,27 @@ describe("Dag sorting", () => {
       ),
     );
   });
+
+  it("adds a secondary sort on shift-click and sends every sort to the request", async () => {
+    localStorage.setItem(DAGS_LIST_DISPLAY_KEY, JSON.stringify("table"));
+    const requestedOrderBy: Array<Array<string>> = [];
+
+    server.use(
+      http.get("/ui/dags", ({ request }) => {
+        requestedOrderBy.push(new URL(request.url).searchParams.getAll("order_by"));
+
+        return HttpResponse.json({ dags: [], total_entries: 0 });
+      }),
+    );
+    render(<AppWrapper initialEntries={["/dags?sort=-last_run_run_after"]} />);
+
+    await waitFor(() => expect(screen.getByTestId("table-list")).toBeInTheDocument());
+    await waitFor(() => expect(requestedOrderBy.at(-1)).toEqual(["-last_run_run_after"]));
+
+    fireEvent.click(screen.getByText("dagId").closest("button") as HTMLButtonElement, { shiftKey: true });
+
+    await waitFor(() => expect(requestedOrderBy.at(-1)).toEqual(["-last_run_run_after", "dag_display_name"]));
+    expect(screen.getByTestId("sort-index-last_run_run_after")).toHaveTextContent("1");
+    expect(screen.getByTestId("sort-index-dag_display_name")).toHaveTextContent("2");
+  });
 });

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -272,8 +272,9 @@ export const DagsList = () => {
   const dagDisplayNamePattern = searchParams.get(NAME_PATTERN) ?? "";
   const advancedSearch = useAdvancedSearch("dags");
 
-  const [sort] = sorting;
-  const orderBy = sort ? `${sort.desc ? "-" : ""}${sort.id}` : "dag_display_name";
+  const orderBy = sorting.length
+    ? sorting.map((sort) => `${sort.desc ? "-" : ""}${sort.id}`)
+    : ["dag_display_name"];
 
   const handleSearchChange = (value: string) => {
     setTableURLState({
@@ -322,7 +323,7 @@ export const DagsList = () => {
     lastDagRunState,
     limit: pagination.pageSize,
     offset: pagination.pageIndex * pagination.pageSize,
-    orderBy: [orderBy],
+    orderBy,
     owners,
     paused,
     pendingHitl,
@@ -367,6 +368,7 @@ export const DagsList = () => {
           columns={columns}
           data={data?.dags ?? []}
           displayMode={display}
+          enableMultiSort
           errorMessage={<ErrorAlert error={error} />}
           filterActions={
             <VStack alignItems="flex-start" gap={2} w="100%">
@@ -388,7 +390,7 @@ export const DagsList = () => {
           onStateChange={setTableURLState}
           presentationActions={
             display === "card" ? (
-              <SortSelect handleSortChange={handleSortChange} orderBy={orderBy} />
+              <SortSelect handleSortChange={handleSortChange} orderBy={orderBy[0]} />
             ) : undefined
           }
           showDisplayToggle


### PR DESCRIPTION
## Why

Sorting the Dags list by latest run puts Dags without any run in reverse alphabetical order. The backend already accepts several `order_by` values since #53408, but the Dags list only sent the first one.

## What

Send every sort from the table state as `order_by`, and write all of them to the URL. Shift-click on a column header adds a secondary sort.

Card view still has a single sort dropdown, so there is no way to set a secondary sort there. But a sort set in table view can still apply after switching to card view. I plan to add a secondary sort control to card view in a follow-up PR.

https://github.com/user-attachments/assets/19b8f50e-88cb-498e-9a95-1184a5661ed0


closes: #46383

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5.1)

Generated-by: Claude Code (Fable 5.1) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)



