### PR TITLE
Chart: Don't set deprecated git-sync branch/rev by default

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -220,12 +220,17 @@ If release name contains chart name it will be used as a full name.
   {{- end }}
   envFrom: {{- include "custom_git_sync_environment_from" . | default "\n  []" | indent 2 }}
   env:
+    {{- /* rev/branch are unset by default; see values.yaml for why. */}}
+    {{- if .Values.dags.gitSync.rev }}
     - name: GIT_SYNC_REV
       value: {{ .Values.dags.gitSync.rev | quote }}
+    {{- end }}
     - name: GITSYNC_REF
       value: {{ .Values.dags.gitSync.ref | quote }}
+    {{- if .Values.dags.gitSync.branch }}
     - name: GIT_SYNC_BRANCH
       value: {{ .Values.dags.gitSync.branch | quote }}
+    {{- end }}
     - name: GIT_SYNC_REPO
       value: {{ .Values.dags.gitSync.repo | quote }}
     - name: GITSYNC_REPO

--- a/chart/tests/helm_tests/other/test_git_sync_scheduler.py
+++ b/chart/tests/helm_tests/other/test_git_sync_scheduler.py
@@ -199,6 +199,26 @@ class TestGitSyncSchedulerTest:
             },
         }
 
+    def test_should_not_set_deprecated_v3_vars_with_default_values(self):
+        """git-sync v4 (the chart's default image) treats --branch/--rev as overriding --ref
+        whenever they're set, not merely as a fallback, so a stock deployment relying on the
+        default `ref` must not also emit the deprecated v3 GIT_SYNC_REV/GIT_SYNC_BRANCH vars.
+        """
+        docs = render_chart(
+            values={
+                "executor": "LocalExecutor",  # needed to have git sync added to the scheduler
+                "dags": {"gitSync": {"enabled": True}},
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        env = jmespath.search("spec.template.spec.containers[1].env", docs[0])
+        env_names = [e["name"] for e in env]
+
+        assert "GIT_SYNC_REV" not in env_names
+        assert "GIT_SYNC_BRANCH" not in env_names
+        assert {"name": "GITSYNC_REF", "value": "v2-2-stable"} in env
+
     def test_validate_if_ssh_params_are_added(self):
         docs = render_chart(
             values={

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -9783,14 +9783,20 @@
                             "default": "https://github.com/apache/airflow.git"
                         },
                         "branch": {
-                            "description": "Git branch",
-                            "type": "string",
-                            "default": "v2-2-stable"
+                            "description": "Git branch. Deprecated, git-sync v3 only: overrides `ref` whenever set, so leave unset (default) unless pinned to git-sync v3.",
+                            "type": [
+                                "null",
+                                "string"
+                            ],
+                            "default": null
                         },
                         "rev": {
-                            "description": "Git revision.",
-                            "type": "string",
-                            "default": "HEAD"
+                            "description": "Git revision. Deprecated, git-sync v3 only: overrides `ref` whenever set, so leave unset (default) unless pinned to git-sync v3.",
+                            "type": [
+                                "null",
+                                "string"
+                            ],
+                            "default": null
                         },
                         "ref": {
                             "description": "Git revision branch, tag, or hash.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -3517,8 +3517,11 @@ dags:
     # SSH example: git@github.com:apache/airflow.git
     # HTTPS example: https://github.com/apache/airflow.git
 
-    branch: v2-2-stable
-    rev: HEAD
+    # git-sync v3 only, deprecated. Leave unset so a default (git-sync v4) deployment is
+    # controlled by `ref` alone: v4 treats `--branch`/`--rev` as overriding `--ref` whenever
+    # they're set, not merely as a fallback, so setting them here would silently take over.
+    branch: ~
+    rev: ~
 
     # The git revision (branch, tag, or hash) to check out, v4 only
     ref: v2-2-stable


### PR DESCRIPTION
git-sync v4 (the chart's default image) treats the deprecated `--branch`/`--rev` flags as overriding `--ref` whenever they're set, not merely as a fallback — but the chart shipped non-empty `branch`/`rev` defaults (`v2-2-stable`/`HEAD`) alongside a default `ref`, so a stock deployment meant to pin a version via `ref` had it silently overridden.

This defaults `branch`/`rev` to unset and only renders their env vars when a user explicitly sets a non-null value, so a default v4 deployment is controlled by `ref` alone while git-sync v3 users who still rely on `branch`/`rev` are unaffected. A prior attempt (#42986) dropped v3 support outright and was rejected by maintainers as a breaking change reserved for a major version bump; this is additive and backward compatible instead.

closes: #42918

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)

Generated-by: Claude Code (Sonnet 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
