### PR TITLE
Keep asset event endpoints working for older Task SDK clients

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/asset_event.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/asset_event.py
@@ -31,6 +31,7 @@ class DagRunAssetReference(StrictBaseModel):
     run_id: str
     dag_id: str
     logical_date: datetime | None
+    run_after: datetime
     start_date: datetime | None
     end_date: datetime | None
     state: str

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
@@ -54,11 +54,17 @@ from airflow.api_fastapi.execution_api.versions.v2026_06_30 import (
 from airflow.api_fastapi.execution_api.versions.v2026_10_30 import (
     AddArgBindingsToTIRunContext,
     AddCallbackRunEndpoint,
+    MakeCreatedDagRunStartDateNullable,
 )
 
 bundle = VersionBundle(
     HeadVersion(),
-    Version("2026-10-30", AddArgBindingsToTIRunContext, AddCallbackRunEndpoint),
+    Version(
+        "2026-10-30",
+        AddArgBindingsToTIRunContext,
+        AddCallbackRunEndpoint,
+        MakeCreatedDagRunStartDateNullable,
+    ),
     Version(
         "2026-06-30",
         AddVariableKeysEndpoint,

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_10_30.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_10_30.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from cadwyn import (
     ResponseInfo,
     VersionChange,
@@ -26,6 +28,7 @@ from cadwyn import (
     schema,
 )
 
+from airflow.api_fastapi.execution_api.datamodels.asset_event import AssetEventsResponse, DagRunAssetReference
 from airflow.api_fastapi.execution_api.datamodels.taskinstance import TIRunContext
 
 
@@ -52,3 +55,28 @@ class AddCallbackRunEndpoint(VersionChange):
     instructions_to_migrate_to_previous_version = (
         endpoint("/callbacks/{callback_id}/run", ["PATCH"]).didnt_exist,
     )
+
+
+class MakeCreatedDagRunStartDateNullable(VersionChange):
+    """Make ``DagRunAssetReference.start_date`` nullable and add ``run_after`` for runs that haven't started yet."""
+
+    description = __doc__
+
+    instructions_to_migrate_to_previous_version = (
+        schema(DagRunAssetReference).field("start_date").had(type=datetime),
+        schema(DagRunAssetReference).field("run_after").didnt_exist,
+    )
+
+    @convert_response_to_previous_version_for(AssetEventsResponse)  # type: ignore[arg-type]
+    def ensure_start_date_in_created_dagruns(response: ResponseInfo) -> None:  # type: ignore[misc]
+        """
+        Give every created Dag run a ``start_date`` and drop ``run_after`` for older clients.
+
+        Older Task SDK clients require ``start_date`` and reject unknown fields, so a queued run
+        borrows ``run_after`` before that field is removed from the payload.
+        """
+        for event in response.body["asset_events"]:
+            for dag_run in event["created_dagruns"]:
+                if dag_run["start_date"] is None:
+                    dag_run["start_date"] = dag_run["run_after"]
+                del dag_run["run_after"]

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_asset_events.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_asset_events.py
@@ -115,7 +115,9 @@ class TestGetAssetEventByAsset:
         )
 
         assert response.status_code == 200
-        assert response.json()["asset_events"][0]["created_dagruns"][0]["start_date"] is None
+        created = response.json()["asset_events"][0]["created_dagruns"][0]
+        assert created["start_date"] is None
+        assert created["run_after"] == DEFAULT_DATE.isoformat().replace("+00:00", "Z")
 
     @pytest.mark.parametrize(
         ("uri", "name"),

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2026_06_30/test_asset_events.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2026_06_30/test_asset_events.py
@@ -1,0 +1,87 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow._shared.timezones import timezone
+from airflow.models.asset import AssetActive, AssetAliasModel, AssetEvent, AssetModel
+from airflow.models.dagrun import DagRun
+from airflow.utils.state import DagRunState
+from airflow.utils.types import DagRunType
+
+from tests_common.test_utils.db import clear_db_assets, clear_db_runs
+
+pytestmark = pytest.mark.db_test
+
+RUN_AFTER = timezone.datetime(2021, 1, 1)
+STARTED_AT = timezone.datetime(2021, 1, 2)
+
+
+@pytest.fixture
+def old_ver_client(client):
+    """Last released execution API in which ``DagRunAssetReference.start_date`` was required."""
+    client.headers["Airflow-API-Version"] = "2026-06-30"
+    return client
+
+
+@pytest.fixture
+def asset_event_with_created_dagruns(session):
+    asset = AssetModel(id=1, name="test_asset", uri="s3://bucket/key", group="asset", extra={})
+    alias = AssetAliasModel(id=1, name="test_alias")
+    alias.assets.append(asset)
+    event = AssetEvent(id=1, asset_id=1, timestamp=RUN_AFTER, extra={}, partition_key=None)
+    alias.asset_events.append(event)
+    queued_run = DagRun(
+        dag_id="created_dag",
+        run_id="queued_run",
+        state=DagRunState.QUEUED,
+        run_type=DagRunType.ASSET_TRIGGERED,
+        run_after=RUN_AFTER,
+    )
+    started_run = DagRun(
+        dag_id="created_dag",
+        run_id="started_run",
+        state=DagRunState.RUNNING,
+        run_type=DagRunType.ASSET_TRIGGERED,
+        run_after=RUN_AFTER,
+        start_date=STARTED_AT,
+    )
+    event.created_dagruns.extend([queued_run, started_run])
+    session.add_all([asset, AssetActive.for_asset(asset), alias, event])
+    session.commit()
+    yield
+    clear_db_runs()
+    clear_db_assets()
+
+
+@pytest.mark.usefixtures("asset_event_with_created_dagruns")
+@pytest.mark.parametrize(
+    ("path", "params"),
+    [
+        ("/execution/asset-events/by-asset", {"name": "test_asset", "uri": None}),
+        ("/execution/asset-events/by-asset-alias", {"name": "test_alias"}),
+    ],
+)
+def test_created_dagruns_always_have_start_date_and_no_run_after(old_ver_client, path, params):
+    response = old_ver_client.get(path, params=params)
+
+    assert response.status_code == 200
+    created = {run["run_id"]: run for run in response.json()["asset_events"][0]["created_dagruns"]}
+    assert created["queued_run"]["start_date"] == RUN_AFTER.isoformat().replace("+00:00", "Z")
+    assert created["started_run"]["start_date"] == STARTED_AT.isoformat().replace("+00:00", "Z")
+    assert all("run_after" not in run for run in created.values())

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -135,6 +135,7 @@ class DagRunAssetReference(BaseModel):
     run_id: Annotated[str, Field(title="Run Id")]
     dag_id: Annotated[str, Field(title="Dag Id")]
     logical_date: Annotated[AwareDatetime | None, Field(title="Logical Date")]
+    run_after: Annotated[AwareDatetime, Field(title="Run After")]
     start_date: Annotated[AwareDatetime | None, Field(title="Start Date")]
     end_date: Annotated[AwareDatetime | None, Field(title="End Date")]
     state: Annotated[str, Field(title="State")]

--- a/task-sdk/src/airflow/sdk/execution_time/schema/schema.json
+++ b/task-sdk/src/airflow/sdk/execution_time/schema/schema.json
@@ -1146,6 +1146,11 @@
           ],
           "title": "Logical Date"
         },
+        "run_after": {
+          "format": "date-time",
+          "title": "Run After",
+          "type": "string"
+        },
         "start_date": {
           "anyOf": [
             {
@@ -1214,6 +1219,7 @@
         "run_id",
         "dag_id",
         "logical_date",
+        "run_after",
         "start_date",
         "end_date",
         "state",

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -1212,6 +1212,7 @@ class TestAssetEventOperations:
                         "dag_id": "created_dag",
                         "run_id": "queued_run",
                         "logical_date": "2023-01-01T00:00:00Z",
+                        "run_after": "2023-01-01T00:00:00Z",
                         "start_date": None,
                         "end_date": None,
                         "state": "queued",

--- a/ts-sdk/src/generated/supervisor.ts
+++ b/ts-sdk/src/generated/supervisor.ts
@@ -37,6 +37,7 @@ export type Extra1 = {
 export type RunId = string;
 export type DagId = string;
 export type LogicalDate = string | null;
+export type RunAfter = string;
 export type StartDate = string | null;
 export type EndDate = string | null;
 export type State = string;
@@ -132,7 +133,7 @@ export type RunId2 = string;
 export type LogicalDate1 = string | null;
 export type DataIntervalStart1 = string | null;
 export type DataIntervalEnd1 = string | null;
-export type RunAfter = string;
+export type RunAfter1 = string;
 export type StartDate1 = string | null;
 export type EndDate1 = string | null;
 export type ClearNumber = number;
@@ -291,7 +292,7 @@ export type RunId4 = string;
 export type LogicalDate2 = string | null;
 export type DataIntervalStart2 = string | null;
 export type DataIntervalEnd2 = string | null;
-export type RunAfter1 = string;
+export type RunAfter2 = string;
 export type StartDate3 = string | null;
 export type EndDate2 = string | null;
 export type ClearNumber1 = number | null;
@@ -600,7 +601,7 @@ export type RenderedMapIndex5 = string | null;
 export type Type79 = "TaskStateStoreResult";
 export type Type80 = "TaskStatesResult";
 export type LogicalDate6 = string | null;
-export type RunAfter2 = string | null;
+export type RunAfter3 = string | null;
 export type Conf2 = {
   [k: string]: unknown;
 } | null;
@@ -685,6 +686,7 @@ export interface DagRunAssetReference {
   run_id: RunId;
   dag_id: DagId;
   logical_date: LogicalDate;
+  run_after: RunAfter;
   start_date: StartDate;
   end_date: EndDate;
   state: State;
@@ -912,7 +914,7 @@ export interface DagRun {
   logical_date: LogicalDate1;
   data_interval_start: DataIntervalStart1;
   data_interval_end: DataIntervalEnd1;
-  run_after: RunAfter;
+  run_after: RunAfter1;
   start_date: StartDate1;
   end_date: EndDate1;
   clear_number?: ClearNumber;
@@ -1149,7 +1151,7 @@ export interface DagRunResult {
   logical_date: LogicalDate2;
   data_interval_start: DataIntervalStart2;
   data_interval_end: DataIntervalEnd2;
-  run_after: RunAfter1;
+  run_after: RunAfter2;
   start_date: StartDate3;
   end_date: EndDate2;
   clear_number?: ClearNumber1;
@@ -1853,7 +1855,7 @@ export interface TaskStates {
  */
 export interface TriggerDagRun {
   logical_date?: LogicalDate6;
-  run_after?: RunAfter2;
+  run_after?: RunAfter3;
   conf?: Conf2;
   reset_dag_run?: ResetDagRun;
   partition_key?: PartitionKey7;


### PR DESCRIPTION
## Why

#71379 made `DagRunAssetReference.start_date` nullable so asset-event endpoints no longer 500 when a created Dag run is still queued. The change was never registered with the Execution API versioning layer, so the server sends `"start_date": null` to every client. All released Task SDKs (1.1.x through 1.3.x) still require `start_date` and use `extra="forbid"`, so `GET /asset-events/by-asset` and `/by-asset-alias` fail client-side with a `ValidationError` whenever an event created a queued run.
## What

- Add `run_after` to `DagRunAssetReference` and register `MakeCreatedDagRunStartDateNullable` in the head version (`2026-10-30`). For older clients the converter fills a null `start_date` with `run_after` and strips `run_after`, mirroring the existing `DagRun` fallback in `MakeDagRunStartDateNullable`.
- Regenerate task-sdk datamodels, the supervisor schema snapshot and `ts-sdk` types.
- Tests: new `versions/v2026_06_30/test_asset_events.py` covers both endpoints for a queued and a started run (fails without the fix); head test now asserts `run_after` is present; task-sdk client test payload gains `run_after`.

related:#71379

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5.1)