### PR TITLE
Clarify when auth managers' is_authorized_hitl_task hook runs

### DIFF
--- a/airflow-core/docs/core-concepts/auth-manager/index.rst
+++ b/airflow-core/docs/core-concepts/auth-manager/index.rst
@@ -143,6 +143,10 @@ These authorization methods are:
 * ``is_authorized_view``: Return whether the user is authorized to access a specific view in Airflow. The view is specified through ``access_view`` (e.g. ``AccessView.CLUSTER_ACTIVITY``). An optional ``team_name`` scopes the check to a team -- see :ref:`team-scoped-view-authorization` below.
 * ``is_authorized_custom_view``: Return whether the user is authorized to access a specific view not defined in Airflow. This view can be provided by the auth manager itself or a plugin defined by the user.
 * ``filter_authorized_menu_items``: Given the list of menu items in the UI, return the list of menu items the user has access to.
+* ``is_authorized_hitl_task``: Return whether the user is authorized to approve or reject a Human-in-the-loop (HITL) task.
+  This is an optional method: the default implementation returns whether the user's ID is in ``assigned_users``, the IDs of the users assigned to the task.
+  Airflow only calls this method for tasks that have assigned users. When a task has none, Airflow skips this method and any user allowed to
+  update the task's HITL detail (``is_authorized_dag`` with ``access_entity=DagAccessEntity.HITL_DETAIL``) can respond.
 
 It should be noted that the ``method`` parameter listed above may only have relevance for a specific subset of the auth manager's authorization methods.
 For example, the ``configuration`` resource is by definition read-only, so only the ``GET`` parameter is relevant in the context of ``is_authorized_configuration``.
@@ -239,7 +243,6 @@ The following methods aren't required to override to have a functional Airflow a
 * ``filter_authorized_dag_ids``: Given a list of Dag IDs, return the list of Dag IDs the user has access to.  If not overridden, it calls ``is_authorized_dag`` for every single Dag passes as parameter.
 * ``filter_authorized_pools``: Given a list of pool names, return the list of pool names the user has access to.  If not overridden, it calls ``is_authorized_pool`` for every single pool passed as parameter.
 * ``filter_authorized_variables``: Given a list of variable keys, return the list of variable keys the user has access to.  If not overridden, it calls ``is_authorized_variable`` for every single variable passed as parameter.
-* ``is_authorized_hitl_task``: Return whether the user is authorized to approve or reject a Human-in-the-loop (HITL) task. Override this method to implement custom authorization logic for HITL tasks. If not overridden, it checks if the user's ID is in the assigned users list.
 
 CLI
 ^^^

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/base_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/base_auth_manager.py
@@ -473,10 +473,14 @@ class BaseAuthManager(Generic[T], LoggingMixin, metaclass=ABCMeta):
         """
         Check if a user is allowed to approve/reject a HITL task.
 
+        Airflow only calls this method for tasks that have assigned users. When a task has none, Airflow
+        skips this method and any user allowed to update the task's HITL detail (``is_authorized_dag``
+        with ``DagAccessEntity.HITL_DETAIL``) can respond.
+
         By default, checks if the user's ID is in the assigned_users set.
         Auth managers can override this method to implement custom logic.
 
-        :param assigned_users: set of user IDs assigned to the task
+        :param assigned_users: set of user IDs assigned to the task, never empty
         :param user: the user to check authorization for
         """
         return user.get_id() in assigned_users

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
@@ -387,10 +387,6 @@ class SimpleAuthManager(BaseAuthManager[SimpleAuthManagerUser]):
             # In all-admin mode, everyone is allowed
             return True
 
-        # If no assigned_users specified, allow access
-        if not assigned_users:
-            return True
-
         # Delegate to parent class for the actual authorization check
         return super().is_authorized_hitl_task(assigned_users=assigned_users, user=user)
 

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/simple/test_simple_auth_manager.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/simple/test_simple_auth_manager.py
@@ -485,8 +485,6 @@ class TestSimpleAuthManager:
             (False, "user1", {"user1"}, True),
             (False, "user2", {"user1"}, False),
             (False, "admin", {"test_user"}, False),
-            # When no assigned_users, allow access
-            (False, "user1", set(), True),
         ],
     )
     def test_is_authorized_hitl_task(self, auth_manager, all_admins, user_id, assigned_users, expected):


### PR DESCRIPTION
## Why
- Neither the docs nor the base docstring say that Airflow only calls the hook for HITL tasks that have assigned users. The only caller sits behind `if hitl_detail_model.assigned_users:`, so a policy for unassigned tasks written in `SimpleAuthManager` never runs.

https://github.com/apache/airflow/blob/20563781c3d9c059985e1f9b741f9414e21bd8f8/airflow-core/src/airflow/api_fastapi/core_api/routes/public/hitl.py#L201-L209

## How
- Move the docs entry to "Authorization related methods", mark it optional and state that Airflow only calls it for tasks with assigned users.
- Remove the unreachable `if not assigned_users: return True` branch from `SimpleAuthManager`, together with the test row that pinned it.

## Verification

- `uv run --frozen --project airflow-core pytest airflow-core/tests/unit/api_fastapi/auth/managers`

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
