### PR TITLE
Preserve DELETE request bodies in HttpAsyncHook

### DIFF
--- a/providers/http/src/airflow/providers/http/hooks/http.py
+++ b/providers/http/src/airflow/providers/http/hooks/http.py
@@ -517,7 +517,7 @@ class AsyncHttpSession(LoggingMixin):
             response = await self._request(
                 url,
                 params=data if self.method == "GET" else None,
-                data=data if self.method in {"POST", "PUT", "PATCH"} else None,
+                data=data if self.method in {"POST", "PUT", "PATCH", "DELETE"} else None,
                 json=json,
                 headers=merged_headers,
                 auth=self.auth,

--- a/providers/http/tests/unit/http/hooks/test_http.py
+++ b/providers/http/tests/unit/http/hooks/test_http.py
@@ -785,6 +785,30 @@ class TestHttpAsyncHook:
                 assert resp.status == 200
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("data", [{"item_id": "42"}, "item_id=42"])
+    @pytest.mark.parametrize("use_external_session", [True, False])
+    @mock.patch(
+        "aiohttp.ClientSession.delete", new_callable=mock.AsyncMock, spec=aiohttp.ClientSession.delete
+    )
+    async def test_async_delete_request_preserves_data(self, mocked_delete, data, use_external_session):
+        hook = HttpAsyncHook(method="DELETE")
+        response = MockAiohttpClientResponse(
+            status=200,
+            method="DELETE",
+            url="http://test:8080/v1/test",
+        )
+        mocked_delete.return_value = response
+
+        if use_external_session:
+            async with aiohttp.ClientSession() as session:
+                await hook.run(session=session, endpoint="v1/test", data=data)
+        else:
+            await hook.run(endpoint="v1/test", data=data)
+
+        assert mocked_delete.call_args.kwargs["data"] == data
+        assert mocked_delete.call_args.kwargs["params"] is None
+
+    @pytest.mark.asyncio
     async def test_async_post_request_with_error_code(self):
         """Test api call asynchronously for POST request with error."""
         hook = HttpAsyncHook()


### PR DESCRIPTION
HttpAsyncHook silently drops `data` supplied to DELETE requests. Forward the request body to aiohttp, matching the synchronous HttpHook behavior. Add regression coverage for string and form payloads with both hook-managed and externally supplied sessions.

Validation in a scoped Breeze environment: 134 HTTP provider tests passed (one version-specific skip), mypy passed for all 29 HTTP-provider files, and provider metadata validation passed. All four regressions fail without the fix. Ruff and applicable fast/manual checks passed; the all-provider mypy sweep and broader CI matrix remain pending.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (OpenAI Codex, gpt-6-astra)

Generated-by: OpenAI Codex (gpt-6-astra) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
