### PR TITLE
Support code packages in MWAA Serverless workflow operators

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/mwaa_serverless.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/mwaa_serverless.py
@@ -98,6 +98,9 @@ class MwaaServerlessCreateWorkflowOperator(AwsBaseOperator[AwsBaseHook]):
 
     :param workflow_name: The name of the workflow. (templated)
     :param definition_s3_location: Dict with ``Bucket`` and ``ObjectKey`` for the YAML definition. (templated)
+    :param code: Optional code location for ``PythonOperator`` and ``BashOperator`` tasks,
+        as a dict with an ``S3Location`` key containing ``Bucket``, ``ObjectKey``, and
+        optionally ``VersionId``. (templated)
     :param role_arn: The execution role ARN. (templated)
     :param description: Optional description. (templated)
     :param tags: Optional tags dict.
@@ -107,15 +110,16 @@ class MwaaServerlessCreateWorkflowOperator(AwsBaseOperator[AwsBaseHook]):
 
     aws_hook_class = AwsBaseHook
     template_fields: tuple[str, ...] = aws_template_fields(
-        "workflow_name", "definition_s3_location", "role_arn", "description"
+        "workflow_name", "definition_s3_location", "code", "role_arn", "description"
     )
-    template_fields_renderers = {"definition_s3_location": "json"}
+    template_fields_renderers = {"definition_s3_location": "json", "code": "json"}
 
     def __init__(
         self,
         *,
         workflow_name: str,
         definition_s3_location: dict[str, str],
+        code: dict[str, Any] | None = None,
         role_arn: str,
         description: str | None = None,
         tags: dict[str, str] | None = None,
@@ -125,6 +129,7 @@ class MwaaServerlessCreateWorkflowOperator(AwsBaseOperator[AwsBaseHook]):
         super().__init__(**kwargs)
         self.workflow_name = workflow_name
         self.definition_s3_location = definition_s3_location
+        self.code = code
         self.role_arn = role_arn
         self.description = description
         self.tags = tags
@@ -140,6 +145,7 @@ class MwaaServerlessCreateWorkflowOperator(AwsBaseOperator[AwsBaseHook]):
             {
                 "Name": self.workflow_name,
                 "DefinitionS3Location": self.definition_s3_location,
+                "Code": self.code,
                 "RoleArn": self.role_arn,
                 "Description": self.description,
                 "Tags": self.tags,
@@ -174,21 +180,25 @@ class MwaaServerlessUpdateWorkflowOperator(AwsBaseOperator[AwsBaseHook]):
     :param workflow_arn: The ARN of the workflow to update. (templated)
     :param definition_s3_location: Dict with ``Bucket``, ``ObjectKey``, and optionally
         ``VersionId`` for the updated YAML definition. (templated)
+    :param code: Optional code location for ``PythonOperator`` and ``BashOperator`` tasks,
+        as a dict with an ``S3Location`` key containing ``Bucket``, ``ObjectKey``, and
+        optionally ``VersionId``. (templated)
     :param role_arn: The execution role ARN. (templated)
     :param description: Optional updated description. (templated)
     """
 
     aws_hook_class = AwsBaseHook
     template_fields: tuple[str, ...] = aws_template_fields(
-        "workflow_arn", "definition_s3_location", "role_arn", "description"
+        "workflow_arn", "definition_s3_location", "code", "role_arn", "description"
     )
-    template_fields_renderers = {"definition_s3_location": "json"}
+    template_fields_renderers = {"definition_s3_location": "json", "code": "json"}
 
     def __init__(
         self,
         *,
         workflow_arn: str,
         definition_s3_location: dict[str, str],
+        code: dict[str, Any] | None = None,
         role_arn: str,
         description: str | None = None,
         **kwargs,
@@ -196,6 +206,7 @@ class MwaaServerlessUpdateWorkflowOperator(AwsBaseOperator[AwsBaseHook]):
         super().__init__(**kwargs)
         self.workflow_arn = workflow_arn
         self.definition_s3_location = definition_s3_location
+        self.code = code
         self.role_arn = role_arn
         self.description = description
 
@@ -209,6 +220,7 @@ class MwaaServerlessUpdateWorkflowOperator(AwsBaseOperator[AwsBaseHook]):
             {
                 "WorkflowArn": self.workflow_arn,
                 "DefinitionS3Location": self.definition_s3_location,
+                "Code": self.code,
                 "RoleArn": self.role_arn,
                 "Description": self.description,
             }

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_mwaa_serverless.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_mwaa_serverless.py
@@ -88,6 +88,7 @@ class TestMwaaServerlessStartWorkflowRunOperator:
 WORKFLOW_NAME = "test-workflow"
 WORKFLOW_ARN = "arn:aws:mwaa-serverless:us-east-1:123456789012:workflow/test-workflow"
 S3_LOCATION = {"Bucket": "test-bucket", "ObjectKey": "workflow.yaml"}
+CODE = {"S3Location": {"Bucket": "test-bucket", "ObjectKey": "code/my_package.zip"}}
 ROLE_ARN = "arn:aws:iam::123456789012:role/test-role"
 
 
@@ -155,6 +156,47 @@ class TestMwaaServerlessCreateWorkflowOperator:
 
         with pytest.raises(ClientError, match="ConflictException"):
             op.execute({})
+
+    @mock.patch.object(AwsBaseHook, "conn", new_callable=mock.PropertyMock)
+    def test_execute_with_code(self, mock_conn):
+        op = MwaaServerlessCreateWorkflowOperator(
+            task_id="create_workflow",
+            workflow_name=WORKFLOW_NAME,
+            definition_s3_location=S3_LOCATION,
+            code=CODE,
+            role_arn=ROLE_ARN,
+        )
+        mock_client = mock.MagicMock()
+        mock_client.create_workflow.return_value = {"WorkflowArn": WORKFLOW_ARN}
+        mock_conn.return_value = mock_client
+
+        result = op.execute({})
+
+        mock_client.create_workflow.assert_called_once_with(
+            Name=WORKFLOW_NAME, DefinitionS3Location=S3_LOCATION, Code=CODE, RoleArn=ROLE_ARN
+        )
+        assert result == WORKFLOW_ARN
+
+    @mock.patch.object(AwsBaseHook, "conn", new_callable=mock.PropertyMock)
+    def test_execute_with_code_version_id(self, mock_conn):
+        code = {"S3Location": {**CODE["S3Location"], "VersionId": "abc123"}}
+        op = MwaaServerlessCreateWorkflowOperator(
+            task_id="create_workflow",
+            workflow_name=WORKFLOW_NAME,
+            definition_s3_location=S3_LOCATION,
+            code=code,
+            role_arn=ROLE_ARN,
+        )
+        mock_client = mock.MagicMock()
+        mock_client.create_workflow.return_value = {"WorkflowArn": WORKFLOW_ARN}
+        mock_conn.return_value = mock_client
+
+        result = op.execute({})
+
+        mock_client.create_workflow.assert_called_once_with(
+            Name=WORKFLOW_NAME, DefinitionS3Location=S3_LOCATION, Code=code, RoleArn=ROLE_ARN
+        )
+        assert result == WORKFLOW_ARN
 
     def test_template_fields(self):
         validate_template_fields(self.operator)
@@ -225,6 +267,33 @@ class TestMwaaServerlessUpdateWorkflowOperator:
 
         with pytest.raises(ClientError):
             self.operator.execute({})
+
+    @mock.patch.object(AwsBaseHook, "conn", new_callable=mock.PropertyMock)
+    def test_execute_with_code(self, mock_conn):
+        op = MwaaServerlessUpdateWorkflowOperator(
+            task_id="update_workflow",
+            workflow_arn=WORKFLOW_ARN,
+            definition_s3_location=S3_LOCATION,
+            code=CODE,
+            role_arn=ROLE_ARN,
+        )
+        mock_client = mock.MagicMock()
+        mock_client.update_workflow.return_value = {
+            "WorkflowArn": WORKFLOW_ARN,
+            "WorkflowVersion": "abc123",
+            "ModifiedAt": "2026-05-12T00:00:00Z",
+        }
+        mock_conn.return_value = mock_client
+
+        result = op.execute({})
+
+        mock_client.update_workflow.assert_called_once_with(
+            WorkflowArn=WORKFLOW_ARN,
+            DefinitionS3Location=S3_LOCATION,
+            Code=CODE,
+            RoleArn=ROLE_ARN,
+        )
+        assert result == WORKFLOW_ARN
 
     def test_template_fields(self):
         validate_template_fields(self.operator)

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_mwaa_serverless.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_mwaa_serverless.py
@@ -158,26 +158,6 @@ class TestMwaaServerlessCreateWorkflowOperator:
             op.execute({})
 
     @mock.patch.object(AwsBaseHook, "conn", new_callable=mock.PropertyMock)
-    def test_execute_with_code(self, mock_conn):
-        op = MwaaServerlessCreateWorkflowOperator(
-            task_id="create_workflow",
-            workflow_name=WORKFLOW_NAME,
-            definition_s3_location=S3_LOCATION,
-            code=CODE,
-            role_arn=ROLE_ARN,
-        )
-        mock_client = mock.MagicMock()
-        mock_client.create_workflow.return_value = {"WorkflowArn": WORKFLOW_ARN}
-        mock_conn.return_value = mock_client
-
-        result = op.execute({})
-
-        mock_client.create_workflow.assert_called_once_with(
-            Name=WORKFLOW_NAME, DefinitionS3Location=S3_LOCATION, Code=CODE, RoleArn=ROLE_ARN
-        )
-        assert result == WORKFLOW_ARN
-
-    @mock.patch.object(AwsBaseHook, "conn", new_callable=mock.PropertyMock)
     def test_execute_with_code_version_id(self, mock_conn):
         code = {"S3Location": {**CODE["S3Location"], "VersionId": "abc123"}}
         op = MwaaServerlessCreateWorkflowOperator(


### PR DESCRIPTION
MWAA Serverless added PythonOperator and BashOperator support, which requires shipping the Python modules and shell scripts those tasks run separately from the YAML workflow definition, through the Code request parameter.

Neither MwaaServerlessCreateWorkflowOperator nor
MwaaServerlessUpdateWorkflowOperator exposed Code, and neither accepts a kwargs passthrough, so the parameter was unreachable. Workflows using those operators could not be created, and their code could not be updated, from Airflow.

Add a `code` parameter to both operators, named after the API field and passed through untouched so a future member of the Code union needs no operator change. prune_dict omits it when unset, so existing DAGs are unaffected.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

kiro

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
