### PR TITLE
Fix airflow roles import crash on a role without permissions

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/cli_commands/role_command.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/cli_commands/role_command.py
@@ -205,28 +205,17 @@ def roles_import(args):
         existing_roles = [role.name for role in appbuilder.sm.get_all_roles()]
         roles_to_import = [role_dict for role_dict in role_list if role_dict["name"] not in existing_roles]
         for role_dict in roles_to_import:
-            if role_dict["name"] not in appbuilder.sm.get_all_roles():
-                if role_dict["action"] == "" or role_dict["resource"] == "":
-                    appbuilder.sm.add_role(role_dict["name"])
-                else:
-                    appbuilder.sm.add_role(role_dict["name"])
-                    role_args = Namespace(
-                        subcommand="add-perms",
-                        role=[role_dict["name"]],
-                        resource=[role_dict["resource"]],
-                        action=role_dict["action"].split(","),
-                    )
-                __roles_add_or_remove_permissions(role_args)
-
-            if role_dict["name"] in appbuilder.sm.get_all_roles():
-                if role_dict["action"] == "" or role_dict["resource"] == "":
-                    pass
-                else:
-                    role_args = Namespace(
-                        subcommand="add-perms",
-                        role=[role_dict["name"]],
-                        resource=[role_dict["resource"]],
-                        action=role_dict["action"].split(","),
-                    )
-                __roles_add_or_remove_permissions(role_args)
+            # ``roles_export`` emits one entry per (role, resource) pair, so a role name
+            # repeats across entries; ``add_role`` returns the existing role after the first.
+            appbuilder.sm.add_role(role_dict["name"])
+            if not role_dict["action"] or not role_dict["resource"]:
+                continue
+            __roles_add_or_remove_permissions(
+                Namespace(
+                    subcommand="add-perms",
+                    role=[role_dict["name"]],
+                    resource=[role_dict["resource"]],
+                    action=role_dict["action"].split(","),
+                )
+            )
         print("roles and permissions successfully imported")

--- a/providers/fab/tests/unit/fab/auth_manager/cli_commands/test_role_command.py
+++ b/providers/fab/tests/unit/fab/auth_manager/cli_commands/test_role_command.py
@@ -226,3 +226,24 @@ class TestCliRoles:
             and permission.action.name == permissions.ACTION_CAN_ACCESS_MENU
             for permission in fakeTeamA.permissions
         )
+
+    def test_cli_import_roles_when_a_role_without_permissions_comes_first(self, tmp_path):
+        fn = tmp_path / "import_roles.json"
+        roles_list = [
+            {"name": "FakeTeamB", "resource": "", "action": ""},
+            {"name": "FakeTeamA", "resource": "Pools", "action": "can_edit,can_read"},
+        ]
+        fn.write_text(json.dumps(roles_list))
+        role_command.roles_import(self.parser.parse_args(["roles", "import", str(fn)]))
+
+        fakeTeamA: Role = self.appbuilder.sm.find_role("FakeTeamA")
+        fakeTeamB: Role = self.appbuilder.sm.find_role("FakeTeamB")
+
+        assert fakeTeamB is not None
+        assert len(fakeTeamB.permissions) == 0
+        assert {
+            (permission.resource.name, permission.action.name) for permission in fakeTeamA.permissions
+        } == {
+            (permissions.RESOURCE_POOL, permissions.ACTION_CAN_EDIT),
+            (permissions.RESOURCE_POOL, permissions.ACTION_CAN_READ),
+        }


### PR DESCRIPTION
`airflow roles export` writes a role that holds no permissions as an entry with an
empty `resource` and `action`, so `airflow roles import` cannot always read back
what `roles export` produced.

Importing such a file behaved differently depending on where that entry sat:

- **first entry** — the command aborted with `UnboundLocalError: cannot access
  local variable 'role_args'`, after the role had already been committed, leaving
  a half-finished import;
- **any later entry** — it silently re-applied the *preceding* entry's
  permissions, because `role_args` was still bound from an earlier iteration.

Either way the export/import round trip that these two commands exist to serve
was broken.

`roles_import` now adds the role unconditionally (`add_role` returns the existing
role, so a role spanning several resources — which `roles_export` emits as several
same-named entries — is safe) and skips the permission step when the entry carries
no resource or action, so the `Namespace` is built only where it is used.

Two surrounding branches went away with it: the outer
`role_dict["name"] not in appbuilder.sm.get_all_roles()` compares a `str` against
a list of `Role` ORM objects and is therefore always true, which made the mirrored
`in` block below it unreachable.

### Why the existing test did not catch this

`test_cli_import_roles` already covers a permissionless role, but places it last
in the fixture, where the stale binding from an earlier iteration papers over the
missing one. The new test puts it first.

### Testing

- `uv run --project providers/fab pytest providers/fab/tests/unit/fab/auth_manager/cli_commands/test_role_command.py` — 9 passed.
- Reverting only the source change (keeping the new test) fails exactly
  `test_cli_import_roles_when_a_role_without_permissions_comes_first` with the real
  `UnboundLocalError`, and nothing else.
- Reproduced on a live CLI before the fix:
  `airflow roles import` on `[{"name": "X", "resource": "", "action": ""}]`
  raised `UnboundLocalError` at `role_command.py:219`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


