### PR TITLE
Avoid parsing templated DateTimeSensorAsync targets at Dag parse time

### DIFF
--- a/providers/standard/src/airflow/providers/standard/sensors/date_time.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/date_time.py
@@ -114,6 +114,15 @@ class DateTimeSensorAsync(DateTimeSensor):
         super().__init__(**kwargs)
         self.end_from_trigger = end_from_trigger
 
+        # A templated target is rendered after Dag parsing, so it cannot be used to
+        # construct the trigger arguments at task initialization time.
+        if (
+            start_from_trigger
+            and isinstance(self.target_time, str)
+            and any(delimiter in self.target_time for delimiter in ("{{", "{%", "{#"))
+        ):
+            start_from_trigger = False
+
         self.start_from_trigger = start_from_trigger
         if self.start_from_trigger:
             # Replaced rather than mutated: ``start_trigger_args`` is a class attribute, so

--- a/providers/standard/tests/unit/standard/sensors/test_date_time.py
+++ b/providers/standard/tests/unit/standard/sensors/test_date_time.py
@@ -158,6 +158,16 @@ class TestDateTimeSensor:
         )
         assert op.start_trigger_args.trigger_kwargs["moment"] == pendulum.datetime(2020, 1, 1, tz="UTC")
 
+    def test_async_start_from_trigger_skips_templated_target_time(self):
+        op = DateTimeSensorAsync(
+            task_id="async_templated",
+            target_time="{{ data_interval_end }}",
+            start_from_trigger=True,
+            dag=self.dag,
+        )
+
+        assert op.start_from_trigger is False
+
     def test_start_trigger_args_are_not_shared_between_tasks(self):
         """Each task must carry its own trigger arguments.
 


### PR DESCRIPTION
## Why

`DateTimeSensorAsync` can be configured with `start_from_trigger=True`, but templated `target_time` values are rendered after Dag parsing. Calling `_moment` in `__init__` therefore parses the raw Jinja expression and crashes the Dag.

## What changed

Keep triggerer-start for concrete targets, but fall back to the normal worker path when `target_time` contains a Jinja template. The worker path resolves the rendered datetime before constructing `DateTimeTrigger`.

Fixes #70284

## Verification

- `uv run --project providers/standard pytest providers/standard/tests/unit/standard/sensors/test_date_time.py -xvs` (16 passed)
- `uvx prek run --stage pre-commit --files providers/standard/src/airflow/providers/standard/sensors/date_time.py providers/standard/tests/unit/standard/sensors/test_date_time.py`
