### PR TITLE
Fix downstream tasks not skipped when using a custom XCom backend

### DIFF
--- a/task-sdk/src/airflow/sdk/bases/xcom.py
+++ b/task-sdk/src/airflow/sdk/bases/xcom.py
@@ -181,6 +181,31 @@ class BaseXCom:
         )
 
     @classmethod
+    async def _aset_xcom_in_db(
+        cls,
+        key: str,
+        value: Any,
+        *,
+        dag_id: str,
+        task_id: str,
+        run_id: str,
+        map_index: int = -1,
+    ) -> None:
+        """Async version of :meth:`_set_xcom_in_db`; see that method for full documentation."""
+        from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
+
+        await SUPERVISOR_COMMS.asend(
+            SetXCom(
+                key=key,
+                value=value,
+                dag_id=dag_id,
+                task_id=task_id,
+                run_id=run_id,
+                map_index=map_index,
+            ),
+        )
+
+    @classmethod
     def get_value(
         cls,
         *,

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -58,6 +58,7 @@ from airflow.sdk.api.datamodels._generated import (
     TIRunContext,
 )
 from airflow.sdk.bases.operator import BaseOperator, ExecutorSafeguard
+from airflow.sdk.bases.skipmixin import XCOM_SKIPMIXIN_KEY
 from airflow.sdk.bases.xcom import BaseXCom
 from airflow.sdk.configuration import conf
 from airflow.sdk.definitions._internal.dag_parsing_context import _airflow_parsing_context_manager
@@ -902,6 +903,14 @@ def _xcom_push(
     # Private function, as we don't want to expose the ability to manually set `mapped_length` to SDK
     # consumers
 
+    if key == XCOM_SKIPMIXIN_KEY:
+        # The scheduler's NotPreviouslySkippedDep reads this control-plane key straight from
+        # the metadata DB, never through a configured XCom backend. Serializing it through one
+        # here would leave the scheduler with an opaque pointer -- or a credentials error --
+        # instead of the real skip decision, so this key always bypasses the backend.
+        _xcom_push_to_db(ti, key=key, value=value)
+        return
+
     XCom.set(
         key=key,
         value=value,
@@ -925,6 +934,11 @@ async def _axcom_push(
     # Private function, as we don't want to expose the ability to manually set `mapped_length` to SDK
     # consumers
 
+    if key == XCOM_SKIPMIXIN_KEY:
+        # See _xcom_push: this control-plane key must always bypass the configured backend.
+        await _axcom_push_to_db(ti, key=key, value=value)
+        return
+
     await XCom.aset(
         key=key,
         value=value,
@@ -940,6 +954,18 @@ async def _axcom_push(
 def _xcom_push_to_db(ti: RuntimeTaskInstance, key: str, value: Any) -> None:
     """Push a XCom directly to metadata DB, bypassing custom xcom_backend."""
     XCom._set_xcom_in_db(
+        key=key,
+        value=value,
+        dag_id=ti.dag_id,
+        task_id=ti.task_id,
+        run_id=ti.run_id,
+        map_index=ti.map_index,
+    )
+
+
+async def _axcom_push_to_db(ti: RuntimeTaskInstance, key: str, value: Any) -> None:
+    """Async version of :func:`_xcom_push_to_db`; see that function for full documentation."""
+    await XCom._aset_xcom_in_db(
         key=key,
         value=value,
         dag_id=ti.dag_id,

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -75,7 +75,9 @@ from airflow.sdk.api.datamodels._generated import (
     TaskInstanceState,
     TIRunContext,
 )
+from airflow.sdk.bases.branch import BaseBranchOperator
 from airflow.sdk.bases.operator import ExecutorSafeguard
+from airflow.sdk.bases.skipmixin import XCOM_SKIPMIXIN_FOLLOWED, XCOM_SKIPMIXIN_KEY
 from airflow.sdk.bases.xcom import BaseXCom
 from airflow.sdk.definitions._internal.types import NOTSET, SET_DURING_EXECUTION, is_arg_set
 from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetUniqueKey, AssetUriRef, Dataset, Model
@@ -172,6 +174,7 @@ from airflow.sdk.execution_time.context import (
 from airflow.sdk.execution_time.task_runner import (
     RuntimeTaskInstance,
     TaskRunnerMarker,
+    _axcom_push,
     _defer_task,
     _execute_task,
     _make_task_span,
@@ -3961,6 +3964,91 @@ class TestXComAfterTaskExecution:
             )
             for x in mock_supervisor_comms.send.call_args_list
         )
+
+    def test_skip_mixin_xcom_push_bypasses_custom_backend(
+        self, create_runtime_ti, mock_supervisor_comms, monkeypatch
+    ):
+        """
+        Regression test for https://github.com/apache/airflow/issues/50491.
+
+        SkipMixin's branch decision is written under XCOM_SKIPMIXIN_KEY and later read
+        straight from the metadata DB by the scheduler's NotPreviouslySkippedDep, which
+        never consults a configured XCom backend. A backend that externalizes values (e.g.
+        to blob storage) must not be allowed to intercept this key, or the scheduler would
+        see an opaque pointer instead of the real decision and fail to skip downstream
+        tasks when they are mapped or cleared.
+        """
+
+        class PointerXCom(BaseXCom):
+            """Stand-in for a backend that externalizes values needing credentials to read."""
+
+            @staticmethod
+            def serialize_value(value, *, key=None, task_id=None, dag_id=None, run_id=None, map_index=None):
+                return "opaque://pointer"
+
+            @staticmethod
+            def deserialize_value(result):
+                raise RuntimeError("no credentials configured")
+
+        monkeypatch.setattr(task_runner, "XCom", PointerXCom)
+
+        class BranchOperator(BaseBranchOperator):
+            def choose_branch(self, context):
+                return "follow_task"
+
+        with DAG(dag_id="test_dag"):
+            branch_task = BranchOperator(task_id="branch_task")
+            follow_task = BaseOperator(task_id="follow_task")
+            skip_task = BaseOperator(task_id="skip_task")
+            branch_task >> [follow_task, skip_task]
+
+        runtime_ti = create_runtime_ti(task=branch_task)
+        run(runtime_ti, context=runtime_ti.get_template_context(), log=mock.MagicMock())
+
+        # The real branch decision must reach the DB verbatim, not the backend's pointer.
+        mock_supervisor_comms.send.assert_any_call(
+            SetXCom(
+                key=XCOM_SKIPMIXIN_KEY,
+                value={XCOM_SKIPMIXIN_FOLLOWED: ["follow_task"]},
+                dag_id="test_dag",
+                run_id="test_run",
+                task_id="branch_task",
+                map_index=-1,
+            ),
+        )
+
+    @pytest.mark.asyncio
+    async def test_skip_mixin_axcom_push_bypasses_custom_backend(
+        self, create_runtime_ti, mock_supervisor_comms, monkeypatch
+    ):
+        """Async twin of test_skip_mixin_xcom_push_bypasses_custom_backend: _axcom_push must apply the
+        same bypass, and must do so through the async supervisor call (not the blocking sync one, which
+        can deadlock when invoked from the event loop thread).
+        """
+
+        class PointerXCom(BaseXCom):
+            @staticmethod
+            def serialize_value(value, *, key=None, task_id=None, dag_id=None, run_id=None, map_index=None):
+                return "opaque://pointer"
+
+        monkeypatch.setattr(task_runner, "XCom", PointerXCom)
+
+        task = BaseOperator(task_id="branch_task")
+        runtime_ti = create_runtime_ti(task=task)
+
+        await _axcom_push(runtime_ti, XCOM_SKIPMIXIN_KEY, {XCOM_SKIPMIXIN_FOLLOWED: ["follow_task"]})
+
+        mock_supervisor_comms.asend.assert_called_once_with(
+            SetXCom(
+                key=XCOM_SKIPMIXIN_KEY,
+                value={XCOM_SKIPMIXIN_FOLLOWED: ["follow_task"]},
+                dag_id="test_dag",
+                run_id="test_run",
+                task_id="branch_task",
+                map_index=-1,
+            ),
+        )
+        mock_supervisor_comms.send.assert_not_called()
 
     def test_get_all_uses_custom_deserialize_value(self, mock_supervisor_comms):
         """


### PR DESCRIPTION
`SkipMixin`'s branch/skip decision is written to XCom under a control-plane key that the scheduler's `NotPreviouslySkippedDep` reads directly from the metadata database, bypassing any configured XCom backend. The task-sdk push path didn't carve out the same exception: a custom backend that externalizes values (e.g. to blob storage) could leave the scheduler holding an opaque pointer instead of the real decision, or fail outright resolving credentials the scheduler process doesn't have — silently breaking skip propagation to downstream tasks once they are mapped or cleared.

This bypasses the configured backend for that one control-plane key on both the sync and async push paths, writing it straight to the metadata DB the same way operator extra links already do. The async path needed its own async-safe DB-write helper rather than reusing the sync one directly, since the existing sync helper blocks on the supervisor comms channel in a way that can deadlock if called from the event loop thread.

closes: #50491

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)

Generated-by: Claude Code (Sonnet 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
