### PR TITLE
Fix GET /assets/{asset_id} returning 500 when asset events share a timestamp

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -573,16 +573,11 @@ def get_asset(
     session: SessionDep,
 ) -> AssetResponse:
     """Get an asset."""
-    # Build a subquery to be used to retrieve the latest AssetEvent by matching timestamp
-    last_asset_event = (
-        select(func.max(AssetEvent.timestamp)).where(AssetEvent.asset_id == asset_id).scalar_subquery()
-    )
-
-    # Now, find the latest AssetEvent details using the subquery from above
     asset_event_rows = session.execute(
-        select(AssetEvent.asset_id, AssetEvent.id, AssetEvent.timestamp).where(
-            AssetEvent.asset_id == asset_id, AssetEvent.timestamp == last_asset_event
-        )
+        select(AssetEvent.asset_id, AssetEvent.id, AssetEvent.timestamp)
+        .where(AssetEvent.asset_id == asset_id)
+        .order_by(AssetEvent.timestamp.desc(), AssetEvent.id.desc())
+        .limit(1)
     ).one_or_none()
 
     # Retrieve the Asset; there should only be one for that asset_id

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
@@ -1702,6 +1702,29 @@ class TestGetAssetEndpoint(TestAssets):
         assert {ref["team_name"] for ref in body["scheduled_dags"]} == {"team-assets"}
         assert {ref["team_name"] for ref in body["producing_tasks"]} == {"team-assets"}
 
+    def test_should_respond_200_with_tied_last_event_timestamps(self, test_client, session):
+        self.create_assets(num=1)
+        for event_id in (1, 2):
+            session.add(
+                AssetEvent(
+                    id=event_id,
+                    asset_id=1,
+                    extra={"foo": "bar"},
+                    source_task_id="source_task_id",
+                    source_dag_id="source_dag_id",
+                    source_run_id=f"source_run_id_{event_id}",
+                    timestamp=DEFAULT_DATE,
+                )
+            )
+        session.commit()
+
+        response = test_client.get("/assets/1")
+        assert response.status_code == 200
+        assert response.json()["last_asset_event"] == {
+            "id": 2,
+            "timestamp": from_datetime_to_zulu_without_ms(DEFAULT_DATE),
+        }
+
     def test_should_respond_401(self, unauthenticated_test_client):
         response = unauthenticated_test_client.get("/assets/1")
         assert response.status_code == 401


### PR DESCRIPTION
### Summary

`GET /assets/{asset_id}` resolves the asset's "last asset event" in two steps: it first computes `max(AssetEvent.timestamp)` for the asset, then re-queries the events matching that timestamp with `.one_or_none()`. Nothing guarantees that timestamp is unique — an asset can be updated by several tasks within the same clock tick, and the timestamp column has no uniqueness constraint. When two or more events tie on the newest timestamp, the second query returns multiple rows and SQLAlchemy raises `MultipleResultsFound`, which surfaces to the caller as `500 Internal Server Error` instead of the asset payload.

This is the same class of bug fixed for `/ui/assets` in #71047 (that fix broke the tie with `max(id)` inside the aggregate query), but the public API endpoint was not covered by it and still carries the original two-step lookup.

### Changes

- `airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py`: replace the `max(timestamp)` subquery + `.one_or_none()` pair with a single ordered query — `ORDER BY timestamp DESC, id DESC LIMIT 1` — so exactly one event is selected and ties are broken deterministically on the highest id, matching the `/ui/assets` behaviour.
- `airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py`: add `TestGetAssetEndpoint::test_should_respond_200_with_tied_last_event_timestamps`, which creates two events for the same asset with identical timestamps and asserts the endpoint returns `200` with the higher event id as `last_asset_event`. The test returns `500` without the source change.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)