### PR TITLE
Fix Google IdP credentials failing when project id cannot be resolved

### DIFF
--- a/generated/known_airflow_exceptions.txt
+++ b/generated/known_airflow_exceptions.txt
@@ -309,7 +309,7 @@ providers/google/src/airflow/providers/google/cloud/triggers/cloud_composer.py::
 providers/google/src/airflow/providers/google/cloud/triggers/cloud_run.py::1
 providers/google/src/airflow/providers/google/cloud/triggers/dataproc.py::5
 providers/google/src/airflow/providers/google/cloud/triggers/kubernetes_engine.py::1
-providers/google/src/airflow/providers/google/cloud/utils/credentials_provider.py::16
+providers/google/src/airflow/providers/google/cloud/utils/credentials_provider.py::15
 providers/google/src/airflow/providers/google/common/hooks/base_google.py::7
 providers/google/src/airflow/providers/google/common/hooks/operation_helpers.py::2
 providers/google/src/airflow/providers/google/firebase/hooks/firestore.py::1

--- a/providers/google/src/airflow/providers/google/cloud/utils/credentials_provider.py
+++ b/providers/google/src/airflow/providers/google/cloud/utils/credentials_provider.py
@@ -405,10 +405,7 @@ class _CredentialProvider(LoggingMixin):
         scopes = list(self.scopes) if self.scopes else None
         credentials, project_id = google.auth.load_credentials_from_dict(info=info, scopes=scopes)
         if not project_id:
-            raise AirflowException(
-                "Project ID could not be determined from default credentials. "
-                "Please provide `key_secret_project_id` parameter."
-            )
+            project_id = ""
         return credentials, project_id
 
     def _get_credentials_using_adc(self) -> tuple[Credentials, str]:

--- a/providers/google/tests/unit/google/cloud/utils/test_credentials_provider.py
+++ b/providers/google/tests/unit/google/cloud/utils/test_credentials_provider.py
@@ -526,6 +526,21 @@ class TestGetGcpCredentialsAndProjectId:
         mock_auth_default.assert_called_once_with(scopes=None)
         assert result == (mock_credentials, "")
 
+    @mock.patch("google.auth.load_credentials_from_dict", autospec=True)
+    def test_get_credentials_using_idp_no_project_id(self, mock_load_credentials_from_dict):
+        mock_credentials = mock.MagicMock()
+        mock_load_credentials_from_dict.return_value = (mock_credentials, None)
+
+        result = get_credentials_and_project_id(
+            credential_config_file=CREDENTIAL_CONFIG_STRING_FILE,
+            idp_issuer_url=IDP_LINK,
+            client_id=CLIENT_ID,
+            client_secret=CLIENT_SECRET,
+        )
+
+        mock_load_credentials_from_dict.assert_called_once()
+        assert result == (mock_credentials, "")
+
 
 class TestGetScopes:
     def test_get_scopes_with_default(self):


### PR DESCRIPTION
## Why

- #60146 made mypy pass after google-auth 2.46.0 added type hints and `google.auth.default()` started returning `str | None`. It did so by raising `AirflowException` whenever the resolved project id is `None`, in three branches of `credentials_provider.py`. That raise fires inside the provider, before the caller can apply a project id it was given explicitly.
- #61217 reported the consequence on the ADC branch: `CloudSecretManagerBackend` failed even when configured with an explicit `project_id`. #61654 fixed that branch by returning an empty string instead of raising, and moved the check to the consumer. The backend now raises `ValueError` only when neither its explicit `project_id` nor ADC provides one.
- The IdP branch kept the raise. It fires before `GoogleBaseHook` can apply the connection's `project` extra, so every Google hook on an IdP connection fails once google-auth cannot resolve a project id.  The message also asks for `key_secret_project_id`, which only the Secret Manager key path reads.

## How

- Return an empty project id from the IdP branch. No new check is needed: the only consumer of this branch is `GoogleBaseHook`, which already overrides the value with the connection's `project` extra and, through `fallback_to_default_project_id`, raises a message naming the fields that work when nothing provides a project id.

## Verification

- Unit test: `uv run --frozen --project providers/google pytest providers/google/tests/unit/google/cloud/utils/test_credentials_provider.py`
- Integration test:

1. Setup

```sh
export AIRFLOW_HOME=/tmp/airflow-idp-check
mkdir -p $AIRFLOW_HOME/dags
export AIRFLOW__CORE__DAGS_FOLDER=$AIRFLOW_HOME/dags
export AIRFLOW__CORE__LOAD_EXAMPLES=False
uv run --frozen airflow db migrate
```

2. Create Dag

```sh
cat > $AIRFLOW_HOME/dags/gcp_idp_check.py <<'EOF'
from airflow.sdk import dag, task


@dag(schedule=None, catchup=False)
def gcp_idp_check():
    @task
    def resolve_project():
        from airflow.providers.google.cloud.hooks.gcs import GCSHook

        hook = GCSHook(gcp_conn_id="gcp_idp")
        credentials, project_id = hook.get_credentials_and_project_id()
        print(f"credentials={type(credentials).__module__}.{type(credentials).__name__}")
        print(f"project_id={project_id!r}")
        print(f"storage_client_project={hook.get_conn().project!r}")

    resolve_project()


gcp_idp_check()
EOF
```

3. Add conn id

```sh
uv run --frozen airflow connections add gcp_idp --conn-type google_cloud_platform --conn-extra '{"credential_config_file": {"type": "external_account", "audience": "//iam.googleapis.com/locations/global/workforcePools/airflow-pool/providers/okta", "subject_token_type": "urn:ietf:params:oauth:token-type:id_token", "token_url": "https://sts.googleapis.com/v1/token"}, "idp_issuer_url": "https://login.example.com/oauth2/token", "client_id": "airflow-prod", "client_secret": "not-used-offline", "project": "my-explicit-project"}'
```

4. Run Dag

```sh
uv run --frozen airflow dags test gcp_idp_check
```

On main branch, this fails with `airflow.sdk.exceptions.AirflowException: Project ID could not be determined from default credentials. Please provide `key_secret_project_id` parameter.`.

On this PR, this runs successfully.

```
credentials=google.auth.identity_pool.Credentials
project_id='my-explicit-project'
storage_client_project='my-explicit-project'
```
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
