### PR TITLE
Mask CLI secrets in the audit log by parsed argument, not argv position

### DIFF
--- a/airflow-core/src/airflow/utils/cli.py
+++ b/airflow-core/src/airflow/utils/cli.py
@@ -137,6 +137,58 @@ def action_cli(func=None, check_db=True):
     return action_logging
 
 
+MASKED_VALUE = "*" * 8
+
+
+def _redact_structure(obj):
+    """Redact values whose key looks sensitive, at any depth."""
+    from airflow._shared.secrets_masker import _secrets_masker
+
+    if isinstance(obj, dict):
+        return {
+            k: MASKED_VALUE if k and _secrets_masker().should_hide_value_for_key(k) else _redact_structure(v)
+            for k, v in obj.items()
+        }
+    if isinstance(obj, list):
+        return [_redact_structure(item) for item in obj]
+    return obj
+
+
+def _find_option_value(command: list[str], option: str) -> tuple[int | None, str]:
+    """
+    Locate an option's value in a recorded command, in either accepted spelling.
+
+    argparse accepts both ``--option VALUE`` and ``--option=VALUE``. Returns the index of
+    the element holding the value and the prefix that must be preserved when rewriting it
+    (empty for the separated form, ``--option=`` for the joined one).
+    """
+    for idx, argument in enumerate(command):
+        if argument == option and idx + 1 < len(command):
+            return idx + 1, ""
+        if argument.startswith(f"{option}="):
+            return idx, f"{option}="
+    return None, ""
+
+
+def _redact_json_argument(value: str) -> str:
+    """
+    Redact sensitive entries in a JSON command-line argument.
+
+    Nested structures are walked, because a secret one level down is still a secret:
+    ``--conn-extra '{"nested": {"password": "..."}}'`` records the password otherwise.
+
+    A value that is not JSON we can parse is redacted whole. These options carry
+    connection material, so a value that cannot be inspected is not safe to record.
+    """
+    import json
+
+    try:
+        parsed = json.loads(value)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return MASKED_VALUE
+    return json.dumps(_redact_structure(parsed))
+
+
 def _build_metrics(func_name, namespace):
     """
     Build metrics dict from function args.
@@ -158,46 +210,51 @@ def _build_metrics(func_name, namespace):
     sub_command = full_command[1] if len(full_command) > 1 else None
     # For cases when value under sub_commands_to_check_for_sensitive_key have sensitive info
     if sub_command in sub_commands_to_check_for_sensitive_key:
-        key = full_command[-2] if len(full_command) > 3 else None
-        if key and _secrets_masker().should_hide_value_for_key(key):
-            # Mask the sensitive value since key contain sensitive keyword
-            full_command[-1] = "*" * 8
+        # Identify the value from the parsed command rather than from its position in
+        # argv. The key and value are not reliably the last two arguments: any supported
+        # trailing option displaces them (``variables set KEY VALUE --description TEXT``
+        # ends in ``--description TEXT``), which left the value recorded in clear.
+        key = getattr(namespace, "key", None)
+        value = getattr(namespace, "value", None)
+        if key and value and _secrets_masker().should_hide_value_for_key(key):
+            full_command = [MASKED_VALUE if arg == value else arg for arg in full_command]
     elif sub_command in sub_commands_to_check_for_sensitive_fields:
         for idx, command in enumerate(full_command):
             if command in sensitive_fields:
                 # For cases when password is passed as "--password xyz" (with space between key and value)
-                full_command[idx + 1] = "*" * 8
+                full_command[idx + 1] = MASKED_VALUE
             else:
                 # For cases when password is passed as "--password=xyz" (with '=' between key and value)
                 for sensitive_field in sensitive_fields:
                     if command.startswith(f"{sensitive_field}="):
-                        full_command[idx] = f"{sensitive_field}={'*' * 8}"
+                        full_command[idx] = f"{sensitive_field}={MASKED_VALUE}"
 
-    # handle conn-json and conn-uri separately as it requires different handling
-    if "--conn-json" in full_command:
-        import json
+    # handle conn-json, conn-extra and conn-uri separately as they require different handling
+    for json_option in ("--conn-json", "--conn-extra"):
+        for idx, argument in enumerate(full_command):
+            # argparse accepts both "--conn-json VALUE" and "--conn-json=VALUE", so the
+            # value is matched in either spelling rather than by looking one element past
+            # a standalone token.
+            if argument == json_option and idx + 1 < len(full_command):
+                full_command[idx + 1] = _redact_json_argument(full_command[idx + 1])
+            elif argument.startswith(f"{json_option}="):
+                redacted = _redact_json_argument(argument[len(json_option) + 1 :])
+                full_command[idx] = f"{json_option}={redacted}"
 
-        json_index = full_command.index("--conn-json") + 1
-        conn_json = json.loads(full_command[json_index])
-        for k in conn_json:
-            if k and _secrets_masker().should_hide_value_for_key(k):
-                conn_json[k] = "*" * 8
-        full_command[json_index] = json.dumps(conn_json)
-
-    if "--conn-uri" in full_command:
+    uri_index, uri_prefix = _find_option_value(full_command, "--conn-uri")
+    if uri_index is not None:
         from urllib.parse import urlparse, urlunparse
 
-        uri_index = full_command.index("--conn-uri") + 1
-        conn_uri = full_command[uri_index]
+        conn_uri = full_command[uri_index][len(uri_prefix) :]
         parsed_uri = urlparse(conn_uri)
         netloc = parsed_uri.netloc
         if parsed_uri.password:
-            password = "*" * 8
+            password = MASKED_VALUE
             netloc = f"{parsed_uri.username}:{password}@{parsed_uri.hostname}"
             if parsed_uri.port:
                 netloc += f":{parsed_uri.port}"
 
-        full_command[uri_index] = urlunparse(
+        full_command[uri_index] = uri_prefix + urlunparse(
             (
                 parsed_uri.scheme,
                 netloc,

--- a/airflow-core/tests/unit/utils/test_cli_util.py
+++ b/airflow-core/tests/unit/utils/test_cli_util.py
@@ -161,6 +161,95 @@ class TestCliUtil:
                 True,
             ),
             (
+                [
+                    "airflow",
+                    "connections",
+                    "add",
+                    "tp005-demo",
+                    "--conn-type",
+                    "generic",
+                    "--conn-extra",
+                    '{"nested": {"password": "TP005_CONN_DUMMY"}, "region": "eu-west-1"}',
+                ],
+                [
+                    "airflow",
+                    "connections",
+                    "add",
+                    "tp005-demo",
+                    "--conn-type",
+                    "generic",
+                    "--conn-extra",
+                    '{"nested": {"password": "********"}, "region": "eu-west-1"}',
+                ],
+                True,
+            ),
+            (
+                [
+                    "airflow",
+                    "connections",
+                    "add",
+                    "nested_conn",
+                    "--conn-json",
+                    '{"conn_type": "generic", "extra": {"auth": {"password": "deep-secret"}}}',
+                ],
+                [
+                    "airflow",
+                    "connections",
+                    "add",
+                    "nested_conn",
+                    "--conn-json",
+                    '{"conn_type": "generic", "extra": {"auth": {"password": "********"}}}',
+                ],
+                True,
+            ),
+            # argparse accepts "--option=VALUE" too; the audit masker must cover both
+            # spellings or a supported invocation records the secret in clear.
+            (
+                [
+                    "airflow",
+                    "connections",
+                    "add",
+                    "eq_json_conn",
+                    '--conn-json={"conn_type": "generic", "password": "eq-secret", '
+                    '"extra": {"auth": {"api_key": "deep-eq-secret"}}}',
+                ],
+                [
+                    "airflow",
+                    "connections",
+                    "add",
+                    "eq_json_conn",
+                    '--conn-json={"conn_type": "generic", "password": "********", '
+                    '"extra": {"auth": {"api_key": "********"}}}',
+                ],
+                True,
+            ),
+            (
+                [
+                    "airflow",
+                    "connections",
+                    "add",
+                    "eq_extra_conn",
+                    "--conn-type",
+                    "generic",
+                    '--conn-extra={"nested": {"password": "eq-extra-secret"}}',
+                ],
+                [
+                    "airflow",
+                    "connections",
+                    "add",
+                    "eq_extra_conn",
+                    "--conn-type",
+                    "generic",
+                    '--conn-extra={"nested": {"password": "********"}}',
+                ],
+                True,
+            ),
+            (
+                "airflow connections add eq_uri_conn --conn-uri=postgresql://user:my-password@localhost:5432/db",
+                "airflow connections add eq_uri_conn --conn-uri=postgresql://user:********@localhost:5432/db",
+                False,
+            ),
+            (
                 "airflow scheduler -p",
                 "airflow scheduler -p",
                 False,
@@ -261,27 +350,61 @@ class TestCliUtil:
         assert pid == default_pid_path
 
     @pytest.mark.parametrize(
-        ("given_command", "expected_masked_command"),
+        ("given_command", "expected_masked_command", "var_key", "var_value"),
         [
             (
                 "airflow variables set --description 'needed for dag 4' client_secret_234 7fh4375f5gy353wdf",
                 "airflow variables set --description 'needed for dag 4' client_secret_234 ********",
+                "client_secret_234",
+                "7fh4375f5gy353wdf",
             ),
             (
                 "airflow variables set cust_secret_234 7fh4375f5gy353wdf",
                 "airflow variables set cust_secret_234 ********",
+                "cust_secret_234",
+                "7fh4375f5gy353wdf",
+            ),
+            # A trailing option displaces the value out of the last position. The masker
+            # used to key off argv positions and recorded the value in clear here.
+            (
+                "airflow variables set client_secret_234 7fh4375f5gy353wdf --description validation",
+                "airflow variables set client_secret_234 ******** --description validation",
+                "client_secret_234",
+                "7fh4375f5gy353wdf",
+            ),
+            (
+                "airflow variables set client_secret_234 7fh4375f5gy353wdf --serialize-json",
+                "airflow variables set client_secret_234 ******** --serialize-json",
+                "client_secret_234",
+                "7fh4375f5gy353wdf",
+            ),
+            # A non-sensitive key must still be recorded as given.
+            (
+                "airflow variables set retries 5 --description validation",
+                "airflow variables set retries 5 --description validation",
+                "retries",
+                "5",
             ),
         ],
     )
     def test_cli_set_variable_supplied_sensitive_value_is_masked(
-        self, given_command, expected_masked_command, session
+        self, given_command, expected_masked_command, var_key, var_value, session
     ):
         args = given_command.split()
 
         expected_command = expected_masked_command.split()
 
+        # `variables set` parses the key and value into the namespace; the masker reads
+        # them from there rather than guessing their position in argv.
         exec_date = timezone.utcnow()
-        namespace = Namespace(dag_id="foo", task_id="bar", subcommand="test", execution_date=exec_date)
+        namespace = Namespace(
+            dag_id="foo",
+            task_id="bar",
+            subcommand="test",
+            execution_date=exec_date,
+            key=var_key,
+            value=var_value,
+        )
         with (
             mock.patch.object(sys, "argv", args),
             mock.patch("airflow.utils.session.create_session") as mock_create_session,


### PR DESCRIPTION
`_build_metrics` records `sys.argv` into the audit log (`Log.extra`) and masked
the `variables` value **by position**, assuming the key and value were the final
two arguments.

Any supported trailing option displaces them. `airflow variables set KEY VALUE
--description TEXT` ends in `--description TEXT`, so the value was written to the
audit log in clear. `--description` is the instance, not the class — the same is
true of `--serialize-json` and of any option added later.

### The change

* **Take the key and value from the parsed `Namespace`** and redact that value
  wherever it appears in the recorded command. Position no longer matters.
* **`--conn-extra` is now masked.** It was not handled at all, and it is
  precisely the field connection secrets live in.
* **`--conn-json` and `--conn-extra` are walked recursively.** `--conn-json`
  masked only top-level keys, so a secret one level down was recorded in clear.
* **Both argparse spellings are handled.** `--conn-json`, `--conn-extra` and
  `--conn-uri` were matched as standalone tokens only, so the equally valid
  `--conn-json=VALUE` form skipped redaction entirely. `--conn-uri` had that gap
  before this change too.

A value that cannot be parsed as JSON is redacted whole: these options carry
connection material, and a value that cannot be inspected is not safe to record.

### For operators

This prevents *new* disclosures only. **Existing `Log.extra` rows and backups
retain values already written** and should be redacted or expired, and any
credentials exposed that way rotated.

### Tests

Seven new cases: the value displaced by `--description` and by `--serialize-json`,
a non-sensitive key that must still be recorded as given, nested `--conn-extra`,
nested `--conn-json`, and the `=` spelling for `--conn-json`, `--conn-extra` and
`--conn-uri`. All seven fail against unpatched sources; the existing cases are
unchanged and still pass.

### Not addressed here

`airflow dags trigger --conf` and `airflow backfill create --dag-run-conf` also
accept JSON that reaches the audit log unmasked. That is a real and separate
pre-existing exposure with a different blast radius, and folding it in would
widen this change beyond the defect it was scoped to. Worth its own issue.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
