### PR TITLE
Add unit tests for BaseBotoWaiter in Amazon provider

### DIFF
--- a/airflow-core/tests/unit/always/test_project_structure.py
+++ b/airflow-core/tests/unit/always/test_project_structure.py
@@ -77,7 +77,6 @@ class TestProjectStructure:
             "providers/amazon/tests/unit/amazon/aws/triggers/test_step_function.py",
             "providers/amazon/tests/unit/amazon/aws/utils/test_rds.py",
             "providers/amazon/tests/unit/amazon/aws/utils/test_sagemaker.py",
-            "providers/amazon/tests/unit/amazon/aws/waiters/test_base_waiter.py",
             "providers/apache/hdfs/tests/unit/apache/hdfs/hooks/test_hdfs.py",
             "providers/apache/hdfs/tests/unit/apache/hdfs/sensors/test_hdfs.py",
             "providers/apache/hive/tests/unit/apache/hive/plugins/test_hive.py",

--- a/providers/amazon/tests/unit/amazon/aws/waiters/test_base_waiter.py
+++ b/providers/amazon/tests/unit/amazon/aws/waiters/test_base_waiter.py
@@ -1,0 +1,109 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+from botocore.waiter import Waiter, WaiterModel
+
+from airflow.providers.amazon.aws.waiters.base_waiter import BaseBotoWaiter
+
+SAMPLE_WAITER_MODEL_CONFIG = {
+    "version": 2,
+    "waiters": {
+        "sample_waiter": {
+            "operation": "DescribeInstances",
+            "delay": 15,
+            "maxAttempts": 40,
+            "acceptors": [
+                {
+                    "matcher": "path",
+                    "expected": "running",
+                    "state": "success",
+                    "argument": "status",
+                }
+            ],
+        }
+    },
+}
+
+
+class TestBaseBotoWaiter:
+    @pytest.fixture
+    def mock_client(self):
+        client = mock.MagicMock()
+        client.meta.service_model.metadata = {"serviceFullName": "EC2"}
+        return client
+
+    def test_init_defaults(self, mock_client):
+        waiter = BaseBotoWaiter(client=mock_client, model_config=SAMPLE_WAITER_MODEL_CONFIG)
+        assert waiter.client is mock_client
+        assert isinstance(waiter.model, WaiterModel)
+        assert waiter.deferrable is False
+
+    def test_init_deferrable(self, mock_client):
+        waiter = BaseBotoWaiter(client=mock_client, model_config=SAMPLE_WAITER_MODEL_CONFIG, deferrable=True)
+        assert waiter.client is mock_client
+        assert isinstance(waiter.model, WaiterModel)
+        assert waiter.deferrable is True
+
+    @mock.patch("airflow.providers.amazon.aws.waiters.base_waiter.create_waiter_with_client")
+    def test_waiter_sync(self, mock_create_waiter, mock_client):
+        waiter_instance = mock.MagicMock(spec=Waiter)
+        mock_create_waiter.return_value = waiter_instance
+
+        boto_waiter = BaseBotoWaiter(
+            client=mock_client, model_config=SAMPLE_WAITER_MODEL_CONFIG, deferrable=False
+        )
+        result = boto_waiter.waiter("sample_waiter")
+
+        mock_create_waiter.assert_called_once_with(
+            waiter_name="sample_waiter", waiter_model=boto_waiter.model, client=mock_client
+        )
+        assert result is waiter_instance
+
+    @mock.patch("aiobotocore.waiter.create_waiter_with_client")
+    def test_waiter_deferrable(self, mock_async_create_waiter, mock_client):
+        async_waiter_instance = mock.MagicMock()
+        mock_async_create_waiter.return_value = async_waiter_instance
+
+        boto_waiter = BaseBotoWaiter(
+            client=mock_client, model_config=SAMPLE_WAITER_MODEL_CONFIG, deferrable=True
+        )
+        result = boto_waiter.waiter("sample_waiter")
+
+        mock_async_create_waiter.assert_called_once_with(
+            waiter_name="sample_waiter", waiter_model=boto_waiter.model, client=mock_client
+        )
+        assert result is async_waiter_instance
+
+    def test_waiter_with_real_botocore_creation(self, mock_client):
+        boto_waiter = BaseBotoWaiter(
+            client=mock_client, model_config=SAMPLE_WAITER_MODEL_CONFIG, deferrable=False
+        )
+        real_waiter = boto_waiter.waiter("sample_waiter")
+        assert isinstance(real_waiter, Waiter)
+        assert real_waiter.name == "sample_waiter"
+
+    def test_waiter_unknown_name_raises_value_error(self, mock_client):
+        boto_waiter = BaseBotoWaiter(
+            client=mock_client, model_config=SAMPLE_WAITER_MODEL_CONFIG, deferrable=False
+        )
+        with pytest.raises(ValueError, match="Waiter does not exist: unknown_waiter"):
+            boto_waiter.waiter("unknown_waiter")


### PR DESCRIPTION
### Why

`providers/amazon/src/airflow/providers/amazon/aws/waiters/base_waiter.py` is listed on the `OVERLOOKED_TESTS` allowlist in `airflow-core/tests/unit/always/test_project_structure.py`, tracked by meta-issue #35442.

`BaseBotoWaiter` is the foundation class used to instantiate both synchronous and asynchronous custom Boto3 waiters across Amazon provider hooks, but lacked a dedicated unit test suite.

### How

Adds `providers/amazon/tests/unit/amazon/aws/waiters/test_base_waiter.py` covering:
- Initialization with default parameters (`deferrable=False`) and custom `deferrable=True`.
- Proper instantiation and attribute assignment of `WaiterModel` and Boto client.
- Synchronous waiter creation path via `botocore.waiter.create_waiter_with_client`.
- Asynchronous / deferrable waiter creation path via `aiobotocore.waiter.create_waiter_with_client`.
- Real `botocore.waiter.Waiter` object generation with valid waiter models.
- Exception handling when an unknown waiter name is requested (`ValueError`).

### What

6 unit tests added. The module's entry is removed from `OVERLOOKED_TESTS` in `airflow-core/tests/unit/always/test_project_structure.py`.

Verified locally:
```
uv run --project providers/amazon pytest providers/amazon/tests/unit/amazon/aws/waiters/test_base_waiter.py -v
# 6 passed, 1 warning in 1.06s

uv run --project airflow-core pytest airflow-core/tests/unit/always/test_project_structure.py -k test_providers_modules_should_have_tests -v
# 1 passed, 10 deselected in 5.22s
```

related: #35442

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
