### PR TITLE
Preserve naive datetime XCom values across worker timezones

### DIFF
--- a/task-sdk/src/airflow/sdk/serde/serializers/datetime.py
+++ b/task-sdk/src/airflow/sdk/serde/serializers/datetime.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
     from airflow.sdk.serde import U
 
-__version__ = 2
+__version__ = 3
 
 serializers = [
     "datetime.date",
@@ -51,6 +51,9 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
 
     if isinstance(o, datetime):
         qn = qualname(o)
+
+        if o.tzinfo is None:
+            return o.isoformat(), qn, __version__, True
 
         tz = serialize_timezone(o.tzinfo) if o.tzinfo else None
 
@@ -95,6 +98,9 @@ def deserialize(cls: type, version: int, data: dict | str) -> datetime.date | da
     if cls is datetime.datetime and isinstance(data, dict):
         return datetime.datetime.fromtimestamp(float(data[TIMESTAMP]), tz=tz)
 
+    if cls is datetime.datetime and isinstance(data, str):
+        return datetime.datetime.fromisoformat(data)
+
     if cls is datetime.datetime and isinstance(data, int | float):
         # Legacy BaseSerialization stored datetimes as a bare UTC timestamp float
         # (rather than serde's {timestamp, tz} dict). Round-trip that form so trigger
@@ -103,6 +109,9 @@ def deserialize(cls: type, version: int, data: dict | str) -> datetime.date | da
 
     if cls is DateTime and isinstance(data, dict):
         return DateTime.fromtimestamp(float(data[TIMESTAMP]), tz=tz)
+
+    if cls is DateTime and isinstance(data, str):
+        return DateTime.fromisoformat(data)
 
     if cls is datetime.timedelta and isinstance(data, str | float):
         return datetime.timedelta(seconds=float(data))

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -814,7 +814,7 @@ class TestWatchedSubprocess:
                 trigger_kwargs={
                     "moment": {
                         "__classname__": "pendulum.datetime.DateTime",
-                        "__version__": 2,
+                        "__version__": 3,
                         "__data__": {
                             "timestamp": 1730982899.0,
                             "tz": {

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -913,7 +913,7 @@ def test_run_deferred_basic(time_machine, create_runtime_ti, mock_supervisor_com
             trigger_kwargs={
                 "moment": {
                     "__classname__": "pendulum.datetime.DateTime",
-                    "__version__": 2,
+                    "__version__": 3,
                     "__data__": {
                         "timestamp": 1732233603.0,
                         "tz": {

--- a/task-sdk/tests/task_sdk/serde/test_serializers.py
+++ b/task-sdk/tests/task_sdk/serde/test_serializers.py
@@ -118,6 +118,28 @@ class TestSerializers:
         else:
             assert input_obj.timestamp() == deserialized_obj.timestamp()
 
+    def test_naive_datetime_round_trip_preserves_wall_clock(self):
+        input_obj = datetime.datetime(2026, 1, 1, 12, 0, 0)
+
+        serialized_obj = serialize(input_obj)
+        deserialized_obj = deserialize(serialized_obj)
+
+        assert serialized_obj[VERSION] == 3
+        assert serialized_obj[DATA] == "2026-01-01T12:00:00"
+        assert deserialized_obj == input_obj
+        assert deserialized_obj.tzinfo is None
+
+    def test_version_2_datetime_payload_remains_readable(self):
+        serialized_obj = {
+            "__classname__": "datetime.datetime",
+            "__version__": 2,
+            "__data__": {"timestamp": 1767268800.0, "tz": None},
+        }
+
+        deserialized_obj = deserialize(serialized_obj)
+
+        assert deserialized_obj.timestamp() == 1767268800.0
+
     @pytest.mark.parametrize(
         ("tz_input", "expected_tz_name"),
         [


### PR DESCRIPTION
Naive `datetime` values are wall-clock values, but the current XCom serializer converts them through local timestamps. When workers use different OS timezones, deserialization changes the value.

This keeps aware datetime serialization backward compatible, serializes naive datetimes as ISO wall-clock strings, and retains readability for existing version-2 payloads. Regression coverage verifies the new representation and legacy compatibility.

closes: #72635

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Copilot (GPT-5)

Generated-by: Copilot (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)