### PR TITLE
Java SDK: Add setVariable and deleteVariable to the task Client

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/language-sdks/java.rst
+++ b/airflow-core/docs/authoring-and-scheduling/language-sdks/java.rst
@@ -463,6 +463,24 @@ represented as Java objects when read back via ``getXCom``.
    ``null`` and the task fails with ``MissingXComException``.  Declare the parameter with a
    boxed type when the upstream XCom may be absent.
 
+Variables
+---------
+
+``Client`` reads, writes, and deletes Airflow Variables. Values are stored as strings. Serialize
+structured data (for example to JSON) before storing it.
+
+.. code-block:: java
+
+    var threshold = (String) client.getVariable("process_threshold");
+    client.setVariable("process_threshold", "42", "Rows above this count take the slow path");
+    client.deleteVariable("legacy_threshold");
+
+.. note::
+
+   A value supplied by a secrets backend (for example an ``AIRFLOW_VAR_*`` environment variable) still
+   takes precedence over the stored value when the Variable is read back. Calling ``setVariable``
+   without a description clears any existing description.
+
 .. _java-sdk/build:
 
 Building and packaging

--- a/airflow-e2e-tests/java-test-bundle/src/java/org/apache/airflow/e2e/TestBundleBuilder.java
+++ b/airflow-e2e-tests/java-test-bundle/src/java/org/apache/airflow/e2e/TestBundleBuilder.java
@@ -24,7 +24,8 @@ import org.apache.airflow.sdk.*;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Bundle of deliberately broken task classes for the runner-behaviour E2E tests.
+ * Bundle for the runner-behaviour E2E tests: deliberately broken task classes that exercise
+ * instantiation failures, and a task that round-trips Airflow Variables through the supervisor.
  */
 public class TestBundleBuilder implements BundleBuilder {
   public static class MissingNoArgConstructor implements Task {
@@ -46,13 +47,28 @@ public class TestBundleBuilder implements BundleBuilder {
     }
   }
 
+  /**
+   * Stores this run's id where the E2E test can read it back through the REST API, then writes
+   * and deletes a scratch variable to exercise the delete path.
+   */
+  public static class WriteAndDeleteVariable implements Task {
+    public void execute(@NotNull Context context, Client client) {
+      client.setVariable(
+          "java_e2e_variable", context.dagRun.runId, "written by the Java SDK e2e test");
+      client.setVariable("java_e2e_scratch", "scratch");
+      client.deleteVariable("java_e2e_scratch");
+    }
+  }
+
   @NotNull
   @Override
   public Iterable<DagDef> getDags() {
-    var dag = new DagDef("java_uninstantiable");
-    dag.addTask("missing_no_arg_constructor", MissingNoArgConstructor.class);
-    dag.addTask("non_static_inner", NonStaticInner.class);
-    return List.of(dag);
+    var uninstantiable = new DagDef("java_uninstantiable");
+    uninstantiable.addTask("missing_no_arg_constructor", MissingNoArgConstructor.class);
+    uninstantiable.addTask("non_static_inner", NonStaticInner.class);
+    var variableWrite = new DagDef("java_variable_write");
+    variableWrite.addTask("write_and_delete", WriteAndDeleteVariable.class);
+    return List.of(uninstantiable, variableWrite);
   }
 
   public static void main(String[] args) {

--- a/airflow-e2e-tests/java-test-bundle/src/resources/dags/java_test_dags.py
+++ b/airflow-e2e-tests/java-test-bundle/src/resources/dags/java_test_dags.py
@@ -36,3 +36,15 @@ def java_uninstantiable():
 
 
 java_uninstantiable()
+
+
+@task.stub(queue="java-test")
+def write_and_delete(): ...
+
+
+@dag(dag_id="java_variable_write")
+def java_variable_write():
+    write_and_delete()
+
+
+java_variable_write()

--- a/airflow-e2e-tests/tests/airflow_e2e_tests/e2e_test_utils/clients.py
+++ b/airflow-e2e-tests/tests/airflow_e2e_tests/e2e_test_utils/clients.py
@@ -159,6 +159,10 @@ class AirflowClient:
             endpoint=f"dags/{dag_id}/dagRuns/{run_id}/taskInstances/{task_id}/xcomEntries/{key}?map_index={map_index}",
         )
 
+    def get_variable(self, key: str):
+        """Get an Airflow Variable via API."""
+        return self._make_request(method="GET", endpoint=f"variables/{key}")
+
     def trigger_dag_and_wait(self, dag_id: str, json=None):
         """Trigger a DAG and wait for it to complete."""
         self.un_pause_dag(dag_id)

--- a/airflow-e2e-tests/tests/airflow_e2e_tests/java_sdk_tests/test_java_sdk_dag.py
+++ b/airflow-e2e-tests/tests/airflow_e2e_tests/java_sdk_tests/test_java_sdk_dag.py
@@ -61,9 +61,11 @@ from __future__ import annotations
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from http import HTTPStatus
 from typing import TYPE_CHECKING
 
 import pytest
+import requests
 
 from airflow_e2e_tests.e2e_test_utils.clients import AirflowClient
 
@@ -81,6 +83,8 @@ _LOG_FETCH_TIMEOUT = 60
 _ANNOTATION_DAG_ID = "java_annotation_example"
 _XCOM_CASTING_DAG_ID = "java_xcom_casting_example"
 _SCALA_SPARK_DAG_ID = "scala_spark_example"
+_VARIABLE_WRITE_DAG_ID = "java_variable_write"
+_VARIABLE_WRITE_DESCRIPTION = "written by the Java SDK e2e test"
 
 
 @dataclass
@@ -177,6 +181,12 @@ def xcom_casting_example_run() -> _CompletedRun:
 def scala_spark_example_run() -> _CompletedRun:
     """Trigger the Scala Spark example once for all of its assertions."""
     return _trigger_and_wait_for_dag(_SCALA_SPARK_DAG_ID, _SPARK_TASK_TIMEOUT)
+
+
+@pytest.fixture(scope="module")
+def variable_write_run() -> _CompletedRun:
+    """Trigger the variable write Dag once for all of its assertions."""
+    return _trigger_and_wait_for_dag(_VARIABLE_WRITE_DAG_ID, _JAVA_TASK_TIMEOUT)
 
 
 class TestJavaSDKAnnotationExample:
@@ -319,6 +329,51 @@ class TestJavaSDKUninstantiableTask:
         assert record.get("taskClass") == expected_task_class, (
             f"instantiation error should name the offending class {expected_task_class!r}, "
             f"got {record.get('taskClass')!r}; record: {record}"
+        )
+
+
+class TestJavaSDKVariableWrite:
+    """Verify a Java task can write and delete Airflow Variables.
+
+    The task lives in the java-test-bundle fixture project (served on the
+    dedicated "java-test" queue). It stores its own run id in
+    ``java_e2e_variable`` and deletes a scratch Variable it has just written,
+    so both paths go through the supervisor and the Task Execution API.
+    """
+
+    def test_variable_written_by_java_task_is_readable(self, variable_write_run: _CompletedRun):
+        """The value and description set from Java are visible through the REST API."""
+        ti = variable_write_run.get_task_instance("write_and_delete")
+        assert ti.get("state") == "success", (
+            "Java 'write_and_delete' task did not succeed.\n"
+            f"  task state : {ti.get('state')!r}\n"
+            f"  dag state  : {variable_write_run.state!r}\n"
+            f"  all tasks  : {variable_write_run.ti_states}"
+        )
+
+        variable = variable_write_run.client.get_variable("java_e2e_variable")
+        assert variable.get("value") == variable_write_run.run_id, (
+            f"java_e2e_variable should hold this run's id {variable_write_run.run_id!r}, got {variable!r}"
+        )
+        assert variable.get("description") == _VARIABLE_WRITE_DESCRIPTION, (
+            f"java_e2e_variable should carry the description set from Java, got {variable!r}"
+        )
+
+    def test_scratch_variable_deleted_by_java_task_is_gone(self, variable_write_run: _CompletedRun):
+        """A Variable written and then deleted from Java no longer exists."""
+        ti = variable_write_run.get_task_instance("write_and_delete")
+        assert ti.get("state") == "success", (
+            "Java 'write_and_delete' task did not succeed.\n"
+            f"  task state : {ti.get('state')!r}\n"
+            f"  dag state  : {variable_write_run.state!r}\n"
+            f"  all tasks  : {variable_write_run.ti_states}"
+        )
+
+        with pytest.raises(requests.HTTPError) as excinfo:
+            variable_write_run.client.get_variable("java_e2e_scratch")
+        assert excinfo.value.response.status_code == HTTPStatus.NOT_FOUND, (
+            f"java_e2e_scratch should have been deleted by the Java task, "
+            f"got HTTP {excinfo.value.response.status_code}"
         )
 
 

--- a/java-sdk/README.md
+++ b/java-sdk/README.md
@@ -608,7 +608,7 @@ prek hook regenerate it.
 | capability: `task-logging` | MUST | ✓ | 3.3 | SLF4J + JPL bridged to the task log |
 | capability: `xcom-read-write` | MUST | ✓ | 3.3 |  |
 | capability: `connection-read` | MUST | ✓ | 3.3 |  |
-| capability: `variable-read-write` | MUST | ✗ | – | getVariable only; no write over the comm socket yet |
+| capability: `variable-read-write` | MUST | ✓ | 3.3 |  |
 | capability: `self-contained-bundle` | MUST | ✓ | 3.3 | Airflow metadata embedded in the jar artifact |
 | capability: `retry-policy` | MAY | ✗ | – | no task-facing retry-policy API yet |
 | capability: `task-state-store` | MAY | ✗ | – | no task-facing state-store API yet |

--- a/java-sdk/capabilities.yaml
+++ b/java-sdk/capabilities.yaml
@@ -70,8 +70,8 @@ capabilities:
     supported: true
     since: "3.3"
   variable-read-write:
-    supported: false
-    note: "getVariable only; no write over the comm socket yet"
+    supported: true
+    since: "3.3"
   self-contained-bundle:
     supported: true
     since: "3.3"

--- a/java-sdk/sdk/module.md
+++ b/java-sdk/sdk/module.md
@@ -47,7 +47,7 @@ meaning of each dimension is defined in the
 | capability: `task-logging` | MUST | ✓ | 3.3 | SLF4J + JPL bridged to the task log |
 | capability: `xcom-read-write` | MUST | ✓ | 3.3 |  |
 | capability: `connection-read` | MUST | ✓ | 3.3 |  |
-| capability: `variable-read-write` | MUST | ✗ | – | getVariable only; no write over the comm socket yet |
+| capability: `variable-read-write` | MUST | ✓ | 3.3 |  |
 | capability: `self-contained-bundle` | MUST | ✓ | 3.3 | Airflow metadata embedded in the jar artifact |
 | capability: `retry-policy` | MAY | ✗ | – | no task-facing retry-policy API yet |
 | capability: `task-state-store` | MAY | ✗ | – | no task-facing state-store API yet |

--- a/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/Client.kt
+++ b/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/Client.kt
@@ -96,6 +96,36 @@ class Client internal constructor(
   fun getVariable(key: String): Any? = impl.getVariable(key).value
 
   /**
+   * Stores an Airflow variable, replacing any existing value.
+   *
+   * The value is stored as-is. Serialize structured data (for example to
+   * JSON) before storing it. Omitting [description] clears any existing
+   * description. A value supplied by a secrets backend (such as an
+   * `AIRFLOW_VAR_*` environment variable) still takes precedence over the
+   * stored value when the variable is read back.
+   *
+   * @param key Variable key.
+   * @param value Value to store.
+   * @param description Description of the variable.
+   * @throws ApiError if the API call fails.
+   */
+  @JvmOverloads fun setVariable(
+    key: String,
+    value: String,
+    description: String? = null,
+  ) = impl.setVariable(key = key, value = value, description = description)
+
+  /**
+   * Deletes an Airflow variable.
+   *
+   * Deleting a variable that does not exist is a no-op.
+   *
+   * @param key Variable key.
+   * @throws ApiError if the API call fails.
+   */
+  fun deleteVariable(key: String) = impl.deleteVariable(key)
+
+  /**
    * Reads an XCom value pushed by another task.
    *
    * The current Dag run's [dagId][TaskInstance.dagId] and

--- a/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/Client.kt
+++ b/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/Client.kt
@@ -99,10 +99,7 @@ class Client internal constructor(
    * Stores an Airflow variable, replacing any existing value.
    *
    * The value is stored as-is. Serialize structured data (for example to
-   * JSON) before storing it. Omitting [description] clears any existing
-   * description. A value supplied by a secrets backend (such as an
-   * `AIRFLOW_VAR_*` environment variable) still takes precedence over the
-   * stored value when the variable is read back.
+   * JSON) before storing it.
    *
    * @param key Variable key.
    * @param value Value to store.
@@ -117,8 +114,6 @@ class Client internal constructor(
 
   /**
    * Deletes an Airflow variable.
-   *
-   * Deleting a variable that does not exist is a no-op.
    *
    * @param key Variable key.
    * @throws ApiError if the API call fails.

--- a/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/execution/Client.kt
+++ b/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/execution/Client.kt
@@ -21,9 +21,12 @@ package org.apache.airflow.sdk.execution
 
 import kotlinx.coroutines.runBlocking
 import org.apache.airflow.sdk.execution.comm.ConnectionResult
+import org.apache.airflow.sdk.execution.comm.DeleteVariable
 import org.apache.airflow.sdk.execution.comm.GetConnection
 import org.apache.airflow.sdk.execution.comm.GetVariable
 import org.apache.airflow.sdk.execution.comm.GetXCom
+import org.apache.airflow.sdk.execution.comm.OKResponse
+import org.apache.airflow.sdk.execution.comm.PutVariable
 import org.apache.airflow.sdk.execution.comm.SetXCom
 import org.apache.airflow.sdk.execution.comm.VariableResult
 import org.apache.airflow.sdk.execution.comm.XComResult
@@ -45,6 +48,14 @@ interface Client {
   fun getConnection(id: String): ConnectionResult
 
   fun getVariable(key: String): VariableResult
+
+  fun setVariable(
+    key: String,
+    value: String,
+    description: String?,
+  )
+
+  fun deleteVariable(key: String)
 
   fun getXCom(
     key: String,
@@ -88,6 +99,24 @@ class CoordinatorClient(
     runBlocking {
       exec.communicate<VariableResult>(GetVariable().also { it.key = key })
     }
+
+  override fun setVariable(
+    key: String,
+    value: String,
+    description: String?,
+  ) {
+    val message =
+      PutVariable().also {
+        it.key = key
+        it.value = value
+        it.description = description
+      }
+    runBlocking { exec.communicate<Unit>(message) }
+  }
+
+  override fun deleteVariable(key: String) {
+    runBlocking { exec.communicate<OKResponse>(DeleteVariable().also { it.key = key }) }
+  }
 
   override fun setXCom(
     key: String,

--- a/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/execution/Frame.kt
+++ b/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/execution/Frame.kt
@@ -19,12 +19,14 @@
 
 package org.apache.airflow.sdk.execution
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.util.StdDateFormat
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import org.apache.airflow.sdk.execution.comm.Discriminator
+import org.apache.airflow.sdk.execution.comm.PutVariable
 import org.msgpack.core.MessagePack
 import org.msgpack.core.MessageUnpacker
 import org.msgpack.core.buffer.ArrayBufferInput
@@ -37,6 +39,17 @@ data class RawFrame(
   val rawError: Any?,
 )
 
+/**
+ * jsonschema2pojo stamps every model with `@JsonInclude(NON_NULL)`, so
+ * Jackson drops null fields from the wire map. The supervisor requires these
+ * fields to be present. When one is missing it fails validation, logs the
+ * frame and never replies, so the caller blocks forever.
+ */
+private val REQUIRED_NULLABLE_REQUESTS = setOf(PutVariable::class.java)
+
+@JsonInclude(JsonInclude.Include.ALWAYS)
+private abstract class KeepNullFields
+
 object Frame {
   internal const val MAX_FRAME_LENGTH = 0xFFFF_FFFFL
 
@@ -47,6 +60,7 @@ object Frame {
       registerModule(JavaTimeModule())
       registerModule(TimestampToJavaOffsetDateTimeModule())
       setDateFormat(StdDateFormat().withColonInTimeZone(true))
+      REQUIRED_NULLABLE_REQUESTS.forEach { addMixIn(it, KeepNullFields::class.java) }
     }
 
   fun encodeRequest(

--- a/java-sdk/sdk/src/test/kotlin/org/apache/airflow/sdk/ClientTest.kt
+++ b/java-sdk/sdk/src/test/kotlin/org/apache/airflow/sdk/ClientTest.kt
@@ -34,6 +34,14 @@ private class FakeTransport(
 
   override fun getVariable(key: String): VariableResult = throw NotImplementedError()
 
+  override fun setVariable(
+    key: String,
+    value: String,
+    description: String?,
+  ) = throw NotImplementedError()
+
+  override fun deleteVariable(key: String) = throw NotImplementedError()
+
   override fun getXCom(
     key: String,
     dagId: String,

--- a/java-sdk/sdk/src/test/kotlin/org/apache/airflow/sdk/execution/CommTest.kt
+++ b/java-sdk/sdk/src/test/kotlin/org/apache/airflow/sdk/execution/CommTest.kt
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.msgpack.core.MessagePack
+import org.msgpack.core.buffer.ArrayBufferInput
 import java.io.ByteArrayOutputStream
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
@@ -134,6 +135,84 @@ class CommsTest {
       packer.packNil()
     }
     return out.toByteArray()
+  }
+
+  private fun okResponseFrame(id: Int): ByteArray {
+    val out = ByteArrayOutputStream()
+    MessagePack.newDefaultPacker(out).use { packer ->
+      packer.packArrayHeader(3)
+      packer.packInt(id)
+      packer.packMapHeader(2)
+      packer.packString("type")
+      packer.packString("OKResponse")
+      packer.packString("ok")
+      packer.packBoolean(true)
+      packer.packNil()
+    }
+    return out.toByteArray()
+  }
+
+  // The supervisor answers a request that yields no result with a bare `[id]` frame.
+  private fun emptyResponseFrame(id: Int): ByteArray {
+    val out = ByteArrayOutputStream()
+    MessagePack.newDefaultPacker(out).use { packer ->
+      packer.packArrayHeader(1)
+      packer.packInt(id)
+    }
+    return out.toByteArray()
+  }
+
+  private fun errorResponseFrame(id: Int): ByteArray {
+    val out = ByteArrayOutputStream()
+    MessagePack.newDefaultPacker(out).use { packer ->
+      packer.packArrayHeader(3)
+      packer.packInt(id)
+      packer.packNil()
+      packer.packMapHeader(2)
+      packer.packString("type")
+      packer.packString("ErrorResponse")
+      packer.packString("detail")
+      packer.packMapHeader(1)
+      packer.packString("status_code")
+      packer.packInt(500)
+    }
+    return out.toByteArray()
+  }
+
+  private fun readRequest(fromClient: ByteChannel): RawFrame =
+    runBlocking {
+      val prefix = fromClient.readByteArray(4)
+      val payload = fromClient.readByteArray(Frame.parseLengthPrefix(prefix).toInt())
+      Frame.decodeRaw(ArrayBufferInput(payload))
+    }
+
+  /**
+   * Run one call on the public client against a fake supervisor that answers
+   * its single request with [response]. Returns the raw request body as sent
+   * on the wire and the exception the call threw, if any.
+   */
+  private fun roundTrip(
+    response: (Int) -> ByteArray,
+    call: (PublicClient) -> Unit,
+  ): Pair<Map<*, *>, Throwable?> {
+    val toClient = ByteChannel(autoFlush = true)
+    val fromClient = ByteChannel(autoFlush = true)
+    val comm = CoordinatorComm(toClient, fromClient)
+    val client = PublicClient(StartupDetails(), CoordinatorClient(comm))
+
+    val requests = ConcurrentLinkedQueue<RawFrame>()
+    val server =
+      Thread {
+        val request = readRequest(fromClient)
+        requests.add(request)
+        runBlocking { toClient.writeFrame(response(request.id)) }
+      }
+    server.start()
+    val failure = runCatching { call(client) }.exceptionOrNull()
+    server.join()
+    comm.close()
+
+    return (requests.single().rawBody as Map<*, *>) to failure
   }
 
   private suspend fun ByteChannel.writeFrame(payload: ByteArray) {
@@ -261,6 +340,50 @@ class CommsTest {
     Assertions.assertTrue(errors.isEmpty(), "concurrent public-client calls failed: $errors")
     Assertions.assertEquals(n, results.size)
     comm.close()
+  }
+
+  @Test
+  @DisplayName("setVariable keeps a null description on the wire so the supervisor accepts the request")
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  fun setVariableKeepsNullDescriptionOnTheWire() {
+    val (body, failure) = roundTrip(::emptyResponseFrame) { it.setVariable("k", "v") }
+
+    Assertions.assertNull(failure, "setVariable should return normally on an empty response, got $failure")
+    Assertions.assertEquals("PutVariable", body["type"])
+    Assertions.assertEquals("k", body["key"])
+    Assertions.assertEquals("v", body["value"])
+    Assertions.assertTrue(body.containsKey("description"), "description must be sent even when null: $body")
+    Assertions.assertNull(body["description"])
+  }
+
+  @Test
+  @DisplayName("setVariable sends the description when one is given")
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  fun setVariableSendsDescription() {
+    val (body, failure) = roundTrip(::emptyResponseFrame) { it.setVariable("k", "v", "why") }
+
+    Assertions.assertNull(failure, "setVariable should return normally on an empty response, got $failure")
+    Assertions.assertEquals("why", body["description"])
+  }
+
+  @Test
+  @DisplayName("deleteVariable sends the key and accepts the supervisor's OK response")
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  fun deleteVariableAcceptsOkResponse() {
+    val (body, failure) = roundTrip(::okResponseFrame) { it.deleteVariable("k") }
+
+    Assertions.assertNull(failure, "deleteVariable should return normally on OKResponse, got $failure")
+    Assertions.assertEquals("DeleteVariable", body["type"])
+    Assertions.assertEquals("k", body["key"])
+  }
+
+  @Test
+  @DisplayName("deleteVariable raises ApiError when the supervisor reports an error")
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  fun deleteVariableRaisesApiErrorOnErrorResponse() {
+    val (_, failure) = roundTrip(::errorResponseFrame) { it.deleteVariable("k") }
+
+    Assertions.assertInstanceOf(ApiError::class.java, failure)
   }
 
   @Test

--- a/java-sdk/sdk/src/test/kotlin/org/apache/airflow/sdk/execution/TaskTest.kt
+++ b/java-sdk/sdk/src/test/kotlin/org/apache/airflow/sdk/execution/TaskTest.kt
@@ -214,6 +214,14 @@ class TaskTest {
 
         override fun getVariable(key: String) = throw UnsupportedOperationException("not used in test")
 
+        override fun setVariable(
+          key: String,
+          value: String,
+          description: String?,
+        ): Unit = throw UnsupportedOperationException("not used in test")
+
+        override fun deleteVariable(key: String): Unit = throw UnsupportedOperationException("not used in test")
+
         override fun getXCom(
           key: String,
           dagId: String,


### PR DESCRIPTION
Add `setVariable` and `deleteVariable` to the Java SDK task `Client`, which completes the `variable-read-write` runtime capability.

## How
- Add `Client.setVariable(key, value, description)` and `Client.deleteVariable(key)`. `description` defaults to null. `setVariable` has `@JvmOverloads`, like the existing `getXCom` and `setXCom`, because Java cannot use Kotlin default arguments. With the annotation, Java code can call it with two arguments.
- In `CoordinatorClient`, `setVariable` sends a `PutVariable` message to the supervisor. `deleteVariable` sends `DeleteVariable` and waits for the supervisor's `OKResponse`.
- A Jackson mixin in `Frame.kt` serializes `PutVariable` with `@JsonInclude(ALWAYS)`. jsonschema2pojo annotates generated models with `NON_NULL`, so without the mixin a null `description` would be missing from the wire map. The supervisor would then fail validation and never reply, and the JVM would block forever.

## Verification
- `./gradlew :sdk:test :sdk:ktlintCheck`
- `breeze testing airflow-e2e-tests --e2e-test-mode java_sdk tests/airflow_e2e_tests/java_sdk_tests/test_java_sdk_dag.py`

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
