### PR TITLE
Make suppress_logs_and_warning CLI decorator return the wrapped result

### DIFF
--- a/airflow-core/src/airflow/utils/cli.py
+++ b/airflow-core/src/airflow/utils/cli.py
@@ -462,28 +462,27 @@ def suppress_logs_and_warning(f: T) -> T:
     def _wrapper(*args, **kwargs):
         _check_cli_args(args)
         if args[0].verbose:
-            f(*args, **kwargs)
-        else:
-            from airflow._shared.logging.structlog import respect_stdlib_disable
+            return f(*args, **kwargs)
+        from airflow._shared.logging.structlog import respect_stdlib_disable
 
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                logging.disable(logging.CRITICAL)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            logging.disable(logging.CRITICAL)
 
-                def drop(*_, **__):
-                    from structlog import DropEvent
+            def drop(*_, **__):
+                from structlog import DropEvent
 
-                    raise DropEvent()
+                raise DropEvent()
 
-                old_fn = respect_stdlib_disable.__code__
-                respect_stdlib_disable.__code__ = drop.__code__
-                try:
-                    f(*args, **kwargs)
-                finally:
-                    # logging output again depends on the effective
-                    # levels of individual loggers
-                    logging.disable(logging.NOTSET)
-                    respect_stdlib_disable.__code__ = old_fn
+            old_fn = respect_stdlib_disable.__code__
+            respect_stdlib_disable.__code__ = drop.__code__
+            try:
+                return f(*args, **kwargs)
+            finally:
+                # logging output again depends on the effective
+                # levels of individual loggers
+                logging.disable(logging.NOTSET)
+                respect_stdlib_disable.__code__ = old_fn
 
     return cast("T", _wrapper)
 

--- a/airflow-core/tests/unit/utils/test_cli_util.py
+++ b/airflow-core/tests/unit/utils/test_cli_util.py
@@ -376,3 +376,13 @@ def test_should_enable_hot_reload(dev_flag, env_var, expected):
 
     with mock.patch.dict(os.environ, env, clear=True):
         assert cli.should_enable_hot_reload(args) is expected
+
+
+@pytest.mark.non_db_test_override
+@pytest.mark.parametrize("verbose", [True, False])
+def test_suppress_logs_and_warning_returns_wrapped_value(verbose):
+    @cli.suppress_logs_and_warning
+    def command(args):
+        return "result"
+
+    assert command(Namespace(verbose=verbose)) == "result"


### PR DESCRIPTION
`suppress_logs_and_warning` in `airflow/utils/cli.py` called the wrapped function on both of its branches (`--verbose` and not) without returning the result, so every caller received `None`. The other decorators stacked on CLI command functions (`action_cli`, `providers_configuration_loaded`, `provide_session`) all pass the return value through, so this one was the odd one out.

This is a decorator-transparency fix, not a user-facing bug fix: none of the 49 commands currently decorated (core CLI commands plus the FAB provider's `users`/`roles` commands) returns a value from its own body, and `airflow/__main__.py` discards the result of `args.func(args)`. Nothing observable changes today; the change removes a trap for any future command that does return something.

The `else:` block is flattened because ruff rule `RET505` (enabled in `pyproject.toml`) rejects an `else` after `return`. The body of that block is unchanged apart from the added `return`; the restore logic in `finally` still runs before the value is returned.

A parametrized test covers both branches and fails on `main`. It carries `@pytest.mark.non_db_test_override` because the test module is marked `db_test` at module level while this test needs no database.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5.1)

Generated-by: Claude Code (Fable 5.1) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

