### PR TITLE
Stop trigger rule evaluation removing valid mapped task instances

### DIFF
--- a/airflow-core/newsfragments/72668.bugfix.rst
+++ b/airflow-core/newsfragments/72668.bugfix.rst
@@ -1,0 +1,1 @@
+Stop the ``all_success`` trigger rule from marking mapped task instances ``REMOVED`` when their expansion input did not change

--- a/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import collections.abc
 import functools
 from collections import Counter
-from collections.abc import Iterator, KeysView, Mapping
+from collections.abc import Collection, Iterator, KeysView, Mapping
 from typing import TYPE_CHECKING, NamedTuple
 
 from sqlalchemy import and_, func, or_, select
@@ -87,6 +87,28 @@ class _UpstreamTIStates(NamedTuple):
             success_setup=setup_counter.get(TaskInstanceState.SUCCESS, 0),
             skipped_setup=setup_counter.get(TaskInstanceState.SKIPPED, 0),
         )
+
+
+def _covers_expansion_one_to_one(task, counted_task_ids: Collection[str]) -> bool:
+    """
+    Whether the counted upstream instances map 1:1 onto this task's expansion.
+
+    Inferring instance removal from upstream state counts is only sound when this task expands
+    over exactly one XCom reference, that reference is the entire counted upstream set, and no
+    literal or mapped task group multiplies the length. Otherwise the task's expansion length
+    has no relation to the counts: comparing ``map_index`` against the success count would
+    remove valid instances (static lists, zips, multiple upstreams).
+    """
+    if task.get_closest_mapped_task_group() is not None:
+        return False
+    iter_deps = getattr(task, "iter_mapped_dependencies", None)
+    if iter_deps is None:
+        return False
+    referenced = [op.task_id for op in iter_deps()]
+    if len(referenced) != 1 or set(referenced) != set(counted_task_ids):
+        return False
+    expand_value = task._get_specified_expand_input().value
+    return not isinstance(expand_value, Mapping) or len(expand_value) == 1
 
 
 class TriggerRuleDep(BaseTIDep):
@@ -318,9 +340,8 @@ class TriggerRuleDep(BaseTIDep):
                     new_state = TaskInstanceState.UPSTREAM_FAILED
                 elif skipped:
                     new_state = TaskInstanceState.SKIPPED
-                elif removed and success and ti.map_index > -1:
-                    if ti.map_index >= success:
-                        new_state = TaskInstanceState.REMOVED
+                # No REMOVED inference here: a task can only expand over a direct upstream,
+                # and this branch counts indirect setups only.
 
             if new_state is not None:
                 if (
@@ -432,9 +453,12 @@ class TriggerRuleDep(BaseTIDep):
                         new_state = TaskInstanceState.UPSTREAM_FAILED
                     elif skipped:
                         new_state = TaskInstanceState.SKIPPED
-                    elif removed and success and ti.map_index > -1:
-                        if ti.map_index >= success:
-                            new_state = TaskInstanceState.REMOVED
+                    elif removed and ti.map_index > -1:
+                        # All counted (live) instances are successes here, so with a strict 1:1
+                        # mapping the success count is the ti's own post-shrink expansion length.
+                        if upstream_done and _covers_expansion_one_to_one(task, task.upstream_task_ids):
+                            if ti.map_index >= success:
+                                new_state = TaskInstanceState.REMOVED
                 elif trigger_rule == TR.ALL_FAILED:
                     if success or skipped:
                         new_state = TaskInstanceState.SKIPPED

--- a/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -89,23 +89,25 @@ class _UpstreamTIStates(NamedTuple):
         )
 
 
-def _covers_expansion_one_to_one(task, counted_task_ids: Collection[str]) -> bool:
+def _covers_expansion_one_to_one(task: Operator, counted_task_ids: Collection[str]) -> bool:
     """
     Whether the counted upstream instances map 1:1 onto this task's expansion.
 
     Inferring instance removal from upstream state counts is only sound when this task expands
-    over exactly one XCom reference, that reference is the entire counted upstream set, and no
-    literal or mapped task group multiplies the length. Otherwise the task's expansion length
-    has no relation to the counts: comparing ``map_index`` against the success count would
-    remove valid instances (static lists, zips, multiple upstreams).
+    over exactly one XCom reference, that reference is the entire counted upstream set, the
+    referenced task is itself expanded (an unmapped task has one instance however long the list
+    it returns), and no literal or mapped task group multiplies the length. Otherwise the task's
+    expansion length has no relation to the counts: comparing ``map_index`` against the success
+    count would remove valid instances (static lists, zips, multiple upstreams).
     """
-    if task.get_closest_mapped_task_group() is not None:
+    from airflow.serialization.definitions.mappedoperator import is_mapped
+
+    if task.get_closest_mapped_task_group() is not None or not is_mapped(task):
         return False
-    iter_deps = getattr(task, "iter_mapped_dependencies", None)
-    if iter_deps is None:
+    referenced = list(task.iter_mapped_dependencies())
+    if len(referenced) != 1 or {op.task_id for op in referenced} != set(counted_task_ids):
         return False
-    referenced = [op.task_id for op in iter_deps()]
-    if len(referenced) != 1 or set(referenced) != set(counted_task_ids):
+    if not referenced[0].get_needs_expansion():
         return False
     expand_value = task._get_specified_expand_input().value
     return not isinstance(expand_value, Mapping) or len(expand_value) == 1
@@ -453,7 +455,7 @@ class TriggerRuleDep(BaseTIDep):
                         new_state = TaskInstanceState.UPSTREAM_FAILED
                     elif skipped:
                         new_state = TaskInstanceState.SKIPPED
-                    elif removed and ti.map_index > -1:
+                    elif removed and success and ti.map_index > -1:
                         # All counted (live) instances are successes here, so with a strict 1:1
                         # mapping the success count is the ti's own post-shrink expansion length.
                         if upstream_done and _covers_expansion_one_to_one(task, task.upstream_task_ids):

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -1246,8 +1246,8 @@ class TestTaskInstance:
             ["all_success", _UpstreamTIStates(2, 0, 0, 0, 0, 0, 0, 0), True, None, False],
             ["all_success", _UpstreamTIStates(2, 0, 1, 0, 0, 0, 0, 0), True, State.UPSTREAM_FAILED, False],
             ["all_success", _UpstreamTIStates(2, 1, 0, 0, 0, 0, 0, 0), True, State.SKIPPED, False],
-            # ti.map_index >= success
-            ["all_success", _UpstreamTIStates(3, 0, 0, 0, 2, 0, 0, 0), True, State.REMOVED, True],
+            # 1:1 mapped upstream shrank: map_index >= success once the upstream is done
+            ["all_success", _UpstreamTIStates(3, 0, 0, 0, 2, 5, 0, 0), True, State.REMOVED, True],
             #
             # Tests for one_success
             #

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -1248,6 +1248,8 @@ class TestTaskInstance:
             ["all_success", _UpstreamTIStates(2, 1, 0, 0, 0, 0, 0, 0), True, State.SKIPPED, False],
             # 1:1 mapped upstream shrank: map_index >= success once the upstream is done
             ["all_success", _UpstreamTIStates(3, 0, 0, 0, 2, 5, 0, 0), True, State.REMOVED, True],
+            # same counts while the upstream is still running: no removal inference yet
+            ["all_success", _UpstreamTIStates(3, 0, 0, 0, 2, 0, 0, 0), True, None, True],
             #
             # Tests for one_success
             #

--- a/airflow-core/tests/unit/ti_deps/deps/test_trigger_rule_dep.py
+++ b/airflow-core/tests/unit/ti_deps/deps/test_trigger_rule_dep.py
@@ -2381,3 +2381,65 @@ class TestTriggerRuleUpstreamCountMemo:
         assert evolved.upstream_task_id_counts is dep_context.upstream_task_id_counts
         evolved.upstream_task_id_counts[("d", "r", frozenset({"u2"}))] = [("u2", 1)]
         assert ("d", "r", frozenset({"u2"})) in dep_context.upstream_task_id_counts
+
+
+class TestRemovedInferenceOnlyForOneToOneMapping:
+    """
+    A removed upstream instance may only remove downstream instances when the downstream
+    expands 1:1 over exactly that upstream and every upstream instance is done. The success
+    count says nothing about any other topology's expansion length.
+    """
+
+    def test_static_downstream_survives_upstream_shrink(self, dag_maker, session):
+        with dag_maker("test_static_downstream_shrink", serialized=True):
+
+            @task
+            def process(x):
+                return x
+
+            @task
+            def notify(channel):
+                return channel
+
+            processed = process.expand(x=[1, 2, 3, 4, 5])
+            alerts = notify.expand(channel=["email", "slack", "pagerduty"])
+            processed >> alerts
+
+        dr = dag_maker.create_dagrun()
+        dr.task_instance_scheduling_decisions(session=session)
+        session.flush()
+
+        for ti in dr.get_task_instances(session=session):
+            if ti.task_id == "process":
+                ti.set_state(
+                    TaskInstanceState.SUCCESS if ti.map_index < 2 else TaskInstanceState.REMOVED,
+                    session=session,
+                )
+        session.flush()
+
+        dr.task_instance_scheduling_decisions(session=session)
+        session.flush()
+        session.expire_all()
+
+        notify_states = {
+            ti.map_index: ti.state for ti in dr.get_task_instances(session=session) if ti.task_id == "notify"
+        }
+        assert notify_states == {0: None, 1: None, 2: None}
+
+    def test_one_to_one_downstream_not_removed_while_upstream_running(self, session, get_mapped_task_dagrun):
+        dr, task, _ = get_mapped_task_dagrun()
+
+        still_running = dr.get_task_instance(task_id="do_something", map_index=1, session=session)
+        still_running.state = TaskInstanceState.RUNNING
+        session.merge(still_running)
+        session.flush()
+
+        ti = dr.get_task_instance(task_id="do_something_else", map_index=2, session=session)
+        ti.task = task
+        _test_trigger_rule(
+            ti=ti,
+            session=session,
+            flag_upstream_failed=True,
+            expected_reason="requires all upstream tasks to have succeeded",
+            expected_ti_state=None,
+        )

--- a/airflow-core/tests/unit/ti_deps/deps/test_trigger_rule_dep.py
+++ b/airflow-core/tests/unit/ti_deps/deps/test_trigger_rule_dep.py
@@ -2426,6 +2426,81 @@ class TestRemovedInferenceOnlyForOneToOneMapping:
         }
         assert notify_states == {0: None, 1: None, 2: None}
 
+    def test_indirect_setup_shrink_does_not_remove_literal_mapped_downstream(self, dag_maker, session):
+        with dag_maker("test_indirect_setup_shrink", serialized=True):
+
+            @task
+            def prepare(x):
+                return x
+
+            @task
+            def process(x):
+                return x
+
+            @task
+            def notify(channel):
+                return channel
+
+            prepared = prepare.expand(x=[1, 2, 3, 4, 5])
+            processed = process.expand(x=[1, 2, 3, 4, 5])
+            alerts = notify.expand(channel=["email", "slack", "pagerduty"])
+            prepared.as_setup() >> processed >> alerts
+
+        dr = dag_maker.create_dagrun()
+        dr.task_instance_scheduling_decisions(session=session)
+        session.flush()
+
+        for ti in dr.get_task_instances(session=session):
+            if ti.task_id == "prepare":
+                ti.set_state(
+                    TaskInstanceState.SUCCESS if ti.map_index < 2 else TaskInstanceState.REMOVED,
+                    session=session,
+                )
+            elif ti.task_id == "process":
+                ti.set_state(TaskInstanceState.SUCCESS, session=session)
+        session.flush()
+
+        dr.task_instance_scheduling_decisions(session=session)
+        session.flush()
+        session.expire_all()
+
+        notify_states = {
+            ti.map_index: ti.state for ti in dr.get_task_instances(session=session) if ti.task_id == "notify"
+        }
+        assert notify_states == {0: None, 1: None, 2: None}
+
+    def test_unmapped_upstream_removed_keeps_downstream_instances(self, dag_maker, session):
+        with dag_maker("test_unmapped_upstream_removed", serialized=True) as dag:
+
+            @task
+            def producer():
+                return [1, 2, 3]
+
+            @task
+            def work(arg):
+                return arg
+
+            work.expand(arg=producer())
+
+        dr = dag_maker.create_dagrun()
+        work_ti = dr.get_task_instance("work", session=session)
+        work_ti.map_index = 0
+        dag_version = DagVersion.get_latest_version(dag.dag_id, session=session)
+        for map_index in range(1, 3):
+            expanded = TaskInstance(
+                work_ti.task, run_id=dr.run_id, map_index=map_index, dag_version_id=dag_version.id
+            )
+            session.add(expanded)
+            expanded.dag_run = dr
+        dr.get_task_instance("producer", session=session).set_state(
+            TaskInstanceState.REMOVED, session=session
+        )
+        session.flush()
+
+        ti = dr.get_task_instance("work", map_index=2, session=session)
+        ti.task = dag.get_task("work")
+        _test_trigger_rule(ti=ti, session=session, flag_upstream_failed=True, expected_ti_state=None)
+
     def test_one_to_one_downstream_not_removed_while_upstream_running(self, session, get_mapped_task_dagrun):
         dr, task, _ = get_mapped_task_dagrun()
 


### PR DESCRIPTION
The `all_success` trigger rule can silently mark mapped task instances REMOVED although their own expansion input never changed. The instances never execute and the run still completes green.

Reproduced through the real scheduling-decision path. `notify` maps over an unchanged 3-element literal downstream of a mapped task that shrank from 5 to 2 on a rerun:

```
GATE notify before decision: {0: None, 1: None, 2: None}
GATE notify after decision:  {2: 'removed', ...}
```

### Root cause

Since 2.4 the flag-upstream-failed path infers staleness by comparing an instance's `map_index` against the aggregate upstream success count. That proxy only equals the instance's own new expansion length when the task expands 1:1 over exactly the counted upstream and every upstream instance is done. For any other topology the comparison removes valid instances: a static list downstream of a shrunk mapped task, a zip, several upstream tasks summed into one count, or an evaluation that runs while upstream instances are still finishing. The dep's own pass arithmetic agrees the rule is satisfied in these cases (`num_failures` is 0).

### Fix

The inference now fires only for a strict 1:1 mapping, where the task's sole expansion reference is exactly the counted upstream and nothing multiplies the length, and only once the upstream is fully done, which also closes the race. The setup-constraint path no longer infers removal at all: a task can only expand over a direct upstream, and that path counts indirect setups only. The rerun-deadlock scenario the inference was introduced for still resolves; its tests pass unchanged.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
