### PR TITLE
Fix Configuration page e2e test failing when the first option has no value (#72724)

### DIFF
--- a/airflow-core/src/airflow/ui/tests/e2e/pages/ConfigurationPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/ConfigurationPage.ts
@@ -38,6 +38,12 @@ export class ConfigurationPage extends BasePage {
     });
   }
 
+  public getRowByKey(key: string): Locator {
+    return this.rows.filter({
+      has: this.page.getByTestId("table-cell-key").filter({ hasText: new RegExp(`^${key}$`) }),
+    });
+  }
+
   public async navigate(): Promise<void> {
     await expect(async () => {
       await this.navigateTo("/configs");

--- a/airflow-core/src/airflow/ui/tests/e2e/specs/configuration.spec.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/specs/configuration.spec.ts
@@ -31,8 +31,14 @@ test.describe("Configuration Page", () => {
 
     const firstRow = configurationPage.rows.nth(0);
 
-    await expect(firstRow.locator("td").nth(0)).not.toBeEmpty();
-    await expect(firstRow.locator("td").nth(1)).not.toBeEmpty();
-    await expect(firstRow.locator("td").nth(2)).not.toBeEmpty();
+    await expect(firstRow.getByTestId("table-cell-section")).not.toBeEmpty();
+    await expect(firstRow.getByTestId("table-cell-key")).not.toBeEmpty();
+
+    // Many options legitimately have an empty value, so check a row that always has one.
+    const dagsFolderRow = configurationPage.getRowByKey("dags_folder");
+
+    await expect(dagsFolderRow).toHaveCount(1);
+    await expect(dagsFolderRow.getByTestId("table-cell-section")).toHaveText("core");
+    await expect(dagsFolderRow.getByTestId("table-cell-value")).not.toBeEmpty();
   });
 });


### PR DESCRIPTION
Backport of #72724 to `v3-3-test` for the 3.3.2 release.

Fixes the Configuration page e2e test, which failed when the first select option has no value. Test-only change (`ConfigurationPage.ts` + `configuration.spec.ts`); applied cleanly onto `v3-3-test`. Keeps the RC's e2e suite green.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)