### PR TITLE
Fix XCom loss in deferrable KubernetesPodOperator when pod is already terminal

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -803,7 +803,7 @@ class KubernetesPodOperator(BaseOperator):
         if not self.deferrable:
             return self.execute_sync(context)
 
-        self.execute_async(context)
+        return self.execute_async(context)
 
     def execute_sync(self, context: Context):
         result = None
@@ -955,7 +955,7 @@ class KubernetesPodOperator(BaseOperator):
         del self.client
         del self.pod_manager
 
-    def execute_async(self, context: Context) -> None:
+    def execute_async(self, context: Context) -> Any:
         if self.pod_request_obj is None:
             self.pod_request_obj = self.build_pod_request_obj(context)
         for callback in self.callbacks:
@@ -991,9 +991,8 @@ class KubernetesPodOperator(BaseOperator):
         # provider where invoke_defer_method does not accept context parameter
         sig = inspect.signature(self.invoke_defer_method)
         if "context" in sig.parameters:
-            self.invoke_defer_method(context=context)
-        else:
-            self.invoke_defer_method()
+            return self.invoke_defer_method(context=context)
+        return self.invoke_defer_method()
 
     def convert_config_file_to_dict(self):
         """Convert passed config_file to dict representation."""
@@ -1006,7 +1005,7 @@ class KubernetesPodOperator(BaseOperator):
 
     def invoke_defer_method(
         self, last_log_time: DateTime | None = None, context: Context | None = None
-    ) -> None:
+    ) -> Any:
         """Redefine triggers which are being used in child classes."""
         self.convert_config_file_to_dict()
 
@@ -1071,7 +1070,7 @@ class KubernetesPodOperator(BaseOperator):
             pod_container_state == ContainerState.TERMINATED or pod_container_state == ContainerState.FAILED
         ):
             self.log.info("Skipping deferral as pod is already in a terminal state")
-            self.trigger_reentry(
+            return self.trigger_reentry(
                 context=context,
                 event={
                     "status": "failed" if pod_container_state == ContainerState.FAILED else "success",
@@ -1084,8 +1083,7 @@ class KubernetesPodOperator(BaseOperator):
                     **(self.trigger_kwargs or {}),
                 },
             )
-        else:
-            self.defer(trigger=trigger, method_name="trigger_reentry", timeout=defer_timeout)
+        self.defer(trigger=trigger, method_name="trigger_reentry", timeout=defer_timeout)
 
     def trigger_reentry(self, context: Context, event: dict[str, Any]) -> Any:
         """

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
@@ -355,8 +355,7 @@ class SparkKubernetesOperator(KubernetesPodOperator):
         self._setup_spark_configuration(context)
 
         if self.deferrable:
-            self.execute_async(context)
-            return
+            return self.execute_async(context)
 
         return super().execute(context)
 

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -3155,6 +3155,73 @@ class TestKubernetesPodOperatorAsync:
         assert trigger.trigger_kwargs["_execution_deadline"] == expected_deadline
         assert exc.value.timeout == datetime.timedelta(seconds=270 + 60)
 
+    @patch(KUB_OP_PATH.format("trigger_reentry"))
+    @patch(KUB_OP_PATH.format("convert_config_file_to_dict"))
+    @patch("airflow.providers.cncf.kubernetes.operators.pod.BaseHook.get_connection")
+    def test_invoke_defer_method_returns_trigger_reentry_result_when_pod_already_terminal(
+        self, mocked_get_connection, mocked_convert_config, mocked_trigger_reentry
+    ):
+        """
+        When the pod is already terminal, ``invoke_defer_method`` calls
+        ``trigger_reentry`` inline instead of deferring. Its return value carries the
+        XCom sidecar output, so it has to be propagated to the caller -- in the regular
+        deferral path Airflow takes it from the resume method and stores it as
+        ``return_value``.
+
+        Dropping it makes ``do_xcom_push`` silently produce no ``return_value`` while
+        the task still succeeds, and downstream tasks pulling that XCom get ``None``.
+        """
+        mocked_get_connection.side_effect = AirflowNotFoundException("connection not found")
+        mocked_trigger_reentry.return_value = {"key": "value"}
+
+        k = KubernetesPodOperator(
+            task_id=TEST_TASK_ID,
+            namespace=TEST_NAMESPACE,
+            image=TEST_IMAGE,
+            name=TEST_NAME,
+            on_finish_action="keep_pod",
+            in_cluster=True,
+            deferrable=True,
+            do_xcom_push=True,
+        )
+        k.pod = MagicMock()
+        k.pod.metadata.name = TEST_NAME
+        k.pod.metadata.namespace = TEST_NAMESPACE
+
+        context = {"ti": MagicMock()}
+        with patch(f"{TRIGGER_CLASS}.define_pod_container_state", return_value=ContainerState.TERMINATED):
+            result = k.invoke_defer_method(context=context)
+
+        mocked_trigger_reentry.assert_called_once()
+        assert result == {"key": "value"}
+
+    @patch(KUB_OP_PATH.format("invoke_defer_method"))
+    @patch(KUB_OP_PATH.format("build_pod_request_obj"))
+    @patch(KUB_OP_PATH.format("get_or_create_pod"))
+    def test_execute_returns_deferrable_result(
+        self, mocked_get_or_create_pod, mocked_build_pod_request_obj, mocked_invoke_defer_method
+    ):
+        """
+        ``execute`` has to hand the deferrable result back to Airflow the same way the
+        synchronous branch does, otherwise the value produced by the inline
+        ``trigger_reentry`` call never becomes the task's ``return_value`` XCom.
+        """
+        mocked_invoke_defer_method.return_value = {"key": "value"}
+        mocked_get_or_create_pod.return_value = MagicMock()
+
+        k = KubernetesPodOperator(
+            task_id=TEST_TASK_ID,
+            namespace=TEST_NAMESPACE,
+            image=TEST_IMAGE,
+            name=TEST_NAME,
+            on_finish_action="keep_pod",
+            in_cluster=True,
+            deferrable=True,
+            do_xcom_push=True,
+        )
+
+        assert k.execute(context={"ti": MagicMock()}) == {"key": "value"}
+
     @patch(KUB_OP_PATH.format("convert_config_file_to_dict"))
     @patch("airflow.providers.cncf.kubernetes.operators.pod.BaseHook.get_connection")
     def test_invoke_defer_method_pads_defer_timeout_for_slow_poll_interval(

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_spark_kubernetes.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_spark_kubernetes.py
@@ -1272,7 +1272,8 @@ class TestSparkKubernetesOperator:
 
         mock_execute_async.assert_called_once_with(context)
         mock_parent_execute.assert_not_called()
-        assert result is None
+        # The deferrable result carries the XCom sidecar output, so it has to reach the caller.
+        assert result is mock_execute_async.return_value
 
     def test_execute_non_deferrable_calls_super(
         self,


### PR DESCRIPTION
## Why

When the pod reaches a terminal state before the operator defers, `invoke_defer_method` calls `trigger_reentry` inline instead of deferring:

```python
if context and (
    pod_container_state == ContainerState.TERMINATED or pod_container_state == ContainerState.FAILED
):
    self.log.info("Skipping deferral as pod is already in a terminal state")
    self.trigger_reentry(...)          # return value dropped
else:
    self.defer(trigger=trigger, method_name="trigger_reentry", timeout=defer_timeout)
```

`trigger_reentry` ends with:

```python
if self.do_xcom_push:
    return xcom_sidecar_output
```

That value was dropped at every level above it — `invoke_defer_method`, `execute_async`, and the deferrable branch of `execute` all called down without returning.

In the regular deferral path Airflow takes the return value of the resume method (`trigger_reentry`) and stores it as `return_value`, so the loss only happens on this shortcut. `execute_sync` already returns its result, which is why non-deferrable runs are unaffected.

The failure is silent. The task still succeeds, and `pod_name` / `pod_namespace` are pushed separately by `execute_async`, so the XCom entries look populated:

| | XCom keys |
|---|---|
| shortcut path | `pod_name`, `pod_namespace` |
| regular deferral | `pod_name`, `pod_namespace`, `return_value` |

Downstream tasks pulling that XCom get `None`. In our deployment a Jinja template doing `{{ ti.xcom_pull(task_ids="fetch")["data_key"] }}` failed with `'None' has no attribute 'data_key'`, three retries deep, while the upstream task was reported as `success`. Retrying cannot help — the XCom is already gone.

Task logs make the two paths easy to tell apart:

```
# affected
Reusing existing pod '...' (phase=Running, reason=) since it is not terminated or evicted.
Skipping deferral as pod is already in a terminal state
Deleting pod: ...
                          <- no "Pushing xcom"

# working
Pausing task as DEFERRED.
Deleting pod: ...
Pushing xcom
```

Pods that finish within a second or two hit this often, which is why it showed up intermittently across several DAGs rather than as a hard failure.

## What

Propagate the return value through the call sites, and widen the two return annotations (`-> None` → `-> Any`) accordingly.

`SparkKubernetesOperator.execute` dropped the deferrable result the same way, so it is fixed in the same commit — otherwise the fix would stop at `KubernetesPodOperator` and Spark tasks would still lose `return_value`.

New tests:

- `test_invoke_defer_method_returns_trigger_reentry_result_when_pod_already_terminal` — the inline call's result is returned
- `test_execute_returns_deferrable_result` — `execute` hands the deferrable result back, as the synchronous branch already does

Both fail on `main` with `assert None == {'key': 'value'}` and pass with the change.

One existing test was updated: `test_execute_deferrable_does_not_call_super` asserted `result is None`, which pinned the dropped-return behaviour rather than the "does not call super" contract the test is named for. It now asserts the result reaches the caller.

## Scope notes

- Subclasses overriding `invoke_defer_method` are unaffected. `GKEStartPodOperator` (google) only calls `self.defer(...)`, so it has no shortcut path. `EksPodOperator` (amazon) has the same inline shortcut and still returns `None`; this change neither breaks it nor fixes it. I left it out to keep this PR to one provider — it looks worth a separate PR.
- I could not find an existing issue or PR for this. #72502 fixes a different XCom-loss path (`container_logs` substring check in the synchronous branch), and #67226 fixed a related case where the deferrable path dropped `multiple_outputs` handling.

## Testing

```
pytest providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py \
       providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_spark_kubernetes.py
```

300 passed. Two failures and ten errors (`TestSuppress`, `write_logs`) reproduce identically on unmodified `main` on my machine, so they are local environment issues rather than regressions from this change.

`ruff check` and `ruff format --check` pass on all touched files.

## Gen-AI disclosure

This PR was prepared with the assistance of Gen-AI tools. The root cause was located by reading provider source and correlating it against Airflow API data and task logs from a real deployment where the bug occurred. I reviewed the diff and the tests, ran them locally, and I am able to explain and stand behind the change.