### PR TITLE
Fix td_format rendering negative durations as large positive ones

### DIFF
--- a/airflow-core/newsfragments/72703.bugfix.rst
+++ b/airflow-core/newsfragments/72703.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``td_format`` rendering negative durations as large positive ones. A negative duration is now formatted by magnitude and prefixed with ``-``, and the ``timedelta`` and numeric inputs agree for the same duration.

--- a/shared/timezones/src/airflow_shared/timezones/timezone.py
+++ b/shared/timezones/src/airflow_shared/timezones/timezone.py
@@ -231,13 +231,20 @@ def td_format(td_object: None | dt.timedelta | float | int) -> str | None:
 
     For example timedelta(seconds=3752) would become `1h:2M:32s`.
     If the time is less than a second, the return will be `<1s`.
+    A negative duration is formatted by magnitude and prefixed with `-`,
+    so timedelta(seconds=-3752) would become `-1h:2M:32s`.
     """
     if td_object is None:
         return None
+    # Format the magnitude and re-apply the sign at the end. Formatting a negative
+    # duration directly does not work: the day-to-month division below floors, so
+    # e.g. days=-1 becomes months=-1, days=+29, and `_format_part` then drops the
+    # negative month and leaves the 29 days behind.
+    is_negative = td_object < dt.timedelta(0) if isinstance(td_object, dt.timedelta) else td_object < 0
     if isinstance(td_object, dt.timedelta):
-        delta = relativedelta() + td_object
+        delta = relativedelta() + abs(td_object)
     else:
-        delta = relativedelta(seconds=int(td_object))
+        delta = relativedelta(seconds=int(abs(td_object)))
     # relativedelta for timedelta cannot convert days to months
     # so calculate months by assuming 30 day months and normalize
     months, delta.days = divmod(delta.days, 30)
@@ -258,7 +265,7 @@ def td_format(td_object: None | dt.timedelta | float | int) -> str | None:
     joined = ":".join(part for part in parts if part)
     if not joined:
         return "<1s"
-    return joined
+    return f"-{joined}" if is_negative else joined
 
 
 def parse_timezone(name: str | int) -> FixedTimezone | Timezone:

--- a/shared/timezones/src/airflow_shared/timezones/timezone.py
+++ b/shared/timezones/src/airflow_shared/timezones/timezone.py
@@ -232,7 +232,8 @@ def td_format(td_object: None | dt.timedelta | float | int) -> str | None:
     For example timedelta(seconds=3752) would become `1h:2M:32s`.
     If the time is less than a second, the return will be `<1s`.
     A negative duration is formatted by magnitude and prefixed with `-`,
-    so timedelta(seconds=-3752) would become `-1h:2M:32s`.
+    so timedelta(seconds=-3752) would become `-1h:2M:32s`. A magnitude below
+    one second is still `<1s`, without a sign.
     """
     if td_object is None:
         return None
@@ -240,10 +241,11 @@ def td_format(td_object: None | dt.timedelta | float | int) -> str | None:
     # duration directly does not work: the day-to-month division below floors, so
     # e.g. days=-1 becomes months=-1, days=+29, and `_format_part` then drops the
     # negative month and leaves the 29 days behind.
-    is_negative = td_object < dt.timedelta(0) if isinstance(td_object, dt.timedelta) else td_object < 0
     if isinstance(td_object, dt.timedelta):
+        is_negative = td_object < dt.timedelta(0)
         delta = relativedelta() + abs(td_object)
     else:
+        is_negative = td_object < 0
         delta = relativedelta(seconds=int(abs(td_object)))
     # relativedelta for timedelta cannot convert days to months
     # so calculate months by assuming 30 day months and normalize

--- a/shared/timezones/tests/timezones/test_timezone.py
+++ b/shared/timezones/tests/timezones/test_timezone.py
@@ -97,6 +97,25 @@ class TestTimezone:
         td = 434343600.0
         assert timezone.td_format(td) == "13y:11m:17d:3h"
 
+    def test_td_format_negative(self):
+        td = datetime.timedelta(seconds=-3752)
+        assert timezone.td_format(td) == "-1h:2M:32s"
+        td = datetime.timedelta(days=-5)
+        assert timezone.td_format(td) == "-5d"
+        td = -3752
+        assert timezone.td_format(td) == "-1h:2M:32s"
+        td = -3752.0
+        assert timezone.td_format(td) == "-1h:2M:32s"
+        td = -434343600.0
+        assert timezone.td_format(td) == "-13y:11m:17d:3h"
+        # a magnitude below one second reads the same either way
+        td = datetime.timedelta(seconds=-0.4)
+        assert timezone.td_format(td) == "<1s"
+        td = -0.123
+        assert timezone.td_format(td) == "<1s"
+        # the timedelta and the numeric branch agree for the same duration
+        assert timezone.td_format(datetime.timedelta(seconds=-3752)) == timezone.td_format(-3752)
+
 
 @pytest.mark.parametrize(
     ("input_datetime", "output_datetime"),


### PR DESCRIPTION
Closes: #72694

`td_format` renders a negative duration as a large positive one:

```python
td_format(timedelta(seconds=-3752))   # '29d:22h:57M:28s'
td_format(timedelta(days=-5))         # '25d'
td_format(-3752)                      # '<1s'
```

The last two lines are the same duration expressed two ways and they disagree.

### Cause

The day-to-month conversion uses `divmod`, which floors:

```python
months, delta.days = divmod(delta.days, 30)
```

so a `relativedelta` of `days=-1` becomes `months=-1, days=+29`. `_format_part` skips any component below 1, which drops the `-1 month` that would have cancelled the `+29 days` and leaves the days behind.

The numeric branch differs because `relativedelta(seconds=-3752)` keeps a single negative `seconds` field instead of borrowing a day, so every component is dropped and the empty result falls through to `<1s`.

### Change

Format the magnitude, then re-apply the sign. This keeps the existing output for non-negative durations untouched and makes the two input types agree:

```python
td_format(timedelta(seconds=-3752))   # '-1h:2M:32s'
td_format(timedelta(days=-5))         # '-5d'
td_format(-3752)                      # '-1h:2M:32s'
```

A magnitude below one second still reads `<1s` regardless of sign, since prefixing a sign onto `<1s` would not tell the reader anything useful.

### Tests

Adds `test_td_format_negative` alongside the existing `test_td_format`, covering both input types, the sub-second case, and the agreement between the two branches. It fails on `main` with `'29d:22h:57M:28s' != '-1h:2M:32s'`.

I also checked the sign invariant `td_format(-x) == "-" + td_format(x)` over 20,000 randomly generated durations for both input types, along with cross-type agreement — no violations. That sweep is not included in the test file, since the explicit cases cover the behaviour and are easier to read.

`ruff check` and `ruff format` are clean at the pinned 0.16.4, and the `shared/timezones` suite passes (31 passed).
