### PR TITLE
Read XCom without object reconstruction during dependency evaluation

### DIFF
--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -93,7 +93,12 @@ from airflow.models.log import Log
 from airflow.models.taskinstancekey import TaskInstanceKey
 from airflow.models.taskmap import TaskMap
 from airflow.models.taskreschedule import TaskReschedule
-from airflow.models.xcom import XCOM_RETURN_KEY, LazyXComSelectSequence, XComModel
+from airflow.models.xcom import (
+    XCOM_RETURN_KEY,
+    LazyXComPrimitivesSelectSequence,
+    LazyXComSelectSequence,
+    XComModel,
+)
 from airflow.serialization.enums import stringify_encoding_keys
 from airflow.settings import task_instance_mutation_hook
 from airflow.task.priority_strategy import validate_and_load_priority_weight_strategy
@@ -2055,9 +2060,16 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
         map_indexes: int | Iterable[int] | None = None,
         default: Any = None,
         run_id: str | None = None,
+        full: bool = True,
     ) -> Any:
         """:meta private:"""  # noqa: D400
         # This is only kept for compatibility in tests for now while AIP-72 is in progress.
+        #
+        # `full=False` returns plain JSON types and never runs the Airflow
+        # serialization module, so a stored `__classname__` envelope is not imported or
+        # instantiated. Scheduler-side callers -- the ti_deps that read XCom to decide
+        # whether a task may run -- must pass it: those bytes are task-controlled, and
+        # the security model reserves the scheduler process for installed code.
 
         if dag_id is None:
             dag_id = self.dag_id
@@ -2092,9 +2104,12 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
                 return default
 
             if map_indexes is not None or first.map_index < 0:
-                return XComModel.deserialize_value(first)
+                if full:
+                    return XComModel.deserialize_value(first)
+                return XComModel.deserialize_value_primitives(first)
 
-            return LazyXComSelectSequence.from_select(
+            sequence_cls = LazyXComSelectSequence if full else LazyXComPrimitivesSelectSequence
+            return sequence_cls.from_select(
                 query.with_only_columns(XComModel.value).order_by(None),
                 order_by=[XComModel.map_index.expression],
                 session=session,
@@ -2120,7 +2135,8 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
             ordering.append(case(map_index_whens, value=XComModel.map_index))
         else:
             ordering.append(XComModel.map_index)
-        return LazyXComSelectSequence.from_select(
+        sequence_cls = LazyXComSelectSequence if full else LazyXComPrimitivesSelectSequence
+        return sequence_cls.from_select(
             query.with_only_columns(XComModel.value).order_by(None),
             order_by=ordering,
             session=session,

--- a/airflow-core/src/airflow/models/xcom.py
+++ b/airflow-core/src/airflow/models/xcom.py
@@ -389,6 +389,35 @@ class XComModel(TaskInstanceDependencies):
             # Already deserialized (e.g., set via Task Execution API)
             return result.value
 
+    @staticmethod
+    def deserialize_value_primitives(result: Any) -> Any:
+        """
+        Deserialize an XCom value to plain JSON types only.
+
+        Unlike :meth:`deserialize_value` this never runs the Airflow serialization
+        module, so a ``__classname__`` envelope in the stored value is returned as an
+        ordinary ``dict`` instead of being imported and instantiated.
+
+        This is what scheduler-side readers must use. XCom bytes are written by task
+        code, and the security model reserves the scheduler for code the Deployment
+        Manager installed -- so a value the scheduler consumes to make a scheduling
+        decision must never be able to construct objects in that process. Callers that
+        genuinely need the original Python object (task code pulling another task's
+        return value) keep using :meth:`deserialize_value`.
+
+        :param result: The XCom database row or object containing a ``value`` attribute.
+        :return: The value as plain JSON types (``dict``, ``list``, ``str``, ``int``,
+            ``float``, ``bool`` or ``None``).
+        """
+        if result.value is None:
+            return None
+
+        try:
+            return json.loads(result.value)
+        except (ValueError, TypeError):
+            # Already deserialized (e.g., set via Task Execution API)
+            return result.value
+
 
 class LazyXComSelectSequence(LazySelectSequence[Any]):
     """
@@ -404,6 +433,21 @@ class LazyXComSelectSequence(LazySelectSequence[Any]):
     @staticmethod
     def _process_row(row: Row) -> Any:
         return XComModel.deserialize_value(row)
+
+
+class LazyXComPrimitivesSelectSequence(LazyXComSelectSequence):
+    """
+    Like :class:`LazyXComSelectSequence`, but never reconstructs Python objects.
+
+    Used by scheduler-side XCom reads. See
+    :meth:`XComModel.deserialize_value_primitives`.
+
+    :meta private:
+    """
+
+    @staticmethod
+    def _process_row(row: Row) -> Any:
+        return XComModel.deserialize_value_primitives(row)
 
 
 __compat_imports = {

--- a/airflow-core/src/airflow/ti_deps/deps/not_previously_skipped_dep.py
+++ b/airflow-core/src/airflow/ti_deps/deps/not_previously_skipped_dep.py
@@ -17,8 +17,12 @@
 # under the License.
 from __future__ import annotations
 
+import logging
+
 from airflow.models.taskinstance import PAST_DEPENDS_MET
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
+
+log = logging.getLogger(__name__)
 
 # The following constants are taken from the SkipMixin class in the standard provider
 # The key used by SkipMixin to store XCom data.
@@ -62,15 +66,31 @@ class NotPreviouslySkippedDep(BaseTIDep):
                 # (e.g. LatestOnlyOperator) writes XCom with map_index=-1, so we must
                 # query with -1 instead of the child's map_index.
                 xcom_map_index = ti.map_index if parent.is_mapped else -1
+                # `full=False`: this runs in the scheduler and the value is written by
+                # task code, so it must not be able to import or instantiate anything
+                # here. The payload is a plain mapping of lists of task ids.
                 prev_result = ti.xcom_pull(
                     task_ids=parent.task_id,
                     key=XCOM_SKIPMIXIN_KEY,
                     session=session,
                     map_indexes=xcom_map_index,
+                    full=False,
                 )
 
                 if prev_result is None:
                     # This can happen if the parent task has not yet run.
+                    continue
+
+                if not isinstance(prev_result, dict):
+                    # Not the shape SkipMixin writes. Treat it as absent rather than
+                    # trusting it -- and do not fail the dep, because a task may write
+                    # anything under this key.
+                    log.warning(
+                        "Ignoring malformed %s XCom from task %s: expected a mapping, got %s",
+                        XCOM_SKIPMIXIN_KEY,
+                        parent.task_id,
+                        type(prev_result).__name__,
+                    )
                     continue
 
                 should_skip = False
@@ -93,7 +113,11 @@ class NotPreviouslySkippedDep(BaseTIDep):
                     # ti does not execute.
                     if dep_context.wait_for_past_depends_before_skipping:
                         past_depends_met = ti.xcom_pull(
-                            task_ids=ti.task_id, key=PAST_DEPENDS_MET, session=session, default=False
+                            task_ids=ti.task_id,
+                            key=PAST_DEPENDS_MET,
+                            session=session,
+                            default=False,
+                            full=False,
                         )
                         if not past_depends_met:
                             yield self._failing_status(

--- a/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -328,7 +328,11 @@ class TriggerRuleDep(BaseTIDep):
                     and dep_context.wait_for_past_depends_before_skipping
                 ):
                     past_depends_met = ti.xcom_pull(
-                        task_ids=ti.task_id, key=PAST_DEPENDS_MET, session=session, default=False
+                        task_ids=ti.task_id,
+                        key=PAST_DEPENDS_MET,
+                        session=session,
+                        default=False,
+                        full=False,
                     )
                     if not past_depends_met:
                         yield (
@@ -492,7 +496,11 @@ class TriggerRuleDep(BaseTIDep):
                     and dep_context.wait_for_past_depends_before_skipping
                 ):
                     past_depends_met = ti.xcom_pull(
-                        task_ids=ti.task_id, key=PAST_DEPENDS_MET, session=session, default=False
+                        task_ids=ti.task_id,
+                        key=PAST_DEPENDS_MET,
+                        session=session,
+                        default=False,
+                        full=False,
                     )
                     if not past_depends_met:
                         yield self._failing_status(

--- a/airflow-core/tests/unit/ti_deps/deps/test_not_previously_skipped_dep.py
+++ b/airflow-core/tests/unit/ti_deps/deps/test_not_previously_skipped_dep.py
@@ -214,3 +214,93 @@ def test_unmapped_parent_skip_mapped_downstream(session, dag_maker):
     assert len(list(dep.get_dep_statuses(tis["op2"], DepContext(), session=session))) == 1
     assert not dep.is_met(tis["op2"], session=session)
     assert tis["op2"].state == State.SKIPPED
+
+
+def test_hostile_skipmixin_xcom_is_not_deserialized(session, dag_maker):
+    """
+    A serde envelope stored under the skipmixin key must not be instantiated.
+
+    XCom bytes are written by task code, and the Execution API stores the caller's
+    value verbatim. The scheduler evaluates this dep in-process, so a value reaching
+    it must never be able to import a class or construct an object -- the security
+    model reserves the scheduler for code the Deployment Manager installed.
+    """
+    start_date = pendulum.datetime(2020, 1, 1)
+    with dag_maker(
+        "test_hostile_skipmixin_xcom_dag",
+        schedule=None,
+        start_date=start_date,
+        session=session,
+    ):
+        op1 = BranchPythonOperator(task_id="op1", python_callable=lambda: "op2")
+        op2 = EmptyOperator(task_id="op2")
+        op1 >> op2
+
+    dagrun = dag_maker.create_dagrun(run_type=DagRunType.MANUAL, state=State.RUNNING)
+    ti, ti2 = dagrun.task_instances
+    run_task_instance(ti, op1)
+
+    # Overwrite the parent's skipmixin XCom with a serialization envelope, the shape
+    # `XComDecoder.object_hook` would hand to `deserialize(..., full=True)`.
+    session.execute(delete(XComModel).where(XComModel.key == XCOM_SKIPMIXIN_KEY))
+    # `serialize=False` with a pre-serialized string is exactly what the Execution API
+    # does with a caller-supplied value -- it stores the task's bytes verbatim.
+    XComModel.set(
+        key=XCOM_SKIPMIXIN_KEY,
+        value='{"__classname__": "builtins.dict", "__version__": 1, "__data__": {}}',
+        serialize=False,
+        task_id=ti.task_id,
+        dag_id=ti.dag_id,
+        run_id=ti.run_id,
+        map_index=ti.map_index,
+        session=session,
+    )
+    session.commit()
+
+    dep = NotPreviouslySkippedDep()
+
+    # The envelope is read as an inert mapping. It carries neither "followed" nor
+    # "skipped", so it yields no skip decision and the dep passes.
+    assert len(list(dep.get_dep_statuses(ti2, DepContext(), session=session))) == 0
+    assert dep.is_met(ti2, session=session)
+    assert ti2.state != State.SKIPPED
+
+
+def test_non_mapping_skipmixin_xcom_is_ignored(session, dag_maker):
+    """
+    A skipmixin XCom that is not a mapping is ignored rather than crashing the scheduler.
+
+    Without the shape check the membership test runs against whatever the task wrote, so
+    a scalar raises TypeError inside dependency evaluation.
+    """
+    start_date = pendulum.datetime(2020, 1, 1)
+    with dag_maker(
+        "test_non_mapping_skipmixin_xcom_dag",
+        schedule=None,
+        start_date=start_date,
+        session=session,
+    ):
+        op1 = BranchPythonOperator(task_id="op1", python_callable=lambda: "op2")
+        op2 = EmptyOperator(task_id="op2")
+        op1 >> op2
+
+    dagrun = dag_maker.create_dagrun(run_type=DagRunType.MANUAL, state=State.RUNNING)
+    ti, ti2 = dagrun.task_instances
+    run_task_instance(ti, op1)
+
+    session.execute(delete(XComModel).where(XComModel.key == XCOM_SKIPMIXIN_KEY))
+    XComModel.set(
+        key=XCOM_SKIPMIXIN_KEY,
+        value="5",  # a bare scalar: `"followed" in 5` raises TypeError
+        serialize=False,
+        task_id=ti.task_id,
+        dag_id=ti.dag_id,
+        run_id=ti.run_id,
+        map_index=ti.map_index,
+        session=session,
+    )
+    session.commit()
+
+    dep = NotPreviouslySkippedDep()
+    assert len(list(dep.get_dep_statuses(ti2, DepContext(), session=session))) == 0
+    assert ti2.state != State.SKIPPED


### PR DESCRIPTION
The scheduler evaluates task dependencies in-process, and two of those deps read XCom:

- `NotPreviouslySkippedDep` reads `skipmixin_key` for every parent that inherits from `SkipMixin` — any Branch or ShortCircuit operator, so this is a common path.
- Both it and `TriggerRuleDep` read `past_depends_met` when `wait_for_past_depends_before_skipping` applies.

Both went through `TaskInstance.xcom_pull` → `XComModel.deserialize_value`, which is `json.loads(value, cls=XComDecoder)`. `XComDecoder.object_hook` calls the serialization module with `full=True`, so a nested dict carrying `__classname__` gets imported and instantiated.

The values these deps actually consume are primitives — a mapping of lists of task ids, and a boolean. Nothing here needs an object rebuilt, and the scheduler is the wrong process to rebuild one in: the [security model](https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html) reserves it for code the Deployment Manager installed.

### Change

- `XComModel.deserialize_value_primitives` — plain `json.loads`, no `object_hook`. A `__classname__` envelope comes back as an inert `dict`.
- `LazyXComPrimitivesSelectSequence` alongside `LazyXComSelectSequence`, for the lazy path.
- `full: bool = True` threaded through `TaskInstance.xcom_pull`; `full=False` at the four dep call sites.

All three of `xcom_pull`'s return paths are covered — the direct one and **both** lazy-sequence ones. The lazy path is what a mapped task instance takes, so covering only the direct return would have left the hole open exactly there.

`NotPreviouslySkippedDep` also now checks the skipmixin payload is a mapping before testing membership. It reads whatever the parent task wrote, and a scalar there previously raised `TypeError` inside dependency evaluation instead of being ignored.

Task code pulling another task's return value is unchanged and still receives the original Python object. Only the scheduler-side dep reads are narrowed.

### Tests

Two regression tests, both verified to fail on unpatched sources and pass with the change:

- a serde envelope stored under `skipmixin_key` is read as an inert mapping rather than instantiated;
- a scalar under the same key is ignored rather than raising.

Both write through `XComModel.set(..., serialize=False)` with a pre-serialized string, which is what the Execution API does with a caller-supplied value — `serialize_value` would have rejected the payload, so testing through that door would have proved nothing.

Suites run: `test_not_previously_skipped_dep.py` (8), `test_trigger_rule_dep.py` + `models/test_xcom.py` (202), `test_taskinstance.py -k xcom` (19). All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DKYM5PoVgKC5JqxLso8rn
