### PR TITLE
Add reserved IP ranges to Vertex AI pipeline jobs

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/pipeline_job.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/pipeline_job.py
@@ -185,6 +185,7 @@ class PipelineJobHook(GoogleBaseHook, OperationHelper):
         network: str | None = None,
         create_request_timeout: float | None = None,
         experiment: str | experiment_resources.Experiment | None = None,
+        reserved_ip_ranges: list[str] | None = None,
         # END: run param
     ) -> PipelineJob:
         """
@@ -234,6 +235,9 @@ class PipelineJobHook(GoogleBaseHook, OperationHelper):
             PipelineJob. Metrics produced by the PipelineJob as system.Metric Artifacts will be associated as
             metrics to the current Experiment Run. Pipeline parameters will be associated as parameters to
             the current Experiment Run.
+        :param reserved_ip_ranges: Optional. A list of names for the reserved IP ranges under the VPC
+            network that can be used for this PipelineJob. If set, the PipelineJob will only use IP
+            addresses from these ranges.
         """
         self._pipeline_job = self.get_pipeline_job_object(
             display_name=display_name,
@@ -252,6 +256,7 @@ class PipelineJobHook(GoogleBaseHook, OperationHelper):
         self._pipeline_job.submit(
             service_account=service_account,
             network=network,
+            reserved_ip_ranges=reserved_ip_ranges,
             create_request_timeout=create_request_timeout,
             experiment=experiment,
         )
@@ -279,6 +284,7 @@ class PipelineJobHook(GoogleBaseHook, OperationHelper):
         network: str | None = None,
         create_request_timeout: float | None = None,
         experiment: str | experiment_resources.Experiment | None = None,
+        reserved_ip_ranges: list[str] | None = None,
         # END: run param
     ) -> PipelineJob:
         """
@@ -331,6 +337,9 @@ class PipelineJobHook(GoogleBaseHook, OperationHelper):
             Metrics produced by the PipelineJob as system.Metric Artifacts will be associated as metrics
             to the current Experiment Run. Pipeline parameters will be associated as parameters to
             the current Experiment Run.
+        :param reserved_ip_ranges: Optional. A list of names for the reserved IP ranges under the VPC
+            network that can be used for this PipelineJob. If set, the PipelineJob will only use IP
+            addresses from these ranges.
         """
         self._pipeline_job = self.get_pipeline_job_object(
             display_name=display_name,
@@ -349,6 +358,7 @@ class PipelineJobHook(GoogleBaseHook, OperationHelper):
         self._pipeline_job.submit(
             service_account=service_account,
             network=network,
+            reserved_ip_ranges=reserved_ip_ranges,
             create_request_timeout=create_request_timeout,
             experiment=experiment,
         )

--- a/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/pipeline_job.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/pipeline_job.py
@@ -92,6 +92,9 @@ class RunPipelineJobOperator(GoogleCloudBaseOperator):
         Metrics produced by the PipelineJob as system.Metric Artifacts will be associated as metrics
         to the current Experiment Run. Pipeline parameters will be associated as parameters to
         the current Experiment Run.
+    :param reserved_ip_ranges: Optional. A list of names for the reserved IP ranges under the VPC
+        network that can be used for this PipelineJob. If set, the PipelineJob will only use IP
+        addresses from these ranges.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
@@ -137,6 +140,7 @@ class RunPipelineJobOperator(GoogleCloudBaseOperator):
         network: str | None = None,
         create_request_timeout: float | None = None,
         experiment: str | experiment_resources.Experiment | None = None,
+        reserved_ip_ranges: list[str] | None = None,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
@@ -160,6 +164,7 @@ class RunPipelineJobOperator(GoogleCloudBaseOperator):
         self.network = network
         self.create_request_timeout = create_request_timeout
         self.experiment = experiment
+        self.reserved_ip_ranges = reserved_ip_ranges
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
         self.deferrable = deferrable
@@ -189,6 +194,7 @@ class RunPipelineJobOperator(GoogleCloudBaseOperator):
             failure_policy=self.failure_policy,
             service_account=self.service_account,
             network=self.network,
+            reserved_ip_ranges=self.reserved_ip_ranges,
             create_request_timeout=self.create_request_timeout,
             experiment=self.experiment,
         )

--- a/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_pipeline_job.py
+++ b/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_pipeline_job.py
@@ -246,6 +246,26 @@ class TestPipelineJobWithoutDefaultProjectIdHook:
         )
         mock_client.return_value.common_location_path.assert_called_once_with(TEST_PROJECT_ID, TEST_REGION)
 
+    @pytest.mark.parametrize("method_name", ["run_pipeline_job", "submit_pipeline_job"])
+    @pytest.mark.parametrize("reserved_ip_ranges", [None, [], ["range-1", "range-2"]])
+    @mock.patch(PIPELINE_JOB_STRING.format("PipelineJobHook.get_pipeline_job_object"))
+    def test_pipeline_job_forwards_reserved_ip_ranges(
+        self, mock_get_pipeline_job_object, reserved_ip_ranges, method_name
+    ) -> None:
+        method = getattr(self.hook, method_name)
+
+        method(
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            display_name="display-name",
+            template_path="gs://bucket/template.json",
+            reserved_ip_ranges=reserved_ip_ranges,
+        )
+
+        assert mock_get_pipeline_job_object.return_value.submit.call_args.kwargs["reserved_ip_ranges"] == (
+            reserved_ip_ranges
+        )
+
 
 class TestPipelineJobAsyncHook:
     @pytest.mark.asyncio

--- a/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_pipeline_job.py
+++ b/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_pipeline_job.py
@@ -246,15 +246,33 @@ class TestPipelineJobWithoutDefaultProjectIdHook:
         )
         mock_client.return_value.common_location_path.assert_called_once_with(TEST_PROJECT_ID, TEST_REGION)
 
-    @pytest.mark.parametrize("method_name", ["run_pipeline_job", "submit_pipeline_job"])
-    @pytest.mark.parametrize("reserved_ip_ranges", [None, [], ["range-1", "range-2"]])
+    @pytest.mark.parametrize(
+        "reserved_ip_ranges", [None, [], ["range-1", "range-2"]], ids=["none", "empty", "multiple"]
+    )
     @mock.patch(PIPELINE_JOB_STRING.format("PipelineJobHook.get_pipeline_job_object"))
-    def test_pipeline_job_forwards_reserved_ip_ranges(
-        self, mock_get_pipeline_job_object, reserved_ip_ranges, method_name
+    def test_run_pipeline_job_forwards_reserved_ip_ranges(
+        self, mock_get_pipeline_job_object, reserved_ip_ranges
     ) -> None:
-        method = getattr(self.hook, method_name)
+        self.hook.run_pipeline_job(
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            display_name="display-name",
+            template_path="gs://bucket/template.json",
+            reserved_ip_ranges=reserved_ip_ranges,
+        )
 
-        method(
+        assert mock_get_pipeline_job_object.return_value.submit.call_args.kwargs["reserved_ip_ranges"] == (
+            reserved_ip_ranges
+        )
+
+    @pytest.mark.parametrize(
+        "reserved_ip_ranges", [None, [], ["range-1", "range-2"]], ids=["none", "empty", "multiple"]
+    )
+    @mock.patch(PIPELINE_JOB_STRING.format("PipelineJobHook.get_pipeline_job_object"))
+    def test_submit_pipeline_job_forwards_reserved_ip_ranges(
+        self, mock_get_pipeline_job_object, reserved_ip_ranges
+    ) -> None:
+        self.hook.submit_pipeline_job(
             project_id=TEST_PROJECT_ID,
             region=TEST_REGION,
             display_name="display-name",

--- a/providers/google/tests/unit/google/cloud/operators/test_vertex_ai.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_vertex_ai.py
@@ -2859,9 +2859,10 @@ class TestVertexAIDeleteModelVersionOperator:
 
 
 class TestVertexAIRunPipelineJobOperator:
+    @pytest.mark.parametrize("reserved_ip_ranges", [None, [], ["range-1", "range-2"]])
     @mock.patch(VERTEX_AI_PATH.format("pipeline_job.PipelineJobHook"))
     @mock.patch("google.cloud.aiplatform_v1.types.PipelineJob.to_dict")
-    def test_execute(self, to_dict_mock, mock_hook):
+    def test_execute(self, to_dict_mock, mock_hook, reserved_ip_ranges):
         op = RunPipelineJobOperator(
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
@@ -2880,6 +2881,7 @@ class TestVertexAIRunPipelineJobOperator:
             failure_policy="",
             service_account="",
             network="",
+            reserved_ip_ranges=reserved_ip_ranges,
             create_request_timeout=None,
             experiment=None,
         )
@@ -2900,6 +2902,7 @@ class TestVertexAIRunPipelineJobOperator:
             failure_policy="",
             service_account="",
             network="",
+            reserved_ip_ranges=reserved_ip_ranges,
             create_request_timeout=None,
             experiment=None,
         )


### PR DESCRIPTION
Adds `reserved_ip_ranges` support to `RunPipelineJobOperator` so Vertex AI pipeline jobs can be restricted to configured VPC IP ranges. The value is propagated through both hook submission paths without collapsing `None` or an empty list, with unit coverage at the operator and SDK boundaries.

Tests:
- `pytest providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_pipeline_job.py` (25 passed)
- `pytest providers/google/tests/unit/google/cloud/operators/test_vertex_ai.py -k RunPipelineJobOperator` (6 passed)
- Google provider prek checks, Ruff formatting/lint, and `git diff --check`

closes: #62733

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — OpenAI Codex

Generated-by: OpenAI Codex following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

OpenAI Codex was used for limited implementation and testing assistance. All changes were reviewed and validated by me.

---
Drafted-by: OpenAI Codex (reviewed by @LE0-Lin)