### PR TITLE
Fix region_name being ignored by the Step Functions execution trigger

### DIFF
--- a/airflow-core/tests/unit/always/test_project_structure.py
+++ b/airflow-core/tests/unit/always/test_project_structure.py
@@ -75,7 +75,6 @@ class TestProjectStructure:
             "providers/amazon/tests/unit/amazon/aws/sensors/test_sagemaker.py",
             "providers/amazon/tests/unit/amazon/aws/test_exceptions.py",
             "providers/amazon/tests/unit/amazon/aws/triggers/test_sagemaker_unified_studio.py",
-            "providers/amazon/tests/unit/amazon/aws/triggers/test_step_function.py",
             "providers/amazon/tests/unit/amazon/aws/utils/test_rds.py",
             "providers/amazon/tests/unit/amazon/aws/utils/test_sagemaker.py",
             "providers/amazon/tests/unit/amazon/aws/waiters/test_base_waiter.py",

--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/step_function.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/step_function.py
@@ -46,7 +46,7 @@ class StepFunctionsExecutionCompleteTrigger(AwsBaseWaiterTrigger):
         **kwargs,
     ) -> None:
         super().__init__(
-            serialized_fields={"execution_arn": execution_arn, "region_name": region_name},
+            serialized_fields={"execution_arn": execution_arn},
             waiter_name="step_function_succeeded",
             waiter_args={"executionArn": execution_arn},
             failure_message="Step function failed",
@@ -57,6 +57,7 @@ class StepFunctionsExecutionCompleteTrigger(AwsBaseWaiterTrigger):
             waiter_delay=waiter_delay,
             waiter_max_attempts=waiter_max_attempts,
             aws_conn_id=aws_conn_id,
+            region_name=region_name,
             **kwargs,
         )
 

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_step_function.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_step_function.py
@@ -74,7 +74,7 @@ class TestStepFunctionsExecutionCompleteTrigger:
     @mock.patch.object(StepFunctionHook, "get_waiter")
     @mock.patch.object(StepFunctionHook, "get_async_conn")
     async def test_run_success(self, mock_async_conn, mock_get_waiter):
-        mock_async_conn.__aenter__.return_value = mock.MagicMock()
+        mock_async_conn.return_value.__aenter__.return_value = mock.MagicMock()
         mock_get_waiter().wait = AsyncMock()
         trigger = StepFunctionsExecutionCompleteTrigger(execution_arn=self.EXECUTION_ARN)
 

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_step_function.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_step_function.py
@@ -1,0 +1,89 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+from unittest.mock import AsyncMock
+
+import pytest
+
+from airflow.providers.amazon.aws.hooks.step_function import StepFunctionHook
+from airflow.providers.amazon.aws.triggers.step_function import StepFunctionsExecutionCompleteTrigger
+from airflow.triggers.base import TriggerEvent
+
+BASE_TRIGGER_CLASSPATH = "airflow.providers.amazon.aws.triggers.step_function."
+
+
+class TestStepFunctionsExecutionCompleteTrigger:
+    EXPECTED_WAITER_NAME = "step_function_succeeded"
+    EXECUTION_ARN = (
+        "arn:aws:states:us-east-1:123456789012:execution:"
+        "pseudo-state-machine:020f5b16-b1a1-4149-946f-92dd32d97934"
+    )
+
+    def test_serialization(self):
+        trigger = StepFunctionsExecutionCompleteTrigger(
+            execution_arn=self.EXECUTION_ARN,
+            waiter_delay=10,
+            waiter_max_attempts=5,
+            aws_conn_id="aws_step_function_conn",
+            region_name="eu-central-1",
+        )
+
+        classpath, kwargs = trigger.serialize()
+
+        assert classpath == BASE_TRIGGER_CLASSPATH + "StepFunctionsExecutionCompleteTrigger"
+        assert kwargs.get("execution_arn") == self.EXECUTION_ARN
+        assert kwargs.get("waiter_delay") == 10
+        assert kwargs.get("waiter_max_attempts") == 5
+        assert kwargs.get("aws_conn_id") == "aws_step_function_conn"
+        assert kwargs.get("region_name") == "eu-central-1"
+
+    def test_hook_forwards_connection_config(self):
+        trigger = StepFunctionsExecutionCompleteTrigger(
+            execution_arn=self.EXECUTION_ARN,
+            aws_conn_id="aws_step_function_conn",
+            region_name="eu-central-1",
+            verify=False,
+            botocore_config={"read_timeout": 100},
+        )
+
+        hook = trigger.hook()
+
+        assert isinstance(hook, StepFunctionHook)
+        assert hook.aws_conn_id == "aws_step_function_conn"
+        assert hook._region_name == "eu-central-1"
+        assert hook._verify is False
+        assert hook._config.read_timeout == 100
+
+    @pytest.mark.asyncio
+    @mock.patch.object(StepFunctionHook, "get_waiter")
+    @mock.patch.object(StepFunctionHook, "get_async_conn")
+    async def test_run_success(self, mock_async_conn, mock_get_waiter):
+        mock_async_conn.__aenter__.return_value = mock.MagicMock()
+        mock_get_waiter().wait = AsyncMock()
+        trigger = StepFunctionsExecutionCompleteTrigger(execution_arn=self.EXECUTION_ARN)
+
+        generator = trigger.run()
+        response = await generator.asend(None)
+
+        assert response == TriggerEvent({"status": "success", "execution_arn": self.EXECUTION_ARN})
+        assert mock_get_waiter().wait.call_count == 1
+        mock_get_waiter.assert_any_call(
+            self.EXPECTED_WAITER_NAME, deferrable=True, client=mock.ANY, config_overrides=None
+        )
+        assert mock_get_waiter().wait.call_args.kwargs["executionArn"] == self.EXECUTION_ARN


### PR DESCRIPTION
StepFunctionsExecutionCompleteTrigger accepted region_name but only put it into serialized_fields without forwarding it to AwsBaseWaiterTrigger, so self.region_name stayed None and the deferred waiter always polled Step Functions in the default region instead of the one the operator was configured with. The base class already serializes region_name itself, so the serialized_fields entry was redundant on top of being inert.

Also adds the previously missing dedicated test module for the trigger (tracked in the OVERLOOKED_TESTS allowlist). `test_hook_forwards_connection_config` is the regression test for this fix — it is the one that fails without the production change; `test_serialization` and `test_run_success` are there for module coverage and pass either way.

Claude-Session: https://claude.ai/code/session_01QL3YuSRJuK6WpZGc4jMjd1

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
