### PR TITLE
Stop the Execution API lazy-loading asset event relations per event

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/asset_events.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/asset_events.py
@@ -21,6 +21,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy import and_, select
+from sqlalchemy.orm import joinedload, selectinload
 
 from airflow.api_fastapi.common.db.common import SessionDep
 from airflow.api_fastapi.common.parameters import (
@@ -55,7 +56,13 @@ def _get_asset_events_through_sql_clauses(
     filters: list[BaseParam] | None = None,
 ) -> AssetEventsResponse:
     order_by_clause = AssetEvent.timestamp.asc() if ascending else AssetEvent.timestamp.desc()
-    asset_events_query = select(AssetEvent).join(join_clause).where(where_clause).order_by(order_by_clause)
+    asset_events_query = (
+        select(AssetEvent)
+        .join(join_clause)
+        .where(where_clause)
+        .order_by(order_by_clause)
+        .options(joinedload(AssetEvent.asset), selectinload(AssetEvent.created_dagruns))
+    )
     for filter_ in filters or []:
         asset_events_query = filter_.to_orm(asset_events_query)
     if limit:

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -36,7 +36,7 @@ from pydantic import JsonValue, ValidationError
 from sqlalchemy import and_, func, or_, tuple_, update
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import DataError, NoResultFound, SQLAlchemyError
-from sqlalchemy.orm import contains_eager, joinedload
+from sqlalchemy.orm import contains_eager, joinedload, selectinload
 from sqlalchemy.sql import select
 from structlog.contextvars import bind_contextvars
 
@@ -83,7 +83,7 @@ from airflow.api_fastapi.execution_api.services.task_instances import (
 )
 from airflow.configuration import conf
 from airflow.exceptions import InvalidPartitionKeyError, TaskNotFound
-from airflow.models.asset import AssetActive
+from airflow.models.asset import AssetActive, AssetEvent
 from airflow.models.base import ID_LEN
 from airflow.models.dag import DagModel
 from airflow.models.dagrun import DagRun as DR
@@ -264,7 +264,12 @@ def ti_run(
             session.scalars(
                 select(DR)
                 .filter_by(dag_id=ti.dag_id, run_id=ti.run_id)
-                .options(joinedload(DR.consumed_asset_events), *eager_load_teams(DR.dag_model))
+                .options(
+                    joinedload(DR.consumed_asset_events).options(
+                        joinedload(AssetEvent.asset), selectinload(AssetEvent.source_aliases)
+                    ),
+                    *eager_load_teams(DR.dag_model),
+                )
             )
             .unique()
             .one_or_none()

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_asset_events.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_asset_events.py
@@ -1146,3 +1146,39 @@ def test_get_by_asset_resolves_event_relationships_once(client, session):
         return sum(result.values())
 
     assert _measure(12) == _measure(3)
+
+
+def test_get_by_asset_alias_resolves_a_different_asset_per_event_once(client, session):
+    """by-asset-alias must not lazy-load the asset once per event when every event has its own asset."""
+    from datetime import timedelta
+
+    from airflow.models.asset import AssetActive, AssetAliasModel, AssetEvent, AssetModel
+
+    from tests_common.test_utils.asserts import CountQueries
+
+    def _measure(n):
+        alias = AssetAliasModel(name=f"alias_{n}")
+        for i in range(n):
+            asset = AssetModel(
+                name=f"alias_{n}_asset_{i}", uri=f"s3://alias-{n}/{i}", group="asset", extra={}
+            )
+            session.add_all([asset, AssetActive.for_asset(asset)])
+            session.flush()
+            alias.asset_events.append(
+                AssetEvent(
+                    asset_id=asset.id,
+                    source_dag_id="src",
+                    source_run_id=f"r{i}",
+                    timestamp=DEFAULT_DATE + timedelta(seconds=i),
+                )
+            )
+        session.add(alias)
+        session.commit()
+        with CountQueries() as result:
+            response = client.get("/execution/asset-events/by-asset-alias", params={"name": alias.name})
+        assert response.status_code == 200, response.text
+        assert len(response.json()["asset_events"]) == n
+        assert len({event["asset"]["name"] for event in response.json()["asset_events"]}) == n
+        return sum(result.values())
+
+    assert _measure(12) == _measure(3)

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_asset_events.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_asset_events.py
@@ -1103,3 +1103,46 @@ class TestGetAssetEventByAssetAliasExtraFilter:
         )
         assert response.status_code == 200
         assert len(response.json()["asset_events"]) == expected_count
+
+
+def test_get_by_asset_resolves_event_relationships_once(client, session):
+    """by-asset must not lazy-load created_dagruns and asset once per event."""
+    from datetime import timedelta
+
+    from airflow.models.asset import AssetActive, AssetEvent, AssetModel
+
+    from tests_common.test_utils.asserts import CountQueries
+
+    def _measure(n):
+        asset = AssetModel(name=f"by_asset_{n}", uri=f"s3://by-asset/{n}", group="asset", extra={})
+        session.add_all([asset, AssetActive.for_asset(asset)])
+        session.flush()
+        base = DEFAULT_DATE
+        for i in range(n):
+            event = AssetEvent(
+                asset_id=asset.id,
+                source_dag_id="src",
+                source_run_id=f"r{i}",
+                timestamp=base + timedelta(seconds=i),
+            )
+            event.created_dagruns.append(
+                DagRun(
+                    dag_id=f"by_asset_{n}_{i}",
+                    run_id=f"r{i}",
+                    logical_date=base + timedelta(days=i),
+                    state=DagRunState.QUEUED,
+                    run_type=DagRunType.ASSET_TRIGGERED,
+                    data_interval=(base, base),
+                )
+            )
+            session.add(event)
+        session.commit()
+        with CountQueries() as result:
+            response = client.get(
+                "/execution/asset-events/by-asset", params={"name": asset.name, "uri": asset.uri}
+            )
+        assert response.status_code == 200, response.text
+        assert len(response.json()["asset_events"]) == n
+        return sum(result.values())
+
+    assert _measure(12) == _measure(3)

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -4787,3 +4787,39 @@ class TestEmitTaskSpan:
         }
         _emit_task_span(ti, TaskInstanceState.SUCCESS)
         assert len(self.exporter.get_finished_spans()) == expected_spans
+
+
+def test_ti_run_resolves_consumed_event_relationships_once(client, session, create_task_instance):
+    """ti_run must not lazy-load asset and source_aliases once per consumed asset event."""
+    from tests_common.test_utils.asserts import CountQueries
+
+    def _measure(k):
+        ti = create_task_instance(
+            dag_id=f"consumed_events_dag_{k}", task_id="t", state=State.QUEUED, session=session
+        )
+        for i in range(k):
+            asset = AssetModel(
+                name=f"consumed_{k}_{i}", uri=f"s3://consumed/{k}/{i}", group="asset", extra={}
+            )
+            session.add_all([asset, AssetActive.for_asset(asset)])
+            session.flush()
+            event = AssetEvent(asset_id=asset.id, source_dag_id="src", source_run_id="r1")
+            event.source_aliases.append(AssetAliasModel(name=f"consumed_alias_{k}_{i}"))
+            ti.dag_run.consumed_asset_events.append(event)
+        session.commit()
+        with CountQueries() as result:
+            response = client.patch(
+                f"/execution/task-instances/{ti.id}/run",
+                json={
+                    "state": "running",
+                    "hostname": "h",
+                    "unixname": "u",
+                    "pid": 1,
+                    "start_date": "2024-09-30T12:00:00Z",
+                },
+            )
+        assert response.status_code == 200, response.text
+        assert len(response.json()["dag_run"]["consumed_asset_events"]) == k
+        return sum(result.values())
+
+    assert _measure(5) == _measure(1)


### PR DESCRIPTION
`ti_run` eager-loads `dag_run.consumed_asset_events`, but serialising the run context then reads `event.asset` and `event.source_aliases` on each event, and those load lazily: two `SELECT`s per consumed event, inside the task instance's `FOR UPDATE` transaction, on every task start. Measured with `CountQueries` on Postgres: 9 queries with one consumed event, 47 with twenty.

`/execution/asset-events/by-asset` and `/by-asset-alias` have the same shape one level down: `created_dagruns` loads lazily per event, and `limit` defaults to none, so a task reading `inlet_events` pays one query per event ever recorded for the asset. Measured: 5 queries for 3 events, 32 for 30.

### What changed

- `ti_run`: nest `joinedload(AssetEvent.asset)` and `selectinload(AssetEvent.source_aliases)` under the existing `joinedload(DR.consumed_asset_events)`. Same shape #65422 used to preload `source_aliases` on the executor-events path.
- `_get_asset_events_through_sql_clauses`: add `joinedload(AssetEvent.asset)` and `selectinload(AssetEvent.created_dagruns)`, which is what the public API already does for these rows in `core_api/routes/public/assets.py`. One option set serves both endpoints: the by-asset path keeps its filter join on `AssetEvent.asset` and the loader adds its own aliased join, while the by-alias path filters through `source_aliases`.

Responses are unchanged; only the number of statements changes.

### Tests

- Two regression tests assert a request costs the same number of queries at 1 vs 5 consumed events and at 3 vs 12 asset events. Both fail on main (`14 == 5` for by-asset) and pass with the change.
- Full `test_task_instances.py` and `test_asset_events.py` pass on Postgres via Breeze (259 passed, 1 skipped), as do the CI-selected test types `Always`, `API` and `Providers[common.compat,fab]`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5.1)

Generated-by: Claude Code (Fable 5.1) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
