### PR TITLE
Fix branch operators inside mapped task groups not skipping siblings

### DIFF
--- a/airflow-core/src/airflow/ti_deps/deps/not_previously_skipped_dep.py
+++ b/airflow-core/src/airflow/ti_deps/deps/not_previously_skipped_dep.py
@@ -58,10 +58,26 @@ class NotPreviouslySkippedDep(BaseTIDep):
                     # This can happen if the parent task has not yet run.
                     continue
 
-                # Use the parent's map context to look up the XCom. An unmapped parent
-                # (e.g. LatestOnlyOperator) writes XCom with map_index=-1, so we must
-                # query with -1 instead of the child's map_index.
-                xcom_map_index = ti.map_index if parent.is_mapped else -1
+                # Use the parent's map context to look up the XCom.
+                # - A directly-mapped parent shares the child's map_index.
+                # - A parent inside a mapped task group is not itself mapped
+                #   (parent.is_mapped is False) but still runs at each group
+                #   map_index and writes XCom there.  Detect this by checking
+                #   whether a finished parent TI exists at the child's map_index.
+                # - A truly unmapped parent (e.g. LatestOnlyOperator) always
+                #   writes XCom with map_index=-1; no TI at the child's index.
+                if parent.is_mapped:
+                    xcom_map_index = ti.map_index
+                else:
+                    parent_at_same_index = next(
+                        (
+                            t
+                            for t in finished_tis
+                            if t.task_id == parent.task_id and t.map_index == ti.map_index
+                        ),
+                        None,
+                    )
+                    xcom_map_index = ti.map_index if parent_at_same_index is not None else -1
                 prev_result = ti.xcom_pull(
                     task_ids=parent.task_id,
                     key=XCOM_SKIPMIXIN_KEY,

--- a/airflow-core/tests/unit/ti_deps/deps/test_not_previously_skipped_dep.py
+++ b/airflow-core/tests/unit/ti_deps/deps/test_not_previously_skipped_dep.py
@@ -214,3 +214,61 @@ def test_unmapped_parent_skip_mapped_downstream(session, dag_maker):
     assert len(list(dep.get_dep_statuses(tis["op2"], DepContext(), session=session))) == 1
     assert not dep.is_met(tis["op2"], session=session)
     assert tis["op2"].state == State.SKIPPED
+
+
+def test_branch_in_mapped_taskgroup_skips_non_selected_sibling(session, dag_maker):
+    """
+    A branch operator inside a mapped task group is not itself mapped
+    (parent.is_mapped is False) but runs at each group's map_index and
+    writes its skip XCom there — not at -1.
+
+    NotPreviouslySkippedDep must query the XCom at the matching map_index
+    so siblings are correctly skipped per mapped instance.
+
+    Regression test for https://github.com/apache/airflow/issues/67265
+    """
+    start_date = pendulum.datetime(2020, 1, 1)
+    with dag_maker(
+        "test_branch_in_mapped_tg_dag",
+        schedule=None,
+        start_date=start_date,
+        session=session,
+    ):
+        branch = BranchPythonOperator(task_id="branch", python_callable=lambda: "followed")
+        followed = EmptyOperator(task_id="followed")
+        skipped = EmptyOperator(task_id="skipped")
+        branch >> [followed, skipped]
+
+    dr = dag_maker.create_dagrun(run_type=DagRunType.MANUAL, state=State.RUNNING)
+    tis = {ti.task_id: ti for ti in dr.task_instances}
+
+    # Simulate the branch running inside a mapped task group at map_index=1:
+    # the TI itself has map_index=1 and writes XCom at that index.
+    tis["branch"].map_index = 1
+    tis["branch"].state = State.SUCCESS
+    tis["followed"].map_index = 1
+    tis["skipped"].map_index = 1
+    for ti in tis.values():
+        session.merge(ti)
+    session.flush()  # persist map_index changes before inserting XCom (FK constraint)
+
+    XComModel.set(
+        key=XCOM_SKIPMIXIN_KEY,
+        value={XCOM_SKIPMIXIN_FOLLOWED: ["followed"]},
+        dag_id=dr.dag_id,
+        task_id="branch",
+        run_id=dr.run_id,
+        map_index=1,
+        session=session,
+    )
+
+    dep = NotPreviouslySkippedDep()
+
+    # "followed" is in XCOM_SKIPMIXIN_FOLLOWED — dep is met, task should run.
+    assert dep.is_met(tis["followed"], session=session)
+    assert tis["followed"].state != State.SKIPPED
+
+    # "skipped" is NOT in XCOM_SKIPMIXIN_FOLLOWED — dep fails, task is skipped.
+    assert len(list(dep.get_dep_statuses(tis["skipped"], DepContext(), session=session))) == 1
+    assert not dep.is_met(tis["skipped"], session=session)
+    assert tis["skipped"].state == State.SKIPPED


### PR DESCRIPTION
When a @task.branch lives inside a mapped @task_group it is not itself expanded (parent.is_mapped is False), but its TI runs at the group's map_index and SkipMixin writes the skip XCom there — not at -1. NotPreviouslySkippedDep was querying map_index=-1 for every unmapped parent, finding no XCom, and letting all siblings proceed regardless of what the branch decided.

Detect whether the parent ran in the same mapped context by checking for a finished parent TI at the child's map_index. If one exists, use that index for the XCom lookup; fall back to -1 only for truly unmapped parents (e.g. LatestOnlyOperator) that always write at -1.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
