### PR TITLE
Fail the run visibly when a task vanishes from the Dag while unfinished

### DIFF
--- a/airflow-core/newsfragments/72669.bugfix.rst
+++ b/airflow-core/newsfragments/72669.bugfix.rst
@@ -1,0 +1,1 @@
+Fail a Dag run instead of completing it as success when a task is removed from the Dag while its instance is unfinished

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -1188,7 +1188,14 @@ class DagRun(Base, LoggingMixin):
         if not leaf_task_ids:
             # can happen if dag is exclusively teardown tasks
             leaf_task_ids = {x.task_id for x in dag.tasks if not x.downstream_list}
-        leaf_tis = {ti for ti in tis if ti.task_id in leaf_task_ids if ti.state != TaskInstanceState.REMOVED}
+        # An instance whose task is gone from the Dag has no downstream in it either, so it
+        # is an effective leaf.
+        leaf_tis = {
+            ti
+            for ti in tis
+            if ti.task_id in leaf_task_ids or ti.task_id not in dag.task_dict
+            if ti.state != TaskInstanceState.REMOVED
+        }
         return leaf_tis
 
     def _emit_dagrun_span(self, state: DagRunState):
@@ -1458,7 +1465,18 @@ class DagRun(Base, LoggingMixin):
                 try:
                     ti.task = dag.get_task(ti.task_id)
                 except TaskNotFound:
-                    if ti.state != TaskInstanceState.REMOVED:
+                    if ti.state in State.unfinished:
+                        # Marking an unfinished instance REMOVED would erase a pending retry or
+                        # a live failure and complete the run green. It is failed and yielded
+                        # instead, so the failure counts when the run state is decided.
+                        self.log.error(
+                            "Task for ti %s vanished from the Dag while unfinished. Marking it as failed.",
+                            ti,
+                        )
+                        ti.state = TaskInstanceState.FAILED
+                        session.flush()
+                        yield ti
+                    elif ti.state != TaskInstanceState.REMOVED:
                         self.log.error("Failed to get task for ti %s. Marking it as removed.", ti)
                         ti.state = TaskInstanceState.REMOVED
                         session.flush()

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -5062,3 +5062,46 @@ class TestApplyPartitionDateWindowSubDay:
             session=session,
         )
         assert cleared == 3
+
+
+class TestTaskVanishedFromDagMidRun:
+    """A task removed from the Dag while its instance is unfinished must fail visibly."""
+
+    def _make_run_and_redeploy_without_b(self, dag_maker, session, b_state):
+        with dag_maker("test_vanished_task", serialized=True):
+            EmptyOperator(task_id="a") >> EmptyOperator(task_id="b")
+        dr = dag_maker.create_dagrun()
+        tis = {ti.task_id: ti for ti in dr.get_task_instances(session=session)}
+        tis["a"].set_state(TaskInstanceState.SUCCESS, session=session)
+        tis["b"].set_state(b_state, session=session)
+        session.flush()
+
+        with dag_maker("test_vanished_task", serialized=True):
+            EmptyOperator(task_id="a")
+
+        from airflow.models.dagbag import DBDagBag
+
+        dag = DBDagBag().get_dag_for_run(dr, session=session)
+        assert sorted(dag.task_dict) == ["a"]
+        dr.dag = dag
+        return dr, tis["b"]
+
+    @pytest.mark.parametrize(
+        "b_state",
+        [TaskInstanceState.UP_FOR_RETRY, TaskInstanceState.DEFERRED, TaskInstanceState.QUEUED],
+    )
+    def test_unfinished_instance_fails_the_run(self, dag_maker, session, b_state):
+        dr, ti_b = self._make_run_and_redeploy_without_b(dag_maker, session, b_state)
+        dr.update_state(session=session)
+        session.flush()
+        session.expire_all()
+        assert ti_b.state == TaskInstanceState.FAILED
+        assert dr.state == DagRunState.FAILED
+
+    def test_finished_instance_still_marked_removed(self, dag_maker, session):
+        dr, ti_b = self._make_run_and_redeploy_without_b(dag_maker, session, TaskInstanceState.SUCCESS)
+        dr.update_state(session=session)
+        session.flush()
+        session.expire_all()
+        assert ti_b.state == TaskInstanceState.REMOVED
+        assert dr.state == DagRunState.SUCCESS


### PR DESCRIPTION
On default (unversioned) bundles, redeploying a Dag without one of its tasks while a run still has that task unfinished makes the scheduler erase the pending work and complete the run as success. The success callback fires although a task failed and was waiting to retry.

Reproduced with the scheduler's real version resolution and `update_state`:

```
GATE before: b=up_for_retry, run=running, bundle_version=None
GATE scheduler resolves run to task set: ['a']
GATE after: b=removed, run=success
```

### Root cause

A run with no bundle version always resolves to the latest Dag version. `task_instance_scheduling_decisions` then hits `TaskNotFound` for the vanished task and sets the instance to REMOVED unconditionally, clobbering UP_FOR_RETRY, QUEUED, RUNNING, or DEFERRED. REMOVED instances are excluded from run-state evaluation, so the run completes green. This behavior dates to 2.0.1, which fixed a scheduler crash by choosing unconditional removal. The same file already disagrees with it: `verify_integrity` deliberately refuses to remove instances of a running run.

### Fix

An unfinished instance whose task no longer exists is now failed instead of removed, and counts as an effective leaf (it has no downstream in the Dag), so the run finishes failed and the log says why. Finished instances keep the existing REMOVED behavior. The same scenario now yields:

```
GATE after: b=failed, run=failed
```

The failure callback fires instead of the success one.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
