### PR TITLE
Prevent Dag-existence disclosure on partitioned dag runs listing

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -403,6 +403,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PartitionedDagRunCollectionResponse'
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Not Found
         '422':
           description: Validation Error
           content:

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/partitioned_dag_runs.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/partitioned_dag_runs.py
@@ -40,6 +40,7 @@ from airflow.api_fastapi.core_api.datamodels.ui.partitioned_dag_runs import (
     PartitionedDagRunDetailResponse,
     PartitionedDagRunResponse,
 )
+from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
 from airflow.api_fastapi.core_api.security import (
     ReadableDagsFilterDep,
     requires_access_asset,
@@ -242,6 +243,7 @@ def _build_response(row, required_count: int, received_count: int) -> Partitione
 
 @partitioned_dag_runs_router.get(
     "/partitioned_dag_runs",
+    responses=create_openapi_http_exception_doc([status.HTTP_404_NOT_FOUND]),
     dependencies=[Depends(requires_access_asset(method="GET"))],
 )
 def get_partitioned_dag_runs(

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/partitioned_dag_runs.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/partitioned_dag_runs.py
@@ -283,15 +283,17 @@ def get_partitioned_dag_runs(
 
     if not (rows := session.execute(query).all()):
         if dag_id.value is not None and total_entries == 0:
-            # Scope the existence probe to Dags the caller may read: without this, an
-            # unreadable-but-existing Dag returns 200-empty while a nonexistent Dag
-            # returns 404, letting the caller distinguish the two and learn which Dags
-            # exist outside their permitted set.
-            dag_exists_query = select(DagModel.dag_id).where(DagModel.dag_id == dag_id.value)
+            # An unreadable-but-existing Dag must not be distinguishable from a
+            # nonexistent one, otherwise a caller can probe by dag_id and learn which
+            # Dags exist outside their permitted set. Since readable_dag_ids already
+            # comes from DagModel, membership in the set proves existence and skips
+            # the extra query and IN list; only the admin path needs the probe.
             if readable_dag_ids is not None:
-                dag_exists_query = dag_exists_query.where(DagModel.dag_id.in_(readable_dag_ids))
-            dag_exists = session.scalar(dag_exists_query)
-            if dag_exists is None:
+                if dag_id.value not in readable_dag_ids:
+                    raise HTTPException(
+                        status.HTTP_404_NOT_FOUND, f"Dag with id {dag_id.value} was not found"
+                    )
+            elif session.scalar(select(DagModel.dag_id).where(DagModel.dag_id == dag_id.value)) is None:
                 raise HTTPException(status.HTTP_404_NOT_FOUND, f"Dag with id {dag_id.value} was not found")
         return PartitionedDagRunCollectionResponse(partitioned_dag_runs=[], total=total_entries)
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/partitioned_dag_runs.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/partitioned_dag_runs.py
@@ -285,11 +285,8 @@ def get_partitioned_dag_runs(
 
     if not (rows := session.execute(query).all()):
         if dag_id.value is not None and total_entries == 0:
-            # An unreadable-but-existing Dag must not be distinguishable from a
-            # nonexistent one, otherwise a caller can probe by dag_id and learn which
-            # Dags exist outside their permitted set. Since readable_dag_ids already
-            # comes from DagModel, membership in the set proves existence and skips
-            # the extra query and IN list; only the admin path needs the probe.
+            # An unreadable-but-existing Dag must return 404 too — otherwise the caller
+            # can probe by dag_id and learn which Dags exist outside their permitted set.
             if readable_dag_ids is not None:
                 if dag_id.value not in readable_dag_ids:
                     raise HTTPException(

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/partitioned_dag_runs.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/partitioned_dag_runs.py
@@ -283,7 +283,14 @@ def get_partitioned_dag_runs(
 
     if not (rows := session.execute(query).all()):
         if dag_id.value is not None and total_entries == 0:
-            dag_exists = session.scalar(select(DagModel.dag_id).where(DagModel.dag_id == dag_id.value))
+            # Scope the existence probe to Dags the caller may read: without this, an
+            # unreadable-but-existing Dag returns 200-empty while a nonexistent Dag
+            # returns 404, letting the caller distinguish the two and learn which Dags
+            # exist outside their permitted set.
+            dag_exists_query = select(DagModel.dag_id).where(DagModel.dag_id == dag_id.value)
+            if readable_dag_ids is not None:
+                dag_exists_query = dag_exists_query.where(DagModel.dag_id.in_(readable_dag_ids))
+            dag_exists = session.scalar(dag_exists_query)
             if dag_exists is None:
                 raise HTTPException(status.HTTP_404_NOT_FOUND, f"Dag with id {dag_id.value} was not found")
         return PartitionedDagRunCollectionResponse(partitioned_dag_runs=[], total=total_entries)

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -4771,6 +4771,7 @@ export class PartitionedDagRunService {
                 has_created_dag_run_id: data.hasCreatedDagRunId
             },
             errors: {
+                404: 'Not Found',
                 422: 'Validation Error'
             }
         });

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -8592,6 +8592,10 @@ export type $OpenApiTs = {
                  */
                 200: PartitionedDagRunCollectionResponse;
                 /**
+                 * Not Found
+                 */
+                404: HTTPExceptionResponse;
+                /**
                  * Validation Error
                  */
                 422: HTTPValidationError;

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_partitioned_dag_runs.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_partitioned_dag_runs.py
@@ -301,6 +301,29 @@ class TestGetPartitionedDagRuns:
         dag_ids = {r["dag_id"] for r in body["partitioned_dag_runs"]}
         assert "restricted_dag" not in dag_ids
 
+    @mock.patch(
+        "airflow.api_fastapi.auth.managers.base_auth_manager.BaseAuthManager.get_authorized_dag_ids",
+        return_value={"other_dag"},
+    )
+    def test_dag_id_filter_does_not_disclose_unreadable_dag_existence(
+        self, _, test_client, dag_maker, session
+    ):
+        """
+        An unreadable-but-existing Dag must not be distinguishable from a nonexistent
+        Dag via the ``dag_id`` filter: both return 404. Without the scoped existence
+        probe, the existing Dag returned 200-empty while the nonexistent one returned
+        404, giving the caller an oracle for Dag ids outside their permitted set.
+        """
+        schedule = PartitionedAssetTimetable(assets=Asset(uri="s3://bucket/a", name="a"))
+        with dag_maker(dag_id="restricted_dag", schedule=schedule, serialized=True):
+            EmptyOperator(task_id="t")
+        dag_maker.sync_dagbag_to_db()
+        session.commit()
+
+        existing_unreadable = test_client.get("/partitioned_dag_runs?dag_id=restricted_dag")
+        nonexistent = test_client.get("/partitioned_dag_runs?dag_id=no_such_dag")
+        assert existing_unreadable.status_code == nonexistent.status_code == 404
+
     def test_duplicate_events_count_as_one(self, test_client, dag_maker, session):
         """Multiple log entries for the same asset count as 1 received, not N."""
         asset_def = Asset(uri="s3://bucket/dup0", name="dup0")

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_partitioned_dag_runs.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_partitioned_dag_runs.py
@@ -310,14 +310,18 @@ class TestGetPartitionedDagRuns:
     ):
         """
         An unreadable-but-existing Dag must not be distinguishable from a nonexistent
-        Dag via the ``dag_id`` filter: both return 404. Without the scoped existence
-        probe, the existing Dag returned 200-empty while the nonexistent one returned
-        404, giving the caller an oracle for Dag ids outside their permitted set.
+        Dag via the ``dag_id`` filter: both return 404. Without the scoping, the
+        readable-dags row filter drops the APDR rows, ``total_entries`` collapses to
+        0, and the DagModel probe still finds the Dag — returning 200-empty and
+        giving the caller an oracle for Dag ids outside their permitted set.
         """
         schedule = PartitionedAssetTimetable(assets=Asset(uri="s3://bucket/a", name="a"))
         with dag_maker(dag_id="restricted_dag", schedule=schedule, serialized=True):
             EmptyOperator(task_id="t")
         dag_maker.sync_dagbag_to_db()
+        # An APDR row exists but the readable-dags filter drops it — this is the
+        # branch where the pre-fix DagModel probe leaked existence.
+        session.add(AssetPartitionDagRun(target_dag_id="restricted_dag", partition_key="2024-06-01"))
         session.commit()
 
         existing_unreadable = test_client.get("/partitioned_dag_runs?dag_id=restricted_dag")


### PR DESCRIPTION
The empty-results branch of the `/ui/partitioned_dag_runs` listing raised 404
when a Dag did not exist, but returned 200-empty when a Dag existed but was
outside the caller's permitted set (the readable-dags row filter had already
dropped its rows). A caller could therefore probe by `dag_id` and learn which
identifiers exist beyond what they are allowed to read.

Scope the existence probe to readable Dags so the two cases collapse to the
same 404, matching the "so their existence does not leak either" idiom used
by `PermittedEventLogFilter` / `PermittedAssetEventFilter`. Behavior is
unchanged for callers with full Dag access.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)