### PR TITLE
Add Cloud SQL Auth Proxy v2 mode to CloudSqlProxyRunner

### DIFF
--- a/airflow-core/newsfragments/72785.significant.rst
+++ b/airflow-core/newsfragments/72785.significant.rst
@@ -1,0 +1,22 @@
+Google provider: ``CloudSqlProxyRunner`` can now run Cloud SQL Auth Proxy v2
+
+A new ``sql_proxy_major_version`` option (default ``1``, behavior unchanged) opts into
+the v2 binary: GitHub-releases download URL with its own version regex,
+``--unix-socket`` + positional instance instead of ``-dir``/``-instances``,
+``--auto-iam-authn`` for IAM login, and the v2 ready-line on startup.
+
+v1 cannot complete ``caching_sha2_password`` full authentication, so on Cloud SQL for
+MySQL 8.4 (where it is the default and ``mysql_native_password`` is unavailable) the
+first connection after a server restart, failover or maintenance event fails with
+``1045 Access denied``.
+
+* Types of change
+
+  * [ ] Dag changes
+  * [ ] Config changes
+  * [ ] API changes
+  * [ ] CLI changes
+  * [x] Behaviour changes
+  * [ ] Plugin changes
+  * [ ] Dependency changes
+  * [ ] Code interface changes

--- a/providers/google/src/airflow/providers/google/cloud/hooks/cloud_sql.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/cloud_sql.py
@@ -81,6 +81,7 @@ UNIX_PATH_MAX = 108
 TIME_TO_SLEEP_IN_SECONDS = 20
 
 CLOUD_SQL_PROXY_VERSION_REGEX = re.compile(r"^v?(\d+\.\d+\.\d+)(-\w*.?\d?)?$")
+CLOUD_SQL_PROXY_V2_VERSION_REGEX = re.compile(r"^v2\.\d+\.\d+(-[0-9A-Za-z.-]+)?$")
 
 
 class CloudSqlOperationStatus:
@@ -490,6 +491,9 @@ CLOUD_SQL_PROXY_DOWNLOAD_URL = "https://dl.google.com/cloudsql/cloud_sql_proxy.{
 CLOUD_SQL_PROXY_VERSION_DOWNLOAD_URL = (
     "https://storage.googleapis.com/cloudsql-proxy/{}/cloud_sql_proxy.{}.{}"
 )
+CLOUD_SQL_PROXY_V2_DOWNLOAD_URL = (
+    "https://github.com/GoogleCloudPlatform/cloud-sql-proxy/releases/download/{}/cloud-sql-proxy.{}.{}"
+)
 
 
 class CloudSQLAsyncHook(GoogleBaseAsyncHook):
@@ -560,6 +564,12 @@ class CloudSqlProxyRunner(LoggingMixin):
     :param sql_proxy_binary_path: If specified, then proxy will be
         used from the path specified rather than dynamically generated. This means
         that if the binary is not present in that path it will also be downloaded.
+    :param sql_proxy_major_version: Major version of the Cloud SQL Auth Proxy to run.
+        ``1`` (default) keeps the legacy v1 binary and its ``-dir``/``-instances``
+        flag set. ``2`` runs the v2 binary, which speaks the new flag syntax and
+        supports ``caching_sha2_password`` full authentication on MySQL 8.4
+        (v1 cannot, so first connections after a server restart fail with
+        ``1045 Access denied``).
     """
 
     def __init__(
@@ -572,11 +582,17 @@ class CloudSqlProxyRunner(LoggingMixin):
         sql_proxy_binary_path: str | None = None,
         *,
         sql_proxy_enable_iam_login: bool = False,
+        sql_proxy_major_version: int = 1,
     ) -> None:
         super().__init__()
         self.path_prefix = path_prefix
         if not self.path_prefix:
             raise AirflowException("The path_prefix must not be empty!")
+        if sql_proxy_major_version not in (1, 2):
+            raise AirflowException(
+                f"sql_proxy_major_version must be 1 or 2, got {sql_proxy_major_version!r}"
+            )
+        self.sql_proxy_major_version = sql_proxy_major_version
         self.sql_proxy_was_downloaded = False
         self.sql_proxy_version = sql_proxy_version
         self.download_sql_proxy_dir = None
@@ -592,6 +608,13 @@ class CloudSqlProxyRunner(LoggingMixin):
         self._build_command_line_parameters()
 
     def _build_command_line_parameters(self) -> None:
+        if self.sql_proxy_major_version == 2:
+            self.command_line_parameters.extend(
+                ["--unix-socket", self.cloud_sql_proxy_socket_directory, self.instance_specification]
+            )
+            if self.sql_proxy_enable_iam_login:
+                self.command_line_parameters.append("--auto-iam-authn")
+            return
         self.command_line_parameters.extend(["-dir", self.cloud_sql_proxy_socket_directory])
         self.command_line_parameters.extend(["-instances", self.instance_specification])
         if self.sql_proxy_enable_iam_login:
@@ -636,6 +659,19 @@ class CloudSqlProxyRunner(LoggingMixin):
             processor = "amd64"
         elif processor == "aarch64":
             processor = "arm64"
+        if self.sql_proxy_major_version == 2:
+            if not self.sql_proxy_version:
+                raise AirflowException(
+                    "sql_proxy_version is required with sql_proxy_major_version=2: "
+                    "the v2 binary is released on GitHub and has no 'latest' alias "
+                    "on the legacy download endpoints."
+                )
+            if not CLOUD_SQL_PROXY_V2_VERSION_REGEX.match(self.sql_proxy_version):
+                raise ValueError(
+                    "The sql_proxy_version should match the regular expression "
+                    f"{CLOUD_SQL_PROXY_V2_VERSION_REGEX.pattern}"
+                )
+            return CLOUD_SQL_PROXY_V2_DOWNLOAD_URL.format(self.sql_proxy_version, system, processor)
         if not self.sql_proxy_version:
             download_url = CLOUD_SQL_PROXY_DOWNLOAD_URL.format(system, processor)
         else:
@@ -721,7 +757,7 @@ class CloudSqlProxyRunner(LoggingMixin):
             if "googleapi: Error" in line or "invalid instance name:" in line:
                 self.stop_proxy()
                 raise AirflowException(f"Error when starting the cloud_sql_proxy {line}!")
-            if "Ready for new connections" in line:
+            if "Ready for new connections" in line or "ready to accept new connections" in line:
                 return
 
     def stop_proxy(self) -> None:

--- a/providers/google/tests/unit/google/cloud/hooks/test_cloud_sql.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_cloud_sql.py
@@ -1935,6 +1935,72 @@ class TestCloudSqlProxyRunner:
 
         assert "-enable_iam_login" not in runner.command_line_parameters
 
+    def test_cloud_sql_proxy_runner_v2_builds_v2_command_line(self):
+        runner = CloudSqlProxyRunner(
+            path_prefix="12345678",
+            instance_specification="project:us-east-1:instance",
+            sql_proxy_major_version=2,
+        )
+
+        assert runner.command_line_parameters == [
+            "--unix-socket",
+            "12345678",
+            "project:us-east-1:instance",
+        ]
+
+    def test_cloud_sql_proxy_runner_v2_iam_login_maps_to_auto_iam_authn(self):
+        runner = CloudSqlProxyRunner(
+            path_prefix="12345678",
+            instance_specification="project:us-east-1:instance",
+            sql_proxy_major_version=2,
+            sql_proxy_enable_iam_login=True,
+        )
+
+        assert "--auto-iam-authn" in runner.command_line_parameters
+        assert "-enable_iam_login" not in runner.command_line_parameters
+
+    def test_cloud_sql_proxy_runner_v2_download_url_targets_github_releases(self):
+        runner = CloudSqlProxyRunner(
+            path_prefix="12345678",
+            instance_specification="project:us-east-1:instance",
+            sql_proxy_major_version=2,
+            sql_proxy_version="v2.14.0",
+        )
+
+        assert runner._get_sql_proxy_download_url() == (
+            "https://github.com/GoogleCloudPlatform/cloud-sql-proxy/releases/download/"
+            f"v2.14.0/cloud-sql-proxy.{platform.system().lower()}.{get_processor()}"
+        )
+
+    def test_cloud_sql_proxy_runner_v2_rejects_v1_style_version(self):
+        runner = CloudSqlProxyRunner(
+            path_prefix="12345678",
+            instance_specification="project:us-east-1:instance",
+            sql_proxy_major_version=2,
+            sql_proxy_version="v1.23.0",
+        )
+
+        with pytest.raises(ValueError, match="The sql_proxy_version should match"):
+            runner._get_sql_proxy_download_url()
+
+    def test_cloud_sql_proxy_runner_v2_requires_explicit_version(self):
+        runner = CloudSqlProxyRunner(
+            path_prefix="12345678",
+            instance_specification="project:us-east-1:instance",
+            sql_proxy_major_version=2,
+        )
+
+        with pytest.raises(AirflowException, match="sql_proxy_version is required"):
+            runner._get_sql_proxy_download_url()
+
+    def test_cloud_sql_proxy_runner_rejects_unknown_major_version(self):
+        with pytest.raises(AirflowException, match="sql_proxy_major_version must be 1 or 2"):
+            CloudSqlProxyRunner(
+                path_prefix="12345678",
+                instance_specification="project:us-east-1:instance",
+                sql_proxy_major_version=3,
+            )
+
     @mock.patch("airflow.providers.google.cloud.hooks.cloud_sql.GoogleBaseHook.get_connection")
     def test_cloud_sql_proxy_runner_keeps_key_path_credentials_with_iam_login(self, get_connection):
         connection = Connection(conn_id="google_conn", conn_type="google_cloud_platform")


### PR DESCRIPTION
## Description

Adds a `sql_proxy_major_version` option to `CloudSqlProxyRunner` (default `1` — behavior unchanged) that opts into running the **Cloud SQL Auth Proxy v2** binary.

### Why

The runner is hard-wired to Auth Proxy v1: `CLOUD_SQL_PROXY_DOWNLOAD_URL`/`CLOUD_SQL_PROXY_VERSION_DOWNLOAD_URL` point at the v1 buckets, and `_build_command_line_parameters()` emits `-dir` and `-instances`, both removed in v2. v1 **cannot complete `caching_sha2_password` full authentication** — on Cloud SQL for MySQL 8.4 (where it is the default and `mysql_native_password` is unavailable, ERROR 4052) the first connection after a server restart, failover or maintenance event fails with `1045 Access denied`. Auth Proxy v1 no longer receives development; its startup banner recommends v2.

Reported in #72681.

### What changes

- `sql_proxy_major_version=2` builds the v2 command line: `--unix-socket <dir>` + positional instance connection name, `--auto-iam-authn` when `sql_proxy_enable_iam_login` is set.
- v2 downloads come from GitHub releases (`GoogleCloudPlatform/cloud-sql-proxy`), validated by a v2-specific version regex; an explicit `sql_proxy_version` is **required** in v2 mode (no legacy 'latest' alias exists for the new binary layout).
- `start_proxy` also accepts the v2 ready-line ("ready to accept new connections") alongside the v1 one.
- Unknown major versions are rejected with a clear error.

### Tests

6 new unit tests in `providers/google/tests/unit/google/cloud/hooks/test_cloud_sql.py` (v2 command line, IAM mapping, download URL, v1-style version rejection, version requirement, unknown major version rejection).

```
TestCloudSqlProxyRunner (all, incl. 6 new) .... 18 passed
full file ..................................... 132 passed, 6 env-related failures identical on clean main (baseline-verified via git stash)
```

## Related

Closes #72681
