### PR TITLE
UI: Complete Polish translations and unify slot/deferred wording

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/admin.json
@@ -9,7 +9,11 @@
   "config": {
     "columns": {
       "section": "Sekcja"
-    }
+    },
+    "config_few": "Konfiguracje",
+    "config_many": "Konfiguracji",
+    "config_one": "Konfiguracja",
+    "config_other": "Konfiguracje"
   },
   "connections": {
     "add": "Dodaj połączenie",
@@ -101,7 +105,11 @@
       "dagProcessorJob": "Zadanie procesora Dagów",
       "schedulerJob": "Zadanie harmonogramu",
       "triggererJob": "Zadanie cyngla"
-    }
+    },
+    "job_few": "Zadania",
+    "job_many": "Zadań",
+    "job_one": "Zadanie",
+    "job_other": "Zadania"
   },
   "plugins": {
     "columns": {
@@ -111,24 +119,28 @@
     "importError_many": "Błędów importu wtyczek",
     "importError_one": "Błąd importu wtyczki",
     "importError_other": "Błędy importu wtyczek",
+    "plugin_few": "Wtyczki",
+    "plugin_many": "Wtyczek",
+    "plugin_one": "Wtyczka",
+    "plugin_other": "Wtyczki",
     "searchPlaceholder": "Szukaj po pliku"
   },
   "pools": {
     "add": "Dodaj pulę",
-    "deferredSlotsIncluded": "Uwzględniono odroczone miejsca",
+    "deferredSlotsIncluded": "Uwzględniono odroczone sloty",
     "delete": {
       "title": "Usuń pulę",
       "warning": "To usunie wszystkie metadane związane z pulą i może wpłynąć na zadania korzystające z tej puli."
     },
     "edit": "Edytuj pulę",
     "form": {
-      "checkbox": "Zaznacz, aby uwzględnić zadania odroczone przy obliczaniu wolnych miejsc w puli",
+      "checkbox": "Zaznacz, aby uwzględnić zadania odroczone przy obliczaniu wolnych slotów w puli",
       "description": "Opis",
       "includeDeferred": "Uwzględnij odroczone",
       "nameMaxLength": "Nazwa może zawierać maksymalnie 256 znaków",
       "nameRequired": "Nazwa jest wymagana",
-      "slots": "Miejsca",
-      "slotsHelperText": "Użyj -1 dla nieograniczonej liczby miejsc."
+      "slots": "Sloty",
+      "slotsHelperText": "Użyj -1 dla nieograniczonej liczby slotów."
     },
     "noPoolsFound": "Nie znaleziono pul",
     "pool_few": "Pule",
@@ -146,7 +158,11 @@
     "columns": {
       "packageName": "Nazwa paczki",
       "version": "Wersja"
-    }
+    },
+    "provider_few": "Providery",
+    "provider_many": "Providerów",
+    "provider_one": "Provider",
+    "provider_other": "Providery"
   },
   "variables": {
     "add": "Dodaj zmienną",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/assets.json
@@ -1,5 +1,10 @@
 {
   "additional_data": "Dodatkowe dane",
+  "alias_few": "Aliasy",
+  "alias_many": "Aliasów",
+  "alias_one": "Alias",
+  "alias_other": "Aliasy",
+  "aliases": "Aliasy",
   "asset_few": "Zasoby",
   "asset_many": "Zasobów",
   "asset_one": "Zasób",
@@ -15,6 +20,10 @@
     "deleteWarning": "Zasób utraci ten zachowany wpis magazynu stanu.",
     "edit": "Edytuj wpis magazynu stanu zasobu",
     "emptyState": "Magazyn stanu zasobu przechowuje wartości przypisane do tożsamości zasobu, współdzielone przez wszystkie wykonania Dagów. Workery mogą zapisywać do magazynu stanu zasobu przez Task SDK.",
+    "entry_few": "Wpisy",
+    "entry_many": "Wpisów",
+    "entry_one": "Wpis",
+    "entry_other": "Wpisy",
     "lastUpdatedBy": "Ostatnio zaktualizowane przez",
     "lastUpdatedByApi": "API",
     "lastUpdatedByWatcher": "Watcher",
@@ -44,7 +53,10 @@
     "title": "Utwórz zdarzenie zasobu dla {{name}}"
   },
   "events": "Zdarzenia",
-  "extra": "Dodatkowe",
+  "filters": {
+    "groupPlaceholder": "Szukaj grupy",
+    "lastEventDateRange": "Data ostatniego zdarzenia"
+  },
   "group": "Grupa",
   "lastAssetEvent": "Ostatnie zdarzenie zasobu",
   "name": "Nazwa",
@@ -52,5 +64,10 @@
   "scheduledDags": "Zaplanowane Dagi",
   "scheduling": "Planowanie",
   "searchPlaceholder": "Szukaj zasobów",
-  "taskDependencies": "Zależności zadań"
+  "taskDependencies": "Zależności zadań",
+  "watcher_few": "Watchery",
+  "watcher_many": "Watcherów",
+  "watcher_one": "Watcher",
+  "watcher_other": "Watchery",
+  "watchers": "Watchery"
 }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/browse.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/browse.json
@@ -58,6 +58,10 @@
       "successTitle": "XCom zaktualizowany",
       "title": "Edytuj XCom"
     },
+    "entry_few": "Wpisy XCom",
+    "entry_many": "Wpisów XCom",
+    "entry_one": "Wpis XCom",
+    "entry_other": "Wpisy XCom",
     "key": "Klucz",
     "title": "XCom",
     "value": "Wartość"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/common.json
@@ -30,6 +30,7 @@
   "backfill_many": "Wypełnień wstecznych",
   "backfill_one": "Wypełnienie wsteczne",
   "backfill_other": "Wypełnienia wsteczne",
+  "breadcrumb": "Ścieżka nawigacji",
   "browse": {
     "auditLog": "Log audytu",
     "deadlines": "Terminy",
@@ -98,9 +99,8 @@
   "dagRun_one": "Wykonanie",
   "dagRun_other": "Wykonania",
   "dagRunId": "Identyfikator wykonania",
+  "dagRunState": "Stan wykonania Daga",
   "dagWarnings": "Ostrzeżenia/Błędy Daga",
-  "defaultToGraphView": "Domyślnie widok grafu",
-  "defaultToGridView": "Domyślnie widok siatki",
   "delete": "Usuń",
   "diff": "Porównaj",
   "diffCompareWith": "Porównaj z",
@@ -134,6 +134,10 @@
       "title": "Dostęp zabroniony"
     }
   },
+  "event_few": "Zdarzenia",
+  "event_many": "Zdarzeń",
+  "event_one": "Zdarzenie",
+  "event_other": "Zdarzenia",
   "expand": {
     "collapse": "Zwiń",
     "expand": "Rozwiń",
@@ -149,21 +153,27 @@
   },
   "filter": "Filtr",
   "filters": {
+    "addFilter": "Dodaj filtr",
+    "date": "Data",
     "durationFrom": "Czas trwania od",
     "durationTo": "Czas trwania do",
     "endTime": "Czas zakończenia",
     "logicalDateFrom": "Data logiczna od",
     "logicalDateTo": "Data logiczna do",
+    "removeFilter": "Usuń filtr",
     "runAfterFrom": "Uruchom po (od)",
     "runAfterTo": "Uruchom po (do)",
     "searchAsset": "Szukaj zasobu",
     "selectDateRange": "Wybierz zakres dat",
-    "startTime": "Czas rozpoczęcia"
+    "selectDateTime": "Wybierz datę i godzinę",
+    "startTime": "Czas rozpoczęcia",
+    "time": "Godzina"
   },
   "fullscreen": {
     "tooltip": "Naciśnij {{hotkey}}, aby przejść na pełny ekran"
   },
   "generateToken": "Wygeneruj token",
+  "includedIn": "Zawarte w",
   "key": "Klucz",
   "logicalDate": "Data logiczna",
   "logout": "Wyloguj",
@@ -184,8 +194,9 @@
     "assets": "Zasoby",
     "browse": "Przegląd",
     "dags": "Dagi",
+    "dashboard": "Pulpit",
     "docs": "Pomoc",
-    "home": "Pulpit",
+    "home": "Strona główna",
     "legacyFabViews": "Widoki Fab z Airflow 2",
     "plugins": "Wtyczki",
     "security": "Dostęp"
@@ -202,6 +213,10 @@
     "write": "Napisz"
   },
   "overallStatus": "Stan ogólny",
+  "partition_few": "Partycje",
+  "partition_many": "Partycji",
+  "partition_one": "Partycja",
+  "partition_other": "Partycje",
   "partitionedDagRun_few": "Partycjonowane wykonania Dagów",
   "partitionedDagRun_many": "Partycjonowanych wykonań Dagów",
   "partitionedDagRun_one": "Partycjonowane wykonanie Daga",
@@ -209,6 +224,7 @@
   "partitionedDagRunDetail": {
     "receivedAssetEvents": "Otrzymane zdarzenia zasobów"
   },
+  "pause": "Wstrzymaj",
   "pendingDagRun_few": "{{count}} oczekujące wykonania Dagów",
   "pendingDagRun_many": "{{count}} oczekujących wykonań Dagów",
   "pendingDagRun_one": "{{count}} oczekujące wykonanie Daga",
@@ -261,6 +277,57 @@
   },
   "selectLanguage": "Wybierz język",
   "selected": "Wybrano",
+  "settings": {
+    "clearing": {
+      "preventRunningTask": {
+        "helper": "Pomijaj aktualnie uruchomione zadania podczas czyszczenia instancji zadań.",
+        "label": "Zapobiegaj czyszczeniu uruchomionych zadań"
+      },
+      "runSelection": {
+        "helper": "Opcje wybrane domyślnie podczas czyszczenia wykonania Daga.",
+        "label": "Domyślny wybór przy czyszczeniu wykonania"
+      },
+      "taskSelection": {
+        "helper": "Opcje wybrane domyślnie podczas czyszczenia instancji zadań.",
+        "label": "Domyślny wybór przy czyszczeniu zadań"
+      },
+      "title": "Czyszczenie"
+    },
+    "description": "Te preferencje są zapisywane tylko w tej przeglądarce i obowiązują w całej aplikacji.",
+    "general": {
+      "landingPage": {
+        "helper": "Strona wyświetlana po otwarciu Airflow.",
+        "label": "Strona startowa",
+        "options": {
+          "dags": "Dagi",
+          "dashboard": "Pulpit"
+        }
+      },
+      "title": "Ogólne"
+    },
+    "graph": {
+      "defaultDirection": {
+        "helper": "Kierunek układu grafów Dagów i zasobów, dla których nie ustawiono go indywidualnie.",
+        "label": "Domyślny kierunek grafu"
+      },
+      "title": "Graf"
+    },
+    "marking": {
+      "taskSelection": {
+        "helper": "Opcje wybrane domyślnie podczas oznaczania stanu instancji zadania.",
+        "label": "Domyślny wybór przy oznaczaniu"
+      },
+      "title": "Oznaczanie"
+    },
+    "taskInstance": {
+      "defaultTab": {
+        "helper": "Zakładka wyświetlana jako pierwsza po otwarciu instancji zadania. Linki do konkretnej zakładki nadal ją otwierają.",
+        "label": "Domyślna zakładka instancji zadania"
+      },
+      "title": "Instancja zadania"
+    },
+    "title": "Ustawienia"
+  },
   "shortcuts": {
     "categories": {
       "code": "Kod",
@@ -304,6 +371,11 @@
   },
   "showDetailsPanel": "Pokaż panel szczegółów",
   "signedInAs": "Zalogowano jako",
+  "slot": "Slot",
+  "slot_few": "Sloty",
+  "slot_many": "Slotów",
+  "slot_one": "Slot",
+  "slot_other": "Sloty",
   "source": {
     "hide": "Ukryj źródła",
     "hotkey": "s",
@@ -317,7 +389,7 @@
   "state": "Stan",
   "states": {
     "awaiting_input": "Oczekuje na dane wejściowe",
-    "deferred": "Odłożone",
+    "deferred": "Odroczone",
     "failed": "Niepowodzenie",
     "no_status": "Brak stanu",
     "none": "Brak stanu",
@@ -334,6 +406,7 @@
     "up_for_retry": "Do ponownej próby",
     "upstream_failed": "Niepowodzenie poprzednika"
   },
+  "switchDag": "Przełącz $t(dag_one)",
   "table": {
     "completedAt": "Zakończono o",
     "createdAt": "Utworzono o",
@@ -345,8 +418,10 @@
     "filterReset_other": "Resetuj filtry",
     "from": "Od",
     "maxActiveRuns": "Maksymalna liczba aktywnych wykonań",
+    "noResultsFound": "Nie znaleziono wyników",
     "noTagsFound": "Nie znaleziono etykiet",
     "noTeamsFound": "Nie znaleziono zespołów",
+    "ownerPlaceholder": "Filtruj według właściciela",
     "tagMode": {
       "all": "Wszystkie",
       "any": "Dowolne"
@@ -408,6 +483,14 @@
   "taskInstance_many": "Instancji Zadań",
   "taskInstance_one": "Instancja Zadania",
   "taskInstance_other": "Instancje Zadań",
+  "teams": {
+    "more_few": "i jeszcze {{count}}",
+    "more_many": "i jeszcze {{count}}",
+    "more_one": "i jeszcze {{count}}",
+    "more_other": "i jeszcze {{count}}",
+    "none": "Brak zespołu",
+    "title": "Zespoły"
+  },
   "timeRange": {
     "last12Hours": "Ostatnie 12 godzin",
     "last24Hours": "Ostatnie 24 godziny",
@@ -492,6 +575,7 @@
   "total": "Wszystkie {{state}}",
   "triggered": "Uruchomiony",
   "tryNumber": "Numer próby",
+  "unpause": "Wznów",
   "user": "Profil",
   "validation": {
     "mustBeAtLeast": "Musi wynosić co najmniej {{min}}.",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/components.json
@@ -9,10 +9,22 @@
     "backwards": "Uruchom wstecz",
     "dateRange": "Zakres dat",
     "errorStartDateBeforeEndDate": "Data początkowa musi być wcześniejsza niż data końcowa",
+    "exceptionReason": {
+      "alreadyExists": "Już istnieje",
+      "inFlight": "W trakcie",
+      "unknown": "Nieznany"
+    },
     "maxRuns": "Maksymalna liczba aktywnych wykonań",
     "missingAndErroredRuns": "Brakujące i błędne wykonania",
     "missingRuns": "Brakujące wykonania",
+    "notCreatedReason": "Powód nieutworzenia",
     "overrideExistingParams": "Nadpisz parametry istniejących wykonań",
+    "partitionRange": "Zakres partycji",
+    "partitionsAffected_few": "{{count}} partycje zostaną wypełnione wstecznie:",
+    "partitionsAffected_many": "{{count}} partycji zostanie wypełnionych wstecznie:",
+    "partitionsAffected_one": "{{count}} partycja zostanie wypełniona wstecznie:",
+    "partitionsAffected_other": "{{count}} partycji zostanie wypełnionych wstecznie:",
+    "partitionsNone": "Brak partycji pasujących do wybranego zakresu.",
     "permissionDenied": "Próba nieudana: Użytkownik nie ma uprawnień do tworzenia wypełnień wstecznych.",
     "reprocessBehavior": "Zachowanie ponownego przetwarzania",
     "run": "Uruchom ponowne przetwarzanie",
@@ -31,7 +43,8 @@
     "validation": {
       "datesRequired": "Należy podać zarówno datę początkową, jak i końcową interwału danych.",
       "startBeforeEnd": "Data początkowa interwału danych musi być wcześniejsza lub równa dacie końcowej."
-    }
+    },
+    "viewSlots": "Zobacz sloty dla wypełnienia wstecznego #{{id}}"
   },
   "banner": {
     "backfillInProgress": "Wypełnienie wsteczne w toku",
@@ -129,7 +142,15 @@
     "file": "Plik",
     "location": "linia {{line}} w {{name}}"
   },
+  "passwordToggle": {
+    "hide": "Ukryj wartość",
+    "show": "Pokaż wartość"
+  },
   "reparseDag": "Ponowne przetworznie Daga",
+  "slowestTaskInstances": {
+    "empty": "Brak zakończonych instancji zadań w tym zakresie",
+    "title": "Najwolniejsze instancje zadań"
+  },
   "sortedAscending": "posortowane rosnąco",
   "sortedDescending": "posortowane malejąco",
   "sortedUnsorted": "nieposortowane",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/dag.json
@@ -42,6 +42,7 @@
   },
   "deadlineAlerts": {
     "completionRule": "Musi zakończyć się w ciągu {{interval}} od momentu: {{reference}}",
+    "completionRuleDynamic": "Musi zakończyć się w zmiennym interwale liczonym od momentu: {{reference}}",
     "count_few": "{{count}} terminy",
     "count_many": "{{count}} terminów",
     "count_one": "{{count}} termin",
@@ -157,13 +158,7 @@
       "label": "Liczba wykonań Daga"
     },
     "dependencies": {
-      "label": "Zależności",
-      "options": {
-        "allDagDependencies": "Wszystkie zależności Daga",
-        "externalConditions": "Warunki zewnętrzne",
-        "onlyTasks": "Tylko zadania"
-      },
-      "placeholder": "Zależności"
+      "allDagDependencies": "Wszystkie zależności Daga"
     },
     "graphDirection": {
       "label": "Kierunek grafu"
@@ -258,6 +253,10 @@
     "deleteWarning": "Zadanie utraci te zachowane dane. Jeśli używa tego klucza do śledzenia pracy zewnętrznej (np. zewnętrznego ID zadania), nie będzie mogło jej wznowić.",
     "edit": "Edytuj wpis magazynu stanu zadania",
     "emptyStore": "Magazyn stanu zadania przechowuje wartości zachowywane pomiędzy ponownymi próbami. Workery mogą zapisywać do magazynu stanu zadania przez Task SDK.",
+    "entry_few": "Wpisy",
+    "entry_many": "Wpisów",
+    "entry_one": "Wpis",
+    "entry_other": "Wpisy",
     "expiresAt": {
       "column": "Wygasa o",
       "custom": "Niestandardowy",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/dags.json
@@ -11,18 +11,27 @@
     "allRunTypes": "Wszystkie Typy Wykonań Dagów",
     "allStates": "Wszystkie Stany",
     "anyRunState": "Dowolne wykonanie",
+    "anyRunStatePlaceholder": "Wybierz dowolny stan wykonania…",
     "favorite": {
       "all": "Wszystkie",
       "favorite": "Ulubione",
       "unfavorite": "Nieulubione"
     },
+    "favoriteState": "Stan ulubionych",
+    "favoriteStatePlaceholder": "Wybierz stan ulubionych…",
     "lastRunState": "Ostatnie wykonanie",
+    "lastRunStatePlaceholder": "Wybierz stan ostatniego wykonania…",
+    "noTimetableTypesFound": "Nie znaleziono typów harmonogramu",
     "paused": {
       "active": "Aktywne",
       "all": "Wszystkie",
       "paused": "Wstrzymane"
     },
-    "runIdPatternFilter": "Szukaj Wykonań Dagów"
+    "pausedPlaceholder": "Wybierz stan wstrzymania…",
+    "pausedState": "Stan wstrzymania",
+    "requiresHitlAction": "Wymaga akcji HITL",
+    "runIdPatternFilter": "Szukaj Wykonań Dagów",
+    "timetableType": "Typ harmonogramu"
   },
   "ownerLink": "Link do właściciela {{owner}}",
   "runAndTaskActions": {
@@ -75,6 +84,7 @@
       "preventRunningTasks": "Zapobiegaj ponownemu uruchomieniu, jeśli zadanie jest uruchomione",
       "queueNew": "Kolejkuj nowe zadania",
       "runOnLatestVersion": "Uruchom w najnowszej wersji paczki Dagów",
+      "runOnLatestVersionForced": "Zawsze używa najnowszej — nie ma wcześniejszej wersji, do której można wrócić",
       "upstream": "Taski nadrzędne"
     }
   },

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/dashboard.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/dashboard.json
@@ -19,8 +19,8 @@
     "showMore": "Pokaż więcej",
     "title": "Terminy"
   },
-  "deferredSlotsNotCounted": "Odłożone, ale nieliczone do slotów: {{count}}",
-  "deferredSlotsNotCountedTooltip": "Odłożone zadania pokazane na pasku są liczone do slotów puli. Odłożone zadania pokazane pod paskiem pochodzą z pul, które liczą sloty, nie licząc odłożonych zadań.",
+  "deferredSlotsNotCounted": "Odroczone, ale nieliczone do slotów: {{count}}",
+  "deferredSlotsNotCountedTooltip": "Odroczone zadania pokazane na pasku są liczone do slotów puli. Odroczone zadania pokazane pod paskiem pochodzą z pul, które liczą sloty, nie licząc odroczonych zadań.",
   "favorite": {
     "favoriteDags_few": "Pierwsze {{count}} ulubione Dagi",
     "favoriteDags_many": "Pierwsze {{count}} ulubionych Dagów",
@@ -52,7 +52,7 @@
   },
   "managePools": "Zarządzaj pulami",
   "noAssetEvents": "Nie znaleziono zdarzeń zasobów.",
-  "poolSlots": "",
+  "poolSlots": "Sloty puli",
   "sortBy": {
     "newestFirst": "Najnowsze Pierwsze",
     "oldestFirst": "Najstarsze Pierwsze",


### PR DESCRIPTION
Brings the Polish UI locale to 100% coverage and makes two terms consistent across namespaces.

- **123 missing keys translated** across `admin`, `assets`, `browse`, `common`, `components`, `dag` and `dags` — including the whole new `settings` tree (general / graph / clearing / marking / task instance), the `teams` block, Event / Partition / Slot plural sets, the new filter placeholders, and the backfill partition-range dialog.
- **8 stale keys removed** (absent from `en`, or plural suffixes Polish does not use).
- **`dashboard.poolSlots` was an empty string** and rendered blank in the UI — now filled.
- **Terminology unified:** pool *slots* were "Miejsca" in `admin.json` but "Sloty" everywhere else; task *deferred* state was "Odłożone" in `common`/`dashboard` but "odroczone" in `admin`. Both now read the same on every screen.
- `nav.home` "Pulpit" → "Strona główna", so it no longer collides with the new `nav.dashboard` ("Pulpit").

Plural forms follow the four-way Polish scheme (`_one` nominative sg, `_few` nominative pl, `_many` genitive pl, `_other`).

`breeze ui check-translation-completeness --language pl` reports 0 missing / 0 TODOs / 0 unused, 100% coverage (was 89.8%).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)