### PR TITLE
providers-fab: close sessions after users and roles collection reads

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/roles.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/roles.py
@@ -34,6 +34,7 @@ from airflow.providers.fab.auth_manager.api_fastapi.datamodels.roles import (
 from airflow.providers.fab.auth_manager.api_fastapi.sorting import build_ordering
 from airflow.providers.fab.auth_manager.models import Permission, Role
 from airflow.providers.fab.www.utils import get_fab_auth_manager
+from airflow.utils.session import create_session
 
 if TYPE_CHECKING:
     from airflow.providers.fab.auth_manager.security_manager.override import FabAirflowSecurityManagerOverride
@@ -87,20 +88,18 @@ class FABAuthManagerRoles:
 
     @classmethod
     def get_roles(cls, *, order_by: str, limit: int, offset: int) -> RoleCollectionResponse:
-        security_manager = get_fab_auth_manager().security_manager
-        session = security_manager.session
+        with create_session(scoped=False) as session:
+            total_entries = session.scalars(select(func.count(Role.id))).one()
 
-        total_entries = session.scalars(select(func.count(Role.id))).one()
+            ordering = build_ordering(order_by, allowed={"name": Role.name, "role_id": Role.id})
 
-        ordering = build_ordering(order_by, allowed={"name": Role.name, "role_id": Role.id})
+            stmt = select(Role).order_by(ordering).offset(offset).limit(limit)
+            roles = session.scalars(stmt).unique().all()
 
-        stmt = select(Role).order_by(ordering).offset(offset).limit(limit)
-        roles = session.scalars(stmt).unique().all()
-
-        return RoleCollectionResponse(
-            roles=[RoleResponse.model_validate(r) for r in roles],
-            total_entries=total_entries,
-        )
+            return RoleCollectionResponse(
+                roles=[RoleResponse.model_validate(r) for r in roles],
+                total_entries=total_entries,
+            )
 
     @classmethod
     def delete_role(cls, name: str) -> None:

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/users.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/users.py
@@ -31,6 +31,7 @@ from airflow.providers.fab.auth_manager.api_fastapi.sorting import build_orderin
 from airflow.providers.fab.auth_manager.models import User
 from airflow.providers.fab.auth_manager.security_manager.override import FabAirflowSecurityManagerOverride
 from airflow.providers.fab.www.utils import get_fab_auth_manager
+from airflow.utils.session import create_session
 
 
 class FABAuthManagerUsers:
@@ -66,31 +67,29 @@ class FABAuthManagerUsers:
     @classmethod
     def get_users(cls, *, order_by: str, limit: int, offset: int) -> UserCollectionResponse:
         """Get users with pagination and ordering."""
-        security_manager = get_fab_auth_manager().security_manager
-        session = security_manager.session
+        with create_session(scoped=False) as session:
+            total_entries = session.scalars(select(func.count(User.id))).one()
 
-        total_entries = session.scalars(select(func.count(User.id))).one()
+            ordering = build_ordering(
+                order_by,
+                allowed={
+                    "id": User.id,
+                    "user_id": User.id,
+                    "first_name": User.first_name,
+                    "last_name": User.last_name,
+                    "username": User.username,
+                    "email": User.email,
+                    "active": User.active,
+                },
+            )
 
-        ordering = build_ordering(
-            order_by,
-            allowed={
-                "id": User.id,
-                "user_id": User.id,
-                "first_name": User.first_name,
-                "last_name": User.last_name,
-                "username": User.username,
-                "email": User.email,
-                "active": User.active,
-            },
-        )
+            stmt = select(User).order_by(ordering).offset(offset).limit(limit)
+            users = session.scalars(stmt).unique().all()
 
-        stmt = select(User).order_by(ordering).offset(offset).limit(limit)
-        users = session.scalars(stmt).unique().all()
-
-        return UserCollectionResponse(
-            users=[UserResponse.model_validate(u) for u in users],
-            total_entries=total_entries,
-        )
+            return UserCollectionResponse(
+                users=[UserResponse.model_validate(u) for u in users],
+                total_entries=total_entries,
+            )
 
     @classmethod
     def create_user(cls, body: UserBody) -> UserResponse:

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_roles.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_roles.py
@@ -186,7 +186,8 @@ class TestRolesService:
     # GET /roles
 
     @patch("airflow.providers.fab.auth_manager.api_fastapi.services.roles.build_ordering")
-    def test_get_roles_happy_path(self, build_ordering, get_fab_auth_manager):
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.services.roles.create_session")
+    def test_get_roles_happy_path(self, create_session, build_ordering, get_fab_auth_manager):
         role1 = _make_role_obj("viewer", [("can_read", "DAG")])
         role2 = _make_role_obj("admin", [("can_read", "DAG")])
         fake_roles_result = _FakeScalarRoles([role1, role2])
@@ -196,10 +197,7 @@ class TestRolesService:
             _FakeScalarCount(2),
             fake_roles_result,
         ]
-
-        fab_auth_manager = MagicMock()
-        fab_auth_manager.security_manager = MagicMock(session=session)
-        get_fab_auth_manager.return_value = fab_auth_manager
+        create_session.return_value.__enter__.return_value = session
 
         build_ordering.return_value = column("name").desc()
 
@@ -215,19 +213,21 @@ class TestRolesService:
         assert set(kwargs["allowed"].keys()) == {"name", "role_id"}
 
         assert session.scalars.call_count == 2
+        create_session.assert_called_once_with(scoped=False)
+        create_session.return_value.__exit__.assert_called_once_with(None, None, None)
 
     @patch("airflow.providers.fab.auth_manager.api_fastapi.services.roles.build_ordering")
-    def test_get_roles_invalid_order_by_bubbles_400(self, build_ordering, get_fab_auth_manager):
-        session = MagicMock()
-        fab_auth_manager = MagicMock()
-        fab_auth_manager.security_manager = MagicMock(session=session)
-        get_fab_auth_manager.return_value = fab_auth_manager
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.services.roles.create_session")
+    def test_get_roles_invalid_order_by_bubbles_400(self, create_session, build_ordering, get_fab_auth_manager):
+        create_session.return_value.__enter__.return_value = MagicMock()
 
         build_ordering.side_effect = HTTPException(status_code=400, detail="disallowed")
 
         with pytest.raises(HTTPException) as ex:
             FABAuthManagerRoles.get_roles(order_by="nope", limit=10, offset=0)
         assert ex.value.status_code == 400
+        create_session.assert_called_once_with(scoped=False)
+        create_session.return_value.__exit__.assert_called_once()
 
     # DELETE /roles/{name}
 

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_roles.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_roles.py
@@ -218,7 +218,9 @@ class TestRolesService:
 
     @patch("airflow.providers.fab.auth_manager.api_fastapi.services.roles.build_ordering")
     @patch("airflow.providers.fab.auth_manager.api_fastapi.services.roles.create_session")
-    def test_get_roles_invalid_order_by_bubbles_400(self, create_session, build_ordering, get_fab_auth_manager):
+    def test_get_roles_invalid_order_by_bubbles_400(
+        self, create_session, build_ordering, get_fab_auth_manager
+    ):
         create_session.return_value.__enter__.return_value = MagicMock()
 
         build_ordering.side_effect = HTTPException(status_code=400, detail="disallowed")

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_users.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_users.py
@@ -240,8 +240,9 @@ class TestUsersService:
 
     @patch("airflow.providers.fab.auth_manager.api_fastapi.services.users.build_ordering")
     @patch("airflow.providers.fab.auth_manager.api_fastapi.services.users.select")
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.services.users.create_session")
     def test_get_users_success(
-        self, mock_select, mock_build_ordering, get_fab_auth_manager, fab_auth_manager, security_manager
+        self, mock_create_session, mock_select, mock_build_ordering, get_fab_auth_manager
     ):
         user1 = _make_user_obj(
             username="alice", email="alice@example.com", first_name="Alice", last_name="Liddell"
@@ -251,9 +252,7 @@ class TestUsersService:
         mock_session = MagicMock()
         mock_session.scalars.return_value.one.return_value = 2
         mock_session.scalars.return_value.unique.return_value.all.return_value = [user1, user2]
-        security_manager.session = mock_session
-        fab_auth_manager.security_manager = security_manager
-        get_fab_auth_manager.return_value = fab_auth_manager
+        mock_create_session.return_value.__enter__.return_value = mock_session
 
         mock_build_ordering.return_value = "ordering"
 
@@ -263,11 +262,13 @@ class TestUsersService:
         assert len(out.users) == 2
         assert out.users[0].username == "alice"
         assert out.users[1].username == "bob"
+        mock_create_session.assert_called_once_with(scoped=False)
+        mock_create_session.return_value.__exit__.assert_called_once_with(None, None, None)
 
     @patch("airflow.providers.fab.auth_manager.api_fastapi.services.users.build_ordering")
-    def test_get_users_invalid_order_by(
-        self, mock_build_ordering, get_fab_auth_manager, fab_auth_manager, security_manager
-    ):
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.services.users.create_session")
+    def test_get_users_invalid_order_by(self, mock_create_session, mock_build_ordering, get_fab_auth_manager):
+        mock_create_session.return_value.__enter__.return_value = MagicMock()
         mock_build_ordering.side_effect = HTTPException(
             status_code=400,
             detail="Ordering with 'invalid' is disallowed or the attribute does not exist on the model",
@@ -278,6 +279,8 @@ class TestUsersService:
         with pytest.raises(HTTPException) as ex:
             FABAuthManagerUsers.get_users(order_by="invalid", limit=10, offset=0)
         assert ex.value.status_code == 400
+        mock_create_session.assert_called_once_with(scoped=False)
+        mock_create_session.return_value.__exit__.assert_called_once()
 
     def test_update_user_success(self, get_fab_auth_manager, fab_auth_manager, security_manager):
         user_obj = _make_user_obj(


### PR DESCRIPTION
## Summary

- Replace the thread-local FAB `security_manager.session` in the users and roles collection handlers with explicit `create_session(scoped=False)` contexts.
- Materialize Pydantic responses while the session is open, then close the worker-thread session before returning.
- Add regression assertions that the context manager is created with `scoped=False` and exited on success and validation errors.

This addresses the sync FastAPI/thread-pool session leak described in #72361 and follows the explicit-session pattern used by Airflow's API code.

Fixes #72361

## Testing

- `PYTHONPATH=devel-common/src uv run --project providers/fab --no-dev --with pytest --with pytest-subtests --with pytest-timeout --with time-machine --with pytest-asyncio --with pytest-mock pytest providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_users.py providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_roles.py -q`
- 47 passed, 1 warning