### PR TITLE
Bound remaining single-row lookups with .limit(1)

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dags.py
@@ -436,10 +436,12 @@ def unfavorite_dag(dag_id: str, session: SessionDep, user: GetUserDep):
     user_id = str(user.get_id())
 
     favorite_exists = session.execute(
-        select(DagFavorite).where(
+        select(DagFavorite)
+        .where(
             DagFavorite.dag_id == dag_id,
             DagFavorite.user_id == user_id,
         )
+        .limit(1)
     ).first()
 
     if not favorite_exists:

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -1225,7 +1225,7 @@ def get_previous_task_instance(
     if state:
         query = query.where(TI.state == state)
 
-    ti = session.scalars(query).first()
+    ti = session.scalars(query.limit(1)).first()
 
     if not ti:
         return None

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import re
 from datetime import datetime, timedelta, timezone
 from unittest import mock
 
@@ -33,7 +34,7 @@ from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
-from tests_common.test_utils.asserts import assert_queries_count, count_queries
+from tests_common.test_utils.asserts import assert_queries_count, capture_orm_selects, count_queries
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import (
     clear_db_assets,
@@ -1184,6 +1185,21 @@ class TestUnfavoriteDag(TestDagEndpoint):
     def test_unfavoriting_dag_that_is_not_favorite_returns_409(self, test_client):
         response = test_client.post(f"/dags/{DAG1_ID}/unfavorite")
         assert response.status_code == 409
+
+    def test_unfavorite_dag_existence_check_is_bounded(self, test_client, session):
+        """The existing-favorite existence probe must ask the DB for one row."""
+        session.execute(insert(DagFavorite).values(dag_id=DAG1_ID, user_id="test"))
+        session.commit()
+
+        with capture_orm_selects("dag_favorite") as statements:
+            response = test_client.post(f"/dags/{DAG1_ID}/unfavorite")
+
+        assert response.status_code == 204
+        assert statements, "expected the endpoint to query the dag_favorite table"
+        for sql in statements:
+            assert re.search(r"\bLIMIT 1\b", sql), (
+                f"favorite existence check is not bounded to one row: {sql}"
+            )
 
 
 class TestDagDetails(TestDagEndpoint):

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import re
 from datetime import datetime
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
@@ -58,6 +59,7 @@ from airflow.sdk import Asset, TaskGroup, TriggerRule, task, task_group
 from airflow.state.metastore import MetastoreBackend
 from airflow.utils.state import DagRunState, State, TaskInstanceState, TerminalTIState
 
+from tests_common.test_utils.asserts import capture_orm_selects
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import (
     clear_db_assets,
@@ -3883,6 +3885,28 @@ class TestGetPreviousTI:
         data = response.json()
         assert data["run_id"] == "target_run_1"
         assert data["state"] == State.SUCCESS
+
+    def test_get_previous_ti_query_is_bounded(self, client, session, create_task_instance):
+        """The single-row previous-TI lookup must ask the DB for one row."""
+        for i in range(5):
+            create_task_instance(
+                task_id="test_task",
+                state=State.SUCCESS,
+                logical_date=timezone.datetime(2025, 1, i + 1),
+                run_id=f"run{i + 1}",
+            )
+        session.commit()
+
+        with capture_orm_selects("task_instance") as statements:
+            response = client.get(
+                "/execution/task-instances/previous/dag/test_task",
+                params={"logical_date": "2025-01-05T00:00:00Z"},
+            )
+
+        assert response.status_code == 200
+        assert statements, "expected the endpoint to query the task_instance table"
+        for sql in statements:
+            assert re.search(r"\bLIMIT 1\b", sql), f"previous-TI lookup is not bounded to one row: {sql}"
 
 
 class TestGetTaskStates:

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -3904,6 +3904,7 @@ class TestGetPreviousTI:
             )
 
         assert response.status_code == 200
+        assert response.json()["run_id"] == "run4"
         assert statements, "expected the endpoint to query the task_instance table"
         for sql in statements:
             assert re.search(r"\bLIMIT 1\b", sql), f"previous-TI lookup is not bounded to one row: {sql}"


### PR DESCRIPTION
Follow-up to #72554, and depends on it. That PR restores ``.limit(1)`` on the
four single-row XCom lookups whose ``LIMIT`` was dropped when the code migrated
from the legacy ``Query.first()`` to SQLAlchemy 2.0's ``Result.first()`` (which
does not add a LIMIT of its own — see the ``Result.first`` docstring). A wider
audit of the remaining ``.first()`` calls under ``airflow/api_fastapi/`` turned
up two more sites with the same shape:

- ``execution_api/routes/task_instances.py::get_previous_task_instance`` — reads
  one previous TI ordered by ``logical_date DESC``, no LIMIT. Without the bound
  the query pulls every earlier matching TI into the Python process and returns
  the first. Introduced in #59712.
- ``core_api/routes/public/dags.py::unfavorite_dag`` — probes ``dag_favorite`` for
  the current ``(dag_id, user_id)`` before deletion. The schema bounds the result
  to a single row, so the practical cost here is small, but the pattern is the
  same. Introduced in #51264.

The regression tests reuse the ``capture_orm_selects`` helper #72554 adds to
``devel-common``, so this branch is stacked on top of that PR and should be
merged after it.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)