### PR TITLE
Support team-scoped secrets in LocalFilesystemBackend

### DIFF
--- a/airflow-core/docs/core-concepts/multi-team.rst
+++ b/airflow-core/docs/core-concepts/multi-team.rst
@@ -240,7 +240,8 @@ Variables can be associated with teams when created. Tasks belonging to a team c
 
 When a task requests a variable, the system checks for a team-specific variable first.
 
-Team-scoped variables can be created and managed through the Airflow UI or via environment variables.
+Team-scoped variables can be created and managed through the Airflow UI, via environment variables or via the
+:ref:`local filesystem secrets backend <local_filesystem_secrets>`.
 
 **Via environment variables**, you can set team-scoped variables using the format:
 
@@ -254,12 +255,24 @@ Team-scoped variables can be created and managed through the Airflow UI or via e
 
 The format is: ``AIRFLOW_VAR__{TEAM}___{KEY}`` (note: double underscore before team, triple underscore between team and key)
 
+**Via the local filesystem secrets backend**, prefix the key with the team name in the variables file:
+
+.. code-block:: json
+
+    {
+        "my_variable": "global_value",
+        "team_a___my_variable": "team_a_value"
+    }
+
+The format is: ``{TEAM}___{KEY}`` (triple underscore between team and key)
+
 Team-scoped Connections
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 Connections follow the same pattern as variables. Tasks can access connections owned by their team or global connections.
 
-Team-scoped connections can be created and managed through the Airflow UI or via environment variables.
+Team-scoped connections can be created and managed through the Airflow UI, via environment variables or via the
+:ref:`local filesystem secrets backend <local_filesystem_secrets>`.
 
 **Via environment variables**:
 
@@ -272,6 +285,17 @@ Team-scoped connections can be created and managed through the Airflow UI or via
     export AIRFLOW_CONN__TEAM_A___MY_DATABASE="postgresql://..."
 
 The format is: ``AIRFLOW_CONN__{TEAM}___{CONN_ID}`` (note: double underscore before team, triple underscore between team and connection ID)
+
+**Via the local filesystem secrets backend**, prefix the key with the team name in the connections file:
+
+.. code-block:: json
+
+    {
+        "my_database": "postgresql://...",
+        "team_a___my_database": "postgresql://..."
+    }
+
+The format is: ``{TEAM}___{CONN_ID}`` (triple underscore between team and connection ID)
 
 Team-scoped Pools
 ^^^^^^^^^^^^^^^^^

--- a/airflow-core/docs/security/secrets/secrets-backend/local-filesystem-secrets-backend.rst
+++ b/airflow-core/docs/security/secrets/secrets-backend/local-filesystem-secrets-backend.rst
@@ -145,6 +145,30 @@ describe the variable value. The following is a sample file.
     VAR_A=some_value
     var_B=different_value
 
+Team-scoped Connections and Variables
+"""""""""""""""""""""""""""""""""""""
+
+.. versionadded:: 3.4.0
+
+In :doc:`multi-team mode </core-concepts/multi-team>`, a key of the form ``{TEAM}___{ID}`` (triple underscore
+between the team name and the connection ID or variable key) holds the value for that team only. When a task of
+``team_a`` asks for ``my_database``, the backend returns the ``team_a___my_database`` entry if the file has one
+and the plain ``my_database`` entry otherwise. Tasks of other teams, and lookups made without a team, only see
+the plain entry.
+
+.. code-block:: json
+
+    {
+        "my_database": "postgresql://shared-host/db",
+        "team_a___my_database": "postgresql://team-a-host/db"
+    }
+
+The variables file uses the same key format, and so do the ``YAML`` and ``.env`` formats.
+
+In multi-team mode a connection ID or variable key that itself contains ``___`` is ambiguous, so the backend
+never resolves it. This applies to every lookup, with or without a team, including the team that owns the
+entry. Outside multi-team mode the backend matches keys verbatim and ``___`` has no special meaning.
+
 Storing and Retrieving Configurations
 """""""""""""""""""""""""""""""""""""
 

--- a/airflow-core/src/airflow/secrets/local_filesystem.py
+++ b/airflow-core/src/airflow/secrets/local_filesystem.py
@@ -27,6 +27,7 @@ from json import JSONDecodeError
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from airflow.configuration import conf
 from airflow.exceptions import (
     AirflowException,
     AirflowFileParseException,
@@ -41,6 +42,10 @@ from airflow.utils.file import COMMENT_PATTERN
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 log = logging.getLogger(__name__)
+
+# Separates the team name from the secret id in a team scoped file key, <team>___<id>. The
+# environment variables backend uses the same separator.
+TEAM_SEP = "___"
 
 if TYPE_CHECKING:
     from airflow.models.connection import Connection
@@ -314,6 +319,9 @@ class LocalFilesystemBackend(BaseSecretsBackend, LoggingMixin):
 
     ``JSON``, `YAML` and ``.env`` files are supported.
 
+    In multi-team mode, a ``<team>___<id>`` key holds the connection or variable for that team only.
+    Tasks of that team receive it instead of the team agnostic ``<id>`` key.
+
     :param variables_file_path: File location with variables data.
     :param connections_file_path: File location with connection data.
     :param configs_file_path: File location with configuration data.
@@ -355,13 +363,39 @@ class LocalFilesystemBackend(BaseSecretsBackend, LoggingMixin):
             return {}
         return load_configs_dict(self.configs_file)
 
+    @staticmethod
+    def _names_a_team_namespace(secret_id: str) -> bool:
+        """
+        Whether ``secret_id`` spells out a team scoped file key.
+
+        The backend refuses such an id in every scope, as the environment variables backend does.
+        A team agnostic lookup for it would land on a team's key, and a scoped lookup would build
+        a key that another team's name could produce as well.
+
+        The check only runs in multi-team mode. Without it ``team_name`` is always ``None``, so
+        there is no team scoped key to collide with.
+        """
+        if not conf.getboolean("core", "multi_team", fallback=False):
+            return False
+        return TEAM_SEP in secret_id
+
     def get_connection(self, conn_id: str, team_name: str | None = None) -> Connection | None:
-        if conn_id in self._local_connections:
-            return self._local_connections[conn_id]
-        return None
+        if self._names_a_team_namespace(conn_id):
+            return None
+
+        connections = self._local_connections
+        if team_name and (team_conn := connections.get(f"{team_name}{TEAM_SEP}{conn_id}")) is not None:
+            return team_conn
+        return connections.get(conn_id)
 
     def get_variable(self, key: str, team_name: str | None = None) -> str | None:
-        return self._local_variables.get(key)
+        if self._names_a_team_namespace(key):
+            return None
+
+        variables = self._local_variables
+        if team_name and (team_var := variables.get(f"{team_name}{TEAM_SEP}{key}")) is not None:
+            return team_var
+        return variables.get(key)
 
     def get_config(self, key: str) -> str | None:
         return self._local_configs.get(key)

--- a/airflow-core/tests/unit/always/test_secrets_local_filesystem.py
+++ b/airflow-core/tests/unit/always/test_secrets_local_filesystem.py
@@ -34,7 +34,7 @@ from airflow.exceptions import (
 )
 from airflow.models import Variable
 from airflow.secrets import local_filesystem
-from airflow.secrets.local_filesystem import LocalFilesystemBackend
+from airflow.secrets.local_filesystem import TEAM_SEP, LocalFilesystemBackend
 
 from tests_common.test_utils.config import conf_vars
 
@@ -561,3 +561,79 @@ class TestLocalFileBackend:
         assert backend.get_connection("CONN_A") is None
         assert backend.get_variable("VAR_A") is None
         assert backend.get_config("CONF_A") is None
+
+
+# A team scoped secret lives under the ``<TEAM_NAME>___<SECRET_ID>`` key of the same file.
+TEAM_NAME = "team_a"
+OTHER_TEAM_NAME = "team_b"
+SECRET_ID = "dbconn"
+TEAM_VALUE = "mysql://team-scoped-host"
+GLOBAL_VALUE = "mysql://team-agnostic-host"
+
+# The two lookups that follow the team scoping rules.
+LOOKUPS = [pytest.param("connection", id="connection"), pytest.param("variable", id="variable")]
+
+
+def team_scoped_key(team_name: str, secret_id: str = SECRET_ID) -> str:
+    return f"{team_name}{TEAM_SEP}{secret_id}"
+
+
+def write_backend(tmp_path, kind: str, secrets: dict[str, str]) -> LocalFilesystemBackend:
+    path = tmp_path / f"{kind}s.json"
+    path.write_text(json.dumps(secrets))
+    if kind == "connection":
+        return LocalFilesystemBackend(connections_file_path=os.fspath(path))
+    return LocalFilesystemBackend(variables_file_path=os.fspath(path))
+
+
+def lookup(backend: LocalFilesystemBackend, kind: str, secret_id: str, team_name: str | None) -> str | None:
+    if kind == "connection":
+        conn = backend.get_connection(secret_id, team_name)
+        return conn.get_uri() if conn else None
+    return backend.get_variable(secret_id, team_name)
+
+
+class TestLocalFileBackendTeamScope:
+    """Only the team a key is stored for can resolve it."""
+
+    @pytest.fixture(autouse=True)
+    def _multi_team_enabled(self):
+        with conf_vars({("core", "multi_team"): "True"}):
+            yield
+
+    @pytest.mark.parametrize("kind", LOOKUPS)
+    def test_team_scoped_secret_wins_over_the_team_agnostic_one(self, tmp_path, kind):
+        backend = write_backend(
+            tmp_path, kind, {SECRET_ID: GLOBAL_VALUE, team_scoped_key(TEAM_NAME): TEAM_VALUE}
+        )
+
+        assert lookup(backend, kind, SECRET_ID, TEAM_NAME) == TEAM_VALUE
+        assert lookup(backend, kind, SECRET_ID, OTHER_TEAM_NAME) == GLOBAL_VALUE
+        assert lookup(backend, kind, SECRET_ID, None) == GLOBAL_VALUE
+
+    @pytest.mark.parametrize("kind", LOOKUPS)
+    @pytest.mark.parametrize("team_name", [None, OTHER_TEAM_NAME])
+    def test_team_scoped_secret_is_only_resolved_for_its_own_team(self, tmp_path, kind, team_name):
+        backend = write_backend(tmp_path, kind, {team_scoped_key(TEAM_NAME): TEAM_VALUE})
+
+        assert lookup(backend, kind, SECRET_ID, TEAM_NAME) == TEAM_VALUE
+        assert lookup(backend, kind, SECRET_ID, team_name) is None
+
+    @pytest.mark.parametrize("kind", LOOKUPS)
+    @pytest.mark.parametrize("team_name", [None, TEAM_NAME, OTHER_TEAM_NAME])
+    def test_an_id_containing_the_separator_is_refused_in_every_scope(self, tmp_path, kind, team_name):
+        """Spelling the namespace out as the id never reaches the key, even for the team that owns it."""
+        backend = write_backend(tmp_path, kind, {team_scoped_key(TEAM_NAME): TEAM_VALUE})
+
+        assert lookup(backend, kind, team_scoped_key(TEAM_NAME), team_name) is None
+
+
+class TestLocalFileBackendMultiTeamDisabled:
+    """Without multi-team mode ``___`` means nothing, so the backend matches such a key verbatim."""
+
+    @conf_vars({("core", "multi_team"): "False"})
+    @pytest.mark.parametrize("kind", LOOKUPS)
+    def test_key_containing_the_separator_resolves_verbatim(self, tmp_path, kind):
+        backend = write_backend(tmp_path, kind, {team_scoped_key(TEAM_NAME): TEAM_VALUE})
+
+        assert lookup(backend, kind, team_scoped_key(TEAM_NAME), None) == TEAM_VALUE


### PR DESCRIPTION
## Why

- `multi-team.rst` says the local filesystem secrets backend is team-aware. However, `LocalFilesystemBackend.get_connection()` and `get_variable()` accept `team_name` but never use it, so every team gets the same global value and there is no way to define a team-scoped entry in the file.

https://github.com/apache/airflow/blob/123b1be658527d5fafad4736254a07a42da6dd3f/airflow-core/docs/core-concepts/multi-team.rst?plain=1#L106

## How

- A `<team>___<id>` key in the connections or variables file holds that team's value. The lookup tries the team key first and falls back to the plain key. `___` is the separator the environment variables backend already uses.
- With `[core] multi_team` off, nothing changes: the backend matches keys verbatim.

## Verification
- `uv run --frozen --project airflow-core pytest airflow-core/tests/unit/always/test_secrets_local_filesystem.py`

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
