### PR TITLE
[v3-3-test] Prevent Dag-existence disclosure on partitioned dag runs …

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -187,6 +187,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PartitionedDagRunCollectionResponse'
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Not Found
         '422':
           description: Validation Error
           content:

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/partitioned_dag_runs.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/partitioned_dag_runs.py
@@ -38,6 +38,7 @@ from airflow.api_fastapi.core_api.datamodels.ui.partitioned_dag_runs import (
     PartitionedDagRunDetailResponse,
     PartitionedDagRunResponse,
 )
+from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
 from airflow.api_fastapi.core_api.security import (
     ReadableDagsFilterDep,
     requires_access_asset,
@@ -240,6 +241,7 @@ def _build_response(row, required_count: int, received_count: int) -> Partitione
 
 @partitioned_dag_runs_router.get(
     "/partitioned_dag_runs",
+    responses=create_openapi_http_exception_doc([status.HTTP_404_NOT_FOUND]),
     dependencies=[Depends(requires_access_asset(method="GET"))],
 )
 def get_partitioned_dag_runs(
@@ -272,8 +274,14 @@ def get_partitioned_dag_runs(
 
     if not (rows := session.execute(query).all()):
         if dag_id.value is not None:
-            dag_exists = session.scalar(select(DagModel.dag_id).where(DagModel.dag_id == dag_id.value))
-            if dag_exists is None:
+            # An unreadable-but-existing Dag must return 404 too — otherwise the caller
+            # can probe by dag_id and learn which Dags exist outside their permitted set.
+            if readable_dag_ids is not None:
+                if dag_id.value not in readable_dag_ids:
+                    raise HTTPException(
+                        status.HTTP_404_NOT_FOUND, f"Dag with id {dag_id.value} was not found"
+                    )
+            elif session.scalar(select(DagModel.dag_id).where(DagModel.dag_id == dag_id.value)) is None:
                 raise HTTPException(status.HTTP_404_NOT_FOUND, f"Dag with id {dag_id.value} was not found")
         return PartitionedDagRunCollectionResponse(partitioned_dag_runs=[], total=0)
 

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -4608,6 +4608,7 @@ export class PartitionedDagRunService {
                 has_created_dag_run_id: data.hasCreatedDagRunId
             },
             errors: {
+                404: 'Not Found',
                 422: 'Validation Error'
             }
         });

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -8190,6 +8190,10 @@ export type $OpenApiTs = {
                  */
                 200: PartitionedDagRunCollectionResponse;
                 /**
+                 * Not Found
+                 */
+                404: HTTPExceptionResponse;
+                /**
                  * Validation Error
                  */
                 422: HTTPValidationError;

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_partitioned_dag_runs.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_partitioned_dag_runs.py
@@ -256,6 +256,33 @@ class TestGetPartitionedDagRuns:
         dag_ids = {r["dag_id"] for r in body["partitioned_dag_runs"]}
         assert "restricted_dag" not in dag_ids
 
+    @mock.patch(
+        "airflow.api_fastapi.auth.managers.base_auth_manager.BaseAuthManager.get_authorized_dag_ids",
+        return_value={"other_dag"},
+    )
+    def test_dag_id_filter_does_not_disclose_unreadable_dag_existence(
+        self, _, test_client, dag_maker, session
+    ):
+        """
+        An unreadable-but-existing Dag must not be distinguishable from a nonexistent
+        Dag via the ``dag_id`` filter: both return 404. Without the scoping, the
+        readable-dags row filter drops the APDR rows, ``total_entries`` collapses to
+        0, and the DagModel probe still finds the Dag — returning 200-empty and
+        giving the caller an oracle for Dag ids outside their permitted set.
+        """
+        schedule = PartitionedAssetTimetable(assets=Asset(uri="s3://bucket/a", name="a"))
+        with dag_maker(dag_id="restricted_dag", schedule=schedule, serialized=True):
+            EmptyOperator(task_id="t")
+        dag_maker.sync_dagbag_to_db()
+        # An APDR row exists but the readable-dags filter drops it — this is the
+        # branch where the pre-fix DagModel probe leaked existence.
+        session.add(AssetPartitionDagRun(target_dag_id="restricted_dag", partition_key="2024-06-01"))
+        session.commit()
+
+        existing_unreadable = test_client.get("/partitioned_dag_runs?dag_id=restricted_dag")
+        nonexistent = test_client.get("/partitioned_dag_runs?dag_id=no_such_dag")
+        assert existing_unreadable.status_code == nonexistent.status_code == 404
+
     def test_duplicate_events_count_as_one(self, test_client, dag_maker, session):
         """Multiple log entries for the same asset count as 1 received, not N."""
         asset_def = Asset(uri="s3://bucket/dup0", name="dup0")


### PR DESCRIPTION
…listing (#72640)

* Prevent Dag-existence disclosure on partitioned dag runs listing

The empty-results branch of the /ui/partitioned_dag_runs listing raised 404 when a Dag did not exist, but returned 200-empty when a Dag existed but was outside the caller's permitted set (the readable-dags row filter had already dropped its rows). A caller could therefore probe by dag_id and learn which identifiers exist beyond what they are allowed to read.

Scope the existence probe to readable Dags so the two cases collapse to the same 404, matching the "so their existence does not leak either" idiom used by PermittedEventLogFilter / PermittedAssetEventFilter. Behavior is unchanged for callers with full Dag access.

* Simplify existence check and strengthen leak-regression test

readable_dag_ids already comes from DagModel in both in-tree auth managers, so membership in the set proves existence — the extra DagModel round-trip and IN list is only useful for the admin path, where no filter is active.

Add an AssetPartitionDagRun for the unreadable Dag in the regression test so the readable-dags row filter is what drops the rows, matching the scenario the docstring describes.

* Declare 404 response on the partitioned dag runs listing

The listing raises HTTPException(404) when a dag_id filter targets a Dag the caller cannot see, but the route did not declare 404 in its OpenAPI responses. Clients generated from the spec therefore treated 404 as an unexpected transport error rather than a documented outcome, and the API docs page did not surface it.

* Tighten comment on the existence-check branch (cherry picked from commit 5c40e732444ed67c2b3f76c699aace93d520c6a6)

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
