### PR TITLE
Support Managed Knowledge Bases in BedrockCreateKnowledgeBaseOperator

### DIFF
--- a/providers/amazon/docs/operators/bedrock.rst
+++ b/providers/amazon/docs/operators/bedrock.rst
@@ -189,6 +189,23 @@ https://docs.aws.amazon.com/bedrock/latest/userguide/knowledge-base-supported.ht
     :start-after: [START howto_operator_bedrock_create_knowledge_base]
     :end-before: [END howto_operator_bedrock_create_knowledge_base]
 
+You can also create a fully managed knowledge base where Bedrock handles the underlying vector store
+and infrastructure automatically:
+
+.. code-block:: python
+
+    BedrockCreateKnowledgeBaseOperator(
+        task_id="create_managed_knowledge_base",
+        name="my_managed_knowledge_base",
+        role_arn="arn:aws:iam::123456789012:role/BedrockExecutionRole",
+        knowledge_base_configuration={
+            "type": "MANAGED",
+            "managedKnowledgeBaseConfiguration": {
+                "embeddingModelType": "MANAGED",
+            },
+        },
+    )
+
 .. _howto/operator:BedrockDeleteKnowledgeBase:
 
 Delete an Amazon Bedrock Knowledge Base

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/bedrock.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/bedrock.py
@@ -669,12 +669,18 @@ class BedrockCreateKnowledgeBaseOperator(AwsBaseOperator[BedrockAgentHook]):
         :ref:`howto/operator:BedrockCreateKnowledgeBaseOperator`
 
     :param name: The name of the knowledge base. (templated)
-    :param embedding_model_arn: ARN of the model used to create vector embeddings for the knowledge base. (templated)
+    :param embedding_model_arn: ARN of the model used to create vector embeddings for the knowledge base.
+        Required for self-managed VECTOR knowledge bases unless ``knowledge_base_configuration`` is provided. (templated)
     :param role_arn: The ARN of the IAM role with permissions to create the knowledge base. (templated)
-    :param storage_config: Configuration details of the vector database used for the knowledge base. (templated)
+    :param storage_config: Configuration details of the vector database used for the knowledge base.
+        Required for self-managed VECTOR knowledge bases. Omit for MANAGED knowledge bases. (templated)
+    :param knowledge_base_configuration: Complete configuration dictionary for the knowledge base.
+        Can be used for MANAGED knowledge bases or custom VECTOR/KENDRA/SQL configurations.
+        If not provided, a default VECTOR configuration using ``embedding_model_arn`` is created. (templated)
     :param wait_for_indexing: Vector indexing can take some time and there is no apparent way to check the state
         before trying to create the Knowledge Base.  If this is True, and creation fails due to the index not
-        being available, the operator will wait and retry.  (default: True) (templated)
+        being available, the operator will wait and retry.  Has no effect for MANAGED knowledge bases.
+        (default: True) (templated)
     :param indexing_error_retry_delay: Seconds between retries if an index error is encountered. (default 5) (templated)
     :param indexing_error_max_attempts: Maximum number of times to retry when encountering an index error. (default 20) (templated)
     :param create_knowledge_base_kwargs: Any additional optional parameters to pass to the API call. (templated)
@@ -703,6 +709,7 @@ class BedrockCreateKnowledgeBaseOperator(AwsBaseOperator[BedrockAgentHook]):
         "embedding_model_arn",
         "role_arn",
         "storage_config",
+        "knowledge_base_configuration",
         "wait_for_indexing",
         "indexing_error_retry_delay",
         "indexing_error_max_attempts",
@@ -712,9 +719,10 @@ class BedrockCreateKnowledgeBaseOperator(AwsBaseOperator[BedrockAgentHook]):
     def __init__(
         self,
         name: str,
-        embedding_model_arn: str,
-        role_arn: str,
-        storage_config: dict[str, Any],
+        embedding_model_arn: str | None = None,
+        role_arn: str | None = None,
+        storage_config: dict[str, Any] | None = None,
+        knowledge_base_configuration: dict[str, Any] | None = None,
         create_knowledge_base_kwargs: dict[str, Any] | None = None,
         wait_for_indexing: bool = True,
         indexing_error_retry_delay: int = 5,  # seconds
@@ -725,12 +733,16 @@ class BedrockCreateKnowledgeBaseOperator(AwsBaseOperator[BedrockAgentHook]):
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
         **kwargs,
     ):
+        if knowledge_base_configuration is None and "knowledge_base_config" in kwargs:
+            knowledge_base_configuration = kwargs.pop("knowledge_base_config")
+
         super().__init__(**kwargs)
         self.name = name
         self.role_arn = role_arn
         self.storage_config = storage_config
         self.create_knowledge_base_kwargs = create_knowledge_base_kwargs or {}
         self.embedding_model_arn = embedding_model_arn
+        self.knowledge_base_configuration = knowledge_base_configuration
         self.wait_for_indexing = wait_for_indexing
         self.indexing_error_retry_delay = indexing_error_retry_delay
         self.indexing_error_max_attempts = indexing_error_max_attempts
@@ -739,6 +751,21 @@ class BedrockCreateKnowledgeBaseOperator(AwsBaseOperator[BedrockAgentHook]):
         self.waiter_delay = waiter_delay
         self.waiter_max_attempts = waiter_max_attempts
         self.deferrable = deferrable
+
+    @property
+    def knowledge_base_config(self) -> dict[str, Any] | None:
+        if self.knowledge_base_configuration is not None:
+            return self.knowledge_base_configuration
+        if self.embedding_model_arn:
+            return {
+                "type": "VECTOR",
+                "vectorKnowledgeBaseConfiguration": {"embeddingModelArn": self.embedding_model_arn},
+            }
+        return None
+
+    @knowledge_base_config.setter
+    def knowledge_base_config(self, value: dict[str, Any] | None) -> None:
+        self.knowledge_base_configuration = value
 
     def execute_complete(self, context: Context, event: dict[str, Any] | None = None) -> str:
         validated_event = validate_execute_complete_event(event)
@@ -750,10 +777,49 @@ class BedrockCreateKnowledgeBaseOperator(AwsBaseOperator[BedrockAgentHook]):
         return validated_event["knowledge_base_id"]
 
     def execute(self, context: Context) -> str:
-        knowledge_base_config = {
-            "type": "VECTOR",
-            "vectorKnowledgeBaseConfiguration": {"embeddingModelArn": self.embedding_model_arn},
+        if not self.role_arn:
+            raise ValueError("`role_arn` must be specified to create a knowledge base.")
+
+        create_kwargs = self.create_knowledge_base_kwargs.copy()
+
+        if "knowledgeBaseConfiguration" in create_kwargs:
+            knowledge_base_config = create_kwargs.pop("knowledgeBaseConfiguration")
+        elif "knowledge_base_configuration" in create_kwargs:
+            knowledge_base_config = create_kwargs.pop("knowledge_base_configuration")
+        elif "knowledge_base_config" in create_kwargs:
+            knowledge_base_config = create_kwargs.pop("knowledge_base_config")
+        elif self.knowledge_base_configuration is not None:
+            knowledge_base_config = self.knowledge_base_configuration
+        elif self.embedding_model_arn is not None:
+            knowledge_base_config = {
+                "type": "VECTOR",
+                "vectorKnowledgeBaseConfiguration": {"embeddingModelArn": self.embedding_model_arn},
+            }
+        else:
+            raise ValueError(
+                "Either `knowledge_base_configuration` or `embedding_model_arn` must be provided."
+            )
+
+        if "storageConfiguration" in create_kwargs:
+            storage_config = create_kwargs.pop("storageConfiguration")
+        elif "storage_config" in create_kwargs:
+            storage_config = create_kwargs.pop("storage_config")
+        else:
+            storage_config = self.storage_config
+
+        is_managed = knowledge_base_config.get("type") == "MANAGED"
+
+        if not is_managed and knowledge_base_config.get("type") == "VECTOR" and storage_config is None:
+            raise ValueError("`storage_config` is required when creating a VECTOR knowledge base.")
+
+        api_kwargs: dict[str, Any] = {
+            "name": self.name,
+            "roleArn": self.role_arn,
+            "knowledgeBaseConfiguration": knowledge_base_config,
+            **create_kwargs,
         }
+        if storage_config is not None:
+            api_kwargs["storageConfiguration"] = storage_config
 
         def _create_kb():
             # This API call will return the following if the index has not completed, but there is no apparent
@@ -762,13 +828,7 @@ class BedrockCreateKnowledgeBaseOperator(AwsBaseOperator[BedrockAgentHook]):
             #       when calling the CreateKnowledgeBase operation: The knowledge base storage configuration
             #       provided is invalid... no such index [bedrock-sample-rag-index-abc108]
             try:
-                return self.hook.conn.create_knowledge_base(
-                    name=self.name,
-                    roleArn=self.role_arn,
-                    knowledgeBaseConfiguration=knowledge_base_config,
-                    storageConfiguration=self.storage_config,
-                    **self.create_knowledge_base_kwargs,
-                )["knowledgeBase"]["knowledgeBaseId"]
+                return self.hook.conn.create_knowledge_base(**api_kwargs)["knowledgeBase"]["knowledgeBaseId"]
             except ClientError as error:
                 error_message = error.response["Error"]["Message"].lower()
                 is_known_retryable_message = (
@@ -784,6 +844,7 @@ class BedrockCreateKnowledgeBaseOperator(AwsBaseOperator[BedrockAgentHook]):
                         error.response["Error"]["Code"] == "ValidationException",
                         is_known_retryable_message,
                         self.wait_for_indexing,
+                        not is_managed,
                         self.indexing_error_max_attempts > 0,
                     ]
                 ):

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_bedrock.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_bedrock.py
@@ -702,6 +702,129 @@ class TestBedrockCreateKnowledgeBaseOperator:
         assert mock_conn.create_knowledge_base.call_count == 21
         assert mock_sleep.call_count == 20
 
+    def test_create_managed_knowledge_base(self, mock_conn):
+        operator = BedrockCreateKnowledgeBaseOperator(
+            task_id="create_managed_kb",
+            name="managed_kb",
+            role_arn="role-arn",
+            knowledge_base_configuration={
+                "type": "MANAGED",
+                "managedKnowledgeBaseConfiguration": {"embeddingModelType": "MANAGED"},
+            },
+            wait_for_completion=False,
+        )
+
+        result = operator.execute({})
+
+        assert result == self.KNOWLEDGE_BASE_ID
+        mock_conn.create_knowledge_base.assert_called_once_with(
+            name="managed_kb",
+            roleArn="role-arn",
+            knowledgeBaseConfiguration={
+                "type": "MANAGED",
+                "managedKnowledgeBaseConfiguration": {"embeddingModelType": "MANAGED"},
+            },
+        )
+
+    def test_create_managed_knowledge_base_via_create_knowledge_base_kwargs(self, mock_conn):
+        operator = BedrockCreateKnowledgeBaseOperator(
+            task_id="create_managed_kb",
+            name="managed_kb",
+            role_arn="role-arn",
+            create_knowledge_base_kwargs={
+                "knowledgeBaseConfiguration": {
+                    "type": "MANAGED",
+                    "managedKnowledgeBaseConfiguration": {"embeddingModelType": "MANAGED"},
+                }
+            },
+            wait_for_completion=False,
+        )
+
+        result = operator.execute({})
+
+        assert result == self.KNOWLEDGE_BASE_ID
+        mock_conn.create_knowledge_base.assert_called_once_with(
+            name="managed_kb",
+            roleArn="role-arn",
+            knowledgeBaseConfiguration={
+                "type": "MANAGED",
+                "managedKnowledgeBaseConfiguration": {"embeddingModelType": "MANAGED"},
+            },
+        )
+
+    def test_managed_knowledge_base_does_not_retry_indexing(self, mock_conn):
+        """Managed knowledge base does not have a self-managed vector index, so it must not retry."""
+        operator = BedrockCreateKnowledgeBaseOperator(
+            task_id="create_managed_kb",
+            name="managed_kb",
+            role_arn="role-arn",
+            knowledge_base_configuration={
+                "type": "MANAGED",
+                "managedKnowledgeBaseConfiguration": {"embeddingModelType": "MANAGED"},
+            },
+            wait_for_completion=False,
+        )
+        validation_error = self._create_validation_error("no such index [some-index]")
+        mock_conn.create_knowledge_base.side_effect = [validation_error]
+
+        with pytest.raises(ClientError):
+            operator.execute({})
+
+        assert mock_conn.create_knowledge_base.call_count == 1
+
+    def test_missing_role_arn_raises_value_error(self):
+        operator = BedrockCreateKnowledgeBaseOperator(
+            task_id="create_kb",
+            name="my_kb",
+            embedding_model_arn="arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-embed-text-v1",
+            storage_config={"type": "OPENSEARCH_SERVERLESS"},
+            wait_for_completion=False,
+        )
+        with pytest.raises(ValueError, match="`role_arn` must be specified"):
+            operator.execute({})
+
+    def test_missing_config_and_embedding_model_raises_value_error(self):
+        operator = BedrockCreateKnowledgeBaseOperator(
+            task_id="create_kb",
+            name="my_kb",
+            role_arn="role-arn",
+            wait_for_completion=False,
+        )
+        with pytest.raises(
+            ValueError,
+            match="Either `knowledge_base_configuration` or `embedding_model_arn` must be provided",
+        ):
+            operator.execute({})
+
+    def test_vector_kb_missing_storage_config_raises_value_error(self):
+        operator = BedrockCreateKnowledgeBaseOperator(
+            task_id="create_kb",
+            name="my_kb",
+            role_arn="role-arn",
+            embedding_model_arn="arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-embed-text-v1",
+            wait_for_completion=False,
+        )
+        with pytest.raises(
+            ValueError, match="`storage_config` is required when creating a VECTOR knowledge base"
+        ):
+            operator.execute({})
+
+    def test_knowledge_base_config_property_and_alias(self):
+        operator = BedrockCreateKnowledgeBaseOperator(
+            task_id="create_kb",
+            name="my_kb",
+            role_arn="role-arn",
+            knowledge_base_config={
+                "type": "MANAGED",
+                "managedKnowledgeBaseConfiguration": {"embeddingModelType": "MANAGED"},
+            },
+        )
+        assert operator.knowledge_base_configuration == {
+            "type": "MANAGED",
+            "managedKnowledgeBaseConfiguration": {"embeddingModelType": "MANAGED"},
+        }
+        assert operator.knowledge_base_config == operator.knowledge_base_configuration
+
 
 class TestBedrockCreateDataSourceOperator:
     DATA_SOURCE_ID = "data_source_id"


### PR DESCRIPTION
### Description

Amazon Bedrock Managed Knowledge Bases provide a fully managed RAG offering where Bedrock manages the vector store, ingestion pipeline, and retrieval infrastructure automatically without requiring users to configure and maintain a self-managed vector database (e.g. OpenSearch Serverless, Pinecone, etc.).

Previously, `BedrockCreateKnowledgeBaseOperator` could not be used to create managed knowledge bases because:
1. `embedding_model_arn` and `storage_config` were required `__init__` arguments, neither of which applies to a fully managed knowledge base.
2. `storageConfiguration=self.storage_config` was always passed to the underlying `create_knowledge_base` API call, which fails for managed knowledge bases.
3. `knowledgeBaseConfiguration` was hardcoded to `type="VECTOR"` using `embedding_model_arn`. Supplying custom configuration through `create_knowledge_base_kwargs` raised `TypeError: got multiple values for keyword argument`.
4. The vector indexing retry loop (`wait_for_indexing`) retries upon index propagation errors which are only applicable to self-managed vector indices.

### Changes Made

- **Optional Parameters**: Made `embedding_model_arn` and `storage_config` optional (`str | None = None` and `dict[str, Any] | None = None`).
- **Custom Configuration Support**: Added `knowledge_base_configuration` parameter (and alias property `knowledge_base_config`) to support `MANAGED` knowledge bases as well as custom configurations. Handled `knowledgeBaseConfiguration` and `storageConfiguration` in `create_knowledge_base_kwargs` gracefully without keyword conflicts.
- **Conditional `storageConfiguration`**: Only passes `storageConfiguration` to the boto3 `create_knowledge_base` API when `storage_config` is provided.
- **Validation**: Added validation ensuring `role_arn` is specified, either `knowledge_base_configuration` or `embedding_model_arn` is supplied, and `storage_config` is provided when creating a self-managed `VECTOR` knowledge base.
- **Index Retry Bypass**: Bypasses the vector index propagation retry loop when the knowledge base type is `MANAGED`.
- **Documentation**: Updated Bedrock operator documentation in `providers/amazon/docs/operators/bedrock.rst` with an explanation and code example for creating a managed knowledge base.
- **Unit Tests**: Added comprehensive unit tests in `TestBedrockCreateKnowledgeBaseOperator` covering:
  - Creating a managed knowledge base with `knowledge_base_configuration`
  - Creating a managed knowledge base via `create_knowledge_base_kwargs`
  - Verifying managed knowledge bases bypass indexing retry loops
  - Validation errors (missing `role_arn`, missing config/model, missing `storage_config` for VECTOR KB)
  - Property aliasing between `knowledge_base_config` and `knowledge_base_configuration`

closes: #72592

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Antigravity)

Generated-by: Antigravity following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)