### PR TITLE
Make the scheduler's HITL and orphan sweeps retry transient DB errors

### DIFF
--- a/airflow-core/newsfragments/72596.bugfix.rst
+++ b/airflow-core/newsfragments/72596.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the scheduler stopping on a transient database error in its Human-in-the-loop timeout sweep. That sweep, and the orphaned-task sweep, now roll the session back before retrying, so a deadlock costs a scheduler tick rather than the scheduler.

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -52,6 +52,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.exc import DBAPIError, OperationalError
 from sqlalchemy.orm import joinedload, lazyload, load_only, make_transient, selectinload
+from sqlalchemy.orm.exc import StaleDataError
 from sqlalchemy.sql import expression
 
 from airflow import settings
@@ -3508,7 +3509,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     # Issue SQL/finish "Unit of Work", but let @provide_session
                     # commit (or if passed a session, let caller decide when to commit
                     session.flush()
-                except OperationalError:
+                except (DBAPIError, StaleDataError):
                     session.rollback()
                     raise
 
@@ -3553,93 +3554,97 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         """
         for attempt in run_with_db_retries(max_retries, logger=self.log):
             with attempt:
-                now = timezone.utcnow()
-                query = (
-                    select(TI)
-                    .where(
-                        TI.state == TaskInstanceState.AWAITING_INPUT,
-                        TI.trigger_timeout < now,
+                try:
+                    now = timezone.utcnow()
+                    query = (
+                        select(TI)
+                        .where(TI.state == TaskInstanceState.AWAITING_INPUT, TI.trigger_timeout < now)
+                        .options(joinedload(TI.hitl_detail))
+                        # Bound the batch so a single scheduler tick cannot lock/process an unbounded
+                        # backlog of timed-out tasks (which would block concurrent responses/clears);
+                        # any remaining rows are handled on subsequent ticks.
+                        .limit(100)
                     )
-                    .options(joinedload(TI.hitl_detail))
-                    # Bound the batch so a single scheduler tick cannot lock/process an unbounded
-                    # backlog of timed-out tasks (which would block concurrent responses/clears);
-                    # any remaining rows are handled on subsequent ticks.
-                    .limit(100)
-                )
-                # Lock only the TI rows (of=TI) so HA schedulers don't double-resolve, and so the
-                # FOR UPDATE is not applied to the nullable side of the hitl_detail outer join.
-                query = with_row_locks(query, of=TI, session=session, skip_locked=True)
-                timed_out_tis = session.scalars(query).all()
-                if not timed_out_tis:
-                    return
+                    # Lock only the TI rows (of=TI) so HA schedulers don't double-resolve, and so the
+                    # FOR UPDATE is not applied to the nullable side of the hitl_detail outer join.
+                    query = with_row_locks(query, of=TI, session=session, skip_locked=True)
+                    timed_out_tis = session.scalars(query).all()
+                    if not timed_out_tis:
+                        return
 
-                num_resolved = 0
-                num_failed = 0
-                num_unresumable = 0
-                for ti in timed_out_tis:
-                    hitl_detail = ti.hitl_detail
-                    resuming = True
-                    if hitl_detail is not None and hitl_detail.responded_at is not None:
-                        # A response landed just before the deadline; resume with it.
-                        handle_event_submit(
-                            TriggerEvent(hitl_detail.as_resume_event_payload(timedout=False)),
-                            task_instance=ti,
-                            session=session,
-                        )
-                    elif hitl_detail is not None and hitl_detail.defaults is not None:
-                        # Apply the configured defaults as the response, then resume to success.
-                        hitl_detail.chosen_options = list(hitl_detail.defaults)
-                        hitl_detail.params_input = {
-                            key: value["value"] if isinstance(value, dict) and "value" in value else value
-                            for key, value in (hitl_detail.params or {}).items()
-                        }
-                        hitl_detail.responded_by = None
-                        hitl_detail.responded_at = now
-                        session.add(hitl_detail)
-                        handle_event_submit(
-                            TriggerEvent(hitl_detail.as_resume_event_payload(timedout=True)),
-                            task_instance=ti,
-                            session=session,
-                        )
-                    else:
-                        # No defaults and no response: resume into execute_complete with a timeout
-                        # failure event so the operator raises HITLTimeoutError (matching the old
-                        # trigger path), rather than a generic deferral-timeout failure.
-                        handle_event_submit(
-                            TriggerEvent(
-                                {
-                                    "error": "The Human-in-the-loop response timeout has passed "
-                                    "without a response.",
-                                    "error_type": "timeout",
-                                }
-                            ),
-                            task_instance=ti,
-                            session=session,
-                        )
-                        resuming = False
+                    num_resolved = 0
+                    num_failed = 0
+                    num_unresumable = 0
+                    for ti in timed_out_tis:
+                        hitl_detail = ti.hitl_detail
+                        resuming = True
+                        if hitl_detail is not None and hitl_detail.responded_at is not None:
+                            # A response landed just before the deadline; resume with it.
+                            handle_event_submit(
+                                TriggerEvent(hitl_detail.as_resume_event_payload(timedout=False)),
+                                task_instance=ti,
+                                session=session,
+                            )
+                        elif hitl_detail is not None and hitl_detail.defaults is not None:
+                            # Apply the configured defaults as the response, then resume to success.
+                            hitl_detail.chosen_options = list(hitl_detail.defaults)
+                            hitl_detail.params_input = {
+                                key: value["value"] if isinstance(value, dict) and "value" in value else value
+                                for key, value in (hitl_detail.params or {}).items()
+                            }
+                            hitl_detail.responded_by = None
+                            hitl_detail.responded_at = now
+                            session.add(hitl_detail)
+                            handle_event_submit(
+                                TriggerEvent(hitl_detail.as_resume_event_payload(timedout=True)),
+                                task_instance=ti,
+                                session=session,
+                            )
+                        else:
+                            # No defaults and no response: resume into execute_complete with a timeout
+                            # failure event so the operator raises HITLTimeoutError (matching the old
+                            # trigger path), rather than a generic deferral-timeout failure.
+                            handle_event_submit(
+                                TriggerEvent(
+                                    {
+                                        "error": "The Human-in-the-loop response timeout has passed "
+                                        "without a response.",
+                                        "error_type": "timeout",
+                                    }
+                                ),
+                                task_instance=ti,
+                                session=session,
+                            )
+                            resuming = False
 
-                    # ``handle_event_submit`` routes a task instance it could not process to
-                    # ``__fail__`` instead of resuming it. That is neither of the outcomes the
-                    # branches above intended, so it is counted on its own rather than being
-                    # reported as resolved.
-                    if ti.next_method == TRIGGER_FAIL_REPR:
-                        num_unresumable += 1
-                    elif resuming:
-                        num_resolved += 1
-                    else:
-                        num_failed += 1
+                        # ``handle_event_submit`` routes a task instance it could not process to
+                        # ``__fail__`` instead of resuming it. That is neither of the outcomes the
+                        # branches above intended, so it is counted on its own rather than being
+                        # reported as resolved.
+                        if ti.next_method == TRIGGER_FAIL_REPR:
+                            num_unresumable += 1
+                        elif resuming:
+                            num_resolved += 1
+                        else:
+                            num_failed += 1
 
-                # Flush within the retry block so both branches persist consistently (the defaults
-                # branch already flushes via handle_event_submit; the fail branch relies on this).
-                session.flush()
-                if num_resolved or num_failed or num_unresumable:
-                    self.log.info(
-                        "AWAITING_INPUT timeout sweep: %i resolved (response/defaults), %i failed, "
-                        "%i could not be resumed",
-                        num_resolved,
-                        num_failed,
-                        num_unresumable,
-                    )
+                    # Flush within the retry block so both branches persist consistently (the defaults
+                    # branch already flushes via handle_event_submit; the fail branch relies on this).
+                    session.flush()
+                    if num_resolved or num_failed or num_unresumable:
+                        self.log.info(
+                            "AWAITING_INPUT timeout sweep: %i resolved (response/defaults), %i failed, "
+                            "%i could not be resumed",
+                            num_resolved,
+                            num_failed,
+                            num_unresumable,
+                        )
+                except (DBAPIError, StaleDataError):
+                    # A failed flush deactivates the transaction: without this rollback the next
+                    # attempt's first query raises PendingRollbackError, which is not retryable and
+                    # so escapes the loop and stops the scheduler.
+                    session.rollback()
+                    raise
 
     # [START find_and_purge_task_instances_without_heartbeats]
     def _find_and_purge_task_instances_without_heartbeats(self) -> None:

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -40,7 +40,9 @@ import pytest
 import time_machine
 from sqlalchemy import delete, func, inspect, select, update
 from sqlalchemy.dialects import mysql
+from sqlalchemy.exc import IntegrityError, OperationalError, PendingRollbackError
 from sqlalchemy.orm import joinedload
+from sqlalchemy.orm.exc import StaleDataError
 
 from airflow import settings
 from airflow._shared.module_loading import qualname
@@ -318,6 +320,41 @@ def _clean_db():
     clear_db_deadline()
     clear_db_callbacks()
     clear_db_triggers()
+
+
+def _build_deactivating_session(session, error):
+    """Wrap ``session`` so its first flush raises ``error`` and deactivates the transaction."""
+    # Callers must commit their fixture rows first: the rollback this models discards whatever
+    # the failed attempt was holding.
+    flushed = False
+    deactivated = False
+
+    def flush(*args, **kwargs):
+        nonlocal flushed, deactivated
+        if not flushed:
+            flushed = deactivated = True
+            raise error
+        return session.flush(*args, **kwargs)
+
+    def guard(method):
+        def call(*args, **kwargs):
+            if deactivated:
+                raise PendingRollbackError("This Session's transaction has been rolled back")
+            return method(*args, **kwargs)
+
+        return call
+
+    def rollback(*args, **kwargs):
+        nonlocal deactivated
+        deactivated = False
+        return session.rollback(*args, **kwargs)
+
+    wrapped = MagicMock(spec=session, wraps=session)
+    wrapped.flush.side_effect = flush
+    wrapped.execute.side_effect = guard(session.execute)
+    wrapped.scalars.side_effect = guard(session.scalars)
+    wrapped.rollback.side_effect = rollback
+    return wrapped
 
 
 @patch.dict(
@@ -3634,6 +3671,38 @@ class TestSchedulerJob:
 
         ti2 = dr2.get_task_instance(task_id=op1.task_id, session=session)
         assert ti2.state == State.NONE, "Tasks run by Backfill Jobs should be treated the same"
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            pytest.param(
+                IntegrityError("any_statement", "any_params", Exception("any_orig")),
+                id="non-operational-dbapi-error",
+            ),
+            pytest.param(StaleDataError(), id="stale-data-error"),
+        ],
+    )
+    def test_adopt_or_reset_orphaned_tasks_rolls_back_before_retrying(self, error, dag_maker, session):
+        """Every error the retry loop retries is rolled back, not only ``OperationalError``."""
+        with dag_maker("test_adopt_or_reset_rolls_back", session=session):
+            op1 = EmptyOperator(task_id="op1")
+
+        dead_job = Job()
+        session.add(dead_job)
+        session.flush()
+
+        dr = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED)
+        ti = dr.get_task_instance(task_id=op1.task_id, session=session)
+        ti.state = State.QUEUED
+        ti.queued_by_job_id = dead_job.id
+        session.commit()
+
+        might_fail_session = _build_deactivating_session(session, error)
+        self.job_runner = SchedulerJobRunner(job=Job(), num_runs=0)
+        self.job_runner.adopt_or_reset_orphaned_tasks(session=might_fail_session)
+
+        session.refresh(ti)
+        assert ti.state == State.NONE
 
     def test_adopt_or_reset_orphaned_tasks_loads_state_for_reset_logging(
         self, dag_maker, session, mock_executor
@@ -8285,6 +8354,40 @@ class TestSchedulerJob:
         assert ti_good.next_kwargs["event"]["chosen_options"] == ["Approve"]
         # The one it could not resume is reported as such rather than counted as resolved.
         assert mock_log.info.call_args.args[1:] == (1, 0, 1)
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            pytest.param(
+                OperationalError("any_statement", "any_params", Exception("any_orig")), id="dbapi-error"
+            ),
+            pytest.param(StaleDataError(), id="stale-data-error"),
+        ],
+    )
+    def test_awaiting_input_timeout_sweep_rolls_back_before_retrying(self, error, dag_maker, session):
+        """A failed sweep rolls back, so the retry runs against a usable transaction."""
+        with dag_maker(
+            dag_id="test_awaiting_input_retry_rollback",
+            start_date=DEFAULT_DATE,
+            schedule="@once",
+            session=session,
+        ):
+            EmptyOperator(task_id="dummy1")
+        dr = dag_maker.create_dagrun()
+        ti = dr.get_task_instance("dummy1", session=session)
+        ti.state = State.AWAITING_INPUT
+        ti.trigger_timeout = timezone.utcnow() - datetime.timedelta(seconds=60)
+        ti.next_method = "execute_complete"
+        ti.next_kwargs = {}
+        session.commit()
+
+        might_fail_session = _build_deactivating_session(session, error)
+        self.job_runner = SchedulerJobRunner(job=Job())
+        self.job_runner.check_awaiting_input_timeouts(max_retries=2, session=might_fail_session)
+
+        session.refresh(ti)
+        assert ti.state == State.SCHEDULED
+        assert ti.next_kwargs["event"]["error_type"] == "timeout"
 
     def test_retry_on_db_error_when_update_timeout_triggers(self, dag_maker, testing_dag_bundle, session):
         """


### PR DESCRIPTION
## Summary

`check_awaiting_input_timeouts` and `adopt_or_reset_orphaned_tasks` both run inside `run_with_db_retries`, so a deadlock should cost a scheduler tick rather than the scheduler. Neither loop survives one.

A failed flush deactivates the session: `Session._flush` rolls its subtransaction back on any exception, so a plain `StaleDataError` poisons it as surely as a DBAPI error. The retry's first statement then raises `PendingRollbackError`, which the predicate does not match, so it escapes the loop — and the awaiting-input sweep sits on a timer without `non_fatal=True`, taking the scheduler loop with it.

`retry_db_transaction` rolls back for exactly this reason; neither hand-rolled loop picked it up.

## Change

- Roll back before re-raising in `check_awaiting_input_timeouts`, as `retry_db_transaction` does.
- Widen the orphaned-task sweep's guard to `(DBAPIError, StaleDataError)`.

Both guards now name exactly the tuple `run_with_db_retries` retries. That widens no retries — tenacity already retried every `DBAPIError` in the orphaned-task sweep; those retries just died on the next statement.

The sweep body is unchanged apart from the indent under the new `try:`; `check_trigger_timeouts` is the third loop of this shape, and #72595 covers it.

## Tests

Both tests drive a session that deactivates on a failed flush the way SQLAlchemy does; all four cases fail on `main` with `PendingRollbackError`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
