### PR TITLE
[v3-3-test] Complete German UI translations (#71668)

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/de/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/de/common.json
@@ -38,6 +38,7 @@
   "dag_one": "Dag",
   "dag_other": "Dags",
   "dagDetails": {
+    "activeRuns": "Aktive Läufe",
     "catchup": "Nachgeholt",
     "dagRunTimeout": "Dag Lauf Zeitüberschreitung",
     "defaultArgs": "Standard-Parameter",
@@ -72,6 +73,7 @@
     "expectedDuration": "Erwartete mittlere Laufzeit",
     "lastSchedulingDecision": "Letzte Planungsentscheidung",
     "mappedPartitionKey": "Zugeordneter Partitionsschlüssel",
+    "partitionDate": "Partitionsdatum",
     "partitionKey": "Partitionsschlüssel",
     "queuedAt": "Wartend seit",
     "runAfter": "Gelaufen ab",
@@ -84,8 +86,8 @@
   "dagRun_other": "Dag Läufe",
   "dagRunId": "Dag Lauf ID",
   "dagWarnings": "Dag Warnungen und Fehler",
-  "defaultToGraphView": "Graph-Ansicht als Standard",
-  "defaultToGridView": "Gitter-Ansicht als Standard",
+  "defaultToGraphView": "Standardmäßig Graphansicht",
+  "defaultToGridView": "Standardmäßig Gitteransicht",
   "delete": "Löschen",
   "diff": "Differenzansicht",
   "diffCompareWith": "Vergleichen mit",
@@ -134,6 +136,7 @@
   },
   "filter": "Filter",
   "filters": {
+    "date": "Datum",
     "durationFrom": "Laufzeit Von",
     "durationTo": "Laufzeit Bis",
     "endTime": "Endzeitpunkt",
@@ -143,9 +146,15 @@
     "runAfterTo": "Gelaufen-nach bis filtern",
     "searchAsset": "Datenset (Asset) suchen",
     "selectDateRange": "Zeitraum auswählen",
-    "startTime": "Startzeitpunkt"
+    "selectDateTime": "Datum und Uhrzeit auswählen",
+    "startTime": "Startzeitpunkt",
+    "time": "Uhrzeit"
+  },
+  "fullscreen": {
+    "tooltip": "Drücken Sie {{hotkey}} für den Vollbildmodus"
   },
   "generateToken": "Zugriffstoken erzeugen",
+  "includedIn": "Enthalten in",
   "key": "Schlüssel",
   "logicalDate": "Logisches Datum",
   "logout": "Abmelden",
@@ -176,9 +185,12 @@
   "note": {
     "add": "Eine Notiz hinzufügen",
     "dagRun": "Notizen zum Dag Lauf",
+    "edit": "Notiz bearbeiten",
     "label": "Notiz",
     "placeholder": "Eine Notiz hinzufügen...",
-    "taskInstance": "Notizen zu Task Instanzen"
+    "preview": "Vorschau",
+    "taskInstance": "Notizen zu Task Instanzen",
+    "write": "Schreiben"
   },
   "overallStatus": "Gesamtstatus",
   "partitionedDagRun_one": "Partitionierter Dag Lauf",
@@ -219,6 +231,47 @@
   },
   "selectLanguage": "Sprache wählen",
   "selected": "Ausgewählt",
+  "shortcuts": {
+    "categories": {
+      "code": "Code",
+      "dagView": "Dag-Ansicht",
+      "filters": "Filter",
+      "global": "Global",
+      "logs": "Protokolle",
+      "navigation": "Navigation",
+      "runActions": "Lauf- und Task-Aktionen",
+      "search": "Suche"
+    },
+    "descriptions": {
+      "clearRun": "$t(dagRun_one) löschen",
+      "clearTaskInstance": "$t(taskInstance_one) löschen",
+      "downloadLogs": "Protokolle herunterladen",
+      "focusFilterSearch": "Filtersuche fokussieren",
+      "focusLogSearch": "Protokolle durchsuchen",
+      "focusSearch": "Suche fokussieren",
+      "markRunFailed": "$t(dagRun_one) als fehlgeschlagen markieren",
+      "markRunSuccess": "$t(dagRun_one) als erfolgreich markieren",
+      "markTaskFailed": "$t(task_one) als fehlgeschlagen markieren",
+      "markTaskGroupFailed": "$t(taskGroup_one) als fehlgeschlagen markieren",
+      "markTaskGroupSuccess": "$t(taskGroup_one) als erfolgreich markieren",
+      "markTaskSuccess": "$t(task_one) als erfolgreich markieren",
+      "navigateTasks": "Zu $t(task_other) navigieren",
+      "openGraphFilters": "Graphfilter öffnen",
+      "scrollBottom": "Nach unten scrollen",
+      "scrollTop": "Nach oben scrollen",
+      "searchDags": "$t(dag_other) suchen",
+      "showHelp": "$t(shortcuts.title) anzeigen",
+      "toggleExpand": "Alle Gruppen ein- oder ausklappen",
+      "toggleFullscreen": "Vollbild umschalten",
+      "toggleGraphGrid": "Zwischen Graph- und Gitteransicht wechseln",
+      "toggleSource": "Quelle umschalten",
+      "toggleTaskGroup": "$t(taskGroup_one) ein- oder ausklappen",
+      "toggleTimestamp": "Zeitstempel umschalten",
+      "toggleWrap": "$t(wrap.wrap) umschalten"
+    },
+    "empty": "Auf dieser Seite sind keine Tastenkürzel verfügbar.",
+    "title": "Tastenkürzel"
+  },
   "showDetailsPanel": "Detailansicht einblenden",
   "signedInAs": "Angemeldet als",
   "source": {
@@ -285,10 +338,12 @@
   "taskGroup_other": "Task Gruppen",
   "taskId": "Task ID",
   "taskInstance": {
+    "additionalAttributes": "Zusätzliche Attribute der Task Instanz",
     "dagVersion": "Dag Version",
     "executor": "Ausführungsumgebung",
     "executorConfig": "Konfiguration der Ausführungsumgebung",
     "hostname": "Hostname",
+    "id": "ID",
     "maxTries": "Maximale Versuche",
     "pid": "PID",
     "pool": "Pool",
@@ -298,11 +353,13 @@
     "queuedWhen": "Wartend seit",
     "renderedMapIndex": "Planungs-Index Anzeige",
     "scheduledWhen": "Geplant ab",
+    "trigger": "Auslöser",
     "triggerer": {
       "assigned": "Zugewiesene Abrufumgebung",
       "class": "Abruf-Klasse",
       "createdAt": "Zeitpunkt der Erstellung",
       "id": "Abrufungs ID",
+      "job": "Abrufumgebungs-Job",
       "latestHeartbeat": "Letztes Lebenszeichen",
       "title": "Abrufumgebungs-Information"
     },

--- a/airflow-core/src/airflow/ui/public/i18n/locales/de/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/de/components.json
@@ -65,6 +65,7 @@
     "lastDagRun_other": "Letzte {{count}} Dag Läufe",
     "lastTaskInstance_one": "Letzte Task Instanz",
     "lastTaskInstance_other": "Letzte {{count}} Task Instanzen",
+    "medianTotalDuration": "Gesamt: {{duration}}",
     "queuedDuration": "Zeit in der Warteschlange",
     "runAfter": "Lauf ab",
     "runDuration": "Laufzeit"
@@ -112,6 +113,10 @@
     "file": "Datei",
     "location": "Zeile {{line}} in {{name}}"
   },
+  "passwordToggle": {
+    "hide": "Wert ausblenden",
+    "show": "Wert anzeigen"
+  },
   "reparseDag": "Dag neu parsen",
   "sortedAscending": "aufsteigend sortiert",
   "sortedDescending": "absteigend sortiert",
@@ -137,6 +142,7 @@
     "loading": "Lade Dag Information...",
     "loadingFailed": "Das Laden der Dag Informationen ist fehlgeschlagen. Bitte versuchen Sie es noch einmal.",
     "manualRunDenied": "Manuelles Auslösen dieses Dags ist nicht erlaubt.",
+    "partitionKeyHelp": "Optional – gilt nur für partitionierte Dags",
     "runIdHelp": "Optional - wird automatisch erzeugt wenn nicht angegeben",
     "selectDescription": "Einen einzelnen Lauf dieses Dags auslösen",
     "selectLabel": "Einzelner Lauf",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/de/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/de/dag.json
@@ -42,6 +42,7 @@
   },
   "deadlineAlerts": {
     "completionRule": "Muss innerhalb von {{interval}} nach {{reference}} abgeschlossen sein",
+    "completionRuleDynamic": "Muss innerhalb eines variablen, ab {{reference}} gemessenen Intervalls abgeschlossen werden",
     "count_one": "{{count}} Frist",
     "count_other": "{{count}} Fristen",
     "referenceType": {
@@ -91,10 +92,6 @@
     "critical": "CRITICAL",
     "debug": "DEBUG",
     "error": "ERROR",
-    "fullscreen": {
-      "button": "Vollbild",
-      "tooltip": "Taste {{hotkey}} für Vollbildmodus"
-    },
     "info": "INFO",
     "noTryNumber": "Keine Versuchsnummer",
     "search": {
@@ -149,7 +146,7 @@
     "dependencies": {
       "label": "Abhängigkeiten",
       "options": {
-        "allDagDependencies": "Alle Dag Abhängigkeiten",
+        "allDagDependencies": "Alle Dag-Abhängigkeiten",
         "externalConditions": "Externe Bedingungen",
         "onlyTasks": "Nur Tasks"
       },

--- a/airflow-core/src/airflow/ui/public/i18n/locales/de/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/de/dags.json
@@ -10,11 +10,13 @@
   "filters": {
     "allRunTypes": "Alle Arten von Läufen",
     "allStates": "Alle Stati",
+    "anyRunState": "Beliebiger Lauf",
     "favorite": {
       "all": "Alle",
       "favorite": "Favorisierte",
       "unfavorite": "Nicht favorisierte"
     },
+    "lastRunState": "Letzter Lauf",
     "paused": {
       "active": "Aktiv",
       "all": "Alle",
@@ -73,6 +75,7 @@
       "preventRunningTasks": "Zurücksetzen von laufenden Tasks verhindern",
       "queueNew": "Neue Tasks einplanen",
       "runOnLatestVersion": "Mit neuester Bündel-Version ausführen",
+      "runOnLatestVersionForced": "Verwendet immer die neueste Version — es gibt keine frühere Version, zu der zurückgekehrt werden kann",
       "upstream": "Vorangegangene"
     }
   },
@@ -89,8 +92,8 @@
       "desc": "Sortiert nach Anzeigename (Z-A)"
     },
     "lastRunStartDate": {
-      "asc": "Sortiert nach letztem Startdatum (Erster-Letzter)",
-      "desc": "Sortiert nach letztem Startdatum (Letzter-Erster)"
+      "asc": "Sortiert nach Startdatum des letzten Laufes (Früheste-Späteste)",
+      "desc": "Sortiert nach Startdatum des letzten Laufes (Späteste-Früheste)"
     },
     "lastRunState": {
       "asc": "Sortiert nach dem Status des letzten Laufes (A-Z)",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/de/dashboard.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/de/dashboard.json
@@ -1,4 +1,22 @@
 {
+  "alerts": {
+    "seeLessContext": "Weniger anzeigen",
+    "seeMoreContext": "Mehr anzeigen",
+    "showMoreAlerts_one": "+{{count}} weitere Warnung",
+    "showMoreAlerts_other": "+{{count}} weitere Warnungen"
+  },
+  "deadlines": {
+    "pending": {
+      "empty": "Keine bevorstehenden Fristen",
+      "title": "Bevorstehend"
+    },
+    "recentlyMissed": {
+      "empty": "Keine verpassten Fristen",
+      "title": "Verpasste Fristen"
+    },
+    "showMore": "Mehr anzeigen",
+    "title": "Fristen"
+  },
   "deferredSlotsNotCounted": "Delegierte Tasks, die nicht für die Pool-Belegung zählen: {{count}}",
   "deferredSlotsNotCountedTooltip": "Delegierte Tasks, die in der Leiste angezeigt werden, werden bei der Berechnung der Pool-Belegung berücksichtigt. Delegierte Tasks, die unterhalb der Leiste angezeigt werden, stammen aus Pools, die delegierte Tasks nicht für ihre Belegung berücksichtigen.",
   "favorite": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/de/hitl.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/de/hitl.json
@@ -24,6 +24,20 @@
     "success": "{{taskId}} Interaktion erfolgreich",
     "title": "Erforderliche Interaktion - {{taskId}}"
   },
+  "review": {
+    "detail": {
+      "selectRequiredAction": "Wählen Sie eine erforderliche Interaktion aus, um Details anzuzeigen"
+    },
+    "list": {
+      "completedRequiredActions": "Abgeschlossene erforderliche Interaktionen ({{count}})",
+      "loadError": "Erforderliche Interaktionen konnten nicht geladen werden",
+      "loadingActions": "Erforderliche Interaktionen werden geladen ...",
+      "pendingRequiredActions": "Ausstehende erforderliche Interaktionen ({{count}})"
+    },
+    "openReviewDrawer": "Prüfbereich öffnen",
+    "pageLimitHint": "Hier werden nur die ersten Interaktionen angezeigt. Verwenden Sie \"$t(review.viewAll)\", um alle anzuzeigen.",
+    "viewAll": "Alle erforderlichen Interaktionen anzeigen"
+  },
   "state": {
     "approvalReceived": "Genehmigung erhalten",
     "approvalRequired": "Genehmigung erforderlich",


### PR DESCRIPTION
Backport of #71668 to `v3-3-test` for the Airflow 3.3.2 patch release, **adapted to v3-3-test's key structure**.

#71668 completed German translations against main's i18n keys, which diverged from v3-3-test (pluralization + multi-team + run-state-filter features not backported). To backport only what v3-3-test needs:
- `admin.json` kept at v3-3-test's structure (its changes were all main-only pluralized keys).
- Ran `breeze ui check-translation-completeness --language de --remove-unused` to strip every German key with no v3-3-test English counterpart.

Result: German fills only for keys v3-3-test actually has — de coverage 92.4% → **98.4%**, no main-only keys, i18n completeness passes.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)