### PR TITLE
Fail KubernetesPodOperator when on_kill interrupted the pod

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -886,6 +886,17 @@ class KubernetesPodOperator(BaseOperator):
                 pod=pod_to_clean, remote_pod=self.remote_pod, context=context, result=result
             )
 
+        if self._killed:
+            # on_kill() ran while the block above was waiting on the pod, and that wait
+            # returned normally because the pod it was watching simply went away. The
+            # workload never finished, so falling through here would finalise the task
+            # instance as success. This check sits after the finally block on purpose: if
+            # the body raised, that exception propagates untouched and already fails the
+            # task with its own reason.
+            raise AirflowException(
+                f"Pod {self.pod and self.pod.metadata.name} was interrupted before it completed."
+            )
+
         if self.do_xcom_push:
             return result
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -139,6 +139,10 @@ class FoundMoreThanOnePodFailure(AirflowException):
     """When during reconnect more than one matching pod was found."""
 
 
+class PodInterrupted(AirflowException):
+    """When ``on_kill`` deleted the pod before its workload completed."""
+
+
 class KubernetesPodOperator(BaseOperator):
     """
     Execute a task in a Kubernetes Pod.
@@ -893,9 +897,8 @@ class KubernetesPodOperator(BaseOperator):
             # instance as success. This check sits after the finally block on purpose: if
             # the body raised, that exception propagates untouched and already fails the
             # task with its own reason.
-            raise AirflowException(
-                f"Pod {self.pod and self.pod.metadata.name} was interrupted before it completed."
-            )
+            pod_name = self.pod.metadata.name if self.pod else self.name
+            raise PodInterrupted(f"Pod {pod_name} was interrupted before it completed.")
 
         if self.do_xcom_push:
             return result

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -38,6 +38,7 @@ from airflow.providers.cncf.kubernetes.operators.pod import (
     POD_IDENTIFIER_STATE_KEY,
     KubernetesPodOperator,
     PodEventType,
+    PodInterrupted,
     _optionally_suppress,
 )
 from airflow.providers.cncf.kubernetes.secret import Secret
@@ -858,7 +859,7 @@ class TestKubernetesPodOperator:
         calls on_kill(), which deletes the child, and the wait in execute_sync then returns
         normally because the pod it was watching has gone away. cleanup() skips its usual
         failure signalling once _killed is set, so execute_sync used to fall through and
-        return, and the task was recorded as success (apache/airflow#71202).
+        return, and the task was recorded as success.
         """
         k = self._interrupted_pod_operator()
         running_pod = self._running_pod()
@@ -873,7 +874,7 @@ class TestKubernetesPodOperator:
         context = create_context(k)
         context["ti"].xcom_push = MagicMock()
 
-        with pytest.raises(AirflowException, match="was interrupted before it completed"):
+        with pytest.raises(PodInterrupted, match="was interrupted before it completed"):
             k.execute(context=context)
 
     @patch(HOOK_CLASS, new=MagicMock)
@@ -896,14 +897,14 @@ class TestKubernetesPodOperator:
 
         def _kill_then_fail(pod):
             k.on_kill()
-            raise AirflowException("original failure")
+            raise RuntimeError("original failure")
 
         await_pod_completion_mock.side_effect = _kill_then_fail
 
         context = create_context(k)
         context["ti"].xcom_push = MagicMock()
 
-        with pytest.raises(AirflowException, match="original failure"):
+        with pytest.raises(RuntimeError, match="original failure"):
             k.execute(context=context)
 
     @pytest.mark.parametrize(

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -823,6 +823,89 @@ class TestKubernetesPodOperator:
 
         assert result == should_delete
 
+    def _interrupted_pod_operator(self, **kwargs):
+        return KubernetesPodOperator(
+            namespace="default",
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["sleep 120"],
+            name="sleep-worker",
+            task_id="task",
+            do_xcom_push=False,
+            get_logs=True,
+            **kwargs,
+        )
+
+    @staticmethod
+    def _running_pod():
+        pod = MagicMock()
+        pod.metadata.name = "sleep-worker"
+        pod.metadata.namespace = "default"
+        pod.status.phase = PodPhase.RUNNING
+        return pod
+
+    @patch(HOOK_CLASS, new=MagicMock)
+    @patch(KUB_OP_PATH.format("get_or_create_pod"))
+    @patch(KUB_OP_PATH.format("find_pod"))
+    @patch(KUB_OP_PATH.format("await_pod_completion"))
+    def test_execute_sync_fails_when_on_kill_ran_during_the_wait(
+        self, await_pod_completion_mock, find_pod_mock, get_or_create_pod_mock
+    ):
+        """A pod interrupted by on_kill must not finalise the task instance as success.
+
+        Under KubernetesExecutor the task pod and the KPO child pod can be interrupted
+        within about a second of each other. SIGTERM reaches the task process, the runner
+        calls on_kill(), which deletes the child, and the wait in execute_sync then returns
+        normally because the pod it was watching has gone away. cleanup() skips its usual
+        failure signalling once _killed is set, so execute_sync used to fall through and
+        return, and the task was recorded as success (apache/airflow#71202).
+        """
+        k = self._interrupted_pod_operator()
+        running_pod = self._running_pod()
+        get_or_create_pod_mock.return_value = running_pod
+        find_pod_mock.return_value = running_pod
+        self.await_pod_mock.return_value = running_pod
+
+        # The wait returns rather than raising: the log stream simply ended when the
+        # child pod was deleted out from under it.
+        await_pod_completion_mock.side_effect = lambda pod: k.on_kill()
+
+        context = create_context(k)
+        context["ti"].xcom_push = MagicMock()
+
+        with pytest.raises(AirflowException, match="was interrupted before it completed"):
+            k.execute(context=context)
+
+    @patch(HOOK_CLASS, new=MagicMock)
+    @patch(KUB_OP_PATH.format("get_or_create_pod"))
+    @patch(KUB_OP_PATH.format("find_pod"))
+    @patch(KUB_OP_PATH.format("await_pod_completion"))
+    def test_execute_sync_keeps_the_original_error_when_on_kill_ran(
+        self, await_pod_completion_mock, find_pod_mock, get_or_create_pod_mock
+    ):
+        """When the body already failed, that failure is what the user needs to see.
+
+        The interrupted-pod check sits after the finally block on purpose, so it cannot
+        replace an exception that is already propagating.
+        """
+        k = self._interrupted_pod_operator()
+        running_pod = self._running_pod()
+        get_or_create_pod_mock.return_value = running_pod
+        find_pod_mock.return_value = running_pod
+        self.await_pod_mock.return_value = running_pod
+
+        def _kill_then_fail(pod):
+            k.on_kill()
+            raise AirflowException("original failure")
+
+        await_pod_completion_mock.side_effect = _kill_then_fail
+
+        context = create_context(k)
+        context["ti"].xcom_push = MagicMock()
+
+        with pytest.raises(AirflowException, match="original failure"):
+            k.execute(context=context)
+
     @pytest.mark.parametrize(
         "pod_phase",
         [


### PR DESCRIPTION
closes: #71202

### The bug

Under `KubernetesExecutor` there are two pods: the per-task pod the executor creates, and the child
pod `KubernetesPodOperator.execute()` creates for the user's workload. When both are interrupted
within about a second of each other, the task instance is recorded as **success** even though the
child pod never finished. A second user confirmed the same behaviour on their production clusters in
the issue thread.

The sequence:

1. SIGTERM reaches the task process, and the runner calls `on_kill()`.
2. `on_kill()` sets `self._killed` and deletes the child pod.
3. The wait inside `execute_sync` — `await_pod_completion`, following container logs — returns
   *normally* rather than raising, because the pod it was watching has simply gone away.
4. The `finally` block runs `post_complete_action` → `cleanup`, and `cleanup` returns early on
   `self._killed` before reaching any of its failure signalling.
5. `execute_sync` falls through to its `return`, so the operator reports success.

`cleanup`'s early return is correct on its own terms — it exists so the pod is not deleted a second
time, since a duplicate delete can raise and trigger a spurious retry. The gap is that skipping the
deletion also skips the only place that would have failed the task.

### The fix

Raise from `execute_sync` when the body completed while `_killed` is set.

The placement matters and is the reason this is not done inside `cleanup`: `cleanup` is called from a
`finally` block, so raising there would replace an exception that is already propagating. When the
body failed on its own, that failure is what the operator should surface — it already fails the task,
with a more specific reason. Putting the check after the `finally` means it only fires on the path
that would otherwise have returned success. `cleanup` keeps its early return unchanged, so the
double-delete it guards against still cannot happen.

### Tests

Two regression tests in `test_pod.py`:

- `test_execute_sync_fails_when_on_kill_ran_during_the_wait` — drives the exact sequence above, with
  the wait returning normally after `on_kill()` fires. Fails on `main` (the call returns instead of
  raising), passes with this change.
- `test_execute_sync_keeps_the_original_error_when_on_kill_ran` — the body raises after `on_kill()`;
  asserts the original exception still propagates rather than being replaced. This is what pins the
  placement of the check.

Neither test needs a cluster.

---

**Gen-AI disclosure:** I used an AI coding assistant while working on this. I traced the interrupted
path through `execute_sync`, `cleanup` and `on_kill` myself, modelled the control flow before and
after the change to confirm the success path is the only one that changes behaviour, and reviewed
the final diff before submitting.
