### PR TITLE
[v3-3-test] UI: Set the API client base URL before the first startup request (#72374)

### DIFF
--- a/airflow-core/newsfragments/72374.bugfix.rst
+++ b/airflow-core/newsfragments/72374.bugfix.rst
@@ -1,0 +1,1 @@
+The UI now configures the generated API client's base URL from ``<base href>`` in a module with no application dependencies, so a request issued while the app is still initializing -- the i18n version lookup that builds the translation cache buster -- is resolved against the configured path prefix instead of being sent to the origin root.

--- a/airflow-core/src/airflow/ui/src/basePath.ts
+++ b/airflow-core/src/airflow/ui/src/basePath.ts
@@ -1,0 +1,39 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { OpenAPI } from "openapi/requests/core/OpenAPI";
+
+// Airflow can be served under a path prefix (`[api] base_url`), which the server renders
+// into `<base href>`.
+const baseHref = document.querySelector("head > base")?.getAttribute("href") ?? "";
+
+export const basePath = new URL(baseHref, globalThis.location.origin).pathname.replace(/\/$/u, "");
+
+// The generated client is configured here, in a module with no app dependencies, rather
+// than next to the query client. Anything that issues a request while the app is still
+// initializing has to observe the configured base -- i18n requests the version at module
+// scope to build a cache buster -- and importing that request's module first would
+// otherwise send it to the origin root instead of the prefix. Importing anything derived
+// from the base href now orders this assignment ahead of the request.
+OpenAPI.BASE = baseHref.endsWith("/") ? baseHref.slice(0, -1) : baseHref;
+
+// Encode path params as full URI components so values containing "/" (e.g. a variable key
+// like "/foo") become "%2Ffoo" rather than a literal "//", which proxies may collapse. The
+// generated client otherwise defaults to encodeURI, which leaves "/" untouched.
+// The backend automatically decodes path params.
+OpenAPI.ENCODE_PATH = encodeURIComponent;

--- a/airflow-core/src/airflow/ui/src/i18n/config.ts
+++ b/airflow-core/src/airflow/ui/src/i18n/config.ts
@@ -22,6 +22,9 @@ import Backend from "i18next-http-backend";
 import { initReactI18next } from "react-i18next";
 
 import { VersionService } from "openapi/requests/services.gen";
+// Also configures the generated client, which must happen before the version
+// request below. See src/basePath.
+import { basePath } from "src/basePath";
 
 import { registerDayjsLocaleSync } from "./dayjsLocale";
 
@@ -60,10 +63,6 @@ export const namespaces = [
   "components",
   "hitl",
 ] as const;
-
-const baseHref = document.querySelector("head > base")?.getAttribute("href") ?? "";
-const baseUrl = new URL(baseHref, globalThis.location.origin);
-const basePath = new URL(baseUrl).pathname.replace(/\/$/u, "");
 
 const supportedCodes: Array<string> = supportedLanguages.map((lang) => lang.code);
 

--- a/airflow-core/src/airflow/ui/src/queryClient.test.ts
+++ b/airflow-core/src/airflow/ui/src/queryClient.test.ts
@@ -1,0 +1,65 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import axios from "axios";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Airflow can be served under a path prefix (`[api] base_url`), which the
+// server renders into `<base href>`. Every API request must be resolved
+// against it, otherwise requests land on the origin root, where a reverse
+// proxy in front of Airflow may route them to an entirely different service.
+const BASE_HREF = "/workflows/";
+
+describe("API client base path", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    document.head.innerHTML = `<base href="${BASE_HREF}" />`;
+  });
+
+  afterEach(() => {
+    document.head.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("prefixes requests issued while the app is initializing", async () => {
+    const requested: Array<string> = [];
+
+    vi.spyOn(axios, "request").mockImplementation((config) => {
+      requested.push(String(config.url));
+
+      return Promise.resolve({
+        config,
+        data: { git_version: null, version: "3.3.1" },
+        headers: {},
+        status: 200,
+        statusText: "OK",
+      });
+    });
+
+    // Importing the query client pulls in the app's initialization chain. That
+    // chain includes i18n, which requests the version at module scope to build
+    // a cache buster -- so this request is issued before any component mounts.
+    await import("src/queryClient");
+
+    await vi.waitFor(() => {
+      expect(requested.length).toBeGreaterThan(0);
+    });
+
+    expect(requested.filter((url) => !url.startsWith(BASE_HREF))).toEqual([]);
+  });
+});

--- a/airflow-core/src/airflow/ui/src/queryClient.ts
+++ b/airflow-core/src/airflow/ui/src/queryClient.ts
@@ -18,22 +18,13 @@
  */
 import { MutationCache, QueryClient } from "@tanstack/react-query";
 
-import { OpenAPI } from "openapi/requests/core/OpenAPI";
+// Imported for its side effect: configures the generated client's base URL and path
+// encoding. Kept in its own module so the configuration is applied before any module
+// that requests something while the app is initializing. See src/basePath.
+import "src/basePath";
 import { toaster } from "src/components/ui";
 import i18n from "src/i18n/config";
 import { getErrorStatus } from "src/utils";
-
-// Dynamically set the base URL for XHR requests based on the meta tag.
-OpenAPI.BASE = document.querySelector("head>base")?.getAttribute("href") ?? "";
-if (OpenAPI.BASE.endsWith("/")) {
-  OpenAPI.BASE = OpenAPI.BASE.slice(0, -1);
-}
-
-// Encode path params as full URI components so values containing "/" (e.g. a variable key like
-// "/foo") become "%2Ffoo" rather than a literal "//", which proxies may collapse. The generated
-// client otherwise defaults to encodeURI, which leaves "/" untouched.
-// The backend automatically decodes path params.
-OpenAPI.ENCODE_PATH = encodeURIComponent;
 
 const RETRY_COUNT = 3;
 


### PR DESCRIPTION
Backport of #72374 to `v3-3-test` for the Airflow 3.3.2 patch release.

Conflict resolution in `queryClient.ts`: main imports `toaster` from `src/system-components` (the #72349 rename, not backported), so I kept v3-3-test's path `src/components/ui`. Dropping the direct `OpenAPI` import is intentional — the new `basePath.ts` now sets `OpenAPI.BASE`/`ENCODE_PATH`.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)