### PR TITLE
Stop agent scratch directories from breaking the boring-cyborg check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,11 @@ ENV/
 !.claude/skills/upgrade-fab-provider
 !.claude/skills/magpie-setup
 
+# Claude Code write-tracking scratch dirs. Created next to whatever
+# directory a tool call ran in, so they turn up anywhere in the tree —
+# the .claude/* rule above only covers the repo root.
+**/.claude/.cc-writes/
+
 # Kiro
 .kiro/
 

--- a/scripts/ci/prek/boring_cyborg.py
+++ b/scripts/ci/prek/boring_cyborg.py
@@ -78,7 +78,8 @@ for p in providers_root.glob("**/provider.yaml"):
 # Check for missing translations
 EXCEPTIONS = ["en"]
 for p in AIRFLOW_ROOT_PATH.glob("airflow-core/src/airflow/ui/public/i18n/locales/*"):
-    if p.is_dir():
+    # Locale codes never start with a dot; skip tool scratch dirs (.claude, .DS_Store, ...)
+    if p.is_dir() and not p.name.startswith("."):
         lang_id = p.name
         expected_key = f"translation:{lang_id}"
         if lang_id not in EXCEPTIONS and expected_key not in cyborg_config[CONFIG_KEY]:


### PR DESCRIPTION
Coding agents (Claude Code, and anything else using the same write-tracking convention) create `.claude/.cc-writes/` scratch directories next to whatever directory a tool call ran in, so they turn up anywhere in the tree — this checkout had 22 of them, under `dev/`, `providers/`, `ts-sdk/docs/`, and so on.

**The failure this fixes.** When one lands in the UI locales directory, `boring_cyborg.py` globs `locales/*` and treats every directory as a locale code, so it reports:

```
Found 1 problems:
Translation [.claude] is missing in [translation:.claude] section.
Please correct the above in .github/boring-cyborg.yml
```

The commit is blocked, and the message points at `boring-cyborg.yml`, which is not where the problem is. The directories are empty, so `git status` shows nothing and the real cause is invisible without `ls -a`.

**Changes:**

- `scripts/ci/prek/boring_cyborg.py` — skip dot-directories when enumerating locales. Locale codes never start with a dot. This matches the guard `check_shared_distributions_usage.py` already uses.
- `.gitignore` — add `**/.claude/.cc-writes/`. The existing `.claude/*` rule contains a slash, so git anchors it to the repo root; nested occurrences were only ignored for contributors who happen to have a matching pattern in their personal global ignore file.

**Verified** by recreating `locales/.claude/.cc-writes` and re-running the hook: exits 1 before, "No found problems" after. `git -c core.excludesFile=/dev/null check-ignore` confirms the new pattern catches nested dirs without relying on a global ignore.

**Not changed:** the other dir-iterating prek scripts don't need this — `check_no_new_airflow_core_utils_modules.py` and `check_shared_distributions_usage.py` already skip dot-names, and the two `shared/` ones gate on a `pyproject.toml` marker. No unit test: `boring_cyborg.py` raises `SystemExit` when imported as a module, so it is deliberately outside the `scripts/tests/ci/prek/` suite, and making a one-line guard testable would mean undoing that.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)