### PR TITLE
Add systemd unit file for Airflow Dag processor

### DIFF
--- a/airflow-core/docs/howto/run-with-systemd.rst
+++ b/airflow-core/docs/howto/run-with-systemd.rst
@@ -67,5 +67,24 @@ New Airflow 3.0 Services
 
 Since Apache Airflow 3.0, additional components have been split out into separate services. The following new unit files are available:
 
+- ``airflow-dag-processor.service`` for Dag file parsing
 - ``airflow-triggerer.service`` for deferrable task triggering
 - ``airflow-api.service`` for the standalone REST API server
+
+Required services
+'''''''''''''''''
+
+At a minimum, you must run the ``scheduler``, the ``dag-processor`` and either the ``webserver`` or the ``api-server``:
+
+- ``airflow-scheduler.service``
+- ``airflow-dag-processor.service``
+- ``airflow-webserver.service`` or ``airflow-api.service``
+
+Without a running Dag processor, Dag files are never parsed and the ``dag_processor`` entry of the
+``/api/v2/monitor/health`` endpoint reports its status as ``unhealthy``.
+
+The ``airflow-triggerer.service`` is optional: start it only if you use deferrable tasks or
+event-driven :doc:`triggers <../authoring-and-scheduling/event-scheduling>`. If it is not running, the
+``triggerer`` entry of the health endpoint reports ``unhealthy``, which is expected and safe to ignore.
+
+See :ref:`Checking Airflow Health Status <check-health/http-endpoint>` for details on how each component reports its health.

--- a/scripts/systemd/README
+++ b/scripts/systemd/README
@@ -9,3 +9,25 @@ By default the environment configuration points to /etc/sysconfig/airflow . You 
 directory and adjust it to your liking.
 
 With some minor changes they probably work on other systemd systems.
+
+Required services
+-----------------
+
+Since Airflow 3.0 the airflow processes that handle the different components are split into separate services. At a
+minimum you need to run the following services:
+
+* airflow-scheduler.service
+* airflow-dag-processor.service
+* airflow-webserver.service or airflow-api.service
+
+Additionally the following services are available and can be enabled as needed:
+
+* airflow-triggerer.service for deferrable task triggering (required only if you use deferrable tasks or event
+  scheduling)
+* airflow-worker.service for a Celery worker
+* airflow-flower.service for a Flower monitoring interface
+* airflow-kerberos.service for the Kerberos renewal daemon
+
+The ``/api/v2/monitor/health`` endpoint reports ``dag_processor`` and ``triggerer`` as ``unhealthy`` when no
+corresponding service is running, so make sure the services you depend on are started. See the "Checking Airflow
+Health Status" documentation for details.

--- a/scripts/systemd/airflow-dag-processor.service
+++ b/scripts/systemd/airflow-dag-processor.service
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[Unit]
+Description=Airflow Dag processor daemon
+After=network.target postgresql.service mysql.service redis.service rabbitmq-server.service
+Wants=postgresql.service mysql.service redis.service rabbitmq-server.service
+
+[Service]
+EnvironmentFile=/etc/sysconfig/airflow
+User=airflow
+Group=airflow
+Type=simple
+ExecStart=/bin/bash -c 'source /home/airflow/airflow_venv/bin/activate && airflow dag-processor'
+Restart=always
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Airflow 3 runs the Dag processor as a standalone process that the scheduler no longer starts, so a systemd deployment must run at least the scheduler, the Dag processor and the api-server. The systemd units that were updated for Airflow 3 left out the Dag processor service, so deployments that only started the scheduler and api-server showed the dag_processor and triggerer entries of /api/v2/monitor/health as unhealthy and, worse, never parsed any Dags.

Add airflow-dag-processor.service and document which services are required and which are optional so the health endpoint reports match the running components.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
