### PR TITLE
Fix StatsD not restarting when overrideMappings or cache.ttl changes

### DIFF
--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -64,13 +64,11 @@ spec:
         {{- if or .Values.labels .Values.statsd.labels }}
           {{- mustMerge .Values.statsd.labels .Values.labels | toYaml | nindent 8 }}
         {{- end }}
-      {{- if or .Values.statsd.extraMappings .Values.statsd.podAnnotations }}
       annotations:
-        checksum/statsd-config: {{ include (print $.Template.BasePath "/configmaps/statsd-configmap.yaml") . | sha256sum }}
-        {{- if .Values.statsd.podAnnotations }}
-          {{- tpl (toYaml .Values.statsd.podAnnotations) . | nindent 8 }}
+        checksum/statsd-config: {{ (include (print $.Template.BasePath "/configmaps/statsd-configmap.yaml") . | fromYaml).data | toYaml | sha256sum }}
+        {{- with .Values.statsd.podAnnotations }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
-      {{- end }}
     spec:
       {{- if .Values.statsd.priorityClassName }}
       priorityClassName: {{ .Values.statsd.priorityClassName }}

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -65,7 +65,7 @@ spec:
           {{- mustMerge .Values.statsd.labels .Values.labels | toYaml | nindent 8 }}
         {{- end }}
       annotations:
-        checksum/statsd-config: {{ (include (print $.Template.BasePath "/configmaps/statsd-configmap.yaml") . | fromYaml).data | toYaml | sha256sum }}
+        checksum/statsd-config: {{ include (print $.Template.BasePath "/configmaps/statsd-configmap.yaml") . | sha256sum }}
         {{- with .Values.statsd.podAnnotations }}
           {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -66,8 +66,8 @@ spec:
         {{- end }}
       annotations:
         checksum/statsd-config: {{ include (print $.Template.BasePath "/configmaps/statsd-configmap.yaml") . | sha256sum }}
-        {{- with .Values.statsd.podAnnotations }}
-          {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- if .Values.statsd.podAnnotations }}
+          {{- tpl (toYaml .Values.statsd.podAnnotations) . | nindent 8 }}
         {{- end }}
     spec:
       {{- if .Values.statsd.priorityClassName }}

--- a/chart/tests/helm_tests/other/test_statsd.py
+++ b/chart/tests/helm_tests/other/test_statsd.py
@@ -358,18 +358,16 @@ class TestStatsd:
         assert "checksum/statsd-config" in jmespath.search("spec.template.metadata.annotations", docs[0])
 
     @pytest.mark.parametrize(
-        ("statsd_values", "expect_rollout"),
+        "statsd_values",
         [
             pytest.param(
                 {"overrideMappings": [{"match": "foo.*", "name": "foo", "match_type": "regex"}]},
-                True,
                 id="overrideMappings",
             ),
-            pytest.param({"cache": {"ttl": "10m"}}, True, id="cache-ttl"),
-            pytest.param({"configMapAnnotations": {"foo": "bar"}}, False, id="configmap-metadata-only"),
+            pytest.param({"cache": {"ttl": "10m"}}, id="cache-ttl"),
         ],
     )
-    def test_configmap_checksum_should_follow_configmap_data(self, statsd_values, expect_rollout):
+    def test_configmap_checksum_should_change_with_configmap_data(self, statsd_values):
         def get_checksum(values):
             docs = render_chart(
                 values={"statsd": {"enabled": True, **values}},
@@ -379,11 +377,7 @@ class TestStatsd:
             assert "checksum/statsd-config" in annotations
             return annotations["checksum/statsd-config"]
 
-        baseline = get_checksum({})
-        if expect_rollout:
-            assert get_checksum(statsd_values) != baseline
-        else:
-            assert get_checksum(statsd_values) == baseline
+        assert get_checksum(statsd_values) != get_checksum({})
 
     def test_should_add_custom_env_variables(self):
         env1 = {"name": "TEST_ENV_1", "value": "test_env_1"}

--- a/chart/tests/helm_tests/other/test_statsd.py
+++ b/chart/tests/helm_tests/other/test_statsd.py
@@ -355,6 +355,35 @@ class TestStatsd:
             jmespath.search("spec.template.metadata.annotations", docs[0])["test_pod_annotation"]
             == "test_pod_annotation_value"
         )
+        assert "checksum/statsd-config" in jmespath.search("spec.template.metadata.annotations", docs[0])
+
+    @pytest.mark.parametrize(
+        ("statsd_values", "expect_rollout"),
+        [
+            pytest.param(
+                {"overrideMappings": [{"match": "foo.*", "name": "foo", "match_type": "regex"}]},
+                True,
+                id="overrideMappings",
+            ),
+            pytest.param({"cache": {"ttl": "10m"}}, True, id="cache-ttl"),
+            pytest.param({"configMapAnnotations": {"foo": "bar"}}, False, id="configmap-metadata-only"),
+        ],
+    )
+    def test_configmap_checksum_should_follow_configmap_data(self, statsd_values, expect_rollout):
+        def get_checksum(values):
+            docs = render_chart(
+                values={"statsd": {"enabled": True, **values}},
+                show_only=["templates/statsd/statsd-deployment.yaml"],
+            )
+            annotations = jmespath.search("spec.template.metadata.annotations", docs[0]) or {}
+            assert "checksum/statsd-config" in annotations
+            return annotations["checksum/statsd-config"]
+
+        baseline = get_checksum({})
+        if expect_rollout:
+            assert get_checksum(statsd_values) != baseline
+        else:
+            assert get_checksum(statsd_values) == baseline
 
     def test_should_add_custom_env_variables(self):
         env1 = {"name": "TEST_ENV_1", "value": "test_env_1"}


### PR DESCRIPTION
The StatsD Deployment only rendered its `checksum/statsd-config` pod annotation when `statsd.extraMappings` or `statsd.podAnnotations` was set. The StatsD ConfigMap, however, also changes with `statsd.overrideMappings` and `statsd.cache.ttl` — so changing either of those updated the ConfigMap without rolling the pod, and `statsd-exporter` (which reads `mappings.yml` only at startup) silently kept serving the old mappings.

The annotation is now rendered unconditionally, matching the `otel-collector` Deployment, so any value that affects the ConfigMap triggers a rollout without having to be enumerated in the template. The checksum itself is unchanged: the full rendered ConfigMap document, the same as every other component in the chart.

**Upgrade note:** on upgrade to this chart version, existing StatsD pods restart once because the annotation is new for installs without `extraMappings`. From then on StatsD rolls on chart version bumps like the other components do.

Verified with `helm template`:

| values | before | after |
|---|---|---|
| `overrideMappings` changed | no rollout | rollout |
| `cache.ttl` changed | no rollout | rollout |
| `extraMappings` changed | rollout | rollout |
| chart version bump only, with `extraMappings` | rollout | rollout |
| chart version bump only, default install | no rollout | rollout |

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5.1)

Generated-by: Claude Code (Fable 5.1) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
