### PR TITLE
Add external access integrations to SnowparkContainerJobOperator

### DIFF
--- a/providers/snowflake/src/airflow/providers/snowflake/operators/snowpark_containers.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/operators/snowpark_containers.py
@@ -64,6 +64,9 @@ class SnowparkContainerJobOperator(BaseOperator):
         This is separate from the ``warehouse`` parameter used by the operator's
         own SQL commands
     :param replicas: (Optional) number of job replicas to run. (default value: 1)
+    :param external_access_integrations: (Optional) Names of the external access
+        integrations that allow your job to access external sites. Names are
+        case-sensitive (default value: None)
     :param wait_for_completion: poll until the job reaches a terminal state.
         When disabled, the job is submitted and the operator returns
         immediately. (default value: True)
@@ -100,6 +103,7 @@ class SnowparkContainerJobOperator(BaseOperator):
         "name",
         "query_warehouse",
         "snowflake_conn_id",
+        "external_access_integrations",
     )
 
     def __init__(
@@ -113,6 +117,7 @@ class SnowparkContainerJobOperator(BaseOperator):
         name: str | None = None,
         query_warehouse: str | None = None,
         replicas: int = 1,
+        external_access_integrations: list[str] | None = None,
         wait_for_completion: bool = True,
         drop_on_completion: bool = True,
         poll_interval: int = 10,
@@ -136,6 +141,7 @@ class SnowparkContainerJobOperator(BaseOperator):
         self.name = name
         self.query_warehouse = query_warehouse
         self.replicas = replicas
+        self.external_access_integrations = external_access_integrations
         self.wait_for_completion = wait_for_completion
         self.drop_on_completion = drop_on_completion
         self.poll_interval = poll_interval
@@ -172,6 +178,9 @@ class SnowparkContainerJobOperator(BaseOperator):
             sql += f" REPLICAS = {self.replicas}"
         if self.query_warehouse:
             sql += f" QUERY_WAREHOUSE = {self.query_warehouse}"
+        if self.external_access_integrations:
+            eais = ", ".join(self.external_access_integrations)
+            sql += f" EXTERNAL_ACCESS_INTEGRATIONS = ({eais})"
         if self.spec_text:
             sql += f" FROM SPECIFICATION $${self.spec_text}$$"
         else:

--- a/providers/snowflake/tests/unit/snowflake/operators/test_snowpark_containers.py
+++ b/providers/snowflake/tests/unit/snowflake/operators/test_snowpark_containers.py
@@ -120,11 +120,26 @@ class TestSnowparkContainerJobOperator:
             pytest.param(
                 {"query_warehouse": "COMPUTE_WH"}, "QUERY_WAREHOUSE = COMPUTE_WH", id="query_warehouse"
             ),
+            pytest.param(
+                {"external_access_integrations": ["test_eai"]},
+                "EXTERNAL_ACCESS_INTEGRATIONS = (test_eai)",
+                id="external_access_integrations_single",
+            ),
+            pytest.param(
+                {"external_access_integrations": ["test_eai", "test_eai_2"]},
+                "EXTERNAL_ACCESS_INTEGRATIONS = (test_eai, test_eai_2)",
+                id="external_access_integrations_multiple",
+            ),
         ),
     )
     def test_build_sql_optional_params(self, kwargs, expected):
         op = _make_operator(**kwargs)
         assert expected in op._build_sql()
+
+    def test_external_access_integrations_in_template_fields(self):
+        op = _make_operator(external_access_integrations=["test_eai"])
+        assert "external_access_integrations" in op.template_fields
+        assert hasattr(op, "external_access_integrations")
 
     @mock.patch(MOCK_HOOK_PATH)
     def test_submit_job_parses_job_name(self, mock_hook_cls):


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
---
This PR adds a new optional `external_access_integrations` parameter to the `SnowparkContainerJobOperator`. By default, application containers don’t have permission to access the internet, so this will enable users to provide the names of external access integrations so their jobs can access external sites. The new clause syntax comes straight from the Snowflake documentation. Fully backwards compatible as it's optional and defaults to `None`. The field was also added as a template field since it's a good candidate. Tests were added/updated to cover the new behavior.


##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] No (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
