### PR TITLE
UI: Complete zh-CN Simplified Chinese translations

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/common.json
@@ -135,6 +135,7 @@
   },
   "filter": "筛选",
   "filters": {
+    "date": "日期",
     "durationFrom": "持续时间起始",
     "durationTo": "持续时间结束",
     "endTime": "结束时间",
@@ -144,12 +145,15 @@
     "runAfterTo": "执行时间结束",
     "searchAsset": "搜索资源",
     "selectDateRange": "选择日期范围",
-    "startTime": "开始时间"
+    "selectDateTime": "选择日期与时间",
+    "startTime": "开始时间",
+    "time": "时间"
   },
   "fullscreen": {
     "tooltip": "按下 {{hotkey}} 进入全屏"
   },
   "generateToken": "生成令牌",
+  "includedIn": "包含于",
   "key": "键",
   "logicalDate": "逻辑日期",
   "logout": "退出登录",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/common.json
@@ -38,6 +38,7 @@
   "dag_one": "Dag",
   "dag_other": "Dags",
   "dagDetails": {
+    "activeRuns": "活跃执行数",
     "catchup": "自动回填",
     "dagRunTimeout": "Dag 执行超时",
     "defaultArgs": "默认参数",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/components.json
@@ -112,6 +112,10 @@
     "file": "文件",
     "location": "第 {{line}} 行，位于 {{name}}"
   },
+  "passwordToggle": {
+    "hide": "隐藏值",
+    "show": "显示值"
+  },
   "reparseDag": "重新解析 Dag",
   "sortedAscending": "递增排序",
   "sortedDescending": "递减排序",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/components.json
@@ -113,8 +113,8 @@
     "location": "第 {{line}} 行，位于 {{name}}"
   },
   "passwordToggle": {
-    "hide": "隐藏值",
-    "show": "显示值"
+    "hide": "隐藏",
+    "show": "显示"
   },
   "reparseDag": "重新解析 Dag",
   "sortedAscending": "递增排序",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/dag.json
@@ -42,6 +42,7 @@
   },
   "deadlineAlerts": {
     "completionRule": "必须在 {{reference}} 后的 {{interval}} 内完成",
+    "completionRuleDynamic": "必须在从 {{reference}} 起算的可变时间间隔内完成",
     "count_one": "{{count}} 个截止期限",
     "count_other": "{{count}} 个截止期限",
     "referenceType": {
@@ -91,10 +92,6 @@
     "critical": "CRITICAL",
     "debug": "DEBUG",
     "error": "ERROR",
-    "fullscreen": {
-      "button": "全屏",
-      "tooltip": "按下 {{hotkey}} 进入全屏"
-    },
     "info": "INFO",
     "noTryNumber": "没有重试次数",
     "search": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/dags.json
@@ -75,6 +75,7 @@
       "preventRunningTasks": "防止重复执行执行中的任务",
       "queueNew": "加入新任务到队列",
       "runOnLatestVersion": "执行最新套件包版本",
+      "runOnLatestVersionForced": "始终使用最新套件包版本，因为没有可回退的旧版本",
       "upstream": "上游"
     }
   },

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/dags.json
@@ -75,7 +75,7 @@
       "preventRunningTasks": "防止重复执行执行中的任务",
       "queueNew": "加入新任务到队列",
       "runOnLatestVersion": "执行最新套件包版本",
-      "runOnLatestVersionForced": "始终使用最新套件包版本，因为没有可回退的旧版本",
+      "runOnLatestVersionForced": "无旧版本可回退",
       "upstream": "上游"
     }
   },


### PR DESCRIPTION
## Why

The Simplified Chinese UI falls back to English for nine strings on `v3-3-test`, leaving the locale below complete coverage ahead of Airflow 3.3.2. The locale also retains two fullscreen keys that the current UI no longer reads.

## What

Translate the missing date and time controls, password visibility labels, asset-run relationship, dynamic deadline rule, latest bundle-version tooltip, and active-run count. Remove the obsolete fullscreen keys. zh-CN now covers all 988 required strings.

## Tests

| Scenario | Result |
| --- | --- |
| Translation completeness | 979/988 before; 988/988 after |
| Production UI build | Passed |

<details><summary>Raw logs</summary>

```text
# upstream/v3-3-test
$ breeze ui check-translation-completeness --language zh-CN
│ All files       │ 988                │ 0                 │ 988            │ 979        │ 9       │ 99.1%    │ 0     │ 2      │
Some translations are not complete!

# PR head
$ breeze ui check-translation-completeness --language zh-CN
│ All files       │ 988                │ 0                 │ 988            │ 988        │ 0       │ 100.0%   │ 0     │ 0      │
All translations are complete!

$ npx --yes pnpm@10.25.0 exec vitest run --exclude src/components/MonacoEditor/pythonFStrings.test.ts
Test Files  97 passed (97)
Tests  781 passed (781)

$ npx --yes pnpm@10.25.0 test src/components/MonacoEditor/pythonFStrings.test.ts
Test Files  1 passed (1)
Tests  12 passed (12)

$ npx --yes pnpm@10.25.0 build
transforming...✓ 5191 modules transformed.
✓ built in 10.76s
```

</details>

## Risk

Only zh-CN resource files change. Runtime logic and English fallback behavior are unchanged.
