### PR TITLE
Fix task error email notification sender fallback to connection and provider defaults

### DIFF
--- a/airflow-core/newsfragments/72745.bugfix.rst
+++ b/airflow-core/newsfragments/72745.bugfix.rst
@@ -1,0 +1,1 @@
+Task SDK error email notifications (``email_on_failure`` / ``email_on_retry``) now pass ``from_email=None`` by default instead of the hardcoded ``airflow@airflow``. This allows custom email backends (e.g. SendGrid, Amazon SES) and ``SmtpNotifier`` to resolve sender identity from connection extras or environment defaults.

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -2161,7 +2161,7 @@ def _send_error_email_notification(
             to=to_emails,
             subject=subject,
             html_content=html_content,
-            from_email=conf.get("email", "from_email", fallback="airflow@airflow"),
+            from_email=conf.get("email", "from_email", fallback=None),
         )
         notifier(email_context)
     except Exception:

--- a/task-sdk/tests/task_sdk/execution_time/test_email_backend.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_email_backend.py
@@ -78,6 +78,28 @@ class TestLegacyEmailBackendNotifier:
             from_email="from@x.com",
         )
 
+    def test_notify_passes_none_from_email_by_default(self):
+        """When from_email is omitted, notify() passes from_email=None to allow backend-defined defaults."""
+        backend = mock.create_autospec(_legacy_email_backend)
+        notifier = _LegacyEmailBackendNotifier(
+            to=["a@b.com"],
+            subject="Subject",
+            html_content="<p>body</p>",
+        )
+        with (
+            mock.patch.object(conf, "getimport", autospec=True, return_value=backend),
+            mock.patch.object(conf, "get", autospec=True, return_value="my_conn"),
+        ):
+            notifier.notify(context={})
+
+        backend.assert_called_once_with(
+            ["a@b.com"],
+            "Subject",
+            "<p>body</p>",
+            conn_id="my_conn",
+            from_email=None,
+        )
+
     def test_notify_raises_when_backend_unresolvable(self):
         """An empty/unloadable backend raises rather than silently doing nothing."""
         notifier = _LegacyEmailBackendNotifier(to="a@b.com")

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -4328,6 +4328,71 @@ class TestEmailNotifications:
         mock_smtp_notifier.assert_not_called()
         log.exception.assert_called()
 
+    def test_default_from_email_is_none_for_smtp_notifier(self, create_runtime_ti, mock_supervisor_comms):
+        """When ``[email] from_email`` is not configured, SmtpNotifier receives from_email=None."""
+        from airflow.sdk.exceptions import AirflowFailException
+        from airflow.sdk.execution_time.task_runner import finalize, run
+
+        class FailingOperator(BaseOperator):
+            def execute(self, context):
+                raise AirflowFailException("Task failed on purpose")
+
+        task = FailingOperator(
+            task_id="default_from_email_smtp_task",
+            email=["test@example.com"],
+            email_on_failure=True,
+        )
+
+        runtime_ti = create_runtime_ti(task=task)
+        context = runtime_ti.get_template_context()
+        log = mock.MagicMock()
+
+        with conf_vars({("email", "from_email"): None}):
+            with mock.patch(
+                "airflow.providers.smtp.notifications.smtp.SmtpNotifier", autospec=True
+            ) as mock_smtp_notifier:
+                state, _, error = run(runtime_ti, context, log)
+                finalize(runtime_ti, state, context, log, error)
+
+                mock_smtp_notifier.assert_called_once()
+                kwargs = mock_smtp_notifier.call_args.kwargs
+                assert kwargs["from_email"] is None
+
+    def test_default_from_email_is_none_for_custom_backend(self, create_runtime_ti, mock_supervisor_comms):
+        """When ``[email] from_email`` is not configured, custom email_backend receives from_email=None."""
+        from airflow.sdk.exceptions import AirflowFailException
+        from airflow.sdk.execution_time.task_runner import finalize, run
+
+        backend = mock.create_autospec(_recording_email_backend)
+
+        class FailingOperator(BaseOperator):
+            def execute(self, context):
+                raise AirflowFailException("Task failed on purpose")
+
+        task = FailingOperator(
+            task_id="default_from_email_custom_backend_task",
+            email=["test@example.com"],
+            email_on_failure=True,
+        )
+
+        runtime_ti = create_runtime_ti(task=task)
+        context = runtime_ti.get_template_context()
+        log = mock.MagicMock()
+
+        with conf_vars(
+            {
+                ("email", "email_backend"): f"{__name__}._recording_email_backend",
+                ("email", "from_email"): None,
+            }
+        ):
+            with mock.patch(f"{__name__}._recording_email_backend", backend):
+                state, _, error = run(runtime_ti, context, log)
+                finalize(runtime_ti, state, context, log, error)
+
+                backend.assert_called_once()
+                _, kwargs = backend.call_args
+                assert kwargs["from_email"] is None
+
     @pytest.mark.enable_redact
     def test_rendered_templates_mask_secrets(self, create_runtime_ti, mock_supervisor_comms):
         """Test that secrets registered with mask_secret() are redacted in rendered template fields."""


### PR DESCRIPTION
In Task SDK, _send_error_email_notification passed a hardcoded fallback string 'airflow@airflow' when [email] from_email was not configured. This bypassed provider-specific defaults (such as SendGrid's SENDGRID_MAIL_FROM env var or SES sender verification) when using _LegacyEmailBackendNotifier, and prevented SmtpNotifier from reaching its connection-extra fallback branch.

Default from_email extraction to None so backends and notifiers can resolve their own sender defaults.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
