### PR TITLE
Fix task-state inconsistency when a fail-fast request fails midway

### DIFF
--- a/airflow-core/src/airflow/models/dagwarning.py
+++ b/airflow-core/src/airflow/models/dagwarning.py
@@ -90,7 +90,6 @@ class DagWarning(Base):
             query = delete(cls).where(cls.dag_id == DagModel.dag_id, DagModel.is_stale == true())
 
         session.execute(query.execution_options(synchronize_session=False))
-        session.commit()
 
 
 class DagWarningType(str, Enum):

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -897,7 +897,6 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
         self.log.error("Recording the task instance as FAILED")
         self.state = TaskInstanceState.FAILED
         session.merge(self)
-        session.commit()
 
     @classmethod
     @provide_session
@@ -1956,6 +1955,12 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
         ti.updated_at = timezone.utcnow()
         session.merge(ti)
         session.flush()
+        # Deliberately committed here (unlike error() above): the only caller, handle_failure(),
+        # is invoked from per-item scheduler batch loops (e.g. process_executor_events,
+        # _purge_task_instances_without_heartbeats) that dispatch non-transactional executor
+        # callbacks right after each item. Deferring to a single end-of-batch commit would let a
+        # later item's failure roll back an earlier item's DB state after its callback was already
+        # sent, leaving the DB and the dispatched callback disagreeing about the outcome.
         session.commit()
 
     @provide_session

--- a/airflow-core/src/airflow/utils/db.py
+++ b/airflow-core/src/airflow/utils/db.py
@@ -178,7 +178,6 @@ def merge_conn(conn: Connection, *, session: Session = NEW_SESSION):
     """Add new Connection."""
     if not session.scalar(select(1).where(conn.__class__.conn_id == conn.conn_id)):
         session.add(conn)
-        session.commit()
 
 
 @provide_session
@@ -194,7 +193,6 @@ def add_default_pool_if_not_exists(*, session: Session = NEW_SESSION):
             include_deferred=False,
         )
         session.add(default_pool)
-        session.commit()
 
 
 @provide_session

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -2568,6 +2568,68 @@ class TestTIUpdateState:
         ti1 = session.get(TaskInstance, ti1.id)
         assert ti1.state == State.FAILED
 
+    def test_ti_update_state_fail_fast_sibling_state_is_not_committed_independently(
+        self, client, session, dag_maker
+    ):
+        """
+        Regression test for apache/airflow#12818.
+
+        The fail-fast cascade (``_stop_remaining_tasks`` -> ``TaskInstance.error()``) runs on the
+        *same*, request-scoped session the route uses for the originating task's own state
+        update -- and that update isn't executed and committed until later in this same
+        request. If ``TaskInstance.error()`` commits on its own, a failure anywhere between the
+        cascade and the route's end-of-request commit leaves the sibling durably FAILED while
+        the triggering task's own state update rolls back: an inconsistent, partially-committed
+        result. Fixed by no longer committing inside ``TaskInstance.error()``.
+        """
+        with dag_maker(dag_id="test_dag_fail_fast_atomicity", fail_fast=True, serialized=True):
+            EmptyOperator(task_id="task1")
+            EmptyOperator(task_id="task2")
+
+        dr = dag_maker.create_dagrun()
+        ti1 = dr.get_task_instance(task_id="task1", session=session)
+        ti1.state = State.RUNNING
+        ti1.start_date = DEFAULT_START_DATE
+
+        # RUNNING (not QUEUED) so the cascade routes ti2 through TaskInstance.error(), the
+        # method this regression covers, rather than the SKIPPED/set_state() path.
+        ti2 = dr.get_task_instance(task_id="task2", session=session)
+        ti2.state = State.RUNNING
+        ti2.start_date = DEFAULT_START_DATE
+        session.commit()
+        session.refresh(ti1)
+        session.refresh(ti2)
+
+        # Force the request to fail *after* the fail-fast cascade has marked ti2 FAILED but
+        # *before* the route's own end-of-request commit -- the exact window the bug exploits.
+        # `Log(...)` is constructed right after the route's own UPDATE executes and right
+        # before its final `session.commit()`. The TestClient re-raises unhandled server
+        # exceptions rather than turning them into a response, so assert on the raise itself.
+        with (
+            mock.patch(
+                "airflow.api_fastapi.execution_api.routes.task_instances.Log",
+                side_effect=RuntimeError("simulated failure between cascade and final commit"),
+            ),
+            pytest.raises(RuntimeError, match="simulated failure between cascade and final commit"),
+        ):
+            client.patch(
+                f"/execution/task-instances/{ti1.id}/state",
+                json={
+                    "state": TerminalTIState.FAILED,
+                    "end_date": DEFAULT_END_DATE.isoformat(),
+                },
+            )
+
+        # The whole request rolled back, including ti1's own update: it never got committed.
+        session.expire_all()
+        ti1 = session.get(TaskInstance, ti1.id)
+        assert ti1.state == State.RUNNING
+
+        # ti2's FAILED state must not have been committed independently of that rollback --
+        # from a separate session, it must look like the cascade never ran.
+        ti2 = session.get(TaskInstance, ti2.id)
+        assert ti2.state == State.RUNNING
+
     def test_ti_update_state_reschedule_mysql_limit_triggers_fail_fast(
         self, client, session, dag_maker, time_machine
     ):

--- a/airflow-core/tests/unit/models/test_dagwarning.py
+++ b/airflow-core/tests/unit/models/test_dagwarning.py
@@ -75,3 +75,6 @@ class TestDagWarning:
         # Assert that the delete method was called twice
         assert delete_mock.call_count == 2
         assert self.session_mock.execute.call_count == 2
+        # Committing is the caller's responsibility (see #12818); a shared session passed in
+        # here must not be committed on the caller's behalf.
+        self.session_mock.commit.assert_not_called()

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -411,6 +411,21 @@ class TestTaskInstance:
         ti.run(mark_success=True)
         assert ti.state == State.SUCCESS
 
+    def test_error_does_not_commit(self, create_task_instance, session):
+        """error() must leave committing to the caller (see #12818)."""
+        ti = create_task_instance()
+        session.commit()
+
+        ti.error(session=session)
+
+        # Not yet committed: a genuinely separate connection (scoped=False, like the
+        # execution API's SessionDep uses) must not see the FAILED state.
+        with create_session(scoped=False) as other_session:
+            other_ti = other_session.get(TaskInstance, ti.id)
+            assert other_ti.state != State.FAILED
+
+        assert ti.state == State.FAILED
+
     @pytest.mark.usefixtures("test_pool")
     def test_run_pooling_task(self, create_task_instance):
         """

--- a/airflow-core/tests/unit/utils/test_db.py
+++ b/airflow-core/tests/unit/utils/test_db.py
@@ -35,12 +35,14 @@ from sqlalchemy import Column, Integer, MetaData, Table, delete, select
 
 from airflow import settings
 from airflow.models import Base as airflow_base
+from airflow.models.connection import Connection
 from airflow.models.team import Team
 from airflow.utils.db import (
     AutocommitEngineForMySQL,
     LazySelectSequence,
     _get_alembic_config,
     _get_current_revision,
+    add_default_pool_if_not_exists,
     check_migrations,
     check_team_names_can_be_lower_cased,
     compare_server_default,
@@ -48,6 +50,7 @@ from airflow.utils.db import (
     create_default_connections,
     downgrade,
     initdb,
+    merge_conn,
     resetdb,
     upgradedb,
 )
@@ -126,6 +129,27 @@ class TestDb:
 
         mock_run_upgradedb.assert_called_once_with(mock_config, None, session, use_migration_files=True)
         mock_initdb.assert_not_called()
+
+    def test_merge_conn_does_not_commit(self, mocker):
+        """merge_conn() must leave committing to the caller (see #12818)."""
+        session = mocker.MagicMock()
+        session.scalar.return_value = None  # no existing connection with this conn_id
+        conn = Connection(conn_id="test_merge_conn_does_not_commit", conn_type="fs")
+
+        merge_conn(conn, session=session)
+
+        session.add.assert_called_once_with(conn)
+        session.commit.assert_not_called()
+
+    def test_add_default_pool_if_not_exists_does_not_commit(self, mocker):
+        """add_default_pool_if_not_exists() must leave committing to the caller (see #12818)."""
+        session = mocker.MagicMock()
+        session.scalar.return_value = None  # default pool doesn't exist yet
+
+        add_default_pool_if_not_exists(session=session)
+
+        session.add.assert_called_once()
+        session.commit.assert_not_called()
 
     def test_database_schema_and_sqlalchemy_model_are_in_sync(self, initialized_db):
         import airflow.models


### PR DESCRIPTION
When a Dag has `fail_fast` enabled, `TaskInstance.error()` committed internally on the shared, request-scoped session the Execution API's `ti_update_state` route uses for its own state update — so the fail-fast cascade's sibling-task FAILED updates landed in the database before that route executed or committed its own UPDATE for the task that actually triggered the cascade. A failure anywhere in between rolled back the route's own change but couldn't undo the sibling's already-committed state, leaving the database durably inconsistent: siblings marked FAILED while the triggering task's own FAILED transition was silently lost.

This removes that internal commit, plus three other call sites verified individually to have no control flow depending on their own commit (`DagWarning.purge_inactive_dag_warnings`, and `utils/db.py`'s `merge_conn`/`add_default_pool_if_not_exists`). Several structurally similar commits were also examined and intentionally left in place — `Job.kill()`/`Job.prepare_for_execution()`, `TaskInstance.save_to_db()`, the team CLI commands, and the scheduler's stuck-in-queued handler — each for a specific reason noted at the call site, since a blanket sweep here is exactly what sank two prior attempts at this issue (#21283, #12822).

This is a scoped fix of the broader cleanup tracked by #12818, not a complete resolution — several other candidates were found during the audit but held back for a follow-up rather than widening this PR's blast radius.

related: #12818

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)

Generated-by: Claude Code (Sonnet 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
