### PR TITLE
Fix collection error and timeout assertion in Snowpark container tests

### DIFF
--- a/providers/snowflake/tests/unit/snowflake/operators/test_snowpark_containers.py
+++ b/providers/snowflake/tests/unit/snowflake/operators/test_snowpark_containers.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import itertools
 from datetime import datetime, timedelta, timezone
 from unittest import mock
 
@@ -173,7 +174,8 @@ class TestSnowparkContainerJobOperator:
         [(True, True), (False, False)],
     )
     @mock.patch("time.sleep")
-    @mock.patch("time.monotonic", side_effect=itertools.count(0, 20))
+    # 0 sets the deadline at 10, 5 admits one poll that observes RUNNING, 10 then trips the timeout.
+    @mock.patch("time.monotonic", side_effect=itertools.count(0, 5))
     @mock.patch(MOCK_HOOK_PATH)
     @mock.patch.object(SnowparkContainerJobOperator, "_log_container_output")
     def test_poll_raises_and_logs_on_timeout(


### PR DESCRIPTION
main is currently broken by this: the module fails to collect, so the ruff and
mypy jobs go red on every open PR, not only ones touching Snowflake. Example
run: https://github.com/apache/airflow/actions/runs/34225812873/job/102064432010

Fixing the import surfaces a second problem from the same change, so both are
here together. Fixing only the import would turn the collection error into two
test failures.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
