### PR TITLE
Fix airflowctl commands crashing instead of printing their result

### DIFF
--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -483,7 +483,7 @@ class CommandFactory:
     func_map: dict[tuple, Callable]
     commands_map: dict[str, list[ActionCommand]]
     group_commands_list: list[CLICommand]
-    output_command_list: list[str]
+    auth_environment_command_list: list[str]
     exclude_operation_names: list[str]
     exclude_method_names: list[str]
     help_texts: dict[str, dict[str, str]]
@@ -500,8 +500,7 @@ class CommandFactory:
         # Excluded Lists are in Class Level for further usage and avoid searching them
         # Exclude parameters that are not needed for CLI from datamodels
         self.excluded_parameters = ["schema_"]
-        # This list is used to determine if the command/operation needs to output data
-        self.output_command_list = [
+        self.auth_environment_command_list = [
             "list",
             "get",
             "create",
@@ -786,8 +785,11 @@ class CommandFactory:
                             )
                         )
 
-            if any(operation.get("name").startswith(cmd) for cmd in self.output_command_list):
-                args.extend([ARG_OUTPUT, ARG_AUTH_ENVIRONMENT])
+            args.append(ARG_OUTPUT)
+            # ``-e/--env`` is inert here (nothing reads ``args.env``), so widening it would only let more
+            # commands accept it and silently target production: https://github.com/apache/airflow/issues/70519
+            if any(operation.get("name").startswith(cmd) for cmd in self.auth_environment_command_list):
+                args.append(ARG_AUTH_ENVIRONMENT)
 
             self.args_map[(operation.get("name"), operation.get("parent").name)] = args
 

--- a/airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py
@@ -26,10 +26,13 @@ from unittest import mock
 import httpx
 import pytest
 
-from airflowctl.api.datamodels.generated import ClearTaskInstancesBody
-from airflowctl.api.operations import DagRunOperations, ServerResponseError
+from airflowctl.api.client import Client
+from airflowctl.api.datamodels.generated import ClearTaskInstancesBody, ConnectionTestResponse
+from airflowctl.api.operations import ConnectionsOperations, DagRunOperations, ServerResponseError
+from airflowctl.ctl import cli_parser
 from airflowctl.ctl.cli_config import (
     ARG_AUTH_TOKEN,
+    ARG_OUTPUT,
     ActionCommand,
     Arg,
     CommandFactory,
@@ -39,6 +42,7 @@ from airflowctl.ctl.cli_config import (
     merge_commands,
     safe_call_command,
 )
+from airflowctl.ctl.console_formatting import AirflowConsole
 from airflowctl.exceptions import (
     AirflowCtlConnectionException,
     AirflowCtlCredentialNotFoundException,
@@ -463,6 +467,19 @@ class TestCommandFactory:
         limit_arg = next(arg for arg in list_args if arg.flags[0] in ("limit", "--limit"))
         assert limit_arg.flags == ("--limit",)
         assert limit_arg.kwargs["type"] is int
+
+    def test_every_generated_command_accepts_the_output_flag(self):
+        """``_get_func`` always prints through ``args.output``, so every generated command must declare it."""
+        command_factory = CommandFactory()
+
+        missing = [
+            f"{group_command.name} {sub_command.name}"
+            for group_command in command_factory.group_commands
+            for sub_command in group_command.subcommands
+            if ARG_OUTPUT not in sub_command.args
+        ]
+
+        assert missing == []
 
 
 class TestCliConfigMethods:
@@ -907,3 +924,16 @@ class TestCliConfigMethods:
         call_kwargs = self._call_generated_command(monkeypatch, DagRunOperations, "list")
 
         assert call_kwargs["state"] is None
+
+    @mock.patch.object(AirflowConsole, "print_as", autospec=True)
+    @mock.patch.object(ConnectionsOperations, "test", autospec=True)
+    def test_connections_test_reaches_the_printer(self, mocked_test, mocked_print_as):
+        """``connections test`` has no CRUD-verb prefix, so argparse used to leave ``args.output`` undefined."""
+        mocked_test.return_value = ConnectionTestResponse(status=True, message="ok")
+        args = cli_parser.get_parser().parse_args(
+            ["connections", "test", "--connection-id", "my_conn", "--conn-type", "http"]
+        )
+
+        args.func(args, api_client=mock.MagicMock(spec=Client))
+
+        assert mocked_print_as.call_args.kwargs["output"] == "json"


### PR DESCRIPTION
Five auto-generated `airflowctl` commands crashed with a raw traceback instead of printing their result:

```console
$ airflowctl connections test --connection-id my_conn --conn-type http
Traceback (most recent call last):
  ...
  File "airflowctl/ctl/cli_config.py", line 926, in _get_func
    output=args.output,
           ^^^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'output'
```

`CommandFactory` generates every `airflowctl` command from the operations layer, and each generated
command finishes by printing through `args.output`. But `--output` was only declared for commands
whose method name started with one of ten CRUD verbs (`list`, `get`, `create`, …). The commands whose
verb was not on that list never got the flag declared, so argparse never put `output` on the
namespace, and they died in the printer — *after* their HTTP request had already been sent and
applied server-side, so the user sees a crash for an operation that actually succeeded.

Affected commands:

| Command | Operation |
|---|---|
| `airflowctl assets materialize` | `AssetsOperations.materialize` |
| `airflowctl backfill pause` | `BackfillOperations.pause` |
| `airflowctl backfill unpause` | `BackfillOperations.unpause` |
| `airflowctl backfill cancel` | `BackfillOperations.cancel` |
| `airflowctl connections test` | `ConnectionsOperations.test` |

Rather than adding the five missing verbs to the list, this drops the condition for `--output`
entirely: there is no generated command that does not print, so the distinction the whitelist tried
to draw does not exist. Guessing by verb prefix is also wrong in both directions — an operation named
`settings` would have matched `set` by accident.

`-e/--env` deliberately keeps the existing whitelist rather than riding along. Nothing reads
`args.env` for generated commands (only `auth login` / `auth token` do), so widening it would replace
today's honest `unrecognized argument` error with silent acceptance of an environment the command
then ignores — running against production credentials while the user believes they targeted staging.
Making `--env` actually work is tracked in #70519.

### Tests

- `test_every_generated_command_accepts_the_output_flag` — asserts no generated command is missing
  `--output`. Without the fix it fails listing exactly the five commands above. This is the guard
  that stops the whitelist coming back.
- `test_connections_test_reaches_the_printer` — drives `connections test` through the real
  `cli_parser.get_parser()` end to end. Without the fix it raises the `AttributeError` above.

Both were confirmed to fail with the source change reverted. Full `airflow-ctl` suite: 389 passed.

### Note for reviewers

`generate-airflowctl-help-images` was skipped locally (it needs Docker). Its hashes already drift on
an unmodified `main` — I verified the identical eight groups differ with and without this change — so
regenerating the SVGs here would only pull unrelated churn into this PR. Happy to add a commit if CI
disagrees.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
