### PR TITLE
Keep the triggerer running when a trigger constructor raises

### DIFF
--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -1402,7 +1402,8 @@ class TriggerRunner:
                 else:
                     trigger_name = f"ID {trigger_id}"
                     trigger_instance = trigger_class(**deserialised_kwargs)
-            except TypeError as err:
+            # Not BaseException: cancellation and shutdown must still reach the runner loop.
+            except Exception as err:
                 self.log.error("Trigger failed to inflate", error=err)
                 self.failed_triggers.append((trigger_id, err))
                 continue

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -1652,6 +1652,44 @@ class TestTriggerRunner:
         assert isinstance(err, TypeError)
         assert "got an unexpected keyword argument 'not_exists_arg'" in str(err)
 
+    @patch("airflow.jobs.triggerer_job_runner.Trigger._decrypt_kwargs")
+    @patch("airflow.jobs.triggerer_job_runner.TriggerRunner.get_trigger_by_classpath")
+    @pytest.mark.asyncio
+    async def test_create_triggers_fails_only_the_trigger_whose_init_raises(
+        self, mock_get_trigger_by_classpath, mock_decrypt_kwargs, cap_structlog
+    ) -> None:
+        class ValidatingTrigger(BaseTrigger):
+            def __init__(self, value):
+                super().__init__()
+                if value is None:
+                    raise ValueError("value must not be None")
+
+            def serialize(self):
+                return ("abc", {"value": None})
+
+            async def run(self):
+                yield TriggerEvent(True)
+
+        mock_get_trigger_by_classpath.return_value = ValidatingTrigger
+        mock_decrypt_kwargs.side_effect = [{"value": None}, {"value": 1}]
+        trigger_runner = TriggerRunner()
+        trigger_runner.to_create.extend(
+            workloads.RunTrigger.model_construct(id=trigger_id, classpath="abc", encrypted_kwargs="fake")
+            for trigger_id in (1, 2)
+        )
+
+        await trigger_runner.create_triggers()
+
+        [(trigger_id, err)] = trigger_runner.failed_triggers
+        assert trigger_id == 1
+        assert isinstance(err, ValueError)
+        assert {"event": "Trigger failed to inflate", "error": err} in cap_structlog
+        assert 1 not in trigger_runner.triggers
+        assert 2 in trigger_runner.triggers
+
+        trigger_runner.triggers[2]["task"].cancel()
+        await trigger_runner.cleanup_finished_triggers()
+
     @pytest.mark.asyncio
     @patch("airflow.sdk.execution_time.task_runner.SUPERVISOR_COMMS", create=True)
     async def test_invalid_trigger(self, supervisor_builder):


### PR DESCRIPTION
## Summary

A trigger whose constructor raises anything but `TypeError` while the triggerer re-creates it stops the whole triggerer: the exception escapes `create_triggers`, the runner subprocess exits, and the supervisor exits with it. After a restart the same trigger is picked up again, so the triggerer crash-loops until the task is cleared. Failures while decrypting or decoding the stored kwargs, or while rebuilding the runtime task instance and template context for a task started from a trigger, take the same path.

- Fail only the offending trigger when its constructor raises, instead of stopping the runner.
- Cover it with a test where one trigger's constructor raises and a second trigger still starts.

A bad classpath a few lines above already fails only that trigger; the constructor guard now does the same, stopping at `Exception` so cancellation and shutdown still reach the runner loop. The `TypeError`-only guard from #31999 came from a readability suggestion in review, not from a reason to let other exceptions through.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5.1)

Generated-by: Claude Code (Fable 5.1) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
