### PR TITLE
Fix docs build crash on newer anyio releases

### DIFF
--- a/devel-common/src/sphinx_exts/pagefind_search/builder.py
+++ b/devel-common/src/sphinx_exts/pagefind_search/builder.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import anyio
+import anyio.to_thread
 from pagefind.index import IndexConfig, PagefindIndex
 from sphinx.util.fileutil import copy_asset
 


### PR DESCRIPTION
`devel-common/src/sphinx_exts/pagefind_search/builder.py`) only `import anyio` and then calls `anyio.to_thread.run_sync(...)`.

**`anyio.to_thread` is a submodule, and `import anyio` alone does not guarantee it's attached to the `anyio` package namespace**.

A dependency bump anywhere in the workspace that changes what gets imported alongside anyio (observed going from anyio 4.14.2 -> 4.15.0, pulled in transitively by an unrelated `pydantic-ai-slim` version bump) removes that incidental side effect and breaks the docs build with:

```
AttributeError: module 'anyio' has no attribute 'to_thread'
sphinx.errors.ExtensionError: Handler <function build_index_finished ...> for event 'build-finished' threw an exception
```

Reproduced and confirmed the fix in isolation:

```
$ uv run --with anyio==4.15.0 --no-project --isolated python -c "import anyio; anyio.to_thread"
AttributeError: module 'anyio' has no attribute 'to_thread'

$ uv run --with anyio==4.15.0 --no-project --isolated python -c "import anyio; import anyio.to_thread; anyio.to_thread.run_sync"
<function run_sync at ...>
```

Importing the submodule explicitly makes the docs build resilient to import-order changes elsewhere in the dependency graph.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)

Generated-by: Claude Code (Sonnet 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)