### PR TITLE
Paginate AppflowHook._log_execution_description to prevent KeyError (#72769)

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/appflow.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/appflow.py
@@ -80,11 +80,21 @@ class AppflowHook(AwsGenericHook["AppflowClient"]):
 
         return execution_id
 
-    def _log_execution_description(self, flow_name: str, execution_id: str):
-        response_desc = self.conn.describe_flow_execution_records(flowName=flow_name)
-        last_execs = {fe["executionId"]: fe for fe in response_desc["flowExecutions"]}
-        exec_details = last_execs[execution_id]
-        self.log.info("Run complete, execution details: %s", exec_details)
+    def _log_execution_description(self, flow_name: str, execution_id: str) -> None:
+        next_token: str | None = None
+        while True:
+            kwargs: dict[str, str | int] = {"flowName": flow_name, "maxResults": 100}
+            if next_token:
+                kwargs["nextToken"] = next_token
+            response_desc = self.conn.describe_flow_execution_records(**kwargs)
+            for fe in response_desc.get("flowExecutions", []):
+                if fe.get("executionId") == execution_id:
+                    self.log.info("Run complete, execution details: %s", fe)
+                    return
+            next_token = response_desc.get("nextToken")
+            if not next_token:
+                break
+        self.log.warning("Execution details for %s not found in flow execution records", execution_id)
 
     def update_flow_filter(self, flow_name: str, filter_tasks, set_trigger_ondemand: bool = False) -> None:
         """

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_appflow.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_appflow.py
@@ -71,9 +71,40 @@ def test_conn_attributes(hook):
 def test_run_flow(hook):
     with mock.patch("airflow.providers.amazon.aws.waiters.base_waiter.BaseBotoWaiter.waiter"):
         hook.run_flow(flow_name=FLOW_NAME, poll_interval=0)
-    hook.conn.describe_flow_execution_records.assert_called_with(flowName=FLOW_NAME)
+    hook.conn.describe_flow_execution_records.assert_called_with(flowName=FLOW_NAME, maxResults=100)
     assert hook.conn.describe_flow_execution_records.call_count == 1
     hook.conn.start_flow.assert_called_once_with(flowName=FLOW_NAME)
+
+
+def test_log_execution_description_paginated(hook):
+    page1 = {
+        "flowExecutions": [{"executionId": "other_id", "executionStatus": "Successful"}],
+        "nextToken": "token123",
+    }
+    page2 = {
+        "flowExecutions": [{"executionId": EXECUTION_ID, "executionStatus": "Successful"}],
+    }
+    hook.conn.describe_flow_execution_records.side_effect = [page1, page2]
+
+    hook._log_execution_description(FLOW_NAME, EXECUTION_ID)
+
+    assert hook.conn.describe_flow_execution_records.call_count == 2
+    hook.conn.describe_flow_execution_records.assert_has_calls(
+        [
+            mock.call(flowName=FLOW_NAME, maxResults=100),
+            mock.call(flowName=FLOW_NAME, maxResults=100, nextToken="token123"),
+        ]
+    )
+
+
+def test_log_execution_description_not_found(hook):
+    hook.conn.describe_flow_execution_records.return_value = {"flowExecutions": []}
+
+    with mock.patch.object(hook.log, "warning") as mock_warn:
+        hook._log_execution_description(FLOW_NAME, "missing_exec_id")
+        mock_warn.assert_called_once_with(
+            "Execution details for %s not found in flow execution records", "missing_exec_id"
+        )
 
 
 def test_update_flow_filter(hook):


### PR DESCRIPTION
closes: #72769

### Rationale for this change

Fixes #72769.

In `AppflowHook.run_flow`, `_log_execution_description` issues a single unpaginated call to `describe_flow_execution_records`. Because `maxResults` defaults to 20 on the AWS AppFlow API, if the execution ID is not present on the first page of results, looking up the execution ID raises a KeyError, failing the task even though AWS AppFlow successfully executed the flow.

### What changes are included in this PR?

1. Updated `AppflowHook._log_execution_description` to loop over paginated `describe_flow_execution_records` calls using `maxResults=100` and `nextToken`.
2. Added fallback logging warning if the execution record is not found across pages, preventing KeyError from crashing a successful flow run.
3. Added unit tests in `test_appflow.py` verifying paginated lookup and missing execution record handling.

### Are these changes tested?

Yes. Added unit tests in `providers/amazon/tests/unit/amazon/aws/hooks/test_appflow.py` and verified all 5 tests pass.