### PR TITLE
Remove dead dag_versions.hasattr mocks and duplicate bundle_url tests

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_versions.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_versions.py
@@ -109,73 +109,6 @@ class TestGetDagVersion(TestDagVersionEndpoint):
         assert response.status_code == 200
         assert response.json() == expected_response
 
-    @pytest.mark.parametrize(
-        ("dag_id", "dag_version", "expected_response"),
-        [
-            [
-                "ANOTHER_DAG_ID",
-                1,
-                {
-                    "bundle_name": "another_bundle_name",
-                    "bundle_version": "some_commit_hash",
-                    "bundle_url": "http://test_host.github.com/tree/some_commit_hash/dags",
-                    "created_at": mock.ANY,
-                    "dag_id": "ANOTHER_DAG_ID",
-                    "id": mock.ANY,
-                    "version_number": 1,
-                    "dag_display_name": "ANOTHER_DAG_ID",
-                },
-            ],
-            [
-                "dag_with_multiple_versions",
-                1,
-                {
-                    "bundle_name": "dag_maker",
-                    "bundle_version": "some_commit_hash1",
-                    "bundle_url": "http://test_host.github.com/tree/some_commit_hash1/dags",
-                    "created_at": mock.ANY,
-                    "dag_id": "dag_with_multiple_versions",
-                    "id": mock.ANY,
-                    "version_number": 1,
-                    "dag_display_name": "dag_with_multiple_versions",
-                },
-            ],
-            [
-                "dag_with_multiple_versions",
-                2,
-                {
-                    "bundle_name": "dag_maker",
-                    "bundle_version": "some_commit_hash2",
-                    "bundle_url": "http://test_host.github.com/tree/some_commit_hash2/dags",
-                    "created_at": mock.ANY,
-                    "dag_id": "dag_with_multiple_versions",
-                    "id": mock.ANY,
-                    "version_number": 2,
-                    "dag_display_name": "dag_with_multiple_versions",
-                },
-            ],
-            [
-                "dag_with_multiple_versions",
-                3,
-                {
-                    "bundle_name": "dag_maker",
-                    "bundle_version": "some_commit_hash3",
-                    "bundle_url": "http://test_host.github.com/tree/some_commit_hash3/dags",
-                    "created_at": mock.ANY,
-                    "dag_id": "dag_with_multiple_versions",
-                    "id": mock.ANY,
-                    "version_number": 3,
-                    "dag_display_name": "dag_with_multiple_versions",
-                },
-            ],
-        ],
-    )
-    @pytest.mark.usefixtures("make_dag_with_multiple_versions")
-    def test_get_dag_version_with_url_template(self, test_client, dag_id, dag_version, expected_response):
-        response = test_client.get(f"/dags/{dag_id}/dagVersions/{dag_version}")
-        assert response.status_code == 200
-        assert response.json() == expected_response
-
     @pytest.mark.usefixtures("make_dag_with_multiple_versions")
     @mock.patch("airflow.models.dag_version.DagBundlesManager.view_url", autospec=True)
     @mock.patch("airflow.models.dagbundle.DagBundleModel.render_url", autospec=True, return_value=None)
@@ -302,11 +235,7 @@ class TestGetDagVersions(TestDagVersionEndpoint):
         ],
     )
     @pytest.mark.usefixtures("make_dag_with_multiple_versions")
-    @mock.patch("airflow.api_fastapi.core_api.datamodels.dag_versions.hasattr")
-    def test_get_dag_versions(
-        self, mock_hasattr, test_client, dag_id, expected_response, expected_query_count
-    ):
-        mock_hasattr.return_value = False
+    def test_get_dag_versions(self, test_client, dag_id, expected_response, expected_query_count):
         with assert_queries_count(expected_query_count):
             response = test_client.get(f"/dags/{dag_id}/dagVersions")
         assert response.status_code == 200
@@ -327,108 +256,6 @@ class TestGetDagVersions(TestDagVersionEndpoint):
         assert body["total_entries"] == 3
         dag_ids = {v["dag_id"] for v in body["dag_versions"]}
         assert dag_ids == {"dag_with_multiple_versions"}
-
-    @pytest.mark.parametrize(
-        ("dag_id", "expected_response", "expected_query_count"),
-        [
-            [
-                "~",
-                {
-                    "dag_versions": [
-                        {
-                            "bundle_name": "another_bundle_name",
-                            "bundle_version": "some_commit_hash",
-                            "bundle_url": "http://test_host.github.com/tree/some_commit_hash/dags",
-                            "created_at": mock.ANY,
-                            "dag_id": "ANOTHER_DAG_ID",
-                            "id": mock.ANY,
-                            "version_number": 1,
-                            "dag_display_name": "ANOTHER_DAG_ID",
-                        },
-                        {
-                            "bundle_name": "dag_maker",
-                            "bundle_version": "some_commit_hash1",
-                            "bundle_url": "http://test_host.github.com/tree/some_commit_hash1/dags",
-                            "created_at": mock.ANY,
-                            "dag_id": "dag_with_multiple_versions",
-                            "id": mock.ANY,
-                            "version_number": 1,
-                            "dag_display_name": "dag_with_multiple_versions",
-                        },
-                        {
-                            "bundle_name": "dag_maker",
-                            "bundle_version": "some_commit_hash2",
-                            "bundle_url": "http://test_host.github.com/tree/some_commit_hash2/dags",
-                            "created_at": mock.ANY,
-                            "dag_id": "dag_with_multiple_versions",
-                            "id": mock.ANY,
-                            "version_number": 2,
-                            "dag_display_name": "dag_with_multiple_versions",
-                        },
-                        {
-                            "bundle_name": "dag_maker",
-                            "bundle_version": "some_commit_hash3",
-                            "bundle_url": "http://test_host.github.com/tree/some_commit_hash3/dags",
-                            "created_at": mock.ANY,
-                            "dag_id": "dag_with_multiple_versions",
-                            "id": mock.ANY,
-                            "version_number": 3,
-                            "dag_display_name": "dag_with_multiple_versions",
-                        },
-                    ],
-                    "total_entries": 4,
-                },
-                3,
-            ],
-            [
-                "dag_with_multiple_versions",
-                {
-                    "dag_versions": [
-                        {
-                            "bundle_name": "dag_maker",
-                            "bundle_version": "some_commit_hash1",
-                            "bundle_url": "http://test_host.github.com/tree/some_commit_hash1/dags",
-                            "created_at": mock.ANY,
-                            "dag_id": "dag_with_multiple_versions",
-                            "id": mock.ANY,
-                            "version_number": 1,
-                            "dag_display_name": "dag_with_multiple_versions",
-                        },
-                        {
-                            "bundle_name": "dag_maker",
-                            "bundle_version": "some_commit_hash2",
-                            "bundle_url": "http://test_host.github.com/tree/some_commit_hash2/dags",
-                            "created_at": mock.ANY,
-                            "dag_id": "dag_with_multiple_versions",
-                            "id": mock.ANY,
-                            "version_number": 2,
-                            "dag_display_name": "dag_with_multiple_versions",
-                        },
-                        {
-                            "bundle_name": "dag_maker",
-                            "bundle_version": "some_commit_hash3",
-                            "bundle_url": "http://test_host.github.com/tree/some_commit_hash3/dags",
-                            "created_at": mock.ANY,
-                            "dag_id": "dag_with_multiple_versions",
-                            "id": mock.ANY,
-                            "version_number": 3,
-                            "dag_display_name": "dag_with_multiple_versions",
-                        },
-                    ],
-                    "total_entries": 3,
-                },
-                5,
-            ],
-        ],
-    )
-    @pytest.mark.usefixtures("make_dag_with_multiple_versions")
-    def test_get_dag_versions_with_url_template(
-        self, test_client, dag_id, expected_response, expected_query_count
-    ):
-        with assert_queries_count(expected_query_count):
-            response = test_client.get(f"/dags/{dag_id}/dagVersions")
-        assert response.status_code == 200
-        assert response.json() == expected_response
 
     @pytest.mark.parametrize(
         ("params", "expected_versions", "expected_total_entries"),

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
@@ -1205,10 +1205,8 @@ class TestDagDetails(TestDagEndpoint):
         ],
     )
     @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
-    @mock.patch("airflow.api_fastapi.core_api.datamodels.dag_versions.hasattr")
     def test_dag_details(
         self,
-        mock_hasattr,
         test_client,
         query_params,
         dag_id,
@@ -1218,7 +1216,6 @@ class TestDagDetails(TestDagEndpoint):
         owner_links,
         last_parse_duration,
     ):
-        mock_hasattr.return_value = False
         response = test_client.get(f"/dags/{dag_id}/details", params=query_params)
         assert response.status_code == expected_status_code
         if expected_status_code != 200:
@@ -1298,109 +1295,6 @@ class TestDagDetails(TestDagEndpoint):
             "timetable_partitioned": False,
             "timetable_periodic": False,
             "timetable_summary": None,
-            "timezone": UTC_JSON_REPR,
-            "team_name": None,
-        }
-        assert res_json == expected
-
-    @pytest.mark.parametrize(
-        ("query_params", "dag_id", "expected_status_code", "dag_display_name", "start_date", "owner_links"),
-        [
-            ({}, "fake_dag_id", 404, "fake_dag", "2023-12-31T00:00:00Z", {}),
-            ({}, DAG2_ID, 200, DAG2_ID, "2021-06-15T00:00:00Z", {}),
-        ],
-    )
-    @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
-    def test_dag_details_with_view_url_template(
-        self,
-        test_client,
-        query_params,
-        dag_id,
-        expected_status_code,
-        dag_display_name,
-        start_date,
-        owner_links,
-    ):
-        response = test_client.get(f"/dags/{dag_id}/details", params=query_params)
-        assert response.status_code == expected_status_code
-        if expected_status_code != 200:
-            return
-
-        # Match expected and actual responses below.
-        res_json = response.json()
-        last_parsed = res_json["last_parsed"]
-        last_parsed_time = res_json["last_parsed_time"]
-        last_parse_duration = res_json["last_parse_duration"]
-        file_token = res_json["file_token"]
-        expected = {
-            "active_runs_count": 0,
-            "allowed_run_types": None,
-            "asset_expression": None,
-            "bundle_name": "dag_maker",
-            "bundle_version": None,
-            "catchup": False,
-            "concurrency": 16,
-            "dag_display_name": dag_display_name,
-            "dag_id": dag_id,
-            "dag_run_timeout": None,
-            "default_args": {
-                "depends_on_past": False,
-                "retries": 1,
-                "retry_delay": "PT5M",
-            },
-            "description": None,
-            "doc_md": "details",
-            "end_date": None,
-            "fileloc": __file__,
-            "file_token": file_token,
-            "has_import_errors": False,
-            "has_task_concurrency_limits": True,
-            "is_backfillable": False,
-            "is_favorite": False,
-            "is_stale": False,
-            "is_paused": False,
-            "is_paused_upon_creation": None,
-            "latest_dag_version": {
-                "bundle_name": "dag_maker",
-                "bundle_url": "http://test_host.github.com/tree/None/dags",
-                "bundle_version": None,
-                "created_at": mock.ANY,
-                "dag_id": "test_dag2",
-                "dag_display_name": dag_display_name,
-                "id": mock.ANY,
-                "version_number": 1,
-            },
-            "last_expired": None,
-            "last_parsed": last_parsed,
-            "last_parsed_time": last_parsed_time,
-            "last_parse_duration": last_parse_duration,
-            "max_active_runs": 16,
-            "max_active_tasks": 16,
-            "max_consecutive_failed_dag_runs": 0,
-            "next_dagrun_data_interval_end": None,
-            "next_dagrun_data_interval_start": None,
-            "next_dagrun_logical_date": None,
-            "next_dagrun_run_after": None,
-            "owners": ["airflow"],
-            "owner_links": {},
-            "params": {
-                "foo": {
-                    "description": None,
-                    "schema": {},
-                    "source": None,
-                    "value": 1,
-                }
-            },
-            "relative_fileloc": "test_dags.py",
-            "render_template_as_native_obj": False,
-            "rerun_with_latest_version": None,
-            "start_date": start_date,
-            "tags": [],
-            "template_search_path": None,
-            "timetable_summary": None,
-            "timetable_description": "Never, external triggers only",
-            "timetable_partitioned": False,
-            "timetable_periodic": False,
             "timezone": UTC_JSON_REPR,
             "team_name": None,
         }

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -290,11 +290,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
         ],
     )
     @pytest.mark.usefixtures("make_dag_with_multiple_versions")
-    @mock.patch("airflow.api_fastapi.core_api.datamodels.dag_versions.hasattr")
-    def test_should_respond_200_with_versions(
-        self, mock_hasattr, test_client, run_id, expected_version_number
-    ):
-        mock_hasattr.return_value = False
+    def test_should_respond_200_with_versions(self, test_client, run_id, expected_version_number):
         response = test_client.get(f"/dags/dag_with_multiple_versions/dagRuns/{run_id}/taskInstances/task1")
         response_data = response.json()
         assert response.status_code == 200
@@ -3092,65 +3088,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
         ],
     )
     @pytest.mark.usefixtures("make_dag_with_multiple_versions")
-    @mock.patch("airflow.api_fastapi.core_api.datamodels.dag_versions.hasattr")
-    def test_should_respond_200_with_versions(
-        self, mock_hasattr, test_client, run_id, expected_version_number, session
-    ):
-        mock_hasattr.return_value = False
-        response = test_client.get(
-            f"/dags/dag_with_multiple_versions/dagRuns/{run_id}/taskInstances/task1/tries/0"
-        )
-        assert response.status_code == 200
-        assert response.json() == {
-            "task_id": "task1",
-            "dag_id": "dag_with_multiple_versions",
-            "dag_display_name": "dag_with_multiple_versions",
-            "dag_run_id": run_id,
-            "map_index": -1,
-            "start_date": None,
-            "end_date": mock.ANY,
-            "duration": None,
-            "state": None,
-            "try_number": 0,
-            "max_tries": 0,
-            "task_display_name": "task1",
-            "hostname": "",
-            "unixname": getuser(),
-            "pool": "default_pool",
-            "pool_slots": 1,
-            "queue": "default",
-            "priority_weight": 1,
-            "operator": "EmptyOperator",
-            "operator_name": "EmptyOperator",
-            "queued_when": None,
-            "scheduled_when": None,
-            "pid": None,
-            "executor": None,
-            "executor_config": "{}",
-            "dag_version": {
-                "id": mock.ANY,
-                "version_number": expected_version_number,
-                "dag_id": "dag_with_multiple_versions",
-                "bundle_name": "dag_maker",
-                "bundle_version": f"some_commit_hash{expected_version_number}",
-                "bundle_url": f"http://test_host.github.com/tree/some_commit_hash{expected_version_number}/dags",
-                "created_at": mock.ANY,
-                "dag_display_name": "dag_with_multiple_versions",
-            },
-        }
-
-    @pytest.mark.parametrize(
-        ("run_id", "expected_version_number"),
-        [
-            ("run1", 1),
-            ("run2", 2),
-            ("run3", 3),
-        ],
-    )
-    @pytest.mark.usefixtures("make_dag_with_multiple_versions")
-    def test_should_respond_200_with_versions_using_url_template(
-        self, test_client, run_id, expected_version_number, session
-    ):
+    def test_should_respond_200_with_versions(self, test_client, run_id, expected_version_number, session):
         response = test_client.get(
             f"/dags/dag_with_multiple_versions/dagRuns/{run_id}/taskInstances/task1/tries/0"
         )
@@ -4644,71 +4582,13 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
         ],
     )
     @pytest.mark.usefixtures("make_dag_with_multiple_versions")
-    @mock.patch("airflow.api_fastapi.core_api.datamodels.dag_versions.hasattr")
-    def test_should_respond_200_with_versions(
-        self, mock_hasattr, test_client, run_id, expected_version_number
-    ):
-        mock_hasattr.return_value = False
+    def test_should_respond_200_with_versions(self, test_client, run_id, expected_version_number):
         response = test_client.get(
             f"/dags/dag_with_multiple_versions/dagRuns/{run_id}/taskInstances/task1/tries"
         )
         response_data = response.json()
         assert response.status_code == 200
         assert response_data["task_instances"][0] == {
-            "task_id": "task1",
-            "dag_id": "dag_with_multiple_versions",
-            "dag_display_name": "dag_with_multiple_versions",
-            "dag_run_id": run_id,
-            "map_index": -1,
-            "start_date": None,
-            "end_date": mock.ANY,
-            "duration": None,
-            "state": mock.ANY,
-            "try_number": 0,
-            "max_tries": 0,
-            "task_display_name": "task1",
-            "hostname": "",
-            "unixname": getuser(),
-            "pool": "default_pool",
-            "pool_slots": 1,
-            "queue": "default",
-            "priority_weight": 1,
-            "operator": "EmptyOperator",
-            "operator_name": "EmptyOperator",
-            "queued_when": None,
-            "scheduled_when": None,
-            "pid": None,
-            "executor": None,
-            "executor_config": "{}",
-            "dag_version": {
-                "id": mock.ANY,
-                "version_number": expected_version_number,
-                "dag_id": "dag_with_multiple_versions",
-                "bundle_name": "dag_maker",
-                "bundle_version": f"some_commit_hash{expected_version_number}",
-                "bundle_url": f"http://test_host.github.com/tree/some_commit_hash{expected_version_number}/dags",
-                "created_at": mock.ANY,
-                "dag_display_name": "dag_with_multiple_versions",
-            },
-        }
-
-    @pytest.mark.parametrize(
-        ("run_id", "expected_version_number"),
-        [
-            ("run1", 1),
-            ("run2", 2),
-            ("run3", 3),
-        ],
-    )
-    @pytest.mark.usefixtures("make_dag_with_multiple_versions")
-    def test_should_respond_200_with_versions_using_url_template(
-        self, test_client, run_id, expected_version_number
-    ):
-        response = test_client.get(
-            f"/dags/dag_with_multiple_versions/dagRuns/{run_id}/taskInstances/task1/tries"
-        )
-        assert response.status_code == 200
-        assert response.json()["task_instances"][0] == {
             "task_id": "task1",
             "dag_id": "dag_with_multiple_versions",
             "dag_display_name": "dag_with_multiple_versions",

--- a/airflow-core/tests/unit/cli/commands/test_asset_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_asset_command.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 import json
 import os
 import typing
-from unittest import mock
 
 import pytest
 
@@ -124,9 +123,7 @@ def test_cli_assets_alias_details(parser: ArgumentParser, stdout_capture) -> Non
     }
 
 
-@mock.patch("airflow.api_fastapi.core_api.datamodels.dag_versions.hasattr")
-def test_cli_assets_materialize(mock_hasattr, parser: ArgumentParser, stdout_capture) -> None:
-    mock_hasattr.return_value = False
+def test_cli_assets_materialize(parser: ArgumentParser, stdout_capture) -> None:
     args = parser.parse_args(["assets", "materialize", "--name=asset1_producer", "--output=json"])
     with stdout_capture as capture:
         asset_command.asset_materialize(args)
@@ -136,47 +133,6 @@ def test_cli_assets_materialize(mock_hasattr, parser: ArgumentParser, stdout_cap
     # Check if output is empty first
     assert output, "No output captured from asset_materialize command"
 
-    run_list = json.loads(output)
-    assert len(run_list) == 1
-
-    # No good way to statically compare these.
-    undeterministic: dict = {
-        "dag_run_id": None,
-        "dag_versions": [],
-        "data_interval_end": None,
-        "data_interval_start": None,
-        "logical_date": None,
-        "queued_at": None,
-        "run_after": "2025-02-12T19:27:59.066046Z",
-    }
-
-    assert run_list[0] | undeterministic == undeterministic | {
-        "conf": {},
-        "bundle_version": None,
-        "dag_display_name": "asset1_producer",
-        "dag_id": "asset1_producer",
-        "end_date": None,
-        "duration": None,
-        "last_scheduling_decision": None,
-        "note": None,
-        "partition_date": None,
-        "partition_key": None,
-        "run_type": "asset_materialization",
-        "start_date": None,
-        "state": "queued",
-        "team_name": None,
-        "triggered_by": "cli",
-        "triggering_user_name": "root",
-        "run_after": "2025-02-12T19:27:59.066046Z",
-    }
-
-
-def test_cli_assets_materialize_with_view_url_template(parser: ArgumentParser, stdout_capture) -> None:
-    args = parser.parse_args(["assets", "materialize", "--name=asset1_producer", "--output=json"])
-    with stdout_capture as capture:
-        asset_command.asset_materialize(args)
-
-    output = capture.getvalue()
     run_list = json.loads(output)
     assert len(run_list) == 1
 


### PR DESCRIPTION
## Why

- `DagVersionResponse` stopped calling `hasattr()` in #57450, when the deprecated `DagBundlesManager.view_url()` fallback moved into `DagVersion.bundle_url` on the model. Six tests still patch `airflow.api_fastapi.core_api.datamodels.dag_versions.hasattr`.
- With the fallback gone from the datamodel, every `*_with_url_template` / `*_using_url_template` variant became identical to its plain counterpart, or a strict subset of it.
  - `test_get_dag_version_with_url_template` is duplicated with `test_get_dag_version`
  - `test_get_dag_versions_with_url_template` is duplicated with `test_get_dag_versions`
  - `test_dag_details_with_view_url_template` is duplicated with `test_dag_details`
  - `test_cli_assets_materialize_with_view_url_template` is duplicated with `test_cli_assets_materialize`
  - `test_should_respond_200_with_versions_using_url_template` is duplicated with `test_should_respond_200_with_versions`

## How

- Drop the dead `@mock.patch(...)` decorator.
- Remove duplicated test cases.

## Verification

- `uv run --frozen --project airflow-core --with-editable shared/secrets_masker --with-editable shared/module_loading pytest airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_versions.py airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py`

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
