### PR TITLE
Clear the task state store when clearing a task instance

### DIFF
--- a/airflow-core/docs/core-concepts/resumable-tasks.rst
+++ b/airflow-core/docs/core-concepts/resumable-tasks.rst
@@ -145,18 +145,23 @@ existing job on retry instead of submitting a new one.
 
 For more details and a working example, see :class:`~airflow.sdk.ResumableJobMixin`.
 
-**Clearing a task is treated the same as a retry**
+**Clearing a task is a controlled reset**
 
-Clearing a task instance does not delete its ``task_state_store`` rows -- they are only removed
-when the ``dag_run`` itself is deleted, or by :ref:`airflow state-store clean
-<task-and-asset-state-store-cleanup>`. For a checkpointed task this is usually what you want:
-clearing resumes from the last checkpoint rather than starting over.
+Clearing a task instance deletes its ``task_state_store`` rows -- an operator-initiated clear
+(through the UI, CLI, API, or ``dag.clear()``) always starts the next attempt from scratch, so it
+never resumes from state that belonged to a previous run of the same task. The state store is keyed
+by positional ``map_index``, so this is what keeps a dynamically mapped task that is re-expanded
+after a clear from silently inheriting the previous item's checkpoint when the mapped list has
+changed.
 
-For an operator with durable execution, it means clearing a task whose external job already
-succeeded reads that stored result back and returns immediately, without resubmitting the job. If
-you want clearing to always resubmit regardless of a prior success, set
-``[state_store] clear_on_success = True``, which deletes a task's state store rows automatically
-when it moves to ``SUCCESS`` (see :doc:`/administration-and-deployment/task-and-asset-state-store`).
+Rows are also removed when the ``dag_run`` itself is deleted, or by :ref:`airflow state-store clean
+<task-and-asset-state-store-cleanup>`. Automatic retries are *not* clears: they keep the task's
+rows, so durable execution can resume a failed attempt from its last checkpoint. Only a deliberate
+clear starts over.
+
+For an operator with durable execution, clearing a task always resubmits the external job rather
+than reconnecting to a prior one. Wrap such logic in an ``if task_state_store.get("job_id")`` check
+only when you expect automatic retries, not clears, to resume the job.
 
 This does not guarantee the external job is still there to reconnect to, though. Clearing a task
 that is actively running (``deferrable=False``) stops the worker process, which runs the

--- a/airflow-core/docs/core-concepts/task-state-store.rst
+++ b/airflow-core/docs/core-concepts/task-state-store.rst
@@ -285,13 +285,22 @@ If the worker process crashes, the task instance is retried. Task store data wri
 Deferrable tasks
 ~~~~~~~~~~~~~~~~
 
-Once a task defers, the Triggerer handles continuity across poke cycles. Use task state store in deferrable tasks only when you need to survive an operator-initiated clear, not for normal poke continuity.
+Once a task defers, the Triggerer handles continuity across poke cycles. Use task state store in
+deferrable tasks for durable job resumption across automatic retries; note that an operator-initiated
+clear wipes the task's state, so a deferred task that is cleared restarts from scratch.
 
 
 Mapped tasks
 ------------
 
 When a task is dynamically mapped (``task.expand(...)``), each map index has its own task state store namespace. ``clear()`` clears only the current index's store.
+
+For mapped tasks the store namespace is keyed by the *positional* ``map_index``, not by the mapped
+value itself. The order in which a mapped task expands is not guaranteed and the underlying list can
+change between runs, so an index that names one item in one run can name a different item in the
+next. Because an operator-initiated clear now deletes a task's state store rows, a re-expanded
+mapped task never inherits the state of the item that previously occupied the same index. Automatic
+retries (which are not clears) keep each index's rows, so resumable mapped tasks still work.
 
 To wipe state across all map indices of a task, use the :doc:`Core API </administration-and-deployment/task-and-asset-state-store>` (e.g. via the UI or CLI) after the task group has finished.
 

--- a/airflow-core/newsfragments/72725.bugfix.rst
+++ b/airflow-core/newsfragments/72725.bugfix.rst
@@ -1,1 +1,0 @@
-Clearing a task now deletes its ``task_state_store`` rows, so a re-expanded dynamically mapped task no longer inherits the state of the item that previously occupied the same positional ``map_index``.

--- a/airflow-core/newsfragments/72725.bugfix.rst
+++ b/airflow-core/newsfragments/72725.bugfix.rst
@@ -1,0 +1,1 @@
+Clearing a task now deletes its ``task_state_store`` rows, so a re-expanded dynamically mapped task no longer inherits the state of the item that previously occupied the same positional ``map_index``.

--- a/airflow-core/newsfragments/72788.bugfix.rst
+++ b/airflow-core/newsfragments/72788.bugfix.rst
@@ -1,0 +1,1 @@
+Clearing a task now deletes its ``task_state_store`` rows, so a re-expanded dynamically mapped task no longer inherits the state of the item that previously occupied the same positional ``map_index``.

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -90,6 +90,7 @@ from airflow.models.deadline_alert import DeadlineAlert as DeadlineAlertModel
 # Import HITLDetail at runtime so SQLAlchemy can resolve the relationship
 from airflow.models.hitl import HITLDetail  # noqa: F401
 from airflow.models.log import Log
+from airflow.models.task_state_store import TaskStateStoreModel
 from airflow.models.taskinstancekey import TaskInstanceKey
 from airflow.models.taskmap import TaskMap
 from airflow.models.taskreschedule import TaskReschedule
@@ -406,6 +407,19 @@ def clear_task_instances(
     for ti in tis:
         ti.prepare_db_for_next_try(session)
 
+        # An operator-initiated clear is a deliberate reset of the task instance. The task state
+        # store is keyed by positional map_index, so a re-expanded mapped list whose contents
+        # changed would otherwise silently hand the new item at a given index the previous item's
+        # state. Wipe the rows here, where the TI uuid is regenerated and XComs are deleted, so a
+        # cleared task never resumes from state belonging to a different logical item.
+        session.execute(
+            delete(TaskStateStoreModel).where(
+                TaskStateStoreModel.dag_id == ti.dag_id,
+                TaskStateStoreModel.run_id == ti.run_id,
+                TaskStateStoreModel.task_id == ti.task_id,
+                TaskStateStoreModel.map_index == ti.map_index,
+            )
+        )
         if ti.state == TaskInstanceState.RUNNING:
             if prevent_running_task:
                 raise AirflowClearRunningTaskException(

--- a/airflow-core/tests/unit/models/test_cleartasks.py
+++ b/airflow-core/tests/unit/models/test_cleartasks.py
@@ -25,6 +25,7 @@ from sqlalchemy import func, select, update
 
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagrun import DagRun
+from airflow.models.task_state_store import TaskStateStoreModel
 from airflow.models.taskinstance import TaskInstance, TaskInstance as TI, clear_task_instances
 from airflow.models.taskinstancehistory import TaskInstanceHistory
 from airflow.models.taskreschedule import TaskReschedule
@@ -97,6 +98,113 @@ class TestClearTasks:
         assert ti1.state is None
         assert ti1.try_number == 1
         assert ti1.max_tries == 3
+
+    def test_clear_task_instances_removes_task_state_store_rows(self, dag_maker, session):
+        """Clearing a task must wipe its task state store rows so a re-run never inherits stale positionally-keyed state."""
+        with dag_maker("test_clear_task_state_store", start_date=DEFAULT_DATE):
+            EmptyOperator(task_id="task0")
+
+        dr = dag_maker.create_dagrun(state=State.RUNNING, run_type=DagRunType.SCHEDULED)
+        ti = dr.task_instances[0]
+        ti.state = State.SUCCESS
+        session.flush()
+
+        session.add(
+            TaskStateStoreModel(
+                dag_run_id=dr.id,
+                dag_id=ti.dag_id,
+                run_id=ti.run_id,
+                task_id=ti.task_id,
+                map_index=-1,
+                key="remote_job_id",
+                value="application_1234",
+            )
+        )
+        session.flush()
+
+        assert (
+            session.scalar(
+                select(TaskStateStoreModel).where(
+                    TaskStateStoreModel.dag_id == ti.dag_id,
+                    TaskStateStoreModel.run_id == ti.run_id,
+                    TaskStateStoreModel.task_id == ti.task_id,
+                )
+            )
+            is not None
+        )
+
+        session.merge(ti)
+        clear_task_instances([ti], session=session)
+        session.flush()
+
+        assert (
+            session.scalar(
+                select(TaskStateStoreModel).where(
+                    TaskStateStoreModel.dag_id == ti.dag_id,
+                    TaskStateStoreModel.run_id == ti.run_id,
+                    TaskStateStoreModel.task_id == ti.task_id,
+                )
+            )
+            is None
+        )
+
+    def test_clear_task_instances_removes_mapped_task_state_store_rows(self, dag_maker, session):
+        """Clearing a mapped task wipes state for each cleared map index so a re-expanded list never inherits stale checkpoints."""
+        with dag_maker("test_clear_mapped_task_state_store", start_date=DEFAULT_DATE) as dag:
+            EmptyOperator(task_id="mapped")
+
+        dr = dag_maker.create_dagrun(state=State.RUNNING, run_type=DagRunType.SCHEDULED)
+        task = dag.task_dict["mapped"]
+        dag_version = DagVersion.get_latest_version(dr.dag_id)
+
+        cleared_tis = []
+        for index in (0, 1, 2):
+            ti = TaskInstance(
+                task,
+                run_id=dr.run_id,
+                map_index=index,
+                state=TaskInstanceState.SUCCESS,
+                dag_version_id=dag_version.id,
+            )
+            session.add(ti)
+            cleared_tis.append(ti)
+            session.add(
+                TaskStateStoreModel(
+                    dag_run_id=dr.id,
+                    dag_id=dr.dag_id,
+                    run_id=dr.run_id,
+                    task_id="mapped",
+                    map_index=index,
+                    key="checkpoint",
+                    value=f"item_{index}",
+                )
+            )
+        session.flush()
+
+        assert (
+            session.scalar(
+                select(func.count(TaskStateStoreModel.id)).where(
+                    TaskStateStoreModel.dag_id == dr.dag_id,
+                    TaskStateStoreModel.run_id == dr.run_id,
+                    TaskStateStoreModel.task_id == "mapped",
+                )
+            )
+            == 3
+        )
+
+        clear_task_instances(cleared_tis, session=session)
+        session.flush()
+
+        assert (
+            session.scalar(
+                select(func.count(TaskStateStoreModel.id)).where(
+                    TaskStateStoreModel.dag_id == dr.dag_id,
+                    TaskStateStoreModel.run_id == dr.run_id,
+                    TaskStateStoreModel.task_id == "mapped",
+                )
+            )
+            == 0
+        )
 
     def test_clear_task_instances_external_executor_id(self, dag_maker):
         with dag_maker(


### PR DESCRIPTION
Clearing a task instance now deletes its `task_state_store` rows, so a re-expanded
dynamically mapped task never inherits the state of the item that previously occupied
the same positional `map_index`.

The state store is keyed by positional `map_index` and previously survived an
operator-initiated clear. If the expanded upstream list changes between runs (an
insertion, deletion, or reordering), index *N* on the second attempt is a different
item than index *N* on the first, and would silently inherit the earlier item's state
(including a stored external-job reference), while the run still reports success.

Airflow's own clear path already regenerates the TaskInstance uuid and deletes XComs
in `clear_task_instances`; this change adds the state store wipe in the same place.
Automatic retries are not clears and still share rows, so durable execution continues
to resume a failed attempt from its last checkpoint. The docs (`resumable-tasks.rst`
and `task-state-store.rst`) are updated to describe clearing as a controlled reset and
to document the positional-index caveat for mapped tasks.

closes: #72725

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — big-pickle (opencode/big-pickle)

Generated-by: big-pickle (opencode/big-pickle) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)