### PR TITLE
Document DAG.test() behavior change in the Airflow 2.7.0 release notes (#72485)

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -6441,6 +6441,17 @@ You can achieve it also by installing airflow with ``[celery]``, ``[cncf.kuberne
 Users who base their images on the ``apache/airflow`` reference image (not slim) should be unaffected - the base
 reference image comes with all the three providers installed.
 
+``DAG.test()`` now returns a ``DagRun`` and no longer stops at the first task failure (#32820)
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+This was an undocumented side effect of adding support for setup/teardown tasks in mapped task
+groups. Previously, ``DAG.test()`` returned ``None``, and if any task raised an exception, the
+whole test run stopped immediately without running the DAG's other schedulable tasks. Now,
+``DAG.test()`` returns the ``DagRun`` it executed, and a failing task no longer aborts the run:
+the remaining tasks keep running according to their trigger rules, just like in a real scheduled
+run. This makes it possible to use ``DAG.test()`` to test DAGs where a task is expected to fail
+but downstream tasks with a different trigger rule (or a parallel mapped task group) should still
+run, without having to fall back to the ``DebugExecutor``.
+
 Improvement Changes
 ^^^^^^^^^^^^^^^^^^^
 

--- a/reproducible_build.yaml
+++ b/reproducible_build.yaml
@@ -1,2 +1,2 @@
-release-notes-hash: 0016af03b467abd6a1e3f1de176adc2f
-source-date-epoch: 1786375005
+release-notes-hash: 450e43a9dd38329434e5f90e2762ff8c
+source-date-epoch: 1788933260


### PR DESCRIPTION
Backport of #72485 to `v3-3-test` for the 3.3.2 release.

Documents an undocumented behavior change from Airflow 2.7.0: `DAG.test()` now returns the `DagRun` it executed and a failing task no longer aborts the run — remaining tasks keep running per their trigger rules. The note is added to the historical 2.7.0 section of `RELEASE_NOTES.rst`, so the shipped release notes stay consistent with `main`.

`reproducible_build.yaml` was regenerated on this branch via the `update-reproducible-source-date-epoch` hook (not taken from `main`, whose hash is computed against `main`'s release notes).

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)