### PR TITLE
Keep legacy Dag tree links working

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/LegacyTreeRedirect.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/LegacyTreeRedirect.test.tsx
@@ -1,0 +1,57 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render, waitFor } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+
+import { LegacyTreeRedirect } from "src/pages/LegacyTreeRedirect";
+
+describe("LegacyTreeRedirect", () => {
+  it("redirects legacy Dag links to the Dag overview", async () => {
+    const router = createMemoryRouter(
+      [
+        { element: <LegacyTreeRedirect />, path: "/tree" },
+        { element: <div>Dag overview</div>, path: "/dags/:dagId" },
+      ],
+      { initialEntries: ["/tree?dag_id=example_dag"] },
+    );
+
+    render(<RouterProvider router={router} />);
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe("/dags/example_dag");
+    });
+  });
+
+  it("redirects legacy links without a Dag ID to the Dag list", async () => {
+    const router = createMemoryRouter(
+      [
+        { element: <LegacyTreeRedirect />, path: "/tree" },
+        { element: <div>Dag list</div>, path: "/dags" },
+      ],
+      { initialEntries: ["/tree"] },
+    );
+
+    render(<RouterProvider router={router} />);
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe("/dags");
+    });
+  });
+});

--- a/airflow-core/src/airflow/ui/src/pages/LegacyTreeRedirect.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/LegacyTreeRedirect.tsx
@@ -1,0 +1,31 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Navigate, useSearchParams } from "react-router-dom";
+
+export const LegacyTreeRedirect = () => {
+  const [searchParams] = useSearchParams();
+  const dagId = searchParams.get("dag_id");
+
+  return (
+    <Navigate
+      replace
+      to={dagId !== null && dagId.length > 0 ? `/dags/${encodeURIComponent(dagId)}` : "/dags"}
+    />
+  );
+};

--- a/airflow-core/src/airflow/ui/src/router.tsx
+++ b/airflow-core/src/airflow/ui/src/router.tsx
@@ -49,6 +49,7 @@ import { GroupTaskInstance } from "src/pages/GroupTaskInstance";
 import { HITLTaskInstances } from "src/pages/HITLTaskInstances";
 import { Jobs } from "src/pages/Jobs";
 import { LandingPage } from "src/pages/LandingPage";
+import { LegacyTreeRedirect } from "src/pages/LegacyTreeRedirect";
 import { MappedTaskInstance } from "src/pages/MappedTaskInstance";
 import { Details as MappedTaskInstanceDetails } from "src/pages/MappedTaskInstance/Details";
 import { Plugins } from "src/pages/Plugins";
@@ -120,6 +121,10 @@ export const routerConfig = [
       {
         element: <DagsList />,
         path: "dags",
+      },
+      {
+        element: <LegacyTreeRedirect />,
+        path: "tree",
       },
       {
         element: (


### PR DESCRIPTION
Airflow 3 no longer serves the Airflow 2 `/tree?dag_id=...` URL, but external integrations such as DataHub still generate it. Those links currently end in a 404.

Add a compatibility route that redirects legacy tree links to the current Dag overview, preserving existing integration links while users migrate to the new URL format. The redirect also handles malformed links without a Dag ID by sending them to the Dag list.

closes: #72631

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Copilot (GPT-5)

Generated-by: Copilot (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)