### PR TITLE
Recover GitDagBundle from a clone interrupted by a killed process

### DIFF
--- a/providers/git/src/airflow/providers/git/bundles/git.py
+++ b/providers/git/src/airflow/providers/git/bundles/git.py
@@ -212,10 +212,6 @@ class GitDagBundle(BaseDagBundle):
                 raise RuntimeError("Error cloning repository") from e
             except InvalidGitRepositoryError as e:
                 raise RuntimeError(f"Invalid git repository at {self.repo_path}") from e
-            # If tracking_ref was just repointed to a SHA that predates this working clone's
-            # last fetch, this checkout fails until the clone is fetched or storage is cleared;
-            # tracked at https://github.com/apache/airflow/issues/71388
-            self.repo.git.checkout(self.tracking_ref)
             self._log.debug("bundle initialize", version=self.version)
             if self.version:
                 if not self._has_version(self.repo, self.version):
@@ -268,16 +264,19 @@ class GitDagBundle(BaseDagBundle):
                     repo = Repo(self.repo_path)
                     repo.git.sparse_checkout("init", "--cone")
                     repo.git.sparse_checkout("set", *self.sparse_dirs)
-                    repo.git.checkout(self.tracking_ref)
             else:
                 self._log.debug("repo exists", repo_path=self.repo_path)
             self.repo = Repo(self.repo_path)
+            # Checkout inside the clone so a repo that cannot resolve the tracking ref (for
+            # example one truncated by a killed `git clone`) is discarded and re-cloned from
+            # the healthy local bare mirror instead of failing forever.
+            self.repo.git.checkout(self.tracking_ref)
         except NoSuchPathError as e:
             # Protection should the bare repo be removed manually
             raise FileNotFoundError(f"Repository path: {self.bare_repo_path} not found") from e
         except (InvalidGitRepositoryError, GitCommandError) as e:
             self._log.warning(
-                "Repository clone/open failed, cleaning up and retrying",
+                "Repository clone/open/checkout failed, cleaning up and retrying",
                 repo_path=self.repo_path,
                 exc=e,
             )

--- a/providers/git/tests/unit/git/bundles/test_git.py
+++ b/providers/git/tests/unit/git/bundles/test_git.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
 import types
 from pathlib import Path
 from unittest import mock
@@ -734,13 +735,13 @@ class TestGitDagBundle:
         assert {"test_dag.py"} == files_in_repo
 
     @mock.patch("airflow.providers.git.bundles.git.GitHook")
-    def test_tracking_ref_commit_sha_promote_fails_without_clearing_storage(self, mock_githook, git_repo):
-        """A SHA created after the bundle's local storage was first populated can't be
-        promoted to in-place: the working clone never fetches it before checkout.
+    def test_tracking_ref_commit_sha_promote_without_clearing_storage(self, mock_githook, git_repo):
+        """Promoting a SHA-pinned tracking_ref to a new commit succeeds in-place.
 
-        This documents a known limitation rather than desired behavior -- it should start
-        passing once the fix tracked at https://github.com/apache/airflow/issues/71388 lands,
-        at which point this test should be updated to assert success instead.
+        The local working clone predates the new commit, so its object database can't
+        satisfy the checkout. The checkout runs inside ``_clone_repo_if_required``'s retry
+        block, which discards the stale clone and re-clones from the healthy local bare
+        mirror instead of failing until storage is cleared by hand.
         """
         repo_path, repo = git_repo
         mock_githook.return_value.repo_url = repo_path
@@ -761,8 +762,11 @@ class TestGitDagBundle:
         # Promote in-place: config change re-creates the bundle against the same local
         # storage. The new commit's objects were never fetched into the working clone.
         bundle = GitDagBundle(name="test", git_conn_id=CONN_HTTPS, tracking_ref=second_commit.hexsha)
-        with pytest.raises(GitCommandError, match="reference is not a tree|unable to read tree"):
-            bundle.initialize()
+        bundle.initialize()
+        assert _version_str(bundle.get_current_version()) == second_commit.hexsha
+        files_in_repo = {f.name for f in bundle.path.iterdir() if f.is_file()}
+        assert {"test_dag.py", "new_test.py"} == files_in_repo
+        assert_repo_is_closed(bundle)
 
     @mock.patch("airflow.providers.git.bundles.git.GitHook")
     def test_tracking_ref_commit_sha_promote_succeeds_with_fresh_storage(self, mock_githook, git_repo):
@@ -789,6 +793,50 @@ class TestGitDagBundle:
         assert _version_str(bundle.get_current_version()) == second_commit.hexsha
         files_in_repo = {f.name for f in bundle.path.iterdir() if f.is_file()}
         assert {"test_dag.py", "new_test.py"} == files_in_repo
+
+    @mock.patch("airflow.providers.git.bundles.git.GitHook")
+    def test_interrupted_clone_version_dir_is_recovered(self, mock_githook, git_repo):
+        """A version directory truncated by a killed `git clone` is repaired on next initialize().
+
+        `git clone` writes the .git skeleton (with the origin config) before it writes refs or
+        checks out the working tree, so a killed clone leaves a directory Git can open but that
+        cannot resolve the tracking ref. Because the checkout now runs inside the retry block,
+        initialize() discards that broken directory and re-clones from the healthy bare mirror
+        instead of failing forever.
+        """
+        repo_path, repo = git_repo
+        mock_githook.return_value.repo_url = repo_path
+        version = repo.head.commit.hexsha
+
+        bundle = GitDagBundle(
+            name="test",
+            git_conn_id=CONN_HTTPS,
+            version=version,
+            tracking_ref=GIT_DEFAULT_BRANCH,
+        )
+
+        # The healthy local bare mirror exists (created by a previous run); only the per-version
+        # clone was interrupted. Reproduce the killed-clone state: .git skeleton present, refs and
+        # packed-refs absent, HEAD unborn, working tree empty.
+        Repo.clone_from(str(repo_path), str(bundle.bare_repo_path), bare=True)
+        Repo.clone_from(
+            str(bundle.bare_repo_path), str(bundle.repo_path), multi_options=["--no-checkout"]
+        ).close()
+        shutil.rmtree(bundle.repo_path / ".git" / "refs")
+        (bundle.repo_path / ".git" / "refs").mkdir()
+        (bundle.repo_path / ".git" / "refs" / "heads").mkdir()
+        (bundle.repo_path / ".git" / "packed-refs").unlink(missing_ok=True)
+
+        assert (bundle.repo_path / ".git").exists()
+        assert not (bundle.repo_path / ".git" / "packed-refs").exists()
+        assert not any(p.is_file() for p in (bundle.repo_path / ".git" / "refs").rglob("*"))
+
+        bundle.initialize()
+
+        assert _version_str(bundle.get_current_version()) == version
+        files_in_repo = {f.name for f in bundle.repo_path.iterdir() if f.is_file()}
+        assert {"test_dag.py"} == files_in_repo
+        assert_repo_is_closed(bundle)
 
     @mock.patch("airflow.providers.git.bundles.git.GitHook")
     def test_refresh_after_force_push_does_not_reclone(self, mock_githook, git_repo):


### PR DESCRIPTION
When `GitDagBundle` is killed while cloning a bundle version, it leaves behind a
version directory that git can open as a repository but that cannot resolve the
configured `tracking_ref`. `git clone` writes the `.git` skeleton before it
writes refs or checks out the working tree, so such a leftover has `.git` with
no refs and an empty working tree. Every later task pinned to that bundle
version then failed on every retry:

```
GitCommandError: git checkout <tracking_ref>
  stderr: 'error: pathspec '<tracking_ref>' did not match any file(s) known to git'
```

because the broken directory was reopened but never repaired or replaced.

## Change

Move `self.repo.git.checkout(self.tracking_ref)` into
`_clone_repo_if_required`, inside its `@retry` / `shutil.rmtree` block. A
repository that cannot resolve the tracking ref is now discarded and re-cloned
from the healthy local bare mirror instead of failing forever. This also lets a
SHA-pinned `tracking_ref` be promoted in-place without clearing local storage
(the case tracked in #71388).

## Tests

- New `test_interrupted_clone_version_dir_is_recovered`: simulates a killed
  clone (`.git` skeleton present, refs/packed-refs absent, empty working tree),
  then asserts `initialize()` restores both the expected version and the Dag
  files. Fails on `main`, passes with this change.
- Updated `test_tracking_ref_commit_sha_promote_without_clearing_storage` (was
  `...promote_fails_without_clearing_storage`) to assert in-place promotion now
  succeeds.
- `providers/git/tests/unit/git/` — 141 passed.
- `ruff`, `ruff format`, and `mypy` on both changed files pass.

closes: #72759

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — opencode (big-pickle)

src-notes: no newsfragment for a provider change (released from `main`).