### PR TITLE
Add tests for the AWS Batch executor boto schemas

### DIFF
--- a/airflow-core/tests/unit/always/test_project_structure.py
+++ b/airflow-core/tests/unit/always/test_project_structure.py
@@ -64,7 +64,6 @@ class TestProjectStructure:
             "providers/amazon/tests/unit/amazon/aws/auth_manager/datamodels/test_login.py",
             "providers/amazon/tests/unit/amazon/aws/auth_manager/security_manager/test_aws_security_manager_override.py",
             "providers/amazon/tests/unit/amazon/aws/executors/batch/test_batch_executor_config.py",
-            "providers/amazon/tests/unit/amazon/aws/executors/batch/test_boto_schema.py",
             "providers/amazon/tests/unit/amazon/aws/executors/ecs/test_ecs_executor_config.py",
             "providers/amazon/tests/unit/amazon/aws/executors/aws_lambda/test_utils.py",
             "providers/amazon/tests/unit/amazon/aws/executors/aws_lambda/docker/test_app.py",

--- a/providers/amazon/tests/unit/amazon/aws/executors/batch/test_boto_schema.py
+++ b/providers/amazon/tests/unit/amazon/aws/executors/batch/test_boto_schema.py
@@ -1,0 +1,124 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+from marshmallow import ValidationError
+
+from airflow.providers.amazon.aws.executors.batch.boto_schema import (
+    BatchDescribeJobsResponseSchema,
+    BatchJobDetailSchema,
+    BatchSubmitJobResponseSchema,
+)
+from airflow.providers.amazon.aws.executors.batch.utils import BatchJob
+
+
+class TestBatchSubmitJobResponseSchema:
+    def test_load_maps_camel_case_job_id_to_snake_case(self):
+        loaded = BatchSubmitJobResponseSchema().load({"jobId": "job-1"})
+
+        assert loaded == {"job_id": "job-1"}
+
+    def test_load_ignores_fields_the_submit_job_api_adds(self):
+        loaded = BatchSubmitJobResponseSchema().load(
+            {"jobId": "job-1", "jobName": "airflow-task", "jobArn": "arn:aws:batch:job-1"}
+        )
+
+        assert loaded == {"job_id": "job-1"}
+
+    def test_load_rejects_response_without_job_id(self):
+        with pytest.raises(ValidationError) as excinfo:
+            BatchSubmitJobResponseSchema().load({"jobName": "airflow-task"})
+
+        assert "jobId" in excinfo.value.messages
+
+    def test_load_rejects_snake_case_job_id(self):
+        with pytest.raises(ValidationError) as excinfo:
+            BatchSubmitJobResponseSchema().load({"job_id": "job-1"})
+
+        assert "jobId" in excinfo.value.messages
+
+
+class TestBatchJobDetailSchema:
+    def test_load_returns_batch_job_instead_of_dict(self):
+        job = BatchJobDetailSchema().load({"jobId": "job-1", "status": "RUNNING", "statusReason": "started"})
+
+        assert isinstance(job, BatchJob)
+        assert job.job_id == "job-1"
+        assert job.status == "RUNNING"
+        assert job.status_reason == "started"
+
+    def test_load_without_status_reason_leaves_it_unset(self):
+        job = BatchJobDetailSchema().load({"jobId": "job-1", "status": "SUCCEEDED"})
+
+        assert job.status_reason is None
+
+    def test_load_ignores_fields_the_describe_jobs_api_adds(self):
+        job = BatchJobDetailSchema().load(
+            {"jobId": "job-1", "status": "FAILED", "jobQueue": "queue-1", "startedAt": 1700000000}
+        )
+
+        assert isinstance(job, BatchJob)
+        assert job.job_id == "job-1"
+
+    @pytest.mark.parametrize(
+        ("payload", "missing_key"),
+        [
+            pytest.param({"status": "RUNNING"}, "jobId", id="without-job-id"),
+            pytest.param({"jobId": "job-1"}, "status", id="without-status"),
+        ],
+    )
+    def test_load_rejects_detail_missing_a_required_field(self, payload, missing_key):
+        with pytest.raises(ValidationError) as excinfo:
+            BatchJobDetailSchema().load(payload)
+
+        assert missing_key in excinfo.value.messages
+
+
+class TestBatchDescribeJobsResponseSchema:
+    def test_load_returns_a_batch_job_per_entry(self):
+        loaded = BatchDescribeJobsResponseSchema().load(
+            {
+                "jobs": [
+                    {"jobId": "job-1", "status": "RUNNING"},
+                    {"jobId": "job-2", "status": "FAILED", "statusReason": "exit code 1"},
+                ]
+            }
+        )
+
+        assert [(job.job_id, job.status, job.status_reason) for job in loaded["jobs"]] == [
+            ("job-1", "RUNNING", None),
+            ("job-2", "FAILED", "exit code 1"),
+        ]
+        assert all(isinstance(job, BatchJob) for job in loaded["jobs"])
+
+    def test_load_accepts_an_empty_job_list(self):
+        loaded = BatchDescribeJobsResponseSchema().load({"jobs": []})
+
+        assert loaded == {"jobs": []}
+
+    def test_load_rejects_response_without_jobs(self):
+        with pytest.raises(ValidationError) as excinfo:
+            BatchDescribeJobsResponseSchema().load({})
+
+        assert "jobs" in excinfo.value.messages
+
+    def test_load_propagates_validation_error_from_a_nested_job(self):
+        with pytest.raises(ValidationError) as excinfo:
+            BatchDescribeJobsResponseSchema().load({"jobs": [{"jobId": "job-1"}]})
+
+        assert "status" in excinfo.value.messages["jobs"][0]


### PR DESCRIPTION
### Why

`providers/amazon/.../executors/batch/boto_schema.py` is on the `OVERLOOKED_TESTS`
allowlist in `airflow-core/tests/unit/always/test_project_structure.py`, tracked by
the meta issue #35442.

Unlike most entries on that list, the three schemas in this module are not covered
indirectly either — no file under any `providers/*/tests/` directory references
`BatchSubmitJobResponseSchema`, `BatchJobDetailSchema` or
`BatchDescribeJobsResponseSchema`. (For contrast, `build_submit_kwargs` in the
sibling `batch_executor_config.py` *is* exercised from `test_batch_executor.py`,
which is why this PR is scoped to `boto_schema.py` alone.)

These schemas parse live AWS Batch API responses, so the behaviour worth pinning
down is the part that is easy to break silently: the `data_key` mapping from the
API's camelCase to Airflow's snake_case, the `unknown = EXCLUDE` policy that lets
the schemas tolerate fields AWS adds over time, and the `@post_load` hook that
makes `BatchJobDetailSchema` return a `BatchJob` rather than a plain dict.

### How

Adds `providers/amazon/tests/unit/amazon/aws/executors/batch/test_boto_schema.py`
with one test class per schema, covering for each:

- the happy-path load and the `jobId` → `job_id` renaming,
- that unknown keys returned by `submit_job` / `describe_jobs` are dropped rather
  than raising,
- that a missing required field raises `ValidationError`,
- that `BatchJobDetailSchema` returns a `BatchJob` instance with `status_reason`
  left as `None` when the API omits it,
- that `BatchDescribeJobsResponseSchema` builds one `BatchJob` per entry, accepts
  an empty `jobs` list, and propagates a nested job's `ValidationError`.

No production code is touched.

### What

13 tests added. The module's entry is removed from `OVERLOOKED_TESTS` in the same
PR, as that list fails when a listed test file exists.

Verified locally:

```
uv run --project providers/amazon pytest \
  providers/amazon/tests/unit/amazon/aws/executors/batch/test_boto_schema.py -v
# 13 passed

uv run --project airflow-core pytest \
  airflow-core/tests/unit/always/test_project_structure.py -q
# 10 passed, 1 xfailed
```

related: #35442

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
