### PR TITLE
[v3-3-test] UI: Avoid 404 links for tasks outside run dates (#71762)

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Graph/TaskLink.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Graph/TaskLink.test.tsx
@@ -46,4 +46,23 @@ describe("TaskLink", () => {
       "/dags/test_dag/runs/test_run/tasks/one_try?log_level=error",
     );
   });
+
+  it("links to the task overview when the run has no task instance", () => {
+    render(
+      <MemoryRouter initialEntries={["/dags/test_dag/runs/test_run/tasks/other_task"]}>
+        <Routes>
+          <Route
+            element={<TaskLink hasTaskInstance={false} id="missing_task" label="missing_task" />}
+            path="/dags/:dagId/runs/:runId/tasks/:taskId"
+          />
+        </Routes>
+      </MemoryRouter>,
+      { wrapper: BaseWrapper },
+    );
+
+    expect(screen.getByRole("link", { name: "missing_task" })).toHaveAttribute(
+      "href",
+      "/dags/test_dag/tasks/missing_task",
+    );
+  });
 });

--- a/airflow-core/src/airflow/ui/src/components/Graph/TaskLink.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Graph/TaskLink.tsx
@@ -25,44 +25,50 @@ import { taskNodeSeparator } from "src/utils/assetGraph";
 
 type Props = {
   readonly dagId?: string;
+  readonly hasTaskInstance?: boolean;
   readonly id: string;
 } & TaskNameProps;
 
-export const TaskLink = forwardRef<HTMLAnchorElement, Props>(({ id, isGroup, isMapped, ...rest }, ref) => {
-  const { dagId: urlDagId = "", groupId, runId, taskId: urlTaskId } = useParams();
-  const [searchParams] = useSearchParams();
+export const TaskLink = forwardRef<HTMLAnchorElement, Props>(
+  ({ hasTaskInstance = true, id, isGroup, isMapped, ...rest }, ref) => {
+    const { dagId: urlDagId = "", groupId, runId, taskId: urlTaskId } = useParams();
+    const [searchParams] = useSearchParams();
 
-  // Extract dagId and taskId from composite ID
-  const parseCompositeId = (compositeId: string) => {
-    const match = new RegExp(`^task:(?<dagId>.*?)${taskNodeSeparator}(?<taskId>.+)$`, "u").exec(compositeId);
+    // Extract dagId and taskId from composite ID
+    const parseCompositeId = (compositeId: string) => {
+      const match = new RegExp(`^task:(?<dagId>.*?)${taskNodeSeparator}(?<taskId>.+)$`, "u").exec(
+        compositeId,
+      );
 
-    if (match) {
-      return { dagId: match[1], taskId: match[2] };
-    }
+      if (match) {
+        return { dagId: match[1], taskId: match[2] };
+      }
 
-    return { dagId: undefined, taskId: undefined };
-  };
+      return { dagId: undefined, taskId: undefined };
+    };
 
-  const { dagId: extractedDagId, taskId: extractedTaskId } = parseCompositeId(id);
-  const dagId = extractedDagId ?? urlDagId;
-  const taskId = extractedTaskId ?? id;
+    const { dagId: extractedDagId, taskId: extractedTaskId } = parseCompositeId(id);
+    const dagId = extractedDagId ?? urlDagId;
+    const taskId = extractedTaskId ?? id;
 
-  const basePath = `/dags/${dagId}${runId === undefined ? "" : `/runs/${runId}`}`;
-  const taskPath = isGroup
-    ? groupId === taskId
-      ? ""
-      : `/tasks/group/${taskId}`
-    : urlTaskId === taskId
-      ? ""
-      : `/tasks/${taskId}${isMapped && urlTaskId !== taskId && runId !== undefined ? "/mapped" : ""}`;
+    const includeRun = runId !== undefined && hasTaskInstance;
+    const basePath = `/dags/${dagId}${includeRun ? `/runs/${runId}` : ""}`;
+    const taskPath = isGroup
+      ? includeRun && groupId === taskId
+        ? ""
+        : `/tasks/group/${taskId}`
+      : includeRun && urlTaskId === taskId
+        ? ""
+        : `/tasks/${taskId}${isMapped && urlTaskId !== taskId && includeRun ? "/mapped" : ""}`;
 
-  const targetSearchParams = new URLSearchParams(searchParams);
+    const targetSearchParams = new URLSearchParams(searchParams);
 
-  targetSearchParams.delete(SearchParamsKeys.TRY_NUMBER);
+    targetSearchParams.delete(SearchParamsKeys.TRY_NUMBER);
 
-  return (
-    <RouterLink ref={ref} to={{ pathname: basePath + taskPath, search: targetSearchParams.toString() }}>
-      <TaskName isGroup={isGroup} isMapped={isMapped} {...rest} />
-    </RouterLink>
-  );
-});
+    return (
+      <RouterLink ref={ref} to={{ pathname: basePath + taskPath, search: targetSearchParams.toString() }}>
+        <TaskName isGroup={isGroup} isMapped={isMapped} {...rest} />
+      </RouterLink>
+    );
+  },
+);

--- a/airflow-core/src/airflow/ui/src/components/Graph/TaskNode.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Graph/TaskNode.tsx
@@ -84,6 +84,9 @@ export const TaskNode = ({
   const thisChildCount = Object.entries(taskInstance?.child_states ?? {})
     .map(([_state, count]) => count)
     .reduce((sum, val) => sum + val, 0);
+  const hasTaskInstance = isGroup
+    ? true
+    : taskInstance?.dag_version_number !== null && taskInstance?.dag_version_number !== undefined;
 
   return (
     <NodeWrapper>
@@ -117,6 +120,7 @@ export const TaskNode = ({
               <LinkOverlay asChild>
                 <TaskLink
                   childCount={thisChildCount}
+                  hasTaskInstance={hasTaskInstance}
                   id={id}
                   isGroup={isGroup}
                   isMapped={isMapped}

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
@@ -53,14 +53,17 @@ export const GridTI = ({
 
   const [searchParams] = useSearchParams();
 
-  const taskUrl = buildTaskInstanceUrl({
-    currentPathname: location.pathname,
-    dagId,
-    isGroup,
-    isMapped: Boolean(isMapped),
-    runId,
-    taskId,
-  });
+  const hasTaskInstance = instance.dag_version_number !== null && instance.dag_version_number !== undefined;
+  const taskUrl = hasTaskInstance
+    ? buildTaskInstanceUrl({
+        currentPathname: location.pathname,
+        dagId,
+        isGroup,
+        isMapped: Boolean(isMapped),
+        runId,
+        taskId,
+      })
+    : `/dags/${dagId}/tasks/${isGroup ? "group/" : ""}${taskId}`;
 
   // Remove try_number query param when navigating to reset to the
   // latest try of the task instance and avoid issues with invalid try numbers:


### PR DESCRIPTION
Backport of #71762 to `v3-3-test` for the Airflow 3.3.2 patch release.

Conflict resolution: `TaskNode.test.tsx` and `GridTI.test.tsx` don't exist on v3-3-test (created by non-backported PRs); #71762 only added cases to them, so those additions were dropped. The fix (`TaskLink.tsx`, `TaskNode.tsx`, `GridTI.tsx`) and `TaskLink.test.tsx` are backported intact.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)