### PR TITLE
Fix Dataproc job not cancelled when killing a deferred task

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/triggers/dataproc.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/dataproc.py
@@ -236,6 +236,9 @@ class DataprocSubmitTrigger(DataprocBaseTrigger):
                 except Exception as e:
                     self.log.error("Failed to cancel the job: %s with error : %s", self.job_id, str(e))
                     raise e
+            else:
+                # The triggerer only calls on_kill() when CancelledError propagates out of run().
+                raise
 
 
 class DataprocSubmitJobDirectTrigger(DataprocBaseTrigger):
@@ -401,6 +404,9 @@ class DataprocSubmitJobDirectTrigger(DataprocBaseTrigger):
                 except Exception as e:
                     self.log.error("Failed to cancel the job: %s with error : %s", self.job_id, str(e))
                     raise e
+            else:
+                # The triggerer only calls on_kill() when CancelledError propagates out of run().
+                raise
 
 
 class DataprocClusterTrigger(DataprocBaseTrigger):

--- a/providers/google/tests/unit/google/cloud/triggers/test_dataproc.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_dataproc.py
@@ -735,6 +735,18 @@ class TestDataprocSubmitTrigger:
 
         await async_gen.aclose()
 
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="Cancellation is handled inline before Airflow 3.3.0")
+    @mock.patch("airflow.providers.google.cloud.triggers.dataproc.DataprocSubmitTrigger.get_async_hook")
+    async def test_submit_trigger_run_reraises_cancelled_error(self, mock_get_async_hook, submit_trigger):
+        mock_async_hook = mock_get_async_hook.return_value
+        mock_async_hook.get_job_client = mock.AsyncMock()
+        mock_async_hook.get_job.side_effect = asyncio.CancelledError
+
+        with pytest.raises(asyncio.CancelledError):
+            async for _ in submit_trigger.run():
+                pass
+
 
 class TestDataprocSubmitJobDirectTrigger:
     def test_serialization(self, submit_job_direct_trigger):
@@ -908,3 +920,19 @@ class TestDataprocSubmitJobDirectTrigger:
             mock_sync_hook.cancel_job.assert_not_called()
 
         await async_gen.aclose()
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="Cancellation is handled inline before Airflow 3.3.0")
+    @mock.patch(
+        "airflow.providers.google.cloud.triggers.dataproc.DataprocSubmitJobDirectTrigger.get_async_hook"
+    )
+    async def test_run_reraises_cancelled_error(self, mock_get_async_hook, submit_job_direct_trigger):
+        mock_hook = mock_get_async_hook.return_value
+        submit_future = asyncio.Future()
+        submit_future.set_result(Job(reference={"job_id": TEST_JOB_ID}))
+        mock_hook.submit_job.return_value = submit_future
+        mock_hook.get_job.side_effect = asyncio.CancelledError
+
+        with pytest.raises(asyncio.CancelledError):
+            async for _ in submit_job_direct_trigger.run():
+                pass


### PR DESCRIPTION
## Summary

The triggerer calls a trigger's `on_kill()` only when `asyncio.CancelledError` propagates out of `run()`. Both Dataproc submit triggers catch it and return, so on Airflow 3.3+ killing or clearing a deferred task leaves:

- the Dataproc job still running
- `Trigger exited without sending an event. Dependent tasks will be failed.` in the triggerer log

Re-raising restores the cleanup path that migrating these triggers to `on_kill()` was meant to keep. The pre-3.3 branch handles cancellation inline and is left alone, so the regression tests are scoped to 3.3+.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
