### PR TITLE
Improve confirmation output when connections are added via cli (#71215)

### DIFF
--- a/airflow-core/src/airflow/cli/commands/connection_command.py
+++ b/airflow-core/src/airflow/cli/commands/connection_command.py
@@ -29,6 +29,7 @@ from urllib.parse import urlsplit, urlunsplit
 from sqlalchemy import select
 from sqlalchemy.orm import exc
 
+from airflow._shared.secrets_masker import redact
 from airflow.cli.simple_table import AirflowConsole
 from airflow.cli.utils import (
     SENSITIVE_PLACEHOLDER,
@@ -365,22 +366,19 @@ def connections_add(args):
     with create_session() as session:
         if not session.scalar(select(Connection).where(Connection.conn_id == new_conn.conn_id).limit(1)):
             session.add(new_conn)
-            msg = "Successfully added `conn_id`={conn_id} : {uri}"
-            msg = msg.format(
-                conn_id=new_conn.conn_id,
-                uri=args.conn_uri
-                or urlunsplit(
-                    (
-                        new_conn.conn_type,
-                        f"{new_conn.login or ''}:{'******' if new_conn.password else ''}"
-                        f"@{new_conn.host or ''}:{new_conn.port or ''}",
-                        new_conn.schema or "",
-                        "",
-                        "",
-                    )
-                ),
+            print(f"Successfully added `conn_id`={new_conn.conn_id}")
+            AirflowConsole().print_as(
+                data=[new_conn],
+                output="table",
+                mapper=lambda conn: {
+                    "conn_id": conn.conn_id,
+                    "conn_type": conn.conn_type,
+                    "host": conn.host,
+                    "login": conn.login,
+                    "port": conn.port,
+                    "extra": redact(conn.extra_dejson),
+                },
             )
-            print(msg)
         else:
             msg = f"A connection with `conn_id`={new_conn.conn_id} already exists."
             raise SystemExit(msg)

--- a/airflow-core/tests/unit/cli/commands/test_connection_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_connection_command.py
@@ -447,7 +447,7 @@ class TestCliAddConnections:
                     "new0-json",
                     f"--conn-json={TEST_JSON}",
                 ],
-                "Successfully added `conn_id`=new0-json : postgres://airflow:******@host:5432/airflow",
+                "Successfully added `conn_id`=new0-json",
                 {
                     "conn_type": "postgres",
                     "description": "new0-json description",
@@ -469,7 +469,7 @@ class TestCliAddConnections:
                     f"--conn-uri={TEST_URL}",
                     "--conn-description=new0 description",
                 ],
-                "Successfully added `conn_id`=new0 : postgresql://airflow:airflow@host:5432/airflow",
+                "Successfully added `conn_id`=new0",
                 {
                     "conn_type": "postgres",
                     "description": "new0 description",
@@ -491,7 +491,7 @@ class TestCliAddConnections:
                     f"--conn-uri={TEST_URL}",
                     "--conn-description=new1 description",
                 ],
-                "Successfully added `conn_id`=new1 : postgresql://airflow:airflow@host:5432/airflow",
+                "Successfully added `conn_id`=new1",
                 {
                     "conn_type": "postgres",
                     "description": "new1 description",
@@ -514,7 +514,7 @@ class TestCliAddConnections:
                     "--conn-extra",
                     '{"extra": "yes"}',
                 ],
-                "Successfully added `conn_id`=new2 : postgresql://airflow:airflow@host:5432/airflow",
+                "Successfully added `conn_id`=new2",
                 {
                     "conn_type": "postgres",
                     "description": None,
@@ -539,7 +539,7 @@ class TestCliAddConnections:
                     "--conn-description",
                     "new3 description",
                 ],
-                "Successfully added `conn_id`=new3 : postgresql://airflow:airflow@host:5432/airflow",
+                "Successfully added `conn_id`=new3",
                 {
                     "conn_type": "postgres",
                     "description": "new3 description",
@@ -566,7 +566,7 @@ class TestCliAddConnections:
                     "--conn-schema=airflow",
                     "--conn-description=  new4 description  ",
                 ],
-                "Successfully added `conn_id`=new4 : hive_metastore://airflow:******@host:9083/airflow",
+                "Successfully added `conn_id`=new4",
                 {
                     "conn_type": "hive_metastore",
                     "description": "  new4 description  ",
@@ -592,7 +592,7 @@ class TestCliAddConnections:
                     '{"extra": "yes"}',
                     "--conn-description=new5 description",
                 ],
-                "Successfully added `conn_id`=new5 : google_cloud_platform://:@:",
+                "Successfully added `conn_id`=new5",
                 {
                     "conn_type": "google_cloud_platform",
                     "description": "new5 description",
@@ -608,7 +608,7 @@ class TestCliAddConnections:
             ),
             pytest.param(
                 ["connections", "add", "new6", "--conn-uri", "aws://?region_name=foo-bar-1"],
-                "Successfully added `conn_id`=new6 : aws://?region_name=foo-bar-1",
+                "Successfully added `conn_id`=new6",
                 {
                     "conn_type": "aws",
                     "description": None,
@@ -624,7 +624,7 @@ class TestCliAddConnections:
             ),
             pytest.param(
                 ["connections", "add", "new7", "--conn-uri", "aws://@/?region_name=foo-bar-1"],
-                "Successfully added `conn_id`=new7 : aws://@/?region_name=foo-bar-1",
+                "Successfully added `conn_id`=new7",
                 {
                     "conn_type": "aws",
                     "description": None,


### PR DESCRIPTION
Backport of #71215 to `v3-3-test` for the 3.3.2 release.

Improves the confirmation output of `airflow connections add` so each added connection is reported clearly. Clean cherry-pick; the CLI connection tests pass (18 passed).

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)