### PR TITLE
Remove unused Breeze uv timeout and WSL helpers

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/common_options.py
+++ b/dev/breeze/src/airflow_breeze/commands/common_options.py
@@ -467,13 +467,6 @@ option_use_uv_default_depends_on_installation_method = click.option(
     "from sources and False for installing from packages).",
     envvar="USE_UV",
 )
-option_uv_http_timeout = click.option(
-    "--uv-http-timeout",
-    help="Deprecated: This option isn't exposed anymore",
-    type=click.IntRange(min=1),
-    default=30,
-    hidden=True,
-)
 option_use_airflow_version = click.option(
     "--use-airflow-version",
     help="Use (reinstall at entry) Airflow version from PyPI. It can also be version (to install from PyPI), "

--- a/dev/breeze/src/airflow_breeze/utils/platforms.py
+++ b/dev/breeze/src/airflow_breeze/utils/platforms.py
@@ -16,11 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import contextlib
-import platform
-import sys
-from pathlib import Path
-
 
 def get_normalized_platform(single_platform: str) -> str:
     """
@@ -28,60 +23,3 @@ def get_normalized_platform(single_platform: str) -> str:
     are using: linux/amd64 and linux/arm64.
     """
     return single_platform.replace("x86_64", "amd64").replace("aarch64", "arm64")
-
-
-def _exists_no_permission_error(p: str) -> bool:
-    try:
-        return Path(p).exists()
-    except PermissionError:
-        return False
-
-
-def message_on_wsl1_detected(release_name: str | None, kernel_version: tuple[int, ...] | None):
-    from airflow_breeze.utils.console import console_print
-
-    console_print("[error]You are running WSL1 - Breeze requires WSL2! Quitting.\n")
-    console_print("[warning]It can also be that our detection mechanism is wrong:[/]\n\n")
-    if release_name:
-        console_print(f"[info]We based our WSL1 detection on the release name: `{release_name}`\n")
-    elif kernel_version:
-        console_print(f"[info]We based our WSL1 detection on the kernel version: `{kernel_version}`\n")
-    console_print(
-        "[info]If you are running WSL2, please report this issue to the maintainers\n"
-        "of Airflow, so we can improve the detection mechanism.\n"
-        "You can also try to run the command with `--uv-http-timeout 900` or "
-        "`--no-use-uv` flag to skip the WSL1 check.\n"
-    )
-
-
-def is_wsl2() -> bool:
-    """
-    Check if the current platform is WSL2. This method will exit with error printing appropriate
-    message if WSL1 is detected as WSL1 is not supported.
-
-    :return: True if the current platform is WSL2, False otherwise (unless it's WSL1 then it exits).
-    """
-    if not sys.platform.startswith("linux"):
-        return False
-    release_name = platform.uname().release
-    has_wsl_interop = _exists_no_permission_error("/proc/sys/fs/binfmt_misc/WSLInterop")
-    microsoft_in_release = "microsoft" in release_name.lower()
-    wsl_conf = _exists_no_permission_error("/etc/wsl.conf")
-    if not has_wsl_interop and not microsoft_in_release and not wsl_conf:
-        return False
-    if microsoft_in_release:
-        # Release name WSL1 detection
-        if "Microsoft" in release_name:
-            message_on_wsl1_detected(release_name=release_name, kernel_version=None)
-            sys.exit(1)
-        return True
-
-    # Kernel WSL1 detection
-    kernel_version: tuple[int, ...] = (0, 0)
-    if len(parts := release_name.split(".", 2)[:2]) == 2:
-        with contextlib.suppress(TypeError, ValueError):
-            kernel_version = tuple(map(int, parts))
-    if kernel_version < (4, 19):
-        message_on_wsl1_detected(release_name=None, kernel_version=kernel_version)
-        sys.exit(1)
-    return True


### PR DESCRIPTION
## Why

#62029 removed the uv timeout override and its callers. The option definition and WSL detection helpers were left unused.

## What

Remove the unused option and WSL helpers. Keep `get_normalized_platform()`, which is still used by Breeze commands and image builds.

related: #62029

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes, Codex (GPT-6)

Generated-by: Codex (GPT-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)