### PR TITLE
[v3-3-test] UI: Label Dag active runs accurately

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dags.py
@@ -245,7 +245,7 @@ def get_dag_details(
         is not None
     )
 
-    # Count active (running + queued) Dag runs for this Dag
+    # Count only running Dag runs: this stat shows runs that are actually executing right now.
     active_runs_count = (
         session.scalar(
             select(func.count())

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ca/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ca/common.json
@@ -38,6 +38,7 @@
   "dag_one": "Dag",
   "dag_other": "Dags",
   "dagDetails": {
+    "activeRuns": "Execucions actives",
     "catchup": "Recuperar (catchup)",
     "dagRunTimeout": "Temps d'espera de l'execució del Dag",
     "defaultArgs": "Arguments per defecte",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -38,6 +38,7 @@
   "dag_one": "Dag",
   "dag_other": "Dags",
   "dagDetails": {
+    "activeRuns": "Active Runs",
     "catchup": "Catchup",
     "dagRunTimeout": "Dag Run Timeout",
     "defaultArgs": "Default Args",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/common.json
@@ -43,6 +43,7 @@
   "dag_one": "Dag",
   "dag_other": "Dags",
   "dagDetails": {
+    "activeRuns": "Ejecuciones Activas",
     "catchup": "Catchup",
     "dagRunTimeout": "Tiempo de Ejecución del Dag",
     "defaultArgs": "Argumentos por Defecto",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/common.json
@@ -43,6 +43,7 @@
   "dag_one": "Dag",
   "dag_other": "Dags",
   "dagDetails": {
+    "activeRuns": "Exécutions actives",
     "catchup": "Rattrapage",
     "dagRunTimeout": "Délai d'exécution du Dag",
     "defaultArgs": "Arguments par défaut",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt/common.json
@@ -43,6 +43,7 @@
   "dag_other": "Dags",
   "dag_zero": "Nenhum Dag",
   "dagDetails": {
+    "activeRuns": "Execuções Ativas",
     "catchup": "Catchup",
     "dagRunTimeout": "Tempo Limite da Execução do Dag",
     "defaultArgs": "Argumentos Padrão",

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Header.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Header.test.tsx
@@ -71,4 +71,15 @@ describe("Header", () => {
     expect(screen.getByText(i18n.t("dag:dagDetails.nextRun"))).toBeInTheDocument();
     expect(screen.queryByText("2024-08-22 19:00:00")).not.toBeInTheDocument();
   });
+
+  it("shows active runs against the maximum number of active runs", () => {
+    render(
+      <Wrapper>
+        <Header dag={{ ...mockDag, active_runs_count: 2, max_active_runs: 2 }} />
+      </Wrapper>,
+    );
+
+    expect(screen.getByText(i18n.t("common:dagDetails.activeRuns"))).toBeInTheDocument();
+    expect(screen.getByText("2 of 2")).toBeInTheDocument();
+  });
 });

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Header.tsx
@@ -106,7 +106,7 @@ export const Header = ({
     },
     ...nextRunStat,
     {
-      label: translate("dagDetails.maxActiveRuns"),
+      label: translate("dagDetails.activeRuns"),
       value:
         dag?.max_active_runs === undefined
           ? undefined


### PR DESCRIPTION
Backport of #72371 to `v3-3-test`.

Cherry-picked from b916de6dab0a34e6ff80a9e54e68c5b5b68ebcb9.

Conflict resolution — `Header.test.tsx`: the incoming hunk placed the new test next to two `multi_team` tests (`shows the team alongside the owner…`, `shows the owner stat…`) that do not exist on `v3-3-test`. Kept only this PR's actual addition (`shows active runs against the maximum number of active runs`) and dropped the two team tests. Everything else applied cleanly: the `dags.py` comment clarification, the `Header.tsx` label change (`maxActiveRuns` → `activeRuns`), and the `activeRuns` string in all five locales.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)