### PR TITLE
Fix airflow dags list --columns help showing wrong default columns

### DIFF
--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -1056,11 +1056,12 @@ ARG_TRIGGERER_TEAM_NAME = Arg(
     help="Team name to scope this triggerer to. Requires core.multi_team to be enabled.",
 )
 
+DEFAULT_DAG_LIST_COLUMNS = ("dag_id", "fileloc", "owners", "is_paused", "bundle_name", "bundle_version")
 ARG_DAG_LIST_COLUMNS = Arg(
     ("--columns",),
     type=string_list_type,
-    help="List of columns to render. (default: ['dag_id', 'fileloc', 'owner', 'is_paused'])",
-    default=("dag_id", "fileloc", "owners", "is_paused", "bundle_name", "bundle_version"),
+    help=f"List of columns to render. (default: {list(DEFAULT_DAG_LIST_COLUMNS)})",
+    default=DEFAULT_DAG_LIST_COLUMNS,
 )
 
 ARG_ASSET_LIST_COLUMNS = Arg(

--- a/airflow-core/tests/unit/cli/test_cli_parser.py
+++ b/airflow-core/tests/unit/cli/test_cli_parser.py
@@ -551,6 +551,18 @@ class TestCli:
         )
 
     @pytest.mark.parametrize(
+        "arg",
+        [
+            pytest.param(cli_config.ARG_DAG_LIST_COLUMNS, id="dags-list"),
+            pytest.param(cli_config.ARG_ASSET_LIST_COLUMNS, id="assets-list"),
+        ],
+    )
+    def test_list_columns_help_matches_default(self, arg):
+        default_columns = list(arg.kwargs["default"])
+
+        assert f"(default: {default_columns})" in arg.kwargs["help"]
+
+    @pytest.mark.parametrize(
         ("executor", "expected_args"),
         [
             ("CeleryExecutor", ["celery"]),


### PR DESCRIPTION
The `--columns` help for `airflow dags list` said the default was `['dag_id', 'fileloc', 'owner', 'is_paused']`, but the actual default has been `('dag_id', 'fileloc', 'owners', 'is_paused', 'bundle_name', 'bundle_version')` since #45779, and the valid field name has always been `owners` (the help said `owner` since the option was introduced in #35250).

Following the help literally (`--columns owner`) prints an "Ignoring the following invalid columns" error and drops the column from the table. The generated CLI reference docs (`cli-and-env-variables-ref.rst`, built via `.. argparse::`) carried the same wrong text.

This PR derives the help string from the same tuple used as `default`, so the two cannot drift apart again, and adds a parametrized test that asserts the `(default: [...])` fragment in the help of both `--columns` arguments (`dags list`, `assets list`) matches their actual `default`.

Rendered help after the change:

```
--columns COLUMNS     List of columns to render. (default: ['dag_id', 'fileloc', 'owners', 'is_paused', 'bundle_name', 'bundle_version'])
```


---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5.1)

Generated-by: Claude Code (Fable 5.1) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
