### PR TITLE
Fix 500 for non-dict JSON bodies on variable/connection endpoints

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/logging/decorators.py
+++ b/airflow-core/src/airflow/api_fastapi/logging/decorators.py
@@ -203,8 +203,11 @@ def action_logging(event: str | None = None):
         masked_body_json = {}
 
         if has_json_body:
-            request_body = await request.json()
-            if isinstance(request_body, dict):
+            # ``request_body`` stays empty unless the body parses to a dict, so the ``.items()``
+            # calls below never see a list or a bare string. The endpoint rejects those with 422.
+            parsed_body = await request.json()
+            if isinstance(parsed_body, dict):
+                request_body = parsed_body
                 masked_body_json = {k: secrets_masker.redact(v, k) for k, v in request_body.items()}
 
                 if event_name in skip_dry_run_events and request_body.get("dry_run", True):

--- a/airflow-core/src/airflow/api_fastapi/logging/decorators.py
+++ b/airflow-core/src/airflow/api_fastapi/logging/decorators.py
@@ -203,8 +203,7 @@ def action_logging(event: str | None = None):
         masked_body_json = {}
 
         if has_json_body:
-            # ``request_body`` stays empty unless the body parses to a dict, so the ``.items()``
-            # calls below never see a list or a bare string. The endpoint rejects those with 422.
+            # Non-dict bodies fall through to the endpoint's own 422.
             parsed_body = await request.json()
             if isinstance(parsed_body, dict):
                 request_body = parsed_body

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -368,6 +368,28 @@ class TestPostConnection(TestConnectionEndpoint):
             ]
         }
 
+    @pytest.mark.parametrize(
+        "body",
+        [
+            [{"connection_id": TEST_CONN_ID, "conn_type": TEST_CONN_TYPE}],
+            '{"connection_id": "a"}',
+            42,
+        ],
+        ids=["list", "string", "number"],
+    )
+    def test_post_should_respond_422_for_non_dict_json_body(self, test_client, session, body):
+        """The audit-log dependency reads the body before validation, so a non-object body still gets a 422."""
+        response = test_client.post("/connections", json=body)
+        assert response.status_code == 422
+        assert response.json()["detail"][0]["loc"] == ["body"]
+        _check_last_log(
+            session,
+            dag_id=None,
+            event="post_connection",
+            logical_date=None,
+            expected_extra={"method": "POST"},
+        )
+
     @conf_vars({("core", "multi_team"): "False"})
     def test_post_rejects_team_name_when_multi_team_disabled(self, test_client):
         response = test_client.post(

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
@@ -805,6 +805,24 @@ class TestPostVariable(TestVariableEndpoint):
             ]
         }
 
+    @pytest.mark.parametrize(
+        "body",
+        [[{"key": "new variable key", "value": "new variable value"}], '{"key": "a"}', 42],
+        ids=["list", "string", "number"],
+    )
+    def test_post_should_respond_422_for_non_dict_json_body(self, test_client, session, body):
+        """The audit-log dependency reads the body before validation, so a non-object body still gets a 422."""
+        response = test_client.post("/variables", json=body)
+        assert response.status_code == 422
+        assert response.json()["detail"][0]["loc"] == ["body"]
+        check_last_log(
+            session,
+            dag_id=None,
+            event="post_variable",
+            logical_date=None,
+            expected_extra={"method": "POST"},
+        )
+
     @conf_vars({("core", "multi_team"): "False"})
     def test_post_rejects_team_name_when_multi_team_disabled(self, test_client):
         body = {


### PR DESCRIPTION
## Why

- `action_logging` is a FastAPI dependency, and dependencies are solved before Pydantic validates the request body. It sees whatever `json.loads` produced, so a list, string or number reaches it as valid JSON.
- Two of its branches read that body as a mapping via `request_body.items()` with no type guard, so `POST /api/v2/variables` and `POST /api/v2/connections` raise `AttributeError` and return 500 instead of the 422 the OpenAPI spec declares.
- `action_logging` commits its audit row before the endpoint runs, so an attempt is recorded even when the request is later rejected. The crash happens before that commit, so on `main` these requests leave no audit row at all.

## How

- Assign the parsed body to `request_body` only when it is a dict, so the variable keeps its `{}` initial value for every other shape.

## Verification

- Unit test: `uv run --frozen --project airflow-core pytest airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py`
- Integration test:

1. Start breeze

```sh
breeze shell --backend sqlite
```

2. Start an API server

```sh
export AIRFLOW__CORE__LOAD_EXAMPLES=False
airflow db migrate
airflow api-server --port 8080 &
until curl -sf -o /dev/null http://localhost:8080/api/v2/version; do sleep 2; done
```

3. Get a token

```sh
TOKEN=$(curl -s -X POST http://localhost:8080/auth/token \
  -H 'Content-Type: application/json' \
  -d '{"username": "admin", "password": "admin"}' \
  | python -c 'import sys, json; print(json.load(sys.stdin)["access_token"])')
```

4. POST a non-dict JSON body to both endpoints

```sh
for path in variables connections; do
  for body in '[{"key": "a"}]' '"a string"' '42'; do
    echo -n "POST /$path <- $body => "
    curl -s -o /tmp/body.json -w 'HTTP %{http_code}\n' \
      -X POST "http://localhost:8080/api/v2/$path" \
      -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d "$body"
    head -c 200 /tmp/body.json; echo
  done
done
```

Before this PR, all six requests return `HTTP 500` with a bare `Internal Server Error`.

With this PR they return the 422 the OpenAPI spec declares:

```
POST /variables <- [{"key": "a"}] => HTTP 422
{"detail":[{"type":"model_attributes_type","loc":["body"],
"msg":"Input should be a valid dictionary or object to extract fields from","input":[{"key":"a"}]}]}
```

5. Confirm valid bodies are unaffected

```sh
curl -s -w '\nHTTP %{http_code}\n' -X POST http://localhost:8080/api/v2/variables \
  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
  -d '{"key": "demo", "value": "s3cr3t", "description": "d"}'

curl -s -w '\nHTTP %{http_code}\n' -X POST http://localhost:8080/api/v2/connections \
  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
  -d '{"connection_id": "demo", "conn_type": "http", "password": "p4ss", "extra": "{\"token\": \"abc\"}"}'
```

6. Check the audit log

```sh
curl -s "http://localhost:8080/api/v2/eventLogs?limit=100" -H "Authorization: Bearer $TOKEN" \
  | python -c '
import sys, json
for r in json.load(sys.stdin)["event_logs"]:
    print("id=%-3s event=%-16s owner=%-6s extra=%s" % (r["event_log_id"], r["event"], r["owner"], r["extra"]))
```

Before this PR, the six rejected requests leave **no audit rows at all** — `action_logging` raises before reaching its `session.commit()`, so the record of the attempt is lost.

With this PR every attempt is recorded:

```
id=1   event=cli_api_server   owner=root   extra={"host_name": "...", "full_command": "..."}
id=2   event=post_variable    owner=admin  extra={"method": "POST"}
id=3   event=post_variable    owner=admin  extra={"method": "POST"}
id=4   event=post_variable    owner=admin  extra={"method": "POST"}
id=5   event=post_connection  owner=admin  extra={"method": "POST"}
id=6   event=post_connection  owner=admin  extra={"method": "POST"}
id=7   event=post_connection  owner=admin  extra={"method": "POST"}
id=8   event=post_variable    owner=admin  extra={"key": "demo", "value": "***", "description": "d", "method": "POST"}
id=9   event=post_connection  owner=admin  extra={"connection_id": "demo", "conn_type": "http", "password": "***", "extra": {"token": "***"}, "method": "POST"}
```

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
