### PR TITLE
Fix Configuration page e2e test failing when the first option has no value

### DIFF
--- a/airflow-core/src/airflow/ui/tests/e2e/pages/ConfigurationPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/ConfigurationPage.ts
@@ -40,6 +40,12 @@ export class ConfigurationPage extends BasePage {
     });
   }
 
+  public getRowByKey(key: string): Locator {
+    return this.rows.filter({
+      has: this.page.getByTestId("table-cell-key").filter({ hasText: new RegExp(`^${key}$`) }),
+    });
+  }
+
   public async navigate(): Promise<void> {
     await expect(async () => {
       await this.navigateTo("/configs");

--- a/airflow-core/src/airflow/ui/tests/e2e/specs/configuration.spec.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/specs/configuration.spec.ts
@@ -31,8 +31,14 @@ test.describe("Configuration Page", () => {
 
     const firstRow = configurationPage.rows.nth(0);
 
-    await expect(firstRow.locator("td").nth(0)).not.toBeEmpty();
-    await expect(firstRow.locator("td").nth(1)).not.toBeEmpty();
-    await expect(firstRow.locator("td").nth(2)).not.toBeEmpty();
+    await expect(firstRow.getByTestId("table-cell-section")).not.toBeEmpty();
+    await expect(firstRow.getByTestId("table-cell-key")).not.toBeEmpty();
+
+    // Many options legitimately have an empty value, so check a row that always has one.
+    const dagsFolderRow = configurationPage.getRowByKey("dags_folder");
+
+    await expect(dagsFolderRow).toHaveCount(1);
+    await expect(dagsFolderRow.getByTestId("table-cell-section")).toHaveText("core");
+    await expect(dagsFolderRow.getByTestId("table-cell-value")).not.toBeEmpty();
   });
 });


### PR DESCRIPTION
The Configuration page e2e test asserted that the first row of the Config table has a non-empty value. Which option comes first depends on the provider fallback defaults, and since #72549 regenerated them from `provider.yaml` the first row is now `hive` / `default_hive_mapred_queue`, whose value is legitimately empty. As a result the Chromium, Firefox and WebKit e2e jobs fail on every main-based PR (for example [this run](https://github.com/apache/airflow/actions/runs/34225965718/job/102075131560)).

This checks the value on `core` / `dags_folder` instead, which always has one, and locates cells by their test ids rather than column position so the assertions no longer depend on which section happens to sort first.

related: #72549

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5.1)

Generated-by: Claude Code (Fable 5.1) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPR1qQYC6BGWc4JoHRgWV3