### PR TITLE
Make the Snowpark container job operator tests collect and pass

### DIFF
--- a/providers/snowflake/tests/unit/snowflake/operators/test_snowpark_containers.py
+++ b/providers/snowflake/tests/unit/snowflake/operators/test_snowpark_containers.py
@@ -187,6 +187,8 @@ class TestSnowparkContainerJobOperator:
         with pytest.raises(TimeoutError, match="did not reach a terminal status"):
             op._poll_for_status()
 
+        describes = [c for c in mock_hook.run.call_args_list if c.args[0].startswith("DESCRIBE SERVICE")]
+        assert len(describes) == 1
         mock_log.assert_called_once_with("RUNNING")
         drop_call = mock.call(f"DROP SERVICE IF EXISTS {JOB_NAME}")
         if drops:

--- a/providers/snowflake/tests/unit/snowflake/operators/test_snowpark_containers.py
+++ b/providers/snowflake/tests/unit/snowflake/operators/test_snowpark_containers.py
@@ -173,7 +173,7 @@ class TestSnowparkContainerJobOperator:
         [(True, True), (False, False)],
     )
     @mock.patch("time.sleep")
-    @mock.patch("time.monotonic", side_effect=itertools.count(0, 20))
+    @mock.patch("time.monotonic", side_effect=[0, 5, 10])
     @mock.patch(MOCK_HOOK_PATH)
     @mock.patch.object(SnowparkContainerJobOperator, "_log_container_output")
     def test_poll_raises_and_logs_on_timeout(


### PR DESCRIPTION
## Summary

The operator test module has never run. Two failures stack up:

- `itertools.count` is called without importing `itertools`, so collection fails and all 45 tests in the module error.
- The mocked clock jumps 20s per read against a 10s timeout, so the poll loop is past its deadline on the first check and logs a status it never observed.

Pinning the three clock reads the loop actually makes fixes both: the timeout fires after exactly one `DESCRIBE SERVICE`, and an implementation that grows a fourth read fails loudly instead of silently shifting the timeline.

The operator needs no change: two real `monotonic()` reads are microseconds apart, so the pre-poll deadline check can only trip for a non-positive timeout.

Left for a follow-up: the mocked hook returns a constant `RUNNING`, so `assert_called_once_with("RUNNING")` separates "polled at least once" from "never polled" rather than the last observed status from an earlier one. Covering that needs a status sequence and a longer deadline.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
