### PR TITLE
Remove unused FAB app-init helpers that could never run

### DIFF
--- a/providers/fab/src/airflow/providers/fab/www/app.py
+++ b/providers/fab/src/airflow/providers/fab/www/app.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from functools import cache
 from os.path import isabs
 
 from flask import Flask
@@ -131,14 +130,3 @@ def create_app(enable_plugins: bool):
         init_jinja_globals(flask_app, enable_plugins=enable_plugins)
         init_wsgi_middleware(flask_app)
     return flask_app
-
-
-@cache
-def cached_app():
-    """Return cached instance of Airflow WWW app."""
-    return create_app()
-
-
-def purge_cached_app():
-    """Remove the cached version of the app in global state."""
-    cached_app.cache_clear()

--- a/providers/fab/src/airflow/providers/fab/www/extensions/init_views.py
+++ b/providers/fab/src/airflow/providers/fab/www/extensions/init_views.py
@@ -23,21 +23,6 @@ from airflow.providers.fab.version_compat import AIRFLOW_V_3_1_PLUS, AIRFLOW_V_3
 log = logging.getLogger(__name__)
 
 
-def init_appbuilder_views(app):
-    """Initialize Web UI views."""
-    from airflow.models import import_all_models
-    from airflow.providers.fab.www import views
-
-    import_all_models()
-
-    appbuilder = app.appbuilder
-
-    # Remove the session from scoped_session registry to avoid
-    # reusing a session with a disconnected connection
-    appbuilder.session.remove()
-    appbuilder.add_view_no_menu(views.FabIndexView())
-
-
 def init_plugins(app):
     """Integrate Flask and FAB with plugins."""
     from airflow import plugins_manager

--- a/providers/fab/tests/unit/fab/auth_manager/conftest.py
+++ b/providers/fab/tests/unit/fab/auth_manager/conftest.py
@@ -35,7 +35,6 @@ def minimal_app_for_auth_api():
             "init_appbuilder",
             "init_api_auth",
             "init_airflow_session_interface",
-            "init_appbuilder_views",
         ]
     )
     def factory():

--- a/providers/fab/tests/unit/fab/decorators.py
+++ b/providers/fab/tests/unit/fab/decorators.py
@@ -19,8 +19,6 @@ from __future__ import annotations
 import functools
 from unittest.mock import patch
 
-from airflow.providers.fab.www.app import purge_cached_app
-
 
 def dont_initialize_flask_app_submodules(_func=None, *, skip_all_except=None):
     if not skip_all_except:
@@ -45,10 +43,8 @@ def dont_initialize_flask_app_submodules(_func=None, *, skip_all_except=None):
                 if method not in skip_all_except:
                     patcher = patch(f"airflow.providers.fab.www.app.{method}", no_op)
                     patcher.start()
-            purge_cached_app()
             result = f(*args, **kwargs)
             patch.stopall()
-            purge_cached_app()
 
             return result
 

--- a/providers/fab/tests/unit/fab/www/views/conftest.py
+++ b/providers/fab/tests/unit/fab/www/views/conftest.py
@@ -54,7 +54,6 @@ def app(examples_dag_bag):
     @dont_initialize_flask_app_submodules(
         skip_all_except=[
             "init_appbuilder",
-            "init_appbuilder_views",
             "init_jinja_globals",
             "init_plugins",
             "init_airflow_session_interface",


### PR DESCRIPTION
Remove three leftovers of the Airflow 2 Flask webserver from the FAB provider: `init_appbuilder_views()`, `cached_app()` / `purge_cached_app()`, and the two conftest entries that referenced `init_appbuilder_views()`.

### Why
- `init_appbuilder_views()` has had no caller since #46914 copied it into the provider. The only view it registers, `FabIndexView`, is already added by `AirflowAppBuilder._add_admin_views()` (since #45765).
- `cached_app()` calls `create_app()` without the required `enable_plugins` argument, so it raises `TypeError` on first use, and `purge_cached_app()` only ever cleared that always-empty cache. Airflow 3 mounts the Flask app object into FastAPI directly and has no use for a gunicorn-style cached factory.

### Verification

- `uv run --project providers/fab pytest providers/fab/tests/unit/fab/www --with-db-init`
- `uv run --project providers/fab pytest providers/fab/tests/unit/fab/auth_manager --with-db-init`
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
