### PR TITLE
Clarify that AccessView.JOBS is the Edge worker management permission

### DIFF
--- a/providers/edge3/docs/ui_plugin.rst
+++ b/providers/edge3/docs/ui_plugin.rst
@@ -64,5 +64,25 @@ To be able to use the UI plugin you need to be in role "Admin" or "Op" or have t
 configure the remote workers (Technical key: AccessView.JOBS). With this permission you can also manage
 the workers like adjusting queues, concurrency, set them to maintenance mode or shutdown the workers.
 
+.. warning::
+
+    "can read on Jobs" (``AccessView.JOBS``) is the **management** permission for Edge workers, not a
+    read-only one. It is deliberately the single permission gating the whole plugin, and the worker
+    management endpoints under ``/edge_worker/ui/`` check only this permission -- the HTTP method is not
+    part of the check. "can read on Plugins" governs only whether the plugin appears in the UI
+    navigation; it is not required in order to call the endpoints.
+
+    A principal holding "can read on Jobs" can therefore shut down, delete, re-queue and retune Edge
+    workers by calling those endpoints directly, whether or not the plugin is visible to them.
+
+    This matters for the default ``Viewer`` role, which **includes "can read on Jobs"**. In a default
+    Flask AppBuilder setup a Viewer does not see the Edge plugin in the navigation (Viewer has no
+    "can read on Plugins"), but can still reach the worker management endpoints. If Viewers in your
+    deployment must not manage Edge workers, remove "can read on Jobs" from that role or give those
+    users a custom role without it.
+
+    Finer-grained separation of read and management permissions for Edge workers is not implemented;
+    it is listed under :doc:`architecture` as a known missing feature.
+
 Note that maintenance mode can also be adjusted via CLI.
 See :ref:`deployment:maintenance` for more details.


### PR DESCRIPTION
The Edge UI plugin docs say that "can read on Plugins" and "can read on Jobs" let you view the UI and manage the workers, but they don't say how the two permissions differ, or what the default `Viewer` role already holds.

Both gaps matter, because the endpoints and the navigation are gated differently:

- The worker management endpoints under `/edge_worker/ui/` check **only** `AccessView.JOBS`, and the check is not method-aware — the same dependency guards the GET reads and the POST/PATCH/DELETE mutations.
- "can read on Plugins" only controls whether the plugin appears in the UI navigation. It is **not** required in order to call the endpoints.

So "can read on Jobs" alone is enough to shut down, delete, re-queue and retune Edge workers, whether or not the plugin is visible to that user.

That is intentional — `AccessView.JOBS` is the management permission for the plugin rather than a read-only grant, as #67379 already documents. What is missing is *why* it reads as surprising: from the code alone, a permission named "can read" guards mutating routes. It's more surprising in a default Flask AppBuilder setup, where `VIEWER_PERMISSIONS` includes `(ACTION_CAN_READ, RESOURCE_JOB)` but not the Plugins read — so a Viewer cannot see the Edge plugin and can still reach its management endpoints.

This adds a warning to the UI plugin docs stating the intent, the split between the two permissions, the consequence for the default Viewer role, and the concrete action for deployments where Viewers must not manage workers. It points at the existing "fine granular access control" entry in `architecture.rst` rather than restating it.

Documentation only; no behaviour change.

---

**Gen-AI disclosure:** this PR was prepared with the assistance of Claude Code. The permission facts were verified against `main` before writing: `VIEWER_PERMISSIONS` in the FAB security-manager override, and the `requires_access_view(access_view=AccessView.JOBS)` dependency on each route in `providers/edge3/.../worker_api/routes/ui.py`. I have reviewed the wording and stand behind it.
