### PR TITLE
Fix td_format rendering of negative durations (#72694)

### DIFF
--- a/shared/timezones/src/airflow_shared/timezones/timezone.py
+++ b/shared/timezones/src/airflow_shared/timezones/timezone.py
@@ -234,6 +234,17 @@ def td_format(td_object: None | dt.timedelta | float | int) -> str | None:
     """
     if td_object is None:
         return None
+
+    prefix = ""
+    if isinstance(td_object, dt.timedelta):
+        if td_object < dt.timedelta(0):
+            prefix = "-"
+            td_object = -td_object
+    elif isinstance(td_object, (int, float)):
+        if td_object < 0:
+            prefix = "-"
+            td_object = -td_object
+
     if isinstance(td_object, dt.timedelta):
         delta = relativedelta() + td_object
     else:
@@ -258,7 +269,7 @@ def td_format(td_object: None | dt.timedelta | float | int) -> str | None:
     joined = ":".join(part for part in parts if part)
     if not joined:
         return "<1s"
-    return joined
+    return f"{prefix}{joined}"
 
 
 def parse_timezone(name: str | int) -> FixedTimezone | Timezone:

--- a/shared/timezones/tests/timezones/test_timezone.py
+++ b/shared/timezones/tests/timezones/test_timezone.py
@@ -96,6 +96,17 @@ class TestTimezone:
         assert timezone.td_format(td) == "3d:11h:32M:32s"
         td = 434343600.0
         assert timezone.td_format(td) == "13y:11m:17d:3h"
+        # Negative durations
+        td = datetime.timedelta(seconds=-3752)
+        assert timezone.td_format(td) == "-1h:2M:32s"
+        td = -3752
+        assert timezone.td_format(td) == "-1h:2M:32s"
+        td = datetime.timedelta(days=-5)
+        assert timezone.td_format(td) == "-5d"
+        td = datetime.timedelta(seconds=-0.4)
+        assert timezone.td_format(td) == "<1s"
+        td = -0.4
+        assert timezone.td_format(td) == "<1s"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
closes: #72694

### Rationale for this change

Fixes #72694.

`td_format` in `shared/timezones` rendered negative `timedelta` objects as large positive durations (e.g. `timedelta(seconds=-3752)` rendered as `29d:22h:57M:28s`). This occurred because `relativedelta` days normalization via `divmod` produced negative months (`months=-1, days=+29`) which were stripped by positive magnitude filtering (`value < 1`). Furthermore, numeric negative inputs (e.g. `-3752`) returned `<1s`.

### What changes are included in this PR?

1. Updated `td_format` in `shared/timezones/src/airflow_shared/timezones/timezone.py` to extract negative sign prefix (`"-"`) and compute duration string using the absolute magnitude of the timedelta or numeric duration.
2. Added test cases in `test_timezone.py` verifying negative `timedelta` and negative numeric inputs format correctly (e.g. `td_format(timedelta(seconds=-3752))` returns `"-1h:2M:32s"`, `td_format(-3752)` returns `"-1h:2M:32s"`, `td_format(timedelta(days=-5))` returns `"-5d"`).

### Are these changes tested?

Yes. Added unit tests in `shared/timezones/tests/timezones/test_timezone.py` and verified all 30 timezone unit tests pass.