### PR TITLE
[v3-3-test] Fix DAGs list page Last Run/Next Run going stale after runs complete (#70667)

### DIFF
--- a/airflow-core/src/airflow/ui/src/queries/useDags.tsx
+++ b/airflow-core/src/airflow/ui/src/queries/useDags.tsx
@@ -59,7 +59,7 @@ export const useDags = ({
   tags?: Array<string>;
   tagsMatchMode?: "all" | "any";
 }) => {
-  const refetchInterval = useAutoRefresh({});
+  const refetchInterval = useAutoRefresh({ checkPendingRuns: true });
 
   const { data, error, isFetching, isLoading } = useDagServiceGetDagsUi(
     {
@@ -83,11 +83,13 @@ export const useDags = ({
     undefined,
     {
       refetchInterval: (query) =>
-        query.state.data?.dags.some(
-          (dag) => !dag.is_paused && dag.latest_dag_runs.some((dr) => isStatePending(dr.state)),
-        )
-          ? refetchInterval
-          : false,
+        refetchInterval === false
+          ? false
+          : query.state.data?.dags.some(
+                (dag) => !dag.is_paused && dag.latest_dag_runs.some((dr) => isStatePending(dr.state)),
+              )
+            ? refetchInterval
+            : refetchInterval * 10,
     },
   );
 


### PR DESCRIPTION
Backport of #70667 to `v3-3-test` for the Airflow 3.3.2 patch release.

Conflict resolution: `useDagRunStateCounts.tsx` doesn't exist on v3-3-test, so its change was dropped. The core fix is in `useDags.tsx` (poll at a longer interval instead of stopping, so Last/Next Run refresh) — it applies cleanly and `checkPendingRuns` is already supported by v3-3-test's `useAutoRefresh`.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)