### PR TITLE
Pin devel dependencies to uv.lock in provider compat CI jobs

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1430,9 +1430,13 @@ function determine_airflow_to_use() {
         # Generate constraints from uv.lock and use them to install development dependencies
         # via the Python script. --no-cache is needed - otherwise there is possibility of
         # overriding temporary environments by multiple parallel processes
+        # --all-packages: without it the export only covers the root project's dependencies.
+        # Anything that only a workspace member's dependency group pulls in, such
+        # as mcp through common.ai's pydantic-ai-slim[mcp], stays unpinned and resolves fresh
+        # from PyPI instead of following uv.lock.
         local constraint_file="/tmp/constraints-from-lock.txt"
         uv export --frozen --no-hashes --no-emit-project --no-emit-workspace --no-editable --no-header \
-            --no-annotate > "${constraint_file}" 2>/dev/null || true
+            --no-annotate --all-packages > "${constraint_file}" 2>/dev/null || true
         uv run --no-cache /opt/airflow/scripts/in_container/install_development_dependencies.py \
            --constraint "${constraint_file}"
         # Some packages might leave legacy typing module which causes test issues

--- a/scripts/docker/entrypoint_ci.sh
+++ b/scripts/docker/entrypoint_ci.sh
@@ -298,9 +298,13 @@ function determine_airflow_to_use() {
         # Generate constraints from uv.lock and use them to install development dependencies
         # via the Python script. --no-cache is needed - otherwise there is possibility of
         # overriding temporary environments by multiple parallel processes
+        # --all-packages: without it the export only covers the root project's dependencies.
+        # Anything that only a workspace member's dependency group pulls in, such
+        # as mcp through common.ai's pydantic-ai-slim[mcp], stays unpinned and resolves fresh
+        # from PyPI instead of following uv.lock.
         local constraint_file="/tmp/constraints-from-lock.txt"
         uv export --frozen --no-hashes --no-emit-project --no-emit-workspace --no-editable --no-header \
-            --no-annotate > "${constraint_file}" 2>/dev/null || true
+            --no-annotate --all-packages > "${constraint_file}" 2>/dev/null || true
         uv run --no-cache /opt/airflow/scripts/in_container/install_development_dependencies.py \
            --constraint "${constraint_file}"
         # Some packages might leave legacy typing module which causes test issues


### PR DESCRIPTION
Since 2026-09-04 the Airflow 3.0.6, 3.1.8 and 3.2.2 provider compatibility jobs fail on some runs and pass on others. When they fail, 40 tests in `providers/common/ai/tests/unit/common/ai/hooks/test_mcp.py` fail and the traceback ends with:

    mcp/client/streamable_http.py:14: from httpx2 import EventSource, ServerSentEvent
    ImportError: cannot import name 'EventSource' from 'httpx2'

- https://github.com/apache/airflow/actions/runs/33911721926/job/101158255498
- https://github.com/apache/airflow/actions/runs/33937740806/job/101231708023
- https://github.com/apache/airflow/actions/runs/33952855498/job/101274604029

The container has mcp 2.1.1, which needs httpx2>=2.5.0. The job builds that environment in three separate resolutions.

1. `entrypoint_ci.sh` reinstalls the development dependencies with constraints exported from `uv.lock`. That export runs without `--all-packages`, so it only covers what the root project depends on. `pydantic-ai-slim[mcp]` is requested only by the common.ai `dev` dependency group, so mcp and fastmcp-slim are absent from the constraints file and get resolved from PyPI on their own, even though uv.lock pins mcp 1.29.0 and fastmcp-slim 3.4.7.

2. Airflow is installed with the constraints of the release under test, which pin idna to 3.10, 3.11 and 3.16 for these three versions. That resolution only covers Airflow's own dependencies, so it contains neither httpx2 nor mcp.

3. The provider wheels are installed without constraints. This resolution includes httpx2, because genai-prices and pagerduty depend on it, and neither needs anything newer than httpx2 2.0. It still leaves out mcp, because the provider's base dependencies do not request the `mcp` extra. httpx2 2.4.0 and later need idna>=3.18, and step 2 left idna below that, so uv has to move one of the two. In CI it keeps idna and downgrades httpx2 to 2.3.0. mcp's httpx2>=2.5.0 requirement is never checked. uv can also go the other way and bump idna instead, which is why the same jobs pass on other days.


With `--all-packages` the export covers every workspace member's dependency groups, so the constraints file pins `mcp==1.29.0` and `fastmcp-slim==3.4.7`, the versions the CI image itself installs from uv.lock. mcp 1.x depends on httpx and httpx-sse rather than httpx2, so whatever happens to httpx2 later cannot break it. This is also what the step was meant to do since #63609: follow uv.lock, so that a lock bump to mcp 2.x fails in the upgrade PR instead of on main.
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
