### PR TITLE
Reuse the explicit dag_run join on the previous-TI lookup

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -36,7 +36,7 @@ from pydantic import JsonValue, ValidationError
 from sqlalchemy import and_, func, or_, tuple_, update
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import DataError, NoResultFound, SQLAlchemyError
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import contains_eager, joinedload, load_only
 from sqlalchemy.sql import select
 from structlog.contextvars import bind_contextvars
 
@@ -1213,7 +1213,7 @@ def get_previous_task_instance(
     query = (
         select(TI)
         .join(DR, (TI.dag_id == DR.dag_id) & (TI.run_id == DR.run_id))
-        .options(joinedload(TI.dag_run))
+        .options(contains_eager(TI.dag_run).load_only(DR.logical_date))
         .where(TI.dag_id == dag_id, TI.task_id == task_id, TI.map_index == map_index)
         .order_by(DR.logical_date.desc())
     )

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -36,7 +36,7 @@ from pydantic import JsonValue, ValidationError
 from sqlalchemy import and_, func, or_, tuple_, update
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import DataError, NoResultFound, SQLAlchemyError
-from sqlalchemy.orm import contains_eager, joinedload, load_only
+from sqlalchemy.orm import contains_eager, joinedload
 from sqlalchemy.sql import select
 from structlog.contextvars import bind_contextvars
 

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -3887,7 +3887,8 @@ class TestGetPreviousTI:
         assert data["state"] == State.SUCCESS
 
     def test_get_previous_ti_query_is_bounded(self, client, session, create_task_instance):
-        """The single-row previous-TI lookup must ask the DB for one row."""
+        """The single-row previous-TI lookup must ask the DB for one row, join ``dag_run`` once,
+        and surface the eager-loaded ``logical_date`` in the response."""
         for i in range(5):
             create_task_instance(
                 task_id="test_task",
@@ -3904,10 +3905,16 @@ class TestGetPreviousTI:
             )
 
         assert response.status_code == 200
-        assert response.json()["run_id"] == "run4"
+        data = response.json()
+        assert data["run_id"] == "run4"
+        assert data["logical_date"] == "2025-01-04T00:00:00Z"
         assert statements, "expected the endpoint to query the task_instance table"
         for sql in statements:
             assert re.search(r"\bLIMIT 1\b", sql), f"previous-TI lookup is not bounded to one row: {sql}"
+            dag_run_join_count = len(re.findall(r"JOIN dag_run(\s|$)", sql))
+            assert dag_run_join_count == 1, (
+                f"previous-TI query joins dag_run {dag_run_join_count} times, expected once: {sql}"
+            )
 
 
 class TestGetTaskStates:

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -3898,7 +3898,10 @@ class TestGetPreviousTI:
             )
         session.commit()
 
-        with capture_orm_selects("task_instance") as statements:
+        with (
+            capture_orm_selects("task_instance") as statements,
+            capture_orm_selects("dag_run") as dag_run_only_selects,
+        ):
             response = client.get(
                 "/execution/task-instances/previous/dag/test_task",
                 params={"logical_date": "2025-01-05T00:00:00Z"},
@@ -3915,6 +3918,10 @@ class TestGetPreviousTI:
             assert dag_run_join_count == 1, (
                 f"previous-TI query joins dag_run {dag_run_join_count} times, expected once: {sql}"
             )
+        assert not dag_run_only_selects, (
+            "logical_date should come from the eager-loaded dag_run join, but a separate "
+            f"SELECT was issued: {dag_run_only_selects}"
+        )
 
 
 class TestGetTaskStates:

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -59,7 +59,7 @@ from airflow.sdk import Asset, TaskGroup, TriggerRule, task, task_group
 from airflow.state.metastore import MetastoreBackend
 from airflow.utils.state import DagRunState, State, TaskInstanceState, TerminalTIState
 
-from tests_common.test_utils.asserts import capture_orm_selects
+from tests_common.test_utils.asserts import assert_queries_count, capture_orm_selects
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import (
     clear_db_assets,
@@ -3900,7 +3900,7 @@ class TestGetPreviousTI:
 
         with (
             capture_orm_selects("task_instance") as statements,
-            capture_orm_selects("dag_run") as dag_run_only_selects,
+            assert_queries_count(1),
         ):
             response = client.get(
                 "/execution/task-instances/previous/dag/test_task",
@@ -3918,10 +3918,6 @@ class TestGetPreviousTI:
             assert dag_run_join_count == 1, (
                 f"previous-TI query joins dag_run {dag_run_join_count} times, expected once: {sql}"
             )
-        assert not dag_run_only_selects, (
-            "logical_date should come from the eager-loaded dag_run join, but a separate "
-            f"SELECT was issued: {dag_run_only_selects}"
-        )
 
 
 class TestGetTaskStates:


### PR DESCRIPTION
Follow-up to #72699. That PR bounded the ``get_previous_task_instance`` lookup
with ``.limit(1)``; @kaxil noted in review that the same query also asks for an
eager-load that duplicates work the mapper already does.

``TaskInstance.dag_run`` is ``lazy="joined"`` (``airflow-core/src/airflow/models/taskinstance.py:727``),
so the explicit ``joinedload(TI.dag_run)`` attaches a parallel ``JOIN dag_run AS dag_run_1``
next to the explicit ``JOIN dag_run`` the query already needs for the
``ORDER BY dag_run.logical_date``. Both joins select the same rows over the same
``(dag_id, run_id)`` FK pair, so every request paid for one extra join.

Switch to ``contains_eager(TI.dag_run)`` so the mapper's eager-load reuses the
explicit join. Compiled SQL drops from ``JOIN dag_run ... JOIN dag_run AS dag_run_1 ...``
to a single ``JOIN dag_run``; the regression test in this PR fails on the old
shape and passes on the new one.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)