### PR TITLE
Honour dag_ignore_file_syntax in Task SDK and example plugin loading

### DIFF
--- a/shared/plugins_manager/src/airflow_shared/plugins_manager/plugins_manager.py
+++ b/shared/plugins_manager/src/airflow_shared/plugins_manager/plugins_manager.py
@@ -241,7 +241,7 @@ def _load_plugins_from_plugin_directory(
         log.debug("Note: Loading plugins from examples as well: %s", plugins_folder)
         example_plugins = importlib.import_module(example_plugins_module)
         example_plugins_folder = next(iter(example_plugins.__path__))
-        example_files = find_path_from_directory(example_plugins_folder, ".airflowignore")
+        example_files = find_path_from_directory(example_plugins_folder, ".airflowignore", ignore_file_syntax)
         plugin_search_locations.append((example_plugins.__name__, example_files))
 
     plugins: list[AirflowPlugin] = []

--- a/shared/plugins_manager/tests/plugins_manager/test_plugins_manager.py
+++ b/shared/plugins_manager/tests/plugins_manager/test_plugins_manager.py
@@ -29,7 +29,16 @@ from airflow_shared.plugins_manager import (
     EntryPointSource,
     PluginsDirectorySource,
     _load_entrypoint_plugins,
+    _load_plugins_from_plugin_directory,
 )
+
+_PLUGIN_SOURCE = """
+from airflow_shared.plugins_manager import AirflowPlugin
+
+
+class Plugin(AirflowPlugin):
+    name = "{name}"
+"""
 
 
 @pytest.fixture
@@ -110,6 +119,32 @@ class TestPluginsManager:
                 "test.plugins.test_plugins_manager",
                 "my_fake_module not found",
             ) in import_errors.items()
+
+
+class TestLoadPluginsFromPluginDirectory:
+    def test_example_plugins_airflowignore_uses_ignore_file_syntax(self, tmp_path, monkeypatch):
+        """The example plugins folder is filtered with the same ignore syntax as the plugins folder."""
+        example_plugins = tmp_path / "example_plugins_for_test"
+        example_plugins.mkdir()
+        (example_plugins / "__init__.py").touch()
+        # ``^`` and ``$`` are literal characters to the glob reader, so only the regexp reader matches.
+        (example_plugins / ".airflowignore").write_text(r"^ignored_.*\.py$")
+        for stem in ("kept_plugin", "ignored_plugin"):
+            (example_plugins / f"{stem}.py").write_text(_PLUGIN_SOURCE.format(name=stem))
+        plugins_folder = tmp_path / "plugins"
+        plugins_folder.mkdir()
+        monkeypatch.syspath_prepend(tmp_path)
+        monkeypatch.delitem(sys.modules, "example_plugins_for_test", raising=False)
+
+        plugins, import_errors = _load_plugins_from_plugin_directory(
+            plugins_folder=str(plugins_folder),
+            load_examples=True,
+            example_plugins_module="example_plugins_for_test",
+            ignore_file_syntax="regexp",
+        )
+
+        assert import_errors == {}
+        assert [plugin.name for plugin in plugins] == ["kept_plugin"]
 
 
 class TestAirflowPluginTeamName:

--- a/task-sdk/src/airflow/sdk/plugins_manager.py
+++ b/task-sdk/src/airflow/sdk/plugins_manager.py
@@ -103,11 +103,13 @@ def _get_plugins() -> tuple[list[AirflowPlugin], dict[str, str]]:
 
     with stats.timer() as timer:
         load_examples = conf.getboolean("core", "LOAD_EXAMPLES")
+        ignore_file_syntax = conf.get_mandatory_value("core", "DAG_IGNORE_FILE_SYNTAX", fallback="glob")
         __register_plugins(
             *_load_plugins_from_plugin_directory(
                 plugins_folder=settings.PLUGINS_FOLDER,
                 load_examples=load_examples,
                 example_plugins_module="airflow.example_dags.plugins" if load_examples else None,
+                ignore_file_syntax=ignore_file_syntax,
             )
         )
         __register_plugins(*_load_entrypoint_plugins())

--- a/task-sdk/tests/task_sdk/test_plugins_manager.py
+++ b/task-sdk/tests/task_sdk/test_plugins_manager.py
@@ -24,10 +24,20 @@ import pytest
 from airflow.sdk import plugins_manager
 from airflow.sdk.plugins_manager import AirflowPlugin
 
+from tests_common.test_utils.config import conf_vars
+
 # ``_disable_ol_plugin`` in ``task-sdk/tests/conftest.py`` is a session-scoped autouse fixture that
 # replaces ``_get_plugins`` with a stub returning no plugins. Capture the real, ``@cache``-wrapped
 # function here at collection time — before any fixture runs — so these tests can put it back.
 _REAL_GET_PLUGINS = plugins_manager._get_plugins
+
+_PLUGIN_SOURCE = """
+from airflow.sdk.plugins_manager import AirflowPlugin
+
+
+class Plugin(AirflowPlugin):
+    name = "{name}"
+"""
 
 
 class TestGetPlugins:
@@ -110,3 +120,27 @@ class TestGetPlugins:
 
         assert [plugin.name for plugin in plugins] == ["plugin_a"]
         assert len(import_errors) == 1
+
+    @conf_vars({("core", "dag_ignore_file_syntax"): "regexp", ("core", "load_examples"): "False"})
+    def test_plugins_folder_airflowignore_uses_dag_ignore_file_syntax(self, tmp_path):
+        """
+        ``.airflowignore`` in the plugins folder is read with ``[core] dag_ignore_file_syntax``.
+
+        ``airflow.plugins_manager`` already passes the setting through. If this copy silently falls
+        back to ``glob``, the scheduler and the task-running process load a different set of plugins
+        from the same folder.
+        """
+        # ``^`` and ``$`` are literal characters to the glob reader, so only the regexp reader matches.
+        (tmp_path / ".airflowignore").write_text(r"^ignored_.*\.py$")
+        for stem in ("kept_plugin", "ignored_plugin"):
+            (tmp_path / f"{stem}.py").write_text(_PLUGIN_SOURCE.format(name=stem))
+
+        with (
+            mock.patch.object(plugins_manager.settings, "PLUGINS_FOLDER", str(tmp_path)),
+            mock.patch.object(plugins_manager.settings, "LAZY_LOAD_PROVIDERS", True),
+            mock.patch.object(plugins_manager, "_load_entrypoint_plugins", return_value=([], {})),
+        ):
+            plugins, import_errors = plugins_manager._get_plugins()
+
+        assert import_errors == {}
+        assert [plugin.name for plugin in plugins] == ["kept_plugin"]


### PR DESCRIPTION
## Why
- #60114 moved `find_path_from_directory` into the shared `module_loading` library, where the ignore syntax defaults to a hard-coded `glob`. To keep the old behaviour, it made `_load_plugins_from_plugin_directory` in airflow-core read `[core] dag_ignore_file_syntax` and pass it to both the plugins folder call and the example plugins folder call.
- #59956 then moved `_load_plugins_from_plugin_directory` into `shared/plugins_manager` but carried over only half of that change: the plugins folder call gets `ignore_file_syntax`, while the example plugins call still uses the hard-coded default.
- #59956 also left the two wrappers calling the function with different arguments. `airflow.plugins_manager` passes `ignore_file_syntax` but `airflow.sdk.plugins_manager` does not.

## How
- Read `dag_ignore_file_syntax` in the Task SDK wrapper and pass it to `_load_plugins_from_plugin_directory`.
- Pass `ignore_file_syntax` to the example plugins `find_path_from_directory` call in the shared library.

## Verification
- `uv run --project task-sdk pytest task-sdk/tests/task_sdk/test_plugins_manager.py`
- `uv run --project shared/plugins_manager pytest shared/plugins_manager/tests/plugins_manager/test_plugins_manager.py`

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
