### PR TITLE
Fix backward-compat helpers.__getattr__ raising AttributeError on dep…

### DIFF
--- a/airflow-core/src/airflow/utils/helpers.py
+++ b/airflow-core/src/airflow/utils/helpers.py
@@ -320,4 +320,6 @@ def __getattr__(name: str):
         DeprecationWarning,
         stacklevel=2,
     )
-    return getattr(__import__(modpath), name)
+    import importlib
+
+    return getattr(importlib.import_module(modpath), name)

--- a/airflow-core/tests/unit/utils/test_helpers.py
+++ b/airflow-core/tests/unit/utils/test_helpers.py
@@ -264,3 +264,25 @@ class SchedulerJobRunner(MockJobRunner):
 
 class TriggererJobRunner(MockJobRunner):
     job_type = "TriggererJob"
+
+
+@pytest.mark.parametrize(
+    ("name", "expected_modpath"),
+    [
+        ("render_template_as_native", "airflow.sdk.definitions.context"),
+        ("render_template_to_string", "airflow.sdk.definitions.context"),
+        ("prevent_duplicates", "airflow.sdk.definitions.mappedoperator"),
+    ],
+)
+def test_deprecated_imports_return_callable(name, expected_modpath):
+    import warnings
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        obj = getattr(helpers, name)
+
+    assert callable(obj), f"{name} should be callable"
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught), "should emit DeprecationWarning"
+    assert any(expected_modpath in str(w.message) for w in caught), (
+        f"warning should mention {expected_modpath}"
+    )


### PR DESCRIPTION
…recated imports

__import__('a.b.c') returns the top-level package 'a', not the leaf module 'a.b.c'. Any caller accessing a deprecated name via airflow.utils.helpers (render_template_as_native, render_template_to_string, prevent_duplicates) received an AttributeError instead of the expected DeprecationWarning and the actual callable.

Switch to importlib.import_module() which returns the correct leaf module.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
