### PR TITLE
UI: Fill Polish translation gaps and unify slot/deferred wording

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/admin.json
@@ -116,20 +116,20 @@
   },
   "pools": {
     "add": "Dodaj pulę",
-    "deferredSlotsIncluded": "Uwzględniono odroczone miejsca",
+    "deferredSlotsIncluded": "Uwzględniono odroczone sloty",
     "delete": {
       "title": "Usuń pulę",
       "warning": "To usunie wszystkie metadane związane z pulą i może wpłynąć na zadania korzystające z tej puli."
     },
     "edit": "Edytuj pulę",
     "form": {
-      "checkbox": "Zaznacz, aby uwzględnić zadania odroczone przy obliczaniu wolnych miejsc w puli",
+      "checkbox": "Zaznacz, aby uwzględnić zadania odroczone przy obliczaniu wolnych slotów w puli",
       "description": "Opis",
       "includeDeferred": "Uwzględnij odroczone",
       "nameMaxLength": "Nazwa może zawierać maksymalnie 256 znaków",
       "nameRequired": "Nazwa jest wymagana",
-      "slots": "Miejsca",
-      "slotsHelperText": "Użyj -1 dla nieograniczonej liczby miejsc."
+      "slots": "Sloty",
+      "slotsHelperText": "Użyj -1 dla nieograniczonej liczby slotów."
     },
     "noPoolsFound": "Nie znaleziono pul",
     "pool_few": "Pule",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/common.json
@@ -147,6 +147,7 @@
   },
   "filter": "Filtr",
   "filters": {
+    "date": "Data",
     "durationFrom": "Czas trwania od",
     "durationTo": "Czas trwania do",
     "endTime": "Czas zakończenia",
@@ -156,12 +157,15 @@
     "runAfterTo": "Uruchom po (do)",
     "searchAsset": "Szukaj zasobu",
     "selectDateRange": "Wybierz zakres dat",
-    "startTime": "Czas rozpoczęcia"
+    "selectDateTime": "Wybierz datę i godzinę",
+    "startTime": "Czas rozpoczęcia",
+    "time": "Godzina"
   },
   "fullscreen": {
     "tooltip": "Naciśnij {{hotkey}}, aby przejść na pełny ekran"
   },
   "generateToken": "Wygeneruj token",
+  "includedIn": "Zawarte w",
   "key": "Klucz",
   "logicalDate": "Data logiczna",
   "logout": "Wyloguj",
@@ -298,7 +302,7 @@
   "state": "Stan",
   "states": {
     "awaiting_input": "Oczekuje na dane wejściowe",
-    "deferred": "Odłożone",
+    "deferred": "Odroczone",
     "failed": "Niepowodzenie",
     "no_status": "Brak stanu",
     "none": "Brak stanu",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/components.json
@@ -129,6 +129,10 @@
     "file": "Plik",
     "location": "linia {{line}} w {{name}}"
   },
+  "passwordToggle": {
+    "hide": "Ukryj wartość",
+    "show": "Pokaż wartość"
+  },
   "reparseDag": "Ponowne przetworznie Daga",
   "sortedAscending": "posortowane rosnąco",
   "sortedDescending": "posortowane malejąco",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/dag.json
@@ -42,6 +42,7 @@
   },
   "deadlineAlerts": {
     "completionRule": "Musi zakończyć się w ciągu {{interval}} od momentu: {{reference}}",
+    "completionRuleDynamic": "Musi zakończyć się w zmiennym interwale liczonym od momentu: {{reference}}",
     "count_few": "{{count}} terminy",
     "count_many": "{{count}} terminów",
     "count_one": "{{count}} termin",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/dags.json
@@ -75,6 +75,7 @@
       "preventRunningTasks": "Zapobiegaj ponownemu uruchomieniu, jeśli zadanie jest uruchomione",
       "queueNew": "Kolejkuj nowe zadania",
       "runOnLatestVersion": "Uruchom w najnowszej wersji paczki Dagów",
+      "runOnLatestVersionForced": "Zawsze używa najnowszej — nie ma wcześniejszej wersji, do której można wrócić",
       "upstream": "Taski nadrzędne"
     }
   },

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/dashboard.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/dashboard.json
@@ -19,8 +19,8 @@
     "showMore": "Pokaż więcej",
     "title": "Terminy"
   },
-  "deferredSlotsNotCounted": "Odłożone, ale nieliczone do slotów: {{count}}",
-  "deferredSlotsNotCountedTooltip": "Odłożone zadania pokazane na pasku są liczone do slotów puli. Odłożone zadania pokazane pod paskiem pochodzą z pul, które liczą sloty, nie licząc odłożonych zadań.",
+  "deferredSlotsNotCounted": "Odroczone, ale nieliczone do slotów: {{count}}",
+  "deferredSlotsNotCountedTooltip": "Odroczone zadania pokazane na pasku są liczone do slotów puli. Odroczone zadania pokazane pod paskiem pochodzą z pul, które liczą sloty, nie licząc odroczonych zadań.",
   "favorite": {
     "favoriteDags_few": "Pierwsze {{count}} ulubione Dagi",
     "favoriteDags_many": "Pierwsze {{count}} ulubionych Dagów",
@@ -52,7 +52,7 @@
   },
   "managePools": "Zarządzaj pulami",
   "noAssetEvents": "Nie znaleziono zdarzeń zasobów.",
-  "poolSlots": "",
+  "poolSlots": "Sloty puli",
   "sortBy": {
     "newestFirst": "Najnowsze Pierwsze",
     "oldestFirst": "Najstarsze Pierwsze",


### PR DESCRIPTION
The 3.3-applicable subset of the equivalent `main` change.

**8 missing keys translated** — keys whose English exists on this branch but had no Polish: the date/time filter labels (`filters.date`, `filters.selectDateTime`, `filters.time`), `includedIn`, the password field toggle, the dynamic deadline rule, and the run-on-latest-version hint.

**8 values corrected:**

- `dashboard.poolSlots` was an empty string and rendered blank.
- Pool *slots* were "Miejsca" in `admin.json` but "Sloty" everywhere else.
- Task *deferred* state was "Odłożone" in `common`/`dashboard` but "odroczone" in `admin`.

**Deliberately not backported:** 115 keys from the main-branch change belong to features that do not exist on 3.3 (the `settings` tree, `teams`, partition backfills, the new dags filters, etc.). The `nav.home` "Pulpit" → "Strona główna" rename is also left out — on `main` it was needed because the new `nav.dashboard` key collided with it, and 3.3 has no `nav.dashboard`.

`breeze ui check-translation-completeness --language pl` reports complete.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)