### PR TITLE
Document that plugin FastAPI apps are not authenticated by Airflow

### DIFF
--- a/airflow-core/docs/administration-and-deployment/plugins.rst
+++ b/airflow-core/docs/administration-and-deployment/plugins.rst
@@ -225,6 +225,53 @@ definitions in Airflow.
     app_with_metadata = {"app": app, "url_prefix": "/some_prefix", "name": "Name of the App"}
 
 
+.. warning::
+
+    **Airflow does not authenticate plugin FastAPI apps. Authenticating them is the
+    plugin author's responsibility.**
+
+    Airflow authenticates the core API with a router-level dependency. A plugin app is
+    attached with ``app.mount()``, and a Starlette mount has its own route table and
+    inherits none of the parent's dependencies, so that dependency never reaches a
+    plugin's routes. No middleware in the API server authenticates them either.
+
+    Every route a plugin exposes is therefore reachable by **anonymous callers** unless
+    the plugin authenticates it itself. The minimal ``app`` above is a structural
+    illustration, not a template to deploy as-is.
+
+    Depend on ``GetUserDep`` to require a caller Airflow has authenticated:
+
+    .. code-block:: python
+
+        from fastapi import FastAPI
+
+        from airflow.api_fastapi.core_api.security import GetUserDep
+
+        app = FastAPI()
+
+
+        @app.get("/dashboard")
+        def dashboard(user: GetUserDep):
+            return {"user": user.get_name()}
+
+    Prefer attaching the dependency once, at the application or router level, so that a
+    route added later does not silently ship unauthenticated:
+
+    .. code-block:: python
+
+        from fastapi import Depends, FastAPI
+
+        from airflow.api_fastapi.core_api.security import get_user
+
+        app = FastAPI(dependencies=[Depends(get_user)])
+
+    Authentication is not authorization. ``GetUserDep`` establishes *who* is calling;
+    whether that user may perform a given action remains the plugin's own decision. This
+    applies to team scoping too — in a multi-team deployment, a plugin that does not check
+    the caller's team serves every team's users the same data.
+
+.. code-block:: python
+
     # Creating a FastAPI middleware that will operates on all the server api requests.
     middleware_with_metadata = {
         "middleware": TrustedHostMiddleware,

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1628,6 +1628,7 @@ Stackdriver
 stackdriver
 stacklevel
 stacktrace
+Starlette
 starttls
 stateful
 StatefulSet


### PR DESCRIPTION
Airflow authenticates the core API with a router-level dependency. A plugin app is attached with `app.mount()`, and a Starlette mount has its own route table and inherits none of the parent's dependencies, so that dependency never reaches a plugin's routes. No middleware in the API server authenticates them either.

The consequence is that every route a plugin exposes is reachable by anonymous callers unless the plugin authenticates it itself — and the documented example is exactly that shape: a plain route, with no authentication and no note saying one is needed. A deployment that follows the docs ships plugin endpoints pre-auth without being told.

### What changed since the first revision

This PR originally mounted every plugin app behind a `PluginAuthenticationMiddleware`, with a `public: True` opt-out. @pierrejeambrun pushed back on that, and the objection is right: it is a breaking change for plugins that legitimately serve anonymous callers, and access control for a plugin's own routes belongs to the plugin author, not to core. Core mounting the app is not core owning its authorization model.

So the enforcement is dropped and the gap is documented where people actually read it. The middleware, the `public` flag, the `app.py` changes and their tests are all gone; this is now a documentation-only change to `plugins.rst`.

### What the docs now say

- Airflow does **not** authenticate plugin FastAPI apps, stated plainly, with the reason (`app.mount()` does not inherit dependencies).
- The minimal example is called out as a structural illustration, not a deployable template.
- `GetUserDep` shown on a route.
- The application-level form, `FastAPI(dependencies=[Depends(get_user)])`, so that a route added later does not silently ship unauthenticated.
- Authentication is not authorization — including team scoping, which a plugin must check for itself.

No behaviour change, so no newsfragment.
