### PR TITLE
Constrain the Teradata compute-cluster example Dag's user-settable Params

### DIFF
--- a/providers/teradata/tests/system/teradata/example_teradata_compute_cluster.py
+++ b/providers/teradata/tests/system/teradata/example_teradata_compute_cluster.py
@@ -146,7 +146,7 @@ with DAG(
         task_id="compute_cluster_decommission_operation",
         compute_profile_name="{{ params.compute_profile_name }}",
         compute_group_name="{{ params.compute_group_name }}",
-        delete_compute_group="{{ params.delete_compute_group }}",
+        delete_compute_group="{{ params.delete_compute_group }}",  # type: ignore[arg-type]
         teradata_conn_id=TERADATA_CONN_ID,
         timeout="{{ params.timeout }}",
     )

--- a/providers/teradata/tests/system/teradata/example_teradata_compute_cluster.py
+++ b/providers/teradata/tests/system/teradata/example_teradata_compute_cluster.py
@@ -45,53 +45,67 @@ except ImportError:
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
 DAG_ID = "example_teradata_computer_cluster"
 
+# The operators below build Teradata DDL by interpolating these names into SQL text.
+# Object names cannot be passed as bind parameters, so anything reaching them must be
+# constrained where it is declared. Params are settable by whoever triggers the Dag --
+# a lower-trust role than the Dag author -- so every Param here is either restricted to
+# a closed set of values (`enum`) or to an identifier shape (`pattern`).
+#
+# `teradata_conn_id` and `compute_attribute` are deliberately NOT Params: the first
+# selects which credentials the task runs under, and the second is a free-form option
+# string with no safe identifier shape. Neither belongs under trigger-time control.
+TERADATA_CONN_ID = "teradata_lake"
+COMPUTE_ATTRIBUTE = "MIN_COMPUTE_COUNT(1) MAX_COMPUTE_COUNT(5) INITIALLY_SUSPENDED('FALSE')"
+
+# Unquoted Teradata object name: a letter followed by letters, digits or underscores.
+OBJECT_NAME_PATTERN = "^[A-Za-z][A-Za-z0-9_]{0,127}$"
+
 with DAG(
     dag_id=DAG_ID,
     start_date=datetime.datetime(2020, 2, 2),
     schedule="@once",
     catchup=False,
-    default_args={"teradata_conn_id": "teradata_lake"},
+    default_args={"teradata_conn_id": TERADATA_CONN_ID},
     render_template_as_native_obj=True,
     params={
         "compute_group_name": Param(
             "compute_group_test",
             type="string",
+            pattern=OBJECT_NAME_PATTERN,
             title="Compute cluster group Name:",
             description="Enter compute cluster group name.",
         ),
         "compute_profile_name": Param(
             "compute_profile_test",
             type="string",
+            pattern=OBJECT_NAME_PATTERN,
             title="Compute cluster profile Name:",
             description="Enter compute cluster profile name.",
         ),
         "query_strategy": Param(
             "STANDARD",
             type="string",
+            enum=["STANDARD", "ANALYTIC"],
             title="Compute cluster instance type:",
             description="Enter compute cluster instance type. Valid values are STANDARD, ANALYTIC",
         ),
         "compute_map": Param(
             "TD_COMPUTE_XSMALL",
             type="string",
+            pattern=OBJECT_NAME_PATTERN,
             title="Compute Map Name:",
             description="Enter compute cluster compute map name.",
         ),
-        "compute_attribute": Param(
-            "MIN_COMPUTE_COUNT(1) MAX_COMPUTE_COUNT(5) INITIALLY_SUSPENDED('FALSE')",
-            type="string",
-            title="Compute cluster compute attribute:",
-            description="Enter compute cluster compute attribute values.",
-        ),
-        "teradata_conn_id": Param(
-            "teradata_lake",
-            type="string",
-            title="Teradata ConnectionId:",
-            description="Enter Teradata connection id.",
+        "delete_compute_group": Param(
+            False,
+            type="boolean",
+            title="Delete the compute group on decommission:",
+            description="Whether decommissioning also deletes the compute group.",
         ),
         "timeout": Param(
             20,
             type="integer",
+            minimum=1,
             title="Timeout:",
             description="Time elapsed before the task times out and fails. Timeout is in minutes.",
         ),
@@ -102,11 +116,11 @@ with DAG(
         task_id="compute_cluster_provision_operation",
         compute_profile_name="{{ params.compute_profile_name }}",
         compute_group_name="{{ params.compute_group_name }}",
-        teradata_conn_id="{{ params.teradata_conn_id }}",
+        teradata_conn_id=TERADATA_CONN_ID,
         timeout="{{ params.timeout }}",
         query_strategy="{{ params.query_strategy }}",
         compute_map="{{ params.compute_map }}",
-        compute_attribute="{{ params.compute_attribute }}",
+        compute_attribute=COMPUTE_ATTRIBUTE,
     )
     # [END teradata_vantage_lake_compute_cluster_provision_howto_guide]
     # [START teradata_vantage_lake_compute_cluster_suspend_howto_guide]
@@ -114,7 +128,7 @@ with DAG(
         task_id="compute_cluster_suspend_operation",
         compute_profile_name="{{ params.compute_profile_name }}",
         compute_group_name="{{ params.compute_group_name }}",
-        teradata_conn_id="{{ params.teradata_conn_id }}",
+        teradata_conn_id=TERADATA_CONN_ID,
         timeout="{{ params.timeout }}",
     )
     # [END teradata_vantage_lake_compute_cluster_suspend_howto_guide]
@@ -123,7 +137,7 @@ with DAG(
         task_id="compute_cluster_resume_operation",
         compute_profile_name="{{ params.compute_profile_name }}",
         compute_group_name="{{ params.compute_group_name }}",
-        teradata_conn_id="{{ params.teradata_conn_id }}",
+        teradata_conn_id=TERADATA_CONN_ID,
         timeout="{{ params.timeout }}",
     )
     # [END teradata_vantage_lake_compute_cluster_resume_howto_guide]
@@ -132,8 +146,8 @@ with DAG(
         task_id="compute_cluster_decommission_operation",
         compute_profile_name="{{ params.compute_profile_name }}",
         compute_group_name="{{ params.compute_group_name }}",
-        delete_compute_group=bool("{{ params.delete_compute_group }}"),
-        teradata_conn_id="{{ params.teradata_conn_id }}",
+        delete_compute_group="{{ params.delete_compute_group }}",
+        teradata_conn_id=TERADATA_CONN_ID,
         timeout="{{ params.timeout }}",
     )
     # [END teradata_vantage_lake_compute_cluster_decommission_howto_guide]


### PR DESCRIPTION
The Teradata compute-cluster operators build DDL by interpolating names into SQL text. Object names cannot be passed as bind parameters, so whatever reaches them has to be constrained where it is declared.

This example declared every value as a free-text `Param` — no `enum`, no `pattern`, no validation — and templated them straight into the operators. Params are settable by whoever triggers the Dag, which is a lower-trust role than the Dag author, so as written the example teaches a shape where a triggering user hands SQL fragments to a task running under someone else's Teradata credentials. Anyone who copies this example inherits that.

### Constrained where they are declared

- `compute_group_name`, `compute_profile_name`, `compute_map` — unquoted Teradata object-name pattern (`^[A-Za-z][A-Za-z0-9_]{0,127}$`).
- `query_strategy` — `enum` of the two values the operator accepts.
- `timeout` — lower bound.

### No longer Params

- `teradata_conn_id` selects *which credentials the task runs under*. That is not trigger-time input; it is now a module constant.
- `compute_attribute` is a free-form option string with no safe identifier shape, so it is a constant too.

The principle the example should be showing: only expose as a `Param` what you can validate.

### Drive-by

`delete_compute_group` on the decommission task was `bool("{{ params.delete_compute_group }}")`. That evaluates a non-empty string at parse time, so it was **always `True`** regardless of input — and the Param it referenced was never declared in the first place. It is now a real boolean Param defaulting to `False`, rendered natively (the Dag already sets `render_template_as_native_obj=True`).

Example Dag only; no provider code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DKYM5PoVgKC5JqxLso8rn
