### PR TITLE
Add missing unit tests for EmptyOperator in standard provider

### DIFF
--- a/airflow-core/tests/unit/always/test_project_structure.py
+++ b/airflow-core/tests/unit/always/test_project_structure.py
@@ -169,7 +169,6 @@ class TestProjectStructure:
             "providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_adls.py",
             "providers/snowflake/tests/unit/snowflake/triggers/test_snowflake_trigger.py",
             "providers/standard/tests/unit/standard/operators/test_branch.py",
-            "providers/standard/tests/unit/standard/operators/test_empty.py",
             "providers/standard/tests/unit/standard/operators/test_latest_only.py",
             "providers/standard/tests/unit/standard/sensors/test_external_task.py",
             "providers/sftp/tests/unit/sftp/test_exceptions.py",

--- a/providers/standard/tests/unit/standard/operators/test_empty.py
+++ b/providers/standard/tests/unit/standard/operators/test_empty.py
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from airflow.providers.standard.operators.empty import EmptyOperator
+from airflow.providers.standard.version_compat import BaseOperator
+
+
+class TestEmptyOperator:
+    def test_empty_operator_init(self):
+        op = EmptyOperator(task_id="test_empty")
+        assert op.task_id == "test_empty"
+        assert op.inherits_from_empty_operator is True
+        assert op.ui_color == "#e8f7e4"
+        assert isinstance(op, BaseOperator)
+
+    def test_empty_operator_execute_none(self):
+        op = EmptyOperator(task_id="test_empty_none")
+        result = op.execute(None)
+        assert result is None
+
+    def test_empty_operator_execute_with_context(self):
+        op = EmptyOperator(task_id="test_empty_context")
+        mock_context = MagicMock()
+        result = op.execute(context=mock_context)
+        assert result is None


### PR DESCRIPTION
This pull request adds unit tests for `EmptyOperator` in `apache-airflow-providers-standard` and removes its entry from `OVERLOOKED_TESTS` in `airflow-core/tests/unit/always/test_project_structure.py`.

### Changes Made
- Added unit tests in `providers/standard/tests/unit/standard/operators/test_empty.py` covering:
  - `EmptyOperator` initialization, attribute verification (`ui_color`, `inherits_from_empty_operator`), and `BaseOperator` inheritance.
  - Safe execution with `None` context.
  - Safe execution with mock context.
- Removed `providers/standard/tests/unit/standard/operators/test_empty.py` from `OVERLOOKED_TESTS` in `test_project_structure.py`.

related: #35442

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
