### PR TITLE
Clarify backfill reprocessing options

### DIFF
--- a/airflow-core/docs/core-concepts/backfill.rst
+++ b/airflow-core/docs/core-concepts/backfill.rst
@@ -27,11 +27,13 @@ Backfill does not make sense for Dags that don't have a time-based schedule.
 Control over data reprocessing
 ------------------------------
 
-There are three options for reprocessing behavior:
+There are three options for reprocessing behavior. The user-facing names and their corresponding
+CLI and REST API values are:
 
-* **none** - if there's already a run for this logical date, do not create another, no matter the state
-* **failed** - if a run exists, if the state is failed, create a new run for this date
-* **completed** - if a run exists, if the state is completed or failed, create a new run for this date
+* **Missing Runs** (``none``) - if there's already a run for this logical date, do not create another,
+  no matter the state
+* **Missing and Errored Runs** (``failed``) - if a run exists and is failed, create a new run for this date
+* **All Runs** (``completed``) - if a run exists and is completed or failed, create a new run for this date
 
 If the latest run is still running or is queued, we do not create another run, no matter the chosen reprocessing behavior.
 

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -413,10 +413,10 @@ ARG_BACKFILL_DRY_RUN = Arg(
 ARG_BACKFILL_REPROCESS_BEHAVIOR = Arg(
     ("--reprocess-behavior",),
     help=(
-        "When a run exists for the logical date, controls whether new runs will be "
-        "created for the date. Default is none."
+        "Select which Dag runs to create: 'none' (Missing Runs), 'failed' (Missing and Errored Runs), "
+        "or 'completed' (All Runs). Default is 'none'."
     ),
-    choices=("none", "completed", "failed"),
+    choices=("none", "failed", "completed"),
 )
 ARG_BACKFILL_RUN_ON_LATEST_VERSION = Arg(
     ("--run-on-latest-version",),

--- a/airflow-core/tests/unit/cli/test_cli_parser.py
+++ b/airflow-core/tests/unit/cli/test_cli_parser.py
@@ -480,6 +480,19 @@ class TestCli:
             with pytest.raises(SystemExit):
                 parser.parse_args([*cmd_args, "--help"])
 
+    def test_backfill_reprocess_behavior_help_uses_user_facing_names(self):
+        parser = cli_parser.get_parser()
+
+        with contextlib.redirect_stdout(StringIO()) as stdout, pytest.raises(SystemExit):
+            parser.parse_args(["backfill", "create", "--help"])
+
+        normalized_help = " ".join(stdout.getvalue().split())
+        assert "--reprocess-behavior {none,failed,completed}" in normalized_help
+        assert (
+            "'none' (Missing Runs), 'failed' (Missing and Errored Runs), or 'completed' (All Runs)"
+            in normalized_help
+        )
+
     def test_dag_cli_should_display_help(self):
         parser = cli_parser.get_parser(dag_parser=True)
 


### PR DESCRIPTION
Align the backfill reprocessing terminology exposed by CLI help and documentation with the labels already used by the UI, while retaining the existing `none`, `failed`, and `completed` values for backward compatibility.

- Map each stable CLI and REST API value to its user-facing name.
- Order the CLI choices from least to most reprocessing.
- Add a regression test for the generated CLI help.

closes: #48515

Testing:
- Targeted CLI help regression test passed; its negative control failed with the previous help text.
- Ruff formatting and lint checks passed.
- Regular applicable prek checks and manual prek checks passed.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — OpenAI Codex (GPT-5)

Generated-by: OpenAI Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---
Drafted-by: OpenAI Codex (GPT-5) (no human review before posting)