### PR TITLE
Warn about the DatabricksSQLStatementsSensor exclusivity tightening

### DIFF
--- a/providers/databricks/docs/changelog.rst
+++ b/providers/databricks/docs/changelog.rst
@@ -26,6 +26,16 @@
 Changelog
 ---------
 
+.. warning::
+  ``DatabricksSQLStatementsSensor`` now rejects the combination of ``statement`` and
+  ``statement_id`` when the Dag is parsed rather than when the task runs, and the check is
+  ``is not None``, so an empty string counts as provided. ``statement="SELECT 1"`` together
+  with ``statement_id=""`` — or with a ``statement_id`` template that renders to ``None``
+  under ``render_template_as_native_obj=True`` — ran the statement in 7.19.0 and now raises
+  at Dag parse time. Pass exactly one of the two and omit the other entirely instead of
+  passing an empty value. The argument-validation errors in this sensor are also now
+  ``ValueError`` rather than ``AirflowException``.
+
 7.19.0
 ......
 


### PR DESCRIPTION
`#70831` moved `DatabricksSQLStatementsSensor`'s exclusivity check from `execute()` to `__init__` and changed it from a truthiness test to `is not None`. That is a behaviour change against a **released** version, because `providers-databricks/7.19.0` (tagged 2026-08-19) already contains #70340 and so ships the `execute()`-time truthiness check:

* `statement="SELECT 1"` with `statement_id=""` runs the statement in 7.19.0, and is a Dag import error now.
* Same for a `statement_id` template that renders to `None` under `render_template_as_native_obj=True` — it is a non-`None` string at construction time, so the pair is rejected at parse time.
* The two argument-validation errors are now `ValueError`, so an `except AirflowException` around them stops matching.

The tightening itself is sanctioned by #70503 and is not in question here. The note explaining it to users was requested during the review of #70831 but did not land before the merge, so the `Changelog` header in this provider still has nothing under it.

The wording is the text written in that review, placed where the file's own header comment asks for it (just below `Changelog`, above the topmost version), in the same shape as the `ComprehendCreateDocumentClassifierOperator` warning at the top of the amazon changelog.

I verified both halves before writing it: `providers-databricks/7.19.0`'s sensor raises `AirflowException` from `execute()` under `if self.statement and self.statement_id`, and `main`'s raises `ValueError` from `__init__` under `if statement is not None and statement_id is not None`. Providers take no newsfragment, so the changelog is the only place this can be said. `check-changelog-format` passes.

related: #70831

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)