### PR TITLE
Respect SMTP connection sender for task email alerts

### DIFF
--- a/providers/smtp/src/airflow/providers/smtp/notifications/smtp.py
+++ b/providers/smtp/src/airflow/providers/smtp/notifications/smtp.py
@@ -35,7 +35,8 @@ class SmtpNotifier(BaseNotifier):
     """
     SMTP Notifier.
 
-    Accepts keyword arguments. The only required arguments are `from_email` and `to`. Examples:
+    Accepts keyword arguments. The only required argument is `to`; `from_email` can be
+    provided directly or resolved from the SMTP connection and email configuration. Examples:
 
     .. code-block:: python
 
@@ -121,10 +122,9 @@ class SmtpNotifier(BaseNotifier):
     def _build_email_content(self, smtp: SmtpHook, context: Context):
         fields_to_re_render = []
         if self.from_email is None:
-            if smtp.from_email is not None:
-                self.from_email = smtp.from_email
-            else:
-                raise ValueError("You should provide `from_email` or define it in the connection")
+            self.from_email = (
+                smtp.from_email or conf.get("email", "from_email", fallback=None) or "airflow@airflow"
+            )
             fields_to_re_render.append("from_email")
         if self.subject is None:
             smtp_default_templated_subject_path: str

--- a/providers/smtp/tests/unit/smtp/notifications/test_smtp.py
+++ b/providers/smtp/tests/unit/smtp/notifications/test_smtp.py
@@ -212,6 +212,77 @@ class TestSmtpNotifier:
             )
 
     @mock.patch("airflow.providers.smtp.notifications.smtp.SmtpHook")
+    def test_notifier_resolves_from_email_from_config(self, mock_smtphook_hook, create_dag_without_db):
+        notifier = SmtpNotifier(
+            to=TEST_RECEIVER,
+            subject=TEST_SUBJECT,
+            html_content=TEST_BODY,
+            smtp_conn_id=SMTP_CONN_ID,
+        )
+        mock_smtphook_hook.return_value.__enter__.return_value.from_email = None
+        context = {"dag": create_dag_without_db(TEST_DAG_ID)}
+
+        with conf_vars({("email", "from_email"): "config_sender@test.com"}):
+            notifier(context)
+
+        mock_smtphook_hook.return_value.__enter__().send_email_smtp.assert_called_once_with(
+            from_email="config_sender@test.com",
+            to=TEST_RECEIVER,
+            subject=TEST_SUBJECT,
+            html_content=TEST_BODY,
+            smtp_conn_id=SMTP_CONN_ID,
+            **DEFAULT_EMAIL_PARAMS,
+        )
+
+    @mock.patch("airflow.providers.smtp.notifications.smtp.SmtpHook")
+    def test_notifier_falls_back_to_default_from_email(self, mock_smtphook_hook, create_dag_without_db):
+        notifier = SmtpNotifier(
+            to=TEST_RECEIVER,
+            subject=TEST_SUBJECT,
+            html_content=TEST_BODY,
+            smtp_conn_id=SMTP_CONN_ID,
+        )
+        mock_smtphook_hook.return_value.__enter__.return_value.from_email = None
+        context = {"dag": create_dag_without_db(TEST_DAG_ID)}
+
+        with conf_vars({("email", "from_email"): ""}):
+            notifier(context)
+
+        mock_smtphook_hook.return_value.__enter__().send_email_smtp.assert_called_once_with(
+            from_email="airflow@airflow",
+            to=TEST_RECEIVER,
+            subject=TEST_SUBJECT,
+            html_content=TEST_BODY,
+            smtp_conn_id=SMTP_CONN_ID,
+            **DEFAULT_EMAIL_PARAMS,
+        )
+
+    @mock.patch("airflow.providers.smtp.notifications.smtp.SmtpHook")
+    def test_notifier_prefers_connection_from_email_over_config(
+        self, mock_smtphook_hook, create_dag_without_db
+    ):
+        notifier = SmtpNotifier(
+            to=TEST_RECEIVER,
+            subject=TEST_SUBJECT,
+            html_content=TEST_BODY,
+            smtp_conn_id=SMTP_CONN_ID,
+        )
+        mock_smtphook_hook.return_value.__enter__.return_value.from_email = TEST_SENDER
+        context = {"dag": create_dag_without_db(TEST_DAG_ID)}
+
+        with conf_vars({("email", "from_email"): "config_sender@test.com"}):
+            notifier(context)
+
+        mock_smtphook_hook.return_value.__enter__().send_email_smtp.assert_called_once_with(
+            from_email=TEST_SENDER,
+            to=TEST_RECEIVER,
+            subject=TEST_SUBJECT,
+            html_content=TEST_BODY,
+            smtp_conn_id=SMTP_CONN_ID,
+            **DEFAULT_EMAIL_PARAMS,
+        )
+
+    @mock.patch("airflow.providers.smtp.notifications.smtp.SmtpHook")
     def test_notifier_with_custom_smtp_conn_id(self, mock_smtphook_hook, create_dag_without_db):
         """Test that a custom smtp_conn_id is correctly passed to SmtpHook."""
         custom_conn_id = "my_custom_smtp"

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -2099,10 +2099,12 @@ def _send_error_email_notification(
 
     email_backend = conf.get("email", "email_backend", fallback=_DEFAULT_EMAIL_BACKEND)
     notifier_description = "SmtpNotifier"
+    from_email = None
 
     if email_backend and email_backend != _DEFAULT_EMAIL_BACKEND:
         notifier_class: _ErrorEmailNotifier = _LegacyEmailBackendNotifier
         notifier_description = f"configured email_backend {email_backend!r}"
+        from_email = conf.get("email", "from_email", fallback="airflow@airflow")
     else:
         try:
             from airflow.providers.smtp.notifications.smtp import SmtpNotifier
@@ -2161,7 +2163,7 @@ def _send_error_email_notification(
             to=to_emails,
             subject=subject,
             html_content=html_content,
-            from_email=conf.get("email", "from_email", fallback="airflow@airflow"),
+            from_email=from_email,
         )
         notifier(email_context)
     except Exception:

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -4145,7 +4145,7 @@ class TestEmailNotifications:
                 else:
                     mock_smtp_notifier.assert_called_once()
                     kwargs = mock_smtp_notifier.call_args.kwargs
-                    assert kwargs["from_email"] == self.FROM
+                    assert kwargs["from_email"] is None
                     assert kwargs["to"] == emails
                     assert (
                         kwargs["html_content"]
@@ -4203,7 +4203,7 @@ class TestEmailNotifications:
                 else:
                     mock_smtp_notifier.assert_called_once()
                     kwargs = mock_smtp_notifier.call_args.kwargs
-                    assert kwargs["from_email"] == self.FROM
+                    assert kwargs["from_email"] is None
                     assert kwargs["to"] == emails
                     assert (
                         kwargs["html_content"]
@@ -4255,7 +4255,7 @@ class TestEmailNotifications:
                     kwargs["html_content"]
                     == "<h1>Custom Template</h1><p>Task: {{ti.task_id}}</p><p>Error: {{exception_html}}</p>"
                 )
-                assert kwargs["from_email"] == self.FROM
+                assert kwargs["from_email"] is None
 
     def test_custom_email_backend_is_used(self, create_runtime_ti, mock_supervisor_comms):
         """A custom ``[email] email_backend`` is wrapped and invoked with rendered fields."""


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Why

Automatic task failure and retry email notifications were resolving `from_email` from `[email] from_email` before creating the default SMTP notifier. That meant the SMTP connection's more specific `from_email` setting could never be used, because `SmtpNotifier` only reads the connection value when `from_email` is `None`.

This caused task alert emails to ignore sender addresses configured on the SMTP connection.

relates: #69262

## Solution

Let the default SMTP notifier receive `from_email=None` from the task runner, so it can resolve the sender in the intended order:

1. SMTP connection `from_email`
2. `[email] from_email`
3. `airflow@airflow`

The legacy custom `[email] email_backend` path continues to receive the configured sender directly, preserving its existing behavior.




##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- `[X]` Yes (please specify the tool below)


Generated-by: [Codex] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
