### PR TITLE
Reuse ClickHouse client instead of reconnecting on every hook call

### DIFF
--- a/providers/clickhousedb/src/airflow/providers/clickhousedb/hooks/clickhouse.py
+++ b/providers/clickhousedb/src/airflow/providers/clickhousedb/hooks/clickhouse.py
@@ -112,7 +112,7 @@ class ClickHouseConnection:
         return Cursor(self._client)
 
     def close(self) -> None:
-        self._client.close()
+        """No-op: the wrapped client is owned/reused by ClickHouseHook; use ClickHouseHook.close()."""
 
     def commit(self) -> None:
         pass  # ClickHouse has no multi-statement transactions
@@ -130,6 +130,10 @@ class ClickHouseHook(DbApiHook):
     :class:`~airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`
     features work out of the box (templating, ``handler``, ``split_statements``,
     etc.).
+
+    The client is created lazily on first use and reused for the lifetime of the
+    hook instance (see :meth:`get_client`). Call :meth:`close` when done, or use the
+    hook as a context manager (``with ClickHouseHook(...) as hook:``).
 
     :param database: Optional database name.  Overrides the ``schema`` field of the
         Airflow connection.  Useful when one connection points to a ClickHouse cluster
@@ -185,6 +189,7 @@ class ClickHouseHook(DbApiHook):
         self.database = database
         self.session_settings: dict[str, Any] = session_settings or {}
         self.client_kwargs: dict[str, Any] = client_kwargs or {}
+        self._client: clickhouse_connect.driver.client.Client | None = None
 
     def _get_client_kwargs(self) -> dict[str, Any]:
         """
@@ -211,6 +216,8 @@ class ClickHouseHook(DbApiHook):
         ``session_settings`` from ``extra`` and from the constructor ``session_settings``
         argument are **merged**, with the constructor argument taking precedence on
         conflicting keys.
+
+        ``autogenerate_session_id`` defaults to ``False`` unless overridden via ``client_kwargs``.
         """
         conn = self.get_connection(self.get_conn_id())
         extra: dict[str, Any] = conn.extra_dejson
@@ -235,6 +242,9 @@ class ClickHouseHook(DbApiHook):
         kwargs: dict[str, Any] = {
             k: v for k, v in merged_client_kwargs.items() if k not in _HOOK_MANAGED_KWARGS
         }
+
+        # Shared/reused client -> no auto-generated session ID unless the caller opts in.
+        kwargs.setdefault("autogenerate_session_id", False)
 
         # Hook-managed connection parameters always take precedence.
         kwargs.update(
@@ -270,23 +280,28 @@ class ClickHouseHook(DbApiHook):
         return kwargs
 
     def get_conn(self) -> ClickHouseConnection:
-        """Return a DB-API 2.0 compatible connection backed by ``clickhouse_connect``."""
-        import clickhouse_connect
-
-        client = clickhouse_connect.get_client(**self._get_client_kwargs())
-        return ClickHouseConnection(client)
+        """Return a DB-API 2.0 compatible connection wrapping the shared ``clickhouse_connect`` client."""
+        return ClickHouseConnection(self.get_client())
 
     def get_client(self) -> clickhouse_connect.driver.client.Client:
-        """
-        Return the raw ``clickhouse_connect`` Client for ClickHouse-specific operations.
+        """Return the shared ``clickhouse_connect`` Client, creating it lazily on first use."""
+        if self._client is None:
+            import clickhouse_connect
 
-        Use this for bulk inserts, streaming queries, or any operation that
-        benefits from the native ``clickhouse_connect`` API rather than DB-API
-        cursors.  The caller is responsible for closing the client.
-        """
-        import clickhouse_connect
+            self._client = clickhouse_connect.get_client(**self._get_client_kwargs())
+        return self._client
 
-        return clickhouse_connect.get_client(**self._get_client_kwargs())
+    def close(self) -> None:
+        """Close the shared ``clickhouse_connect`` client, if one was created, and release its pool."""
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+    def __enter__(self) -> ClickHouseHook:
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
 
     def bulk_insert_rows(
         self,
@@ -306,6 +321,8 @@ class ClickHouseHook(DbApiHook):
         insert context is created once and reused across chunks to avoid a
         repeated ``DESCRIBE TABLE`` round-trip per batch.
 
+        Uses the hook's shared client (see :meth:`get_client`); not closed here.
+
         :param table: Target table name.
         :param rows: List of row tuples to insert.
         :param column_names: Column names matching each position in the row tuples.
@@ -319,16 +336,13 @@ class ClickHouseHook(DbApiHook):
             return
 
         client = self.get_client()
-        try:
-            if batch_size is None:
-                client.insert(table, rows, column_names=column_names)
-            else:
-                ctx = client.create_insert_context(table, column_names=column_names)
-                for i in range(0, len(rows), batch_size):
-                    client.insert(data=rows[i : i + batch_size], context=ctx)
-            self.log.info("Inserted %d rows into %s", len(rows), table)
-        finally:
-            client.close()
+        if batch_size is None:
+            client.insert(table, rows, column_names=column_names)
+        else:
+            ctx = client.create_insert_context(table, column_names=column_names)
+            for i in range(0, len(rows), batch_size):
+                client.insert(data=rows[i : i + batch_size], context=ctx)
+        self.log.info("Inserted %d rows into %s", len(rows), table)
 
     def get_uri(self) -> str:
         """

--- a/providers/clickhousedb/tests/unit/clickhousedb/hooks/test_clickhouse.py
+++ b/providers/clickhousedb/tests/unit/clickhousedb/hooks/test_clickhouse.py
@@ -158,6 +158,7 @@ class TestClickHouseHookGetConn:
             database="analytics",
             secure=False,
             verify=True,
+            autogenerate_session_id=False,
             client_name=ANY,  # always set; format verified in TestClickHouseHookClientName
         )
         assert isinstance(conn, ClickHouseConnection)
@@ -180,6 +181,7 @@ class TestClickHouseHookGetConn:
             connect_timeout=30,
             send_receive_timeout=600,
             compress=False,
+            autogenerate_session_id=False,
             client_name=ANY,  # contains Airflow version + "(my-airflow)" comment
         )
 
@@ -199,6 +201,7 @@ class TestClickHouseHookGetConn:
             database="default",
             secure=False,
             verify=True,
+            autogenerate_session_id=False,
             client_name=ANY,  # always set; format verified in TestClickHouseHookClientName
         )
 
@@ -489,6 +492,27 @@ class TestClickHouseHookClientKwargs:
         assert "settings" not in kwargs
 
     @patch("airflow.providers.clickhousedb.hooks.clickhouse.ClickHouseHook.get_connection")
+    def test_autogenerate_session_id_defaults_to_false(self, mock_get_connection):
+        """The shared/reused client must default to no auto-generated session ID."""
+        mock_get_connection.return_value = BASE_CONN
+        hook = ClickHouseHook(clickhouse_conn_id="clickhouse_test")
+        kwargs = hook._get_client_kwargs()
+
+        assert kwargs["autogenerate_session_id"] is False
+
+    @patch("airflow.providers.clickhousedb.hooks.clickhouse.ClickHouseHook.get_connection")
+    def test_constructor_client_kwargs_can_enable_session_id(self, mock_get_connection):
+        """Users needing session-scoped state can opt back in via constructor client_kwargs."""
+        mock_get_connection.return_value = BASE_CONN
+        hook = ClickHouseHook(
+            clickhouse_conn_id="clickhouse_test",
+            client_kwargs={"autogenerate_session_id": True},
+        )
+        kwargs = hook._get_client_kwargs()
+
+        assert kwargs["autogenerate_session_id"] is True
+
+    @patch("airflow.providers.clickhousedb.hooks.clickhouse.ClickHouseHook.get_connection")
     def test_optional_keys_with_null_values_not_forwarded(self, mock_get_connection):
         """Optional kwargs set to null/None in extra must not be forwarded to the driver."""
         conn = Connection(
@@ -595,6 +619,21 @@ class TestClickHouseHookClientKwargsFromExtra:
 
         assert "http_proxy" not in kwargs
         assert "pool_mgr_params" not in kwargs
+
+    @patch("airflow.providers.clickhousedb.hooks.clickhouse.ClickHouseHook.get_connection")
+    def test_client_kwargs_from_extra_can_enable_session_id(self, mock_get_connection):
+        """Connection-level extra.client_kwargs can also opt back into session IDs."""
+        conn = Connection(
+            conn_id="ch_session_opt_in",
+            conn_type="clickhouse",
+            host="host",
+            extra=json.dumps({"client_kwargs": {"autogenerate_session_id": True}}),
+        )
+        mock_get_connection.return_value = conn
+        hook = ClickHouseHook(clickhouse_conn_id="ch_session_opt_in")
+        kwargs = hook._get_client_kwargs()
+
+        assert kwargs["autogenerate_session_id"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -710,11 +749,12 @@ class TestClickHouseConnection:
         assert isinstance(c1, Cursor)
         assert isinstance(c2, Cursor)
 
-    def test_close_delegates_to_client(self):
+    def test_close_is_noop(self):
+        """close() must NOT close the wrapped client — it is owned/reused by the hook."""
         mock_client = MagicMock()
         conn = ClickHouseConnection(mock_client)
         conn.close()
-        mock_client.close.assert_called_once()
+        mock_client.close.assert_not_called()
 
     def test_commit_is_noop(self):
         ClickHouseConnection(MagicMock()).commit()  # must not raise
@@ -1207,18 +1247,144 @@ class TestClickHouseHookGetClient:
 
     @patch("airflow.providers.clickhousedb.hooks.clickhouse.ClickHouseHook.get_connection")
     @patch("clickhouse_connect.get_client")
-    def test_get_client_and_get_conn_use_same_kwargs(self, mock_get_client, mock_get_connection):
-        """get_client() and get_conn() should build kwargs from the same source."""
+    def test_get_client_and_get_conn_share_same_client(self, mock_get_client, mock_get_connection):
+        """get_client() and get_conn() must return/wrap the same lazily-created client."""
+        mock_get_connection.return_value = BASE_CONN
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        hook = ClickHouseHook(clickhouse_conn_id="clickhouse_test")
+
+        conn = hook.get_conn()
+        client_from_client = hook.get_client()
+
+        # clickhouse_connect.get_client() is only invoked once — the client is reused.
+        mock_get_client.assert_called_once()
+        assert conn._client is client_from_client is mock_client
+
+    @patch("airflow.providers.clickhousedb.hooks.clickhouse.ClickHouseHook.get_connection")
+    @patch("clickhouse_connect.get_client")
+    def test_get_client_is_lazy(self, mock_get_client, mock_get_connection):
+        """The client must not be created until first accessed."""
         mock_get_connection.return_value = BASE_CONN
         hook = ClickHouseHook(clickhouse_conn_id="clickhouse_test")
 
-        hook.get_conn()
-        kwargs_from_conn = mock_get_client.call_args.kwargs
-
+        mock_get_client.assert_not_called()
         hook.get_client()
-        kwargs_from_client = mock_get_client.call_args.kwargs
+        mock_get_client.assert_called_once()
 
-        assert kwargs_from_conn == kwargs_from_client
+    @patch("airflow.providers.clickhousedb.hooks.clickhouse.ClickHouseHook.get_connection")
+    @patch("clickhouse_connect.get_client")
+    def test_get_client_reused_across_multiple_calls(self, mock_get_client, mock_get_connection):
+        """Repeated get_client() calls must reuse the cached client, not create new ones."""
+        mock_get_connection.return_value = BASE_CONN
+        hook = ClickHouseHook(clickhouse_conn_id="clickhouse_test")
+
+        client1 = hook.get_client()
+        client2 = hook.get_client()
+
+        mock_get_client.assert_called_once()
+        assert client1 is client2
+
+
+# ---------------------------------------------------------------------------
+# Tests: ClickHouseHook.close() / context manager
+# ---------------------------------------------------------------------------
+
+
+class TestClickHouseHookClientLifecycle:
+    @patch("airflow.providers.clickhousedb.hooks.clickhouse.ClickHouseHook.get_connection")
+    @patch("clickhouse_connect.get_client")
+    def test_close_closes_and_clears_cached_client(self, mock_get_client, mock_get_connection):
+        mock_get_connection.return_value = BASE_CONN
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        hook = ClickHouseHook(clickhouse_conn_id="clickhouse_test")
+        hook.get_client()
+
+        hook.close()
+
+        mock_client.close.assert_called_once()
+        assert hook._client is None
+
+    @patch("airflow.providers.clickhousedb.hooks.clickhouse.ClickHouseHook.get_connection")
+    @patch("clickhouse_connect.get_client")
+    def test_close_without_client_is_noop(self, mock_get_client, mock_get_connection):
+        """close() before the client is ever created must not raise or call get_client()."""
+        mock_get_connection.return_value = BASE_CONN
+        hook = ClickHouseHook(clickhouse_conn_id="clickhouse_test")
+
+        hook.close()
+
+        mock_get_client.assert_not_called()
+
+    @patch("airflow.providers.clickhousedb.hooks.clickhouse.ClickHouseHook.get_connection")
+    @patch("clickhouse_connect.get_client")
+    def test_close_after_close_is_safe(self, mock_get_client, mock_get_connection):
+        mock_get_connection.return_value = BASE_CONN
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        hook = ClickHouseHook(clickhouse_conn_id="clickhouse_test")
+        hook.get_client()
+
+        hook.close()
+        hook.close()  # must not raise or close the client twice
+
+        mock_client.close.assert_called_once()
+
+    @patch("airflow.providers.clickhousedb.hooks.clickhouse.ClickHouseHook.get_connection")
+    @patch("clickhouse_connect.get_client")
+    def test_new_client_created_after_close(self, mock_get_client, mock_get_connection):
+        """After close(), the next get_client() call must create a fresh client."""
+        mock_get_connection.return_value = BASE_CONN
+        first_client, second_client = MagicMock(), MagicMock()
+        mock_get_client.side_effect = [first_client, second_client]
+        hook = ClickHouseHook(clickhouse_conn_id="clickhouse_test")
+
+        assert hook.get_client() is first_client
+        hook.close()
+        assert hook.get_client() is second_client
+        assert mock_get_client.call_count == 2
+
+    @patch("airflow.providers.clickhousedb.hooks.clickhouse.ClickHouseHook.get_connection")
+    @patch("clickhouse_connect.get_client")
+    def test_context_manager_closes_client_on_exit(self, mock_get_client, mock_get_connection):
+        mock_get_connection.return_value = BASE_CONN
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        with ClickHouseHook(clickhouse_conn_id="clickhouse_test") as hook:
+            hook.get_client()
+
+        mock_client.close.assert_called_once()
+
+    @patch("airflow.providers.clickhousedb.hooks.clickhouse.ClickHouseHook.get_connection")
+    @patch("clickhouse_connect.get_client")
+    def test_context_manager_closes_client_on_exception(self, mock_get_client, mock_get_connection):
+        mock_get_connection.return_value = BASE_CONN
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        hook = ClickHouseHook(clickhouse_conn_id="clickhouse_test")
+        hook.get_client()
+
+        with pytest.raises(RuntimeError, match="boom"), hook:
+            raise RuntimeError("boom")
+
+        mock_client.close.assert_called_once()
+
+    @patch("airflow.providers.clickhousedb.hooks.clickhouse.ClickHouseHook.get_connection")
+    @patch("clickhouse_connect.get_client")
+    def test_get_conn_does_not_close_cached_client(self, mock_get_client, mock_get_connection):
+        mock_get_connection.return_value = BASE_CONN
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        hook = ClickHouseHook(clickhouse_conn_id="clickhouse_test")
+
+        hook.get_conn()
+        hook.get_conn()
+
+        mock_get_client.assert_called_once()
+        mock_client.close.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -1296,8 +1462,8 @@ class TestClickHouseHookBulkInsert:
 
     @patch("airflow.providers.clickhousedb.hooks.clickhouse.ClickHouseHook.get_connection")
     @patch("clickhouse_connect.get_client")
-    def test_client_closed_after_success(self, mock_get_client, mock_get_connection):
-        """Client must be closed after successful insert."""
+    def test_client_not_closed_after_success(self, mock_get_client, mock_get_connection):
+        """Client must NOT be closed after a successful insert — it is reused by the hook."""
         mock_get_connection.return_value = BASE_CONN
         mock_client = MagicMock()
         mock_get_client.return_value = mock_client
@@ -1305,12 +1471,12 @@ class TestClickHouseHookBulkInsert:
         hook = ClickHouseHook(clickhouse_conn_id="clickhouse_test")
         hook.bulk_insert_rows("t", [(1,)], column_names=["id"])
 
-        mock_client.close.assert_called_once()
+        mock_client.close.assert_not_called()
 
     @patch("airflow.providers.clickhousedb.hooks.clickhouse.ClickHouseHook.get_connection")
     @patch("clickhouse_connect.get_client")
-    def test_client_closed_on_insert_error(self, mock_get_client, mock_get_connection):
-        """Client must be closed even when insert raises."""
+    def test_client_not_closed_on_insert_error(self, mock_get_client, mock_get_connection):
+        """Client must remain open (for reuse) even when insert raises."""
         mock_get_connection.return_value = BASE_CONN
         mock_client = MagicMock()
         mock_client.insert.side_effect = RuntimeError("insert failed")
@@ -1320,7 +1486,37 @@ class TestClickHouseHookBulkInsert:
         with pytest.raises(RuntimeError, match="insert failed"):
             hook.bulk_insert_rows("t", [(1,)], column_names=["id"])
 
-        mock_client.close.assert_called_once()
+        mock_client.close.assert_not_called()
+
+    @patch("airflow.providers.clickhousedb.hooks.clickhouse.ClickHouseHook.get_connection")
+    @patch("clickhouse_connect.get_client")
+    def test_bulk_insert_reuses_client_across_calls(self, mock_get_client, mock_get_connection):
+        """Multiple bulk_insert_rows calls on the same hook must share one client."""
+        mock_get_connection.return_value = BASE_CONN
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        hook = ClickHouseHook(clickhouse_conn_id="clickhouse_test")
+        hook.bulk_insert_rows("t", [(1,)], column_names=["id"])
+        hook.bulk_insert_rows("t", [(2,)], column_names=["id"])
+
+        mock_get_client.assert_called_once()
+        assert mock_client.insert.call_count == 2
+
+    @patch("airflow.providers.clickhousedb.hooks.clickhouse.ClickHouseHook.get_connection")
+    @patch("clickhouse_connect.get_client")
+    def test_bulk_insert_rows_reuses_existing_client(self, mock_get_client, mock_get_connection):
+        mock_get_connection.return_value = BASE_CONN
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        hook = ClickHouseHook(clickhouse_conn_id="clickhouse_test")
+        client = hook.get_client()
+
+        hook.bulk_insert_rows("events", [(1, "a")], column_names=["id", "name"])
+
+        mock_get_client.assert_called_once()
+        assert hook.get_client() is client
 
     @patch("airflow.providers.clickhousedb.hooks.clickhouse.ClickHouseHook.get_connection")
     @patch("clickhouse_connect.get_client")


### PR DESCRIPTION
`ClickHouseHook.get_conn()` and `get_client()` each called `clickhouse_connect.get_client()` directly, so every query, `run()` call, and `bulk_insert_rows()` invocation opened a brand new HTTP connection pool and incurred the client-initialization overhead (including a server metadata round trip). `bulk_insert_rows()` then closed that client itself after every call.

This reworks the hook to create the client lazily once and reuse it for the hook's lifetime, matching clickhouse-connect's own client lifecycle guidance (reuse a single client, avoid creating one per query, close it explicitly when done):

- `get_client()` now caches the client on the hook and only calls `clickhouse_connect.get_client()` on first access. `get_conn()` and `bulk_insert_rows()` both reuse the cached client instead of opening a new one.
- Added `ClickHouseHook.close()` to close and clear the cached client, plus `__enter__`/`__exit__` so the hook can be used as a context manager.
- `ClickHouseConnection.close()` is now a no-op. `DbApiHook.run()`/`get_records()`/etc. wrap `get_conn()` in `contextlib.closing(...)`, so this previously ran after *every* query — closing the real client there would have prevented it from being reused.
- Since the client is now shared across calls instead of one client per call, `autogenerate_session_id` defaults to `False` unless overridden via `client_kwargs`, to avoid `ProgrammingError` from concurrent queries sharing one auto-generated session ID.

No public API change — `get_conn()` and `get_client()` keep their existing signatures and return types. Unit tests updated/added to cover lazy creation, client reuse across `get_conn()` / `get_client()` / `bulk_insert_rows()`, `close()` semantics, and the new `autogenerate_session_id` default and overrides.

References:
- https://github.com/ClickHouse/clickhouse-connect/blob/main/docs/driver-api.mdx
- https://github.com/ClickHouse/clickhouse-connect/blob/main/docs/advanced-usage.mdx

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude (Sonnet 5)

Generated-by: Claude (Sonnet 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)