### PR TITLE
Report DogStatsD timer metrics in milliseconds

### DIFF
--- a/airflow-core/newsfragments/72713.bugfix.rst
+++ b/airflow-core/newsfragments/72713.bugfix.rst
@@ -1,0 +1,1 @@
+Report DogStatsD timer metrics in milliseconds instead of seconds.

--- a/shared/observability/src/airflow_shared/observability/metrics/datadog_logger.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/datadog_logger.py
@@ -162,6 +162,7 @@ def get_dogstatsd_logger(
 
     dogstatsd_kwargs: dict[str, Any] = {
         "constant_tags": tags_in_string.split(",") if tags_in_string else [],
+        "use_ms": True,
     }
     if host is not None:
         dogstatsd_kwargs["host"] = host

--- a/shared/observability/tests/observability/metrics/test_stats.py
+++ b/shared/observability/tests/observability/metrics/test_stats.py
@@ -806,6 +806,14 @@ class TestCustomStatsName:
             assert "host" not in kwargs
             assert "port" not in kwargs
 
+    @skip_if_force_lowest_dependencies_marker
+    def test_dogstatsd_timer_uses_milliseconds(self):
+        with mock.patch("datadog.DogStatsd") as mock_dogstatsd:
+            datadog_logger.get_dogstatsd_logger()
+
+        _, kwargs = mock_dogstatsd.call_args
+        assert kwargs["use_ms"] is True
+
     def test_does_send_stats_using_statsd_when_the_name_is_valid(self):
         with (
             mock.patch.object(statsd.StatsClient, "__init__", return_value=None),


### PR DESCRIPTION
Fixes the 1000x under-reporting of timer metrics when the DogStatsD backend is enabled. `Stats.timer()` measures durations in milliseconds, but `datadog.DogStatsd.timed()` defaults to seconds unless `use_ms` is enabled.

This change enables millisecond output in the shared DogStatsD logger and adds a regression test for the constructor configuration.

closes: #72110

Tests:
- `uvx --offline ruff format shared/observability/src/airflow_shared/observability/metrics/datadog_logger.py shared/observability/tests/observability/metrics/test_stats.py`
- `uvx --offline ruff check --fix shared/observability/src/airflow_shared/observability/metrics/datadog_logger.py shared/observability/tests/observability/metrics/test_stats.py`
- `git diff --check`
- Targeted Breeze file and single-test runs were retried after dependencies installed, but pytest did not produce collection or test output within the available time and was stopped. The local tests therefore remain incomplete; no test failure is being reported.

The final diff was reviewed against Airflow's coding and review guidance. AI assistance was used for issue analysis, implementation, and test design.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5) provided issue-analysis, implementation, and test-design assistance.

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---
Drafted-by: Codex (GPT-5) (no human review before posting)