### PR TITLE
Add OAuth2 client credentials auth for OpenLineage HTTP transport

### DIFF
--- a/providers/openlineage/docs/configurations-ref.rst
+++ b/providers/openlineage/docs/configurations-ref.rst
@@ -100,6 +100,54 @@ reads the API key from the same connection password by default. You can also set
 from another Airflow connection. The provider resolves ``airflow_connection_api_key`` to standard OpenLineage
 ``api_key`` auth before creating the OpenLineage client.
 
+.. _configuration_oauth2:openlineage:
+
+OAuth 2.0 client credentials authentication
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+OpenLineage Python client does not ship OAuth 2.0 client credentials authentication for HTTP transports. If your
+OpenLineage backend issues short-lived access tokens with this grant, set ``auth.type`` to
+``airflow.providers.openlineage.token_provider.OAuth2ClientCredentialsTokenProvider``. The provider requests an access
+token from the token endpoint, caches it and requests a new one before it expires. It can be used with ``http`` and
+``async_http`` transports, including those nested in a ``composite`` transport.
+
+.. code-block:: ini
+
+    [openlineage]
+    transport = {"type": "http", "url": "http://example.com:5000", "auth": {"type": "airflow.providers.openlineage.token_provider.OAuth2ClientCredentialsTokenProvider", "tokenEndpoint": "https://auth.example.com/oauth2/token", "clientId": "my-client-id", "clientSecret": "my-client-secret"}}
+
+Supported ``auth`` options:
+
+- ``tokenEndpoint`` (required) - OAuth 2.0 token endpoint URL.
+- ``clientId`` (required) - OAuth 2.0 client ID.
+- ``clientSecret`` (required) - OAuth 2.0 client secret.
+- ``scope`` - space separated scopes to request.
+- ``clientAuthMethod`` - ``client_secret_basic`` (default) sends the client credentials in the ``Authorization`` header,
+  ``client_secret_post`` sends them in the request body.
+- ``tokenRefreshBuffer`` - number of seconds before the token expiry when a new token is requested, defaults to ``120``
+  and is capped at half of the token lifetime. If the token endpoint does not return ``expires_in``, a lifetime of
+  ``300`` seconds is assumed.
+
+The options are also accepted in snake_case (``token_endpoint``, ``client_id``, ``client_secret``, ...), so they can be
+set with OpenLineage client environment variables such as ``OPENLINEAGE__TRANSPORT__AUTH__CLIENT_ID``.
+
+Tokens are cached per process. With the default fork-based task event emission, each task event is emitted from a
+short-lived child process and requests its own token; enable ``execute_in_thread`` to reuse a token across events.
+
+To keep the client secret out of Airflow configuration, set ``auth.type`` to ``airflow_connection_oauth2_client_credentials``
+and store the credentials in an Airflow connection: login is the client ID, password is the client secret and host is the
+token endpoint (unless ``tokenEndpoint`` is set in ``auth``). ``auth.conn_id`` selects the connection; when the config is
+loaded from ``config_conn_id``, that connection is used by default. The other options listed above can be set in ``auth``.
+
+.. code-block:: ini
+
+    [openlineage]
+    transport = {"type": "http", "url": "http://example.com:5000", "auth": {"type": "airflow_connection_oauth2_client_credentials", "conn_id": "openlineage_oauth2"}}
+
+.. code-block:: bash
+
+    export AIRFLOW_CONN_OPENLINEAGE_OAUTH2='{"conn_type": "generic", "login": "my-client-id", "password": "my-client-secret", "host": "https://auth.example.com/oauth2/token"}'
+
 .. note::
   For full list of built-in transport types, specific transport's options or instructions on how to implement your custom transport, refer to
   `Python client documentation <https://openlineage.io/docs/client/python/configuration#transports>`_.

--- a/providers/openlineage/docs/spark.rst
+++ b/providers/openlineage/docs/spark.rst
@@ -181,6 +181,9 @@ as Airflow without manual configuration.
 .. caution::
 
     Currently, only HTTP transport is supported for automatic transport injection (with api_key authentication, if configured).
+    If the transport uses :ref:`OAuth 2.0 client credentials authentication <configuration_oauth2:openlineage>`, the current
+    access token is injected as ``api_key`` authentication, because Spark OpenLineage integration cannot refresh it.
+    Spark applications running longer than the token lifetime will fail to emit OpenLineage events.
 
 
 .. note::

--- a/providers/openlineage/src/airflow/providers/openlineage/token_provider.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/token_provider.py
@@ -119,9 +119,6 @@ class OAuth2ClientCredentialsTokenProvider(TokenProvider):
         else:
             basic_auth = (self.client_id, self.client_secret)
 
-        log.debug(
-            "Requesting OAuth2 access token from `%s` for client `%s`.", self.token_endpoint, self.client_id
-        )
         try:
             response = requests.post(self.token_endpoint, data=data, auth=basic_auth, timeout=10)
             response.raise_for_status()
@@ -140,9 +137,7 @@ class OAuth2ClientCredentialsTokenProvider(TokenProvider):
         # Refresh early, but never so early that every event would trigger a new token request.
         self._refresh_at = time.monotonic() + lifetime - min(self.token_refresh_buffer, lifetime / 2)
         self._access_token = str(access_token)
-        log.debug(
-            "Obtained OAuth2 access token for client `%s`, valid for %s seconds.", self.client_id, lifetime
-        )
+        log.debug("Obtained OAuth2 access token, valid for %s seconds.", lifetime)
 
     def _get_token_lifetime(self, payload: dict[str, Any]) -> float:
         expires_in = payload.get("expires_in", self.DEFAULT_TOKEN_LIFETIME)

--- a/providers/openlineage/src/airflow/providers/openlineage/token_provider.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/token_provider.py
@@ -16,11 +16,20 @@
 # under the License.
 from __future__ import annotations
 
+import logging
+import threading
+import time
 from typing import Any
+
+import requests
+from openlineage.client.transport.http import TokenProvider
 
 from airflow.providers.common.compat.sdk import AirflowException, BaseHook
 
+log = logging.getLogger(__name__)
+
 AIRFLOW_CONNECTION_API_KEY_AUTH_TYPE = "airflow_connection_api_key"
+AIRFLOW_CONNECTION_OAUTH2_AUTH_TYPE = "airflow_connection_oauth2_client_credentials"
 _DEFAULT_EXTRA_KEYS = ("apiKey", "api_key", "apikey", "token", "access_token")
 
 
@@ -30,6 +39,127 @@ class OpenLineageAirflowConnectionAuthError(AirflowException):
 
 class OpenLineageAirflowConnectionConfigError(AirflowException):
     """Raised when OpenLineage config cannot be resolved from an Airflow connection."""
+
+
+class OpenLineageOAuth2ConfigError(AirflowException):
+    """Raised when OpenLineage OAuth2 client credentials auth is misconfigured."""
+
+
+class OpenLineageOAuth2TokenError(AirflowException):
+    """Raised when an OAuth2 access token for OpenLineage HTTP transport cannot be obtained."""
+
+
+def _get_config_value(config: dict[str, Any], *keys: str) -> Any:
+    """Return the first non-empty value found under the given keys (camelCase first, then snake_case)."""
+    for key in keys:
+        value = config.get(key)
+        if value is not None and value != "":
+            return value
+    return None
+
+
+def _get_required_config_value(config: dict[str, Any], *keys: str) -> str:
+    value = _get_config_value(config, *keys)
+    if not value:
+        raise OpenLineageOAuth2ConfigError(
+            f"OpenLineage OAuth2 client credentials auth requires a non-empty `{keys[0]}`."
+        )
+    return str(value)
+
+
+class OAuth2ClientCredentialsTokenProvider(TokenProvider):
+    """
+    OpenLineage HTTP transport ``TokenProvider`` using the OAuth 2.0 client credentials grant (RFC 6749, 4.4).
+
+    Access tokens requested from ``tokenEndpoint`` with ``clientId`` and ``clientSecret`` are cached and
+    requested again ``tokenRefreshBuffer`` seconds before they expire. Options are accepted in camelCase and
+    snake_case, as OpenLineage client environment variables are read in snake_case.
+    """
+
+    DEFAULT_TOKEN_REFRESH_BUFFER = 120.0
+    DEFAULT_TOKEN_LIFETIME = 300.0  # used when the token endpoint does not return `expires_in`
+    CLIENT_AUTH_METHODS = ("client_secret_basic", "client_secret_post")
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        super().__init__(config)
+        self.token_endpoint = _get_required_config_value(config, "tokenEndpoint", "token_endpoint")
+        self.client_id = _get_required_config_value(config, "clientId", "client_id")
+        self.client_secret = _get_required_config_value(config, "clientSecret", "client_secret")
+        self.scope = _get_config_value(config, "scope")
+        self.client_auth_method = str(
+            _get_config_value(config, "clientAuthMethod", "client_auth_method") or self.CLIENT_AUTH_METHODS[0]
+        ).lower()
+        if self.client_auth_method not in self.CLIENT_AUTH_METHODS:
+            raise OpenLineageOAuth2ConfigError(
+                f"OpenLineage OAuth2 auth option `clientAuthMethod` must be one of {self.CLIENT_AUTH_METHODS}, "
+                f"got `{self.client_auth_method}`."
+            )
+        token_refresh_buffer = _get_config_value(config, "tokenRefreshBuffer", "token_refresh_buffer")
+        self.token_refresh_buffer = (
+            self.DEFAULT_TOKEN_REFRESH_BUFFER if token_refresh_buffer is None else float(token_refresh_buffer)
+        )
+        self._lock = threading.Lock()
+        self._access_token: str | None = None
+        self._refresh_at = 0.0
+
+    def get_bearer(self) -> str | None:
+        with self._lock:
+            if self._access_token is None or time.monotonic() >= self._refresh_at:
+                self._request_token()
+            return f"Bearer {self._access_token}"
+
+    def _request_token(self) -> None:
+        data = {"grant_type": "client_credentials"}
+        if self.scope:
+            data["scope"] = self.scope
+        basic_auth = None
+        if self.client_auth_method == "client_secret_post":
+            data["client_id"] = self.client_id
+            data["client_secret"] = self.client_secret
+        else:
+            basic_auth = (self.client_id, self.client_secret)
+
+        log.debug(
+            "Requesting OAuth2 access token from `%s` for client `%s`.", self.token_endpoint, self.client_id
+        )
+        try:
+            response = requests.post(self.token_endpoint, data=data, auth=basic_auth, timeout=10)
+            response.raise_for_status()
+        except requests.RequestException as e:
+            raise OpenLineageOAuth2TokenError(
+                f"OAuth2 token request to `{self.token_endpoint}` failed: {e}"
+            ) from e
+        try:
+            payload = response.json()
+            access_token = payload["access_token"]
+        except (ValueError, KeyError, TypeError):
+            raise OpenLineageOAuth2TokenError(
+                f"OAuth2 token endpoint `{self.token_endpoint}` did not return an `access_token`."
+            ) from None
+        lifetime = self._get_token_lifetime(payload)
+        # Refresh early, but never so early that every event would trigger a new token request.
+        self._refresh_at = time.monotonic() + lifetime - min(self.token_refresh_buffer, lifetime / 2)
+        self._access_token = str(access_token)
+        log.debug(
+            "Obtained OAuth2 access token for client `%s`, valid for %s seconds.", self.client_id, lifetime
+        )
+
+    def _get_token_lifetime(self, payload: dict[str, Any]) -> float:
+        expires_in = payload.get("expires_in", self.DEFAULT_TOKEN_LIFETIME)
+        try:
+            lifetime = float(expires_in)
+        except (TypeError, ValueError):
+            lifetime = 0.0
+        if lifetime <= 0:
+            raise OpenLineageOAuth2TokenError(
+                f"OAuth2 token endpoint `{self.token_endpoint}` returned invalid `expires_in` value `{expires_in}`."
+            )
+        return lifetime
+
+
+OAUTH2_CLIENT_CREDENTIALS_AUTH_TYPE = (
+    f"{OAuth2ClientCredentialsTokenProvider.__module__}.{OAuth2ClientCredentialsTokenProvider.__qualname__}"
+)
 
 
 class AirflowConnectionConfigProvider:
@@ -104,16 +234,58 @@ class AirflowConnectionTokenProvider:
         return None
 
 
+class AirflowConnectionOAuth2ClientCredentialsProvider:
+    """
+    Resolve OAuth2 client credentials for OpenLineage HTTP transport from an Airflow connection.
+
+    The client ID is read from the connection login and the client secret from the connection password.
+    The token endpoint is read from ``tokenEndpoint`` in the auth config if set, otherwise from the
+    connection host. Any other auth options are passed through to
+    :class:`OAuth2ClientCredentialsTokenProvider` unchanged.
+    """
+
+    def __init__(self, config: dict[str, Any], default_conn_id: str | None = None) -> None:
+        self.config = config
+        self.conn_id = config.get("conn_id") or default_conn_id or ""
+        if not self.conn_id:
+            raise OpenLineageAirflowConnectionAuthError(
+                f"OpenLineage `{AIRFLOW_CONNECTION_OAUTH2_AUTH_TYPE}` auth requires a non-empty `conn_id`."
+            )
+
+    def get_auth_config(self) -> dict[str, Any]:
+        connection = BaseHook.get_connection(self.conn_id)
+        token_endpoint = _get_config_value(self.config, "tokenEndpoint", "token_endpoint") or connection.host
+        if not (connection.login and connection.password and token_endpoint):
+            raise OpenLineageAirflowConnectionAuthError(
+                f"OpenLineage `{AIRFLOW_CONNECTION_OAUTH2_AUTH_TYPE}` auth requires connection `{self.conn_id}` "
+                "to have login (client ID), password (client secret) and host (token endpoint, unless "
+                "`tokenEndpoint` is set in auth config)."
+            )
+        options = {
+            key: value
+            for key, value in self.config.items()
+            if key not in ("type", "conn_id", "tokenEndpoint", "token_endpoint")
+        }
+        return {
+            "type": OAUTH2_CLIENT_CREDENTIALS_AUTH_TYPE,
+            **options,
+            "tokenEndpoint": token_endpoint,
+            "clientId": connection.login,
+            "clientSecret": connection.password,
+        }
+
+
 def resolve_airflow_connection_auth(config: dict[str, Any] | None, config_conn_id: str | None = None) -> None:
     """
-    Read the API key from an Airflow connection and put it into the OpenLineage config.
+    Read auth secrets from Airflow connections and put them into the OpenLineage config.
 
     OpenLineage config can contain one transport, a composite transport, or composite transports
     nested inside each other. This function walks through that structure and updates every matching
     ``auth`` block in place.
 
     This only makes sense for HTTP transports: ``airflow_connection_api_key`` is replaced with
-    ``{"type": "api_key", "apiKey": ...}``.
+    ``{"type": "api_key", "apiKey": ...}`` and ``airflow_connection_oauth2_client_credentials`` with
+    :class:`OAuth2ClientCredentialsTokenProvider` config holding the client credentials.
     """
     if not isinstance(config, dict):
         return
@@ -126,6 +298,15 @@ def resolve_airflow_connection_auth(config: dict[str, Any] | None, config_conn_i
         ):
             provider = AirflowConnectionTokenProvider(value, default_conn_id=config_conn_id)
             config[key] = {"type": "api_key", "apiKey": provider.get_api_key()}
+        elif (
+            key == "auth"
+            and isinstance(value, dict)
+            and value.get("type") == AIRFLOW_CONNECTION_OAUTH2_AUTH_TYPE
+        ):
+            oauth2_provider = AirflowConnectionOAuth2ClientCredentialsProvider(
+                value, default_conn_id=config_conn_id
+            )
+            config[key] = oauth2_provider.get_auth_config()
         elif key == "transports" and isinstance(value, list):
             for item in value:
                 resolve_airflow_connection_auth(item, config_conn_id=config_conn_id)

--- a/providers/openlineage/src/airflow/providers/openlineage/utils/spark.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/utils/spark.py
@@ -28,6 +28,10 @@ from airflow.providers.openlineage.plugins.macros import (
     lineage_root_run_id,
     lineage_run_id,
 )
+from airflow.providers.openlineage.token_provider import (
+    OAuth2ClientCredentialsTokenProvider,
+    OpenLineageOAuth2TokenError,
+)
 
 if TYPE_CHECKING:
     from airflow.providers.common.compat.sdk import Context
@@ -74,6 +78,22 @@ def _get_transport_information_as_spark_properties() -> dict:
         if hasattr(tp.config.auth, "api_key") and tp.config.auth.get_bearer():
             properties["auth.type"] = "api_key"
             properties["auth.apiKey"] = tp.config.auth.get_bearer()
+        elif isinstance(tp.config.auth, OAuth2ClientCredentialsTokenProvider):
+            try:
+                bearer = tp.config.auth.get_bearer()
+            except OpenLineageOAuth2TokenError as e:
+                log.warning(
+                    "Failed to obtain OpenLineage OAuth2 access token, injecting Spark transport information "
+                    "without authentication: %s",
+                    e,
+                )
+            else:
+                log.info(
+                    "Injecting current OAuth2 access token as `api_key` auth into Spark properties. Spark cannot "
+                    "refresh it, so Spark applications outliving the token will fail to emit OpenLineage events."
+                )
+                properties["auth.type"] = "api_key"
+                properties["auth.apiKey"] = bearer
 
         if hasattr(tp.config, "custom_headers") and tp.config.custom_headers:
             for key, value in tp.config.custom_headers.items():

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_adapter.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_adapter.py
@@ -55,6 +55,9 @@ from airflow.providers.openlineage.plugins.facets import (
 )
 from airflow.providers.openlineage.token_provider import (
     AIRFLOW_CONNECTION_API_KEY_AUTH_TYPE,
+    AIRFLOW_CONNECTION_OAUTH2_AUTH_TYPE,
+    OAUTH2_CLIENT_CREDENTIALS_AUTH_TYPE,
+    OAuth2ClientCredentialsTokenProvider,
     OpenLineageAirflowConnectionAuthError,
     OpenLineageAirflowConnectionConfigError,
 )
@@ -262,6 +265,55 @@ def test_connection_config_missing_transport_raises_custom_exception(mock_get_co
             match="must contain a `transport` JSON object",
         ):
             OpenLineageAdapter().get_or_create_openlineage_client()
+
+
+@patch.object(BaseHook, "get_connection")
+def test_create_client_from_config_with_oauth2_connection_auth(mock_get_connection):
+    mock_get_connection.return_value = Connection(
+        conn_id="openlineage_default",
+        conn_type="generic",
+        login="my-client-id",
+        password="my-client-secret",
+        host="https://auth.example.com/token",
+    )
+    transport_config = json.dumps(
+        {
+            "type": "http",
+            "url": "http://ol-api:5000",
+            "auth": {"type": AIRFLOW_CONNECTION_OAUTH2_AUTH_TYPE, "conn_id": "openlineage_default"},
+        }
+    )
+
+    with conf_vars({("openlineage", "transport"): transport_config}):
+        client = OpenLineageAdapter().get_or_create_openlineage_client()
+
+    assert client.transport.kind == "http"
+    auth = client.transport.config.auth
+    assert isinstance(auth, OAuth2ClientCredentialsTokenProvider)
+    assert auth.token_endpoint == "https://auth.example.com/token"
+    assert auth.client_id == "my-client-id"
+    assert auth.client_secret == "my-client-secret"
+
+
+def test_create_client_from_config_with_oauth2_token_provider():
+    transport_config = json.dumps(
+        {
+            "type": "http",
+            "url": "http://ol-api:5000",
+            "auth": {
+                "type": OAUTH2_CLIENT_CREDENTIALS_AUTH_TYPE,
+                "tokenEndpoint": "https://auth.example.com/token",
+                "clientId": "my-client-id",
+                "clientSecret": "my-client-secret",
+            },
+        }
+    )
+
+    with conf_vars({("openlineage", "transport"): transport_config}):
+        client = OpenLineageAdapter().get_or_create_openlineage_client()
+
+    assert client.transport.kind == "http"
+    assert isinstance(client.transport.config.auth, OAuth2ClientCredentialsTokenProvider)
 
 
 def test_create_client_from_yaml_config():

--- a/providers/openlineage/tests/unit/openlineage/test_token_provider.py
+++ b/providers/openlineage/tests/unit/openlineage/test_token_provider.py
@@ -17,17 +17,27 @@
 # under the License.
 from __future__ import annotations
 
+import base64
+import time
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import patch
+from urllib.parse import parse_qs
 
 import pytest
+import requests
 
 from airflow.providers.common.compat.sdk import BaseHook, Connection
 from airflow.providers.openlineage.token_provider import (
     AIRFLOW_CONNECTION_API_KEY_AUTH_TYPE,
+    AIRFLOW_CONNECTION_OAUTH2_AUTH_TYPE,
+    OAUTH2_CLIENT_CREDENTIALS_AUTH_TYPE,
     AirflowConnectionConfigProvider,
     AirflowConnectionTokenProvider,
+    OAuth2ClientCredentialsTokenProvider,
     OpenLineageAirflowConnectionAuthError,
     OpenLineageAirflowConnectionConfigError,
+    OpenLineageOAuth2ConfigError,
+    OpenLineageOAuth2TokenError,
     resolve_airflow_connection_auth,
 )
 
@@ -190,3 +200,321 @@ def test_missing_config_raises_custom_exception(mock_get_connection):
         match="must contain a `transport` JSON object",
     ):
         provider.get_config()
+
+
+OAUTH2_TOKEN_ENDPOINT = "https://auth.example.com/token"
+OAUTH2_AUTH_CONFIG = {
+    "type": OAUTH2_CLIENT_CREDENTIALS_AUTH_TYPE,
+    "tokenEndpoint": OAUTH2_TOKEN_ENDPOINT,
+    "clientId": "my-client-id",
+    "clientSecret": "my-client-secret",
+}
+OAUTH2_TOKEN_RESPONSE = {"access_token": "access-token", "token_type": "Bearer", "expires_in": 600}
+
+
+def _oauth2_connection(**kwargs):
+    connection_kwargs = {
+        "conn_id": "openlineage_default",
+        "conn_type": "generic",
+        "login": "my-client-id",
+        "password": "my-client-secret",
+        "host": OAUTH2_TOKEN_ENDPOINT,
+        **kwargs,
+    }
+    return Connection(**connection_kwargs)
+
+
+def test_oauth2_provider_requests_token_with_client_secret_basic(requests_mock):
+    requests_mock.post(OAUTH2_TOKEN_ENDPOINT, json=OAUTH2_TOKEN_RESPONSE)
+
+    provider = OAuth2ClientCredentialsTokenProvider(OAUTH2_AUTH_CONFIG)
+
+    assert provider.get_bearer() == "Bearer access-token"
+    request = requests_mock.last_request
+    expected_credentials = base64.b64encode(b"my-client-id:my-client-secret").decode()
+    assert request.headers["Authorization"] == f"Basic {expected_credentials}"
+    assert parse_qs(request.text) == {"grant_type": ["client_credentials"]}
+
+
+def test_oauth2_provider_requests_token_with_client_secret_post(requests_mock):
+    requests_mock.post(OAUTH2_TOKEN_ENDPOINT, json=OAUTH2_TOKEN_RESPONSE)
+    config = {**OAUTH2_AUTH_CONFIG, "clientAuthMethod": "client_secret_post", "scope": "openid"}
+
+    provider = OAuth2ClientCredentialsTokenProvider(config)
+
+    assert provider.get_bearer() == "Bearer access-token"
+    request = requests_mock.last_request
+    assert "Authorization" not in request.headers
+    assert parse_qs(request.text) == {
+        "grant_type": ["client_credentials"],
+        "client_id": ["my-client-id"],
+        "client_secret": ["my-client-secret"],
+        "scope": ["openid"],
+    }
+
+
+def test_oauth2_provider_accepts_snake_case_options():
+    provider = OAuth2ClientCredentialsTokenProvider(
+        {
+            "token_endpoint": OAUTH2_TOKEN_ENDPOINT,
+            "client_id": "my-client-id",
+            "client_secret": "my-client-secret",
+            "client_auth_method": "client_secret_post",
+            "token_refresh_buffer": "30",
+        }
+    )
+
+    assert provider.token_endpoint == OAUTH2_TOKEN_ENDPOINT
+    assert provider.client_id == "my-client-id"
+    assert provider.client_secret == "my-client-secret"
+    assert provider.client_auth_method == "client_secret_post"
+    assert provider.token_refresh_buffer == 30.0
+
+
+@pytest.mark.parametrize("missing_key", ["tokenEndpoint", "clientId", "clientSecret"])
+def test_oauth2_provider_requires_token_endpoint_and_client_credentials(missing_key):
+    config = {key: value for key, value in OAUTH2_AUTH_CONFIG.items() if key != missing_key}
+
+    with pytest.raises(OpenLineageOAuth2ConfigError, match=f"requires a non-empty `{missing_key}`"):
+        OAuth2ClientCredentialsTokenProvider(config)
+
+
+def test_oauth2_provider_rejects_unknown_client_auth_method():
+    with pytest.raises(OpenLineageOAuth2ConfigError, match="`clientAuthMethod` must be one of"):
+        OAuth2ClientCredentialsTokenProvider({**OAUTH2_AUTH_CONFIG, "clientAuthMethod": "private_key_jwt"})
+
+
+@patch("airflow.providers.openlineage.token_provider.time.monotonic")
+def test_oauth2_provider_caches_token_and_refreshes_before_expiry(mock_monotonic, requests_mock):
+    requests_mock.post(
+        OAUTH2_TOKEN_ENDPOINT,
+        [
+            {"json": {**OAUTH2_TOKEN_RESPONSE, "access_token": "first"}},
+            {"json": {**OAUTH2_TOKEN_RESPONSE, "access_token": "second"}},
+        ],
+    )
+    provider = OAuth2ClientCredentialsTokenProvider(OAUTH2_AUTH_CONFIG)
+
+    mock_monotonic.return_value = 1000.0
+    assert provider.get_bearer() == "Bearer first"
+    mock_monotonic.return_value = 1479.0
+    assert provider.get_bearer() == "Bearer first"
+    assert requests_mock.call_count == 1
+    mock_monotonic.return_value = 1480.0
+    assert provider.get_bearer() == "Bearer second"
+    assert requests_mock.call_count == 2
+
+
+@patch("airflow.providers.openlineage.token_provider.time.monotonic")
+def test_oauth2_provider_limits_refresh_buffer_to_half_of_token_lifetime(mock_monotonic, requests_mock):
+    requests_mock.post(OAUTH2_TOKEN_ENDPOINT, json={**OAUTH2_TOKEN_RESPONSE, "expires_in": 60})
+    provider = OAuth2ClientCredentialsTokenProvider(OAUTH2_AUTH_CONFIG)
+
+    mock_monotonic.return_value = 1000.0
+    provider.get_bearer()
+    mock_monotonic.return_value = 1029.0
+    provider.get_bearer()
+    assert requests_mock.call_count == 1
+    mock_monotonic.return_value = 1030.0
+    provider.get_bearer()
+    assert requests_mock.call_count == 2
+
+
+@patch("airflow.providers.openlineage.token_provider.time.monotonic")
+def test_oauth2_provider_assumes_default_lifetime_without_expires_in(mock_monotonic, requests_mock):
+    requests_mock.post(OAUTH2_TOKEN_ENDPOINT, json={"access_token": "access-token"})
+    provider = OAuth2ClientCredentialsTokenProvider(OAUTH2_AUTH_CONFIG)
+
+    mock_monotonic.return_value = 1000.0
+    provider.get_bearer()
+    mock_monotonic.return_value = 1179.0
+    provider.get_bearer()
+    assert requests_mock.call_count == 1
+    mock_monotonic.return_value = 1180.0
+    provider.get_bearer()
+    assert requests_mock.call_count == 2
+
+
+@pytest.mark.parametrize("expires_in", ["soon", 0, -1])
+def test_oauth2_provider_rejects_invalid_expires_in(expires_in, requests_mock):
+    requests_mock.post(OAUTH2_TOKEN_ENDPOINT, json={"access_token": "access-token", "expires_in": expires_in})
+
+    with pytest.raises(OpenLineageOAuth2TokenError, match="returned invalid `expires_in`"):
+        OAuth2ClientCredentialsTokenProvider(OAUTH2_AUTH_CONFIG).get_bearer()
+
+
+def test_oauth2_provider_raises_on_error_response(requests_mock):
+    requests_mock.post(OAUTH2_TOKEN_ENDPOINT, status_code=401, json={"error": "invalid_client"})
+
+    with pytest.raises(OpenLineageOAuth2TokenError, match="failed: 401 Client Error"):
+        OAuth2ClientCredentialsTokenProvider(OAUTH2_AUTH_CONFIG).get_bearer()
+
+
+@pytest.mark.parametrize(
+    "response", [{"text": "not json"}, {"json": {"token": "access-token"}}, {"json": []}]
+)
+def test_oauth2_provider_requires_access_token_in_response(response, requests_mock):
+    requests_mock.post(OAUTH2_TOKEN_ENDPOINT, **response)
+
+    with pytest.raises(OpenLineageOAuth2TokenError, match="did not return an `access_token`"):
+        OAuth2ClientCredentialsTokenProvider(OAUTH2_AUTH_CONFIG).get_bearer()
+
+
+def test_oauth2_provider_wraps_request_errors(requests_mock):
+    requests_mock.post(OAUTH2_TOKEN_ENDPOINT, exc=requests.ConnectionError("connection refused"))
+
+    with pytest.raises(OpenLineageOAuth2TokenError, match="failed: connection refused"):
+        OAuth2ClientCredentialsTokenProvider(OAUTH2_AUTH_CONFIG).get_bearer()
+
+
+def test_oauth2_provider_requests_token_once_for_concurrent_calls(requests_mock):
+    def slow_token_response(request, context):
+        time.sleep(0.05)
+        return OAUTH2_TOKEN_RESPONSE
+
+    requests_mock.post(OAUTH2_TOKEN_ENDPOINT, json=slow_token_response)
+    provider = OAuth2ClientCredentialsTokenProvider(OAUTH2_AUTH_CONFIG)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        bearers = list(executor.map(lambda _: provider.get_bearer(), range(8)))
+
+    assert bearers == ["Bearer access-token"] * 8
+    assert requests_mock.call_count == 1
+
+
+@patch.object(BaseHook, "get_connection")
+def test_resolve_oauth2_connection_auth(mock_get_connection):
+    mock_get_connection.return_value = _oauth2_connection()
+    config = {
+        "transport": {
+            "type": "http",
+            "url": "http://ol-api:5000",
+            "auth": {
+                "type": AIRFLOW_CONNECTION_OAUTH2_AUTH_TYPE,
+                "conn_id": "openlineage_default",
+                "scope": "openid",
+            },
+        }
+    }
+
+    resolve_airflow_connection_auth(config)
+
+    assert config["transport"]["auth"] == {
+        "type": OAUTH2_CLIENT_CREDENTIALS_AUTH_TYPE,
+        "tokenEndpoint": OAUTH2_TOKEN_ENDPOINT,
+        "clientId": "my-client-id",
+        "clientSecret": "my-client-secret",
+        "scope": "openid",
+    }
+    mock_get_connection.assert_called_once_with("openlineage_default")
+
+
+@patch.object(BaseHook, "get_connection")
+def test_resolve_oauth2_connection_auth_prefers_token_endpoint_from_config(mock_get_connection):
+    mock_get_connection.return_value = _oauth2_connection(host=None)
+    config = {
+        "transport": {
+            "type": "http",
+            "url": "http://ol-api:5000",
+            "auth": {
+                "type": AIRFLOW_CONNECTION_OAUTH2_AUTH_TYPE,
+                "conn_id": "openlineage_default",
+                "token_endpoint": "https://other.example.com/token",
+            },
+        }
+    }
+
+    resolve_airflow_connection_auth(config)
+
+    assert config["transport"]["auth"] == {
+        "type": OAUTH2_CLIENT_CREDENTIALS_AUTH_TYPE,
+        "tokenEndpoint": "https://other.example.com/token",
+        "clientId": "my-client-id",
+        "clientSecret": "my-client-secret",
+    }
+
+
+@patch.object(BaseHook, "get_connection")
+def test_resolve_oauth2_connection_auth_uses_config_conn_id_by_default(mock_get_connection):
+    mock_get_connection.return_value = _oauth2_connection()
+    config = {
+        "transport": {
+            "type": "http",
+            "url": "http://ol-api:5000",
+            "auth": {"type": AIRFLOW_CONNECTION_OAUTH2_AUTH_TYPE},
+        }
+    }
+
+    resolve_airflow_connection_auth(config, config_conn_id="openlineage_default")
+
+    assert config["transport"]["auth"]["clientId"] == "my-client-id"
+    mock_get_connection.assert_called_once_with("openlineage_default")
+
+
+def test_resolve_oauth2_connection_auth_requires_conn_id():
+    config = {"transport": {"type": "http", "auth": {"type": AIRFLOW_CONNECTION_OAUTH2_AUTH_TYPE}}}
+
+    with pytest.raises(OpenLineageAirflowConnectionAuthError, match="requires a non-empty `conn_id`"):
+        resolve_airflow_connection_auth(config)
+
+
+@pytest.mark.parametrize("connection_kwargs", [{"login": None}, {"password": None}, {"host": None}])
+@patch.object(BaseHook, "get_connection")
+def test_resolve_oauth2_connection_auth_requires_login_password_and_host(
+    mock_get_connection, connection_kwargs
+):
+    mock_get_connection.return_value = _oauth2_connection(**connection_kwargs)
+    config = {
+        "transport": {
+            "type": "http",
+            "auth": {"type": AIRFLOW_CONNECTION_OAUTH2_AUTH_TYPE, "conn_id": "openlineage_default"},
+        }
+    }
+
+    with pytest.raises(
+        OpenLineageAirflowConnectionAuthError, match="requires connection `openlineage_default` to have login"
+    ):
+        resolve_airflow_connection_auth(config)
+
+
+@patch.object(BaseHook, "get_connection")
+def test_resolve_connection_auth_in_nested_composite_transport_with_mixed_auth_types(mock_get_connection):
+    connections = {
+        "api_key_conn": Connection(conn_id="api_key_conn", conn_type="http", password="api-key"),
+        "oauth2_conn": _oauth2_connection(conn_id="oauth2_conn"),
+    }
+    mock_get_connection.side_effect = connections.__getitem__
+    config = {
+        "transport": {
+            "type": "composite",
+            "transports": [
+                {
+                    "type": "http",
+                    "url": "http://ol-api-1:5000",
+                    "auth": {"type": AIRFLOW_CONNECTION_API_KEY_AUTH_TYPE, "conn_id": "api_key_conn"},
+                },
+                {
+                    "type": "composite",
+                    "transports": [
+                        {
+                            "type": "http",
+                            "url": "http://ol-api-2:5000",
+                            "auth": {"type": AIRFLOW_CONNECTION_OAUTH2_AUTH_TYPE, "conn_id": "oauth2_conn"},
+                        },
+                        {"type": "console"},
+                    ],
+                },
+            ],
+        }
+    }
+
+    resolve_airflow_connection_auth(config)
+
+    assert config["transport"]["transports"][0]["auth"] == {"type": "api_key", "apiKey": "api-key"}
+    assert config["transport"]["transports"][1]["transports"][0]["auth"] == {
+        "type": OAUTH2_CLIENT_CREDENTIALS_AUTH_TYPE,
+        "tokenEndpoint": OAUTH2_TOKEN_ENDPOINT,
+        "clientId": "my-client-id",
+        "clientSecret": "my-client-secret",
+    }
+    assert config["transport"]["transports"][1]["transports"][1] == {"type": "console"}

--- a/providers/openlineage/tests/unit/openlineage/utils/test_spark.py
+++ b/providers/openlineage/tests/unit/openlineage/utils/test_spark.py
@@ -26,6 +26,11 @@ from openlineage.client.transport.composite import CompositeConfig, CompositeTra
 from openlineage.client.transport.http import HttpConfig, HttpTransport
 from openlineage.client.transport.kafka import KafkaConfig, KafkaTransport
 
+from airflow.providers.openlineage.token_provider import (
+    OAUTH2_CLIENT_CREDENTIALS_AUTH_TYPE,
+    OAuth2ClientCredentialsTokenProvider,
+    OpenLineageOAuth2TokenError,
+)
 from airflow.providers.openlineage.utils.spark import (
     _get_parent_job_information_as_spark_properties,
     _get_transport_information_as_spark_properties,
@@ -62,6 +67,15 @@ EXAMPLE_HTTP_TRANSPORT_CONFIG = {
     "auth": {
         "type": "api_key",
         "apiKey": "secret_123",
+    },
+}
+EXAMPLE_OAUTH2_HTTP_TRANSPORT_CONFIG = {
+    **EXAMPLE_HTTP_TRANSPORT_CONFIG,
+    "auth": {
+        "type": OAUTH2_CLIENT_CREDENTIALS_AUTH_TYPE,
+        "tokenEndpoint": "https://auth.example.com/token",
+        "clientId": "my-client-id",
+        "clientSecret": "my-client-secret",
     },
 }
 EXAMPLE_KAFKA_TRANSPORT_CONFIG = {
@@ -124,6 +138,43 @@ def test_get_transport_information_as_spark_properties(mock_ol_listener):
     )
     result = _get_transport_information_as_spark_properties()
     assert result == EXAMPLE_TRANSPORT_SPARK_PROPERTIES
+
+
+@patch.object(OAuth2ClientCredentialsTokenProvider, "get_bearer", return_value="Bearer access-token")
+@patch("airflow.providers.openlineage.utils.spark.get_openlineage_listener")
+def test_get_transport_information_as_spark_properties_oauth2_auth(mock_ol_listener, mock_get_bearer):
+    fake_listener = mock.MagicMock()
+    mock_ol_listener.return_value = fake_listener
+    fake_listener.adapter.get_or_create_openlineage_client.return_value.transport = HttpTransport(
+        HttpConfig.from_dict(EXAMPLE_OAUTH2_HTTP_TRANSPORT_CONFIG)
+    )
+    result = _get_transport_information_as_spark_properties()
+    assert result == {
+        **EXAMPLE_TRANSPORT_SPARK_PROPERTIES,
+        "spark.openlineage.transport.auth.apiKey": "Bearer access-token",
+    }
+
+
+@patch.object(
+    OAuth2ClientCredentialsTokenProvider,
+    "get_bearer",
+    side_effect=OpenLineageOAuth2TokenError("token request failed"),
+)
+@patch("airflow.providers.openlineage.utils.spark.get_openlineage_listener")
+def test_get_transport_information_as_spark_properties_oauth2_auth_token_error(
+    mock_ol_listener, mock_get_bearer
+):
+    fake_listener = mock.MagicMock()
+    mock_ol_listener.return_value = fake_listener
+    fake_listener.adapter.get_or_create_openlineage_client.return_value.transport = HttpTransport(
+        HttpConfig.from_dict(EXAMPLE_OAUTH2_HTTP_TRANSPORT_CONFIG)
+    )
+    result = _get_transport_information_as_spark_properties()
+    assert result == {
+        key: value
+        for key, value in EXAMPLE_TRANSPORT_SPARK_PROPERTIES.items()
+        if not key.startswith("spark.openlineage.transport.auth.")
+    }
 
 
 @patch("airflow.providers.openlineage.utils.spark.get_openlineage_listener")


### PR DESCRIPTION
Adds OAuth 2.0 client credentials authentication for the OpenLineage HTTP transport.

The OpenLineage Python client ships only static `api_key` authentication (plus an API-key-to-JWT exchange) for HTTP transports, so backends that issue short-lived OAuth 2.0 access tokens could not be used from Airflow without a custom `TokenProvider` on the Python path.

This PR adds:
- `OAuth2ClientCredentialsTokenProvider`, usable as `auth.type` by import path (the client's documented extension mechanism) with `http` and `async_http` transports, including those nested in `composite`. Tokens are cached under a lock and re-requested `tokenRefreshBuffer` seconds before expiry (capped at half the token lifetime). Options accept camelCase and snake_case, so `OPENLINEAGE__TRANSPORT__AUTH__*` environment variables work as well.
- `airflow_connection_oauth2_client_credentials` auth type, resolved like `airflow_connection_api_key` (#66342): client ID from the connection login, client secret from the password, token endpoint from the host.
- Spark transport injection forwards the current access token as `api_key` (as already happens for the client's `jwt` provider) and logs the lifetime caveat; a token error logs a warning instead of failing the Spark task.

Design notes:
- The provider class lives in the Airflow provider because the connection-backed auth type and the Spark injection need it here. A generic version can be upstreamed to openlineage-python later and the connection alias pointed at it.
- No short `oauth2_client_credentials` alias is introduced, so a future native client auth type of that name would not be shadowed by Airflow.
- `time.monotonic` is mocked with `mock.patch` in tests because `time_machine` does not patch it.
- `requests` is imported directly; it is a hard dependency of both `apache-airflow` and `openlineage-python`.

Tested end to end against an OAuth-protected OpenLineage backend (Keycloak client credentials, 600 s tokens): `http`, `async_http` and `composite` transports, connection-backed configuration, a real Dag run, and a soak run confirming the token was refreshed before expiry while the original token was rejected once expired.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5.1)

Generated-by: Claude Code (Fable 5.1) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBfMWG5AG33JMqGGQgAV6v