### PR TITLE
Fix DAG.cli() crashing on dags test --show-dagrun

### DIFF
--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -850,7 +850,7 @@ def dag_test(args, dag: DAG | None = None, *, session: Session = NEW_SESSION) ->
     if show_dagrun or imgcat or filename:
         tis = session.scalars(
             select(TaskInstance).where(
-                TaskInstance.dag_id == args.dag_id,
+                TaskInstance.dag_id == dag.dag_id,
                 TaskInstance.run_id == dr.run_id,
             )
         ).all()

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -945,6 +945,7 @@ class TestCliDags:
     @mock.patch("airflow.cli.commands.dag_command.get_bagged_dag")
     def test_dag_test_show_dag(self, mock_get_dag, mock_render_dag, stdout_capture):
         mock_get_dag.return_value.test.return_value.run_id = "__test_dag_test_show_dag_fake_dag_run_run_id__"
+        mock_get_dag.return_value.dag_id = "example_bash_operator"
 
         cli_args = self.parser.parse_args(
             ["dags", "test", "example_bash_operator", DEFAULT_DATE.isoformat(), "--show-dagrun"]
@@ -968,6 +969,23 @@ class TestCliDags:
         )
         mock_render_dag.assert_has_calls([mock.call(mock_get_dag.return_value, tis=[])])
         assert "SOURCE" in output
+
+    @mock.patch("airflow.cli.commands.dag_command.render_dag", autospec=True)
+    @mock.patch.object(DAG, "test", autospec=True)
+    def test_dag_test_show_dag_from_dag_cli(self, mock_test, mock_render_dag, dag_maker):
+        """``DAG.cli()`` passes the Dag positionally and its parser drops ``dag_id``."""
+        with dag_maker("dag_cli_show_dagrun", schedule=None) as dag:
+            EmptyOperator(task_id="only_task")
+        mock_test.return_value = dag_maker.create_dagrun(run_id="dag_cli_run")
+
+        parser = cli_parser.get_parser(dag_parser=True)
+        dag_command.dag_test(parser.parse_args(["dags", "test", "--show-dagrun"]), dag)
+
+        mock_render_dag.assert_called_once()
+        assert mock_render_dag.call_args.args[0] is dag
+        assert [(ti.dag_id, ti.task_id, ti.run_id) for ti in mock_render_dag.call_args.kwargs["tis"]] == [
+            ("dag_cli_show_dagrun", "only_task", "dag_cli_run")
+        ]
 
     @mock.patch("airflow.dag_processing.dagbag.BundleDagBag")
     def test_dag_test_with_bundle_name(self, mock_dagbag, configure_dag_bundles):

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -972,14 +972,15 @@ class TestCliDags:
 
     @mock.patch("airflow.cli.commands.dag_command.render_dag", autospec=True)
     @mock.patch.object(DAG, "test", autospec=True)
-    def test_dag_test_show_dag_from_dag_cli(self, mock_test, mock_render_dag, dag_maker):
+    def test_dag_test_show_dag_from_dag_cli(self, mock_test, mock_render_dag, dag_maker, stdout_capture):
         """``DAG.cli()`` passes the Dag positionally and its parser drops ``dag_id``."""
         with dag_maker("dag_cli_show_dagrun", schedule=None) as dag:
             EmptyOperator(task_id="only_task")
         mock_test.return_value = dag_maker.create_dagrun(run_id="dag_cli_run")
 
         parser = cli_parser.get_parser(dag_parser=True)
-        dag_command.dag_test(parser.parse_args(["dags", "test", "--show-dagrun"]), dag)
+        with stdout_capture:
+            dag_command.dag_test(parser.parse_args(["dags", "test", "--show-dagrun"]), dag)
 
         mock_render_dag.assert_called_once()
         assert mock_render_dag.call_args.args[0] is dag


### PR DESCRIPTION
Running a Dag file as a script (`python my_dag.py dags test --show-dagrun`) goes through `DAG.cli()`. Its Dag-scoped parser drops the `dag_id` positional and passes the Dag object to the handler instead, so the parsed `Namespace` has no `dag_id` attribute at all. `dag_test` never needed it until it rendered the run: the task instance query read `args.dag_id`, so `--show-dagrun`, `--save-dagrun` and `--imgcat-dagrun` all raised `AttributeError: 'Namespace' object has no attribute 'dag_id'` after the Dag had already run, while the same command without a rendering flag succeeded. The regular `airflow dags test <dag_id> --show-dagrun` path was never affected.

### Fix

The query now filters on the resolved Dag's id. On the regular path that is the same string as `args.dag_id` (the Dag was looked up by it), and on the `DAG.cli()` path it is the only id available. That lookup was the single reader of `args.dag_id` after the Dag is resolved, because `dag or get_bagged_dag(...)` short-circuits when a Dag is passed in.

### Testing

- New `test_dag_test_show_dag_from_dag_cli` drives `dag_test` the way `DAG.cli()` does (Dag-scoped parser, Dag passed positionally), seeds a Dag run with one task instance via `dag_maker`, and asserts that instance reaches `render_dag`. Without the fix it fails on the same `AttributeError`; with it the whole file passes (107 tests).
- `test_dag_test_show_dag` now gives its mocked Dag a real `dag_id`, since a `MagicMock` cannot be bound as a SQL parameter.
- Reproduced end to end on a sqlite metadata DB with a one-task Dag in the dags folder: before the fix the `DAG.cli()` invocation exited 1 with the traceback above; after it prints the same DOT graph as `airflow dags test <dag_id> --show-dagrun`.

Note for reproduction: the Dag file has to live inside a configured bundle and be serialized first (`airflow dags reserialize`), otherwise `dag.test()` fails earlier on both paths with "Cannot create DagRun ... because the dag is not serialized".

Related: #72109 fixed the same `DAG.cli()` dispatch shape for `dags pause` and `dags unpause`.

A pre-existing, separate limitation surfaced during review and is out of scope here: `@action_cli` snapshots `dag_id` from the `Namespace` before the handler runs, so audit `Log` rows for any `DAG.cli()` subcommand carry `dag_id=NULL`. The natural place to fix that is `DAG.cli()` itself.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5.1)

Generated-by: Claude Code (Fable 5.1) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
