### PR TITLE
Fix `airflow variables delete` showing success for a nonexistent key

### DIFF
--- a/airflow-core/src/airflow/cli/commands/variable_command.py
+++ b/airflow-core/src/airflow/cli/commands/variable_command.py
@@ -123,7 +123,9 @@ def variables_set(args):
 @providers_configuration_loaded
 def variables_delete(args):
     """Delete variable by a given name."""
-    Variable.delete(args.key)
+    deleted_count = Variable.delete(args.key)
+    if deleted_count == 0:
+        raise SystemExit(f"Variable {args.key} does not exist")
     print(f"Variable {args.key} deleted")
 
 

--- a/airflow-core/tests/unit/cli/commands/test_variable_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_variable_command.py
@@ -331,6 +331,10 @@ class TestCliVariables:
         with pytest.raises(KeyError):
             Variable.get("foo")
 
+    def test_variables_delete_non_existent(self):
+        with pytest.raises(SystemExit, match="Variable missing_key does not exist"):
+            variable_command.variables_delete(self.parser.parse_args(["variables", "delete", "missing_key"]))
+
     @pytest.mark.parametrize(
         "filename",
         [


### PR DESCRIPTION
### Sumarry

`airflow variables delete <key>` calls `Variable.delete(args.key)` and then unconditionally prints `Variable <key> deleted`
, ignoring the return value. `Variable.delete()` already returns the number of rows deleted, so when `key` does not exist the command still prints a success message and exits 0 -- there is no way to tell, from the CLI's output or exit code, whether anything was actually deleted.

### Change

This PR checks the returned row count and raises `SystemExit` with a "does not exist" message when it is zero.

A test for the existing (successful) delete path already existed; this adds a matching test for the missing-key path.
