### PR TITLE
UI: Fix Grid view for bidirectional TaskGroup dependencies

### DIFF
--- a/airflow-core/src/airflow/serialization/definitions/taskgroup.py
+++ b/airflow-core/src/airflow/serialization/definitions/taskgroup.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING
 import attrs
 import methodtools
 
-from airflow._shared.dagnode.node import TaskGroupMixin
+from airflow._shared.dagnode.node import TaskGroupMixin, has_task_cycle, sort_projected_indices
 from airflow.serialization.definitions.node import DAGNode
 
 if TYPE_CHECKING:
@@ -236,10 +236,10 @@ class SerializedTaskGroup(TaskGroupMixin, DAGNode):
         """
         Sort children topologically — a task always comes after its upstream dependencies.
 
-        See ``TaskGroup.topological_sort`` in task-sdk for the algorithm. Cycles are
-        treated as corrupt input: ``DAG.check_cycle`` rejects cyclic Dags before
-        serialization, so a cycle reaching this code indicates malformed serialized data,
-        and we raise ``ValueError`` rather than silently looping forever.
+        See ``TaskGroup.topological_sort`` in task-sdk for the algorithm. The sibling
+        projection can contain cycles when independent task-level dependencies cross
+        between TaskGroups in both directions. Those components preserve child insertion
+        order; actual task-level cycles are rejected before serialization.
         """
         children = self.children
         if not children:
@@ -329,7 +329,7 @@ class SerializedTaskGroup(TaskGroupMixin, DAGNode):
                 emitted[i] = 1
                 order_append(nodes[i])
             if len(next_pending) == len(pending):
-                raise ValueError(f"A cyclic dependency occurred in dag: {self.dag_id}")
+                return self._sort_cyclic_projection(nodes, projected)
             pending = next_pending
         return order
 
@@ -364,10 +364,20 @@ class SerializedTaskGroup(TaskGroupMixin, DAGNode):
                     queue.append(s)
 
         if processed != n:
-            raise ValueError(f"A cyclic dependency occurred in dag: {self.dag_id}")
+            return self._sort_cyclic_projection(nodes, projected)
 
         sorted_indices = sorted(range(n), key=lambda i: (pass_of[i], i))
         return [nodes[i] for i in sorted_indices]
+
+    def _sort_cyclic_projection(
+        self, nodes: list[DAGNode], projected: list[tuple[int, ...]]
+    ) -> list[DAGNode]:
+        downstream_ids_by_task = {
+            task_id: task.downstream_task_ids for task_id, task in self.dag.task_dict.items()
+        }
+        if has_task_cycle(downstream_ids_by_task):
+            raise ValueError(f"A cyclic dependency occurred in dag: {self.dag_id}")
+        return [nodes[i] for i in sort_projected_indices(projected)]
 
     def add(self, node: DAGNode) -> DAGNode:
         # Set the TG first, as setting it might change the return value of node_id!

--- a/airflow-core/tests/unit/serialization/definitions/test_taskgroup.py
+++ b/airflow-core/tests/unit/serialization/definitions/test_taskgroup.py
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import pytest
+
+from airflow.api_fastapi.core_api.services.ui.task_group import task_group_to_dict_grid
+from airflow.providers.standard.operators.empty import EmptyOperator
+from airflow.sdk import DAG, TaskGroup, timezone
+from airflow.serialization.serialized_objects import DagSerialization
+
+
+@pytest.mark.parametrize("group_count", [2, 3])
+def test_topological_sort_bidirectional_task_level_cross_group_deps(group_count):
+    """Sibling projection cycles do not imply a cycle in the task-level Dag."""
+    outbound = {}
+    inbound = {}
+    with DAG(
+        "test_bidirectional_cross_group_deps",
+        schedule=None,
+        start_date=timezone.datetime(2025, 1, 1),
+    ) as dag:
+        for group_idx in range(group_count):
+            with TaskGroup(f"group_{group_idx}"):
+                for other_idx in range(group_count):
+                    if group_idx == other_idx:
+                        continue
+                    outbound[group_idx, other_idx] = EmptyOperator(task_id=f"to_{other_idx}")
+                    inbound[group_idx, other_idx] = EmptyOperator(task_id=f"from_{other_idx}")
+
+        for source_idx in range(group_count):
+            for target_idx in range(group_count):
+                if source_idx != target_idx:
+                    outbound[source_idx, target_idx] >> inbound[target_idx, source_idx]
+
+    dag.check_cycle()
+    serialized = DagSerialization.from_dict(DagSerialization.to_dict(dag))
+    expected_order = [f"group_{idx}" for idx in range(group_count)]
+
+    assert [node.node_id for node in serialized.task_group.topological_sort()] == expected_order
+    grid = task_group_to_dict_grid(serialized.task_group)
+    assert [child["id"] for child in grid["children"]] == expected_order
+
+    inbound[1, 0] >> outbound[0, 1]
+    cyclic_serialized = DagSerialization.from_dict(DagSerialization.to_dict(dag))
+    with pytest.raises(ValueError, match="A cyclic dependency occurred"):
+        cyclic_serialized.task_group.topological_sort()

--- a/shared/dagnode/src/airflow_shared/dagnode/node.py
+++ b/shared/dagnode/src/airflow_shared/dagnode/node.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import heapq
 from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
 
 import structlog
@@ -65,6 +66,103 @@ class TaskGroupProtocol(Protocol):
 Dag = TypeVar("Dag", bound=DagProtocol)
 Task = TypeVar("Task", bound=TaskProtocol)
 TaskGroup = TypeVar("TaskGroup", bound=TaskGroupProtocol)
+
+
+def has_task_cycle(downstream_ids_by_task: dict[str, set[str]]) -> bool:
+    """Return whether task-level dependencies contain a cycle."""
+    in_degree = {task_id: 0 for task_id in downstream_ids_by_task}
+    for downstream_ids in downstream_ids_by_task.values():
+        for downstream_id in downstream_ids:
+            if downstream_id in in_degree:
+                in_degree[downstream_id] += 1
+
+    ready = [task_id for task_id, degree in in_degree.items() if degree == 0]
+    processed = 0
+    while ready:
+        task_id = ready.pop()
+        processed += 1
+        for downstream_id in downstream_ids_by_task[task_id]:
+            if downstream_id not in in_degree:
+                continue
+            in_degree[downstream_id] -= 1
+            if in_degree[downstream_id] == 0:
+                ready.append(downstream_id)
+    return processed != len(downstream_ids_by_task)
+
+
+def sort_projected_indices(projected: list[tuple[int, ...]]) -> list[int]:
+    """Topologically sort a sibling projection, preserving insertion order within cycles."""
+    n = len(projected)
+    successors: list[list[int]] = [[] for _ in range(n)]
+    for child_idx, dependencies in enumerate(projected):
+        for dependency_idx in dependencies:
+            successors[dependency_idx].append(child_idx)
+
+    visited = bytearray(n)
+    finish_order: list[int] = []
+    for start_idx in range(n):
+        if visited[start_idx]:
+            continue
+        visited[start_idx] = 1
+        stack = [(start_idx, 0)]
+        while stack:
+            node_idx, successor_offset = stack[-1]
+            if successor_offset == len(successors[node_idx]):
+                finish_order.append(node_idx)
+                stack.pop()
+                continue
+            successor_idx = successors[node_idx][successor_offset]
+            stack[-1] = (node_idx, successor_offset + 1)
+            if not visited[successor_idx]:
+                visited[successor_idx] = 1
+                stack.append((successor_idx, 0))
+
+    component_by_node = [-1] * n
+    components: list[list[int]] = []
+    for start_idx in reversed(finish_order):
+        if component_by_node[start_idx] != -1:
+            continue
+        component_idx = len(components)
+        component_by_node[start_idx] = component_idx
+        component: list[int] = []
+        component_stack = [start_idx]
+        while component_stack:
+            node_idx = component_stack.pop()
+            component.append(node_idx)
+            for dependency_idx in projected[node_idx]:
+                if component_by_node[dependency_idx] == -1:
+                    component_by_node[dependency_idx] = component_idx
+                    component_stack.append(dependency_idx)
+        component.sort()
+        components.append(component)
+
+    component_successors: list[set[int]] = [set() for _ in components]
+    component_in_degree = [0] * len(components)
+    for child_idx, dependencies in enumerate(projected):
+        child_component = component_by_node[child_idx]
+        for dependency_idx in dependencies:
+            dependency_component = component_by_node[dependency_idx]
+            if child_component == dependency_component:
+                continue
+            if child_component not in component_successors[dependency_component]:
+                component_successors[dependency_component].add(child_component)
+                component_in_degree[child_component] += 1
+
+    ready = [
+        (component[0], component_idx)
+        for component_idx, component in enumerate(components)
+        if component_in_degree[component_idx] == 0
+    ]
+    heapq.heapify(ready)
+    order: list[int] = []
+    while ready:
+        _, component_idx = heapq.heappop(ready)
+        order.extend(components[component_idx])
+        for successor_component in component_successors[component_idx]:
+            component_in_degree[successor_component] -= 1
+            if component_in_degree[successor_component] == 0:
+                heapq.heappush(ready, (components[successor_component][0], successor_component))
+    return order
 
 
 class GenericDAGNode(Generic[Dag, Task, TaskGroup]):

--- a/shared/dagnode/tests/dagnode/test_node.py
+++ b/shared/dagnode/tests/dagnode/test_node.py
@@ -22,7 +22,7 @@ from unittest import mock
 
 import pytest
 
-from airflow_shared.dagnode.node import GenericDAGNode
+from airflow_shared.dagnode.node import GenericDAGNode, sort_projected_indices
 
 
 class Task:
@@ -81,3 +81,14 @@ class TestDAGNode:
         assert node.label == "test_group_id.test_node_id"
         node.task_group = TaskGroup(prefix_group_id)
         assert node.label == expected_label
+
+
+@pytest.mark.parametrize(
+    ("projected", "expected"),
+    [
+        ([(1,), (0,)], [0, 1]),
+        ([(1,), (2,), (1,)], [1, 2, 0]),
+    ],
+)
+def test_sort_projected_indices(projected, expected):
+    assert sort_projected_indices(projected) == expected

--- a/task-sdk/src/airflow/sdk/definitions/taskgroup.py
+++ b/task-sdk/src/airflow/sdk/definitions/taskgroup.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Any
 import attrs
 
 from airflow.sdk import TriggerRule
-from airflow.sdk._shared.dagnode.node import TaskGroupMixin
+from airflow.sdk._shared.dagnode.node import TaskGroupMixin, has_task_cycle, sort_projected_indices
 from airflow.sdk.definitions._internal.node import DAGNode, validate_group_key
 from airflow.sdk.exceptions import (
     AirflowDagCycleException,
@@ -561,7 +561,9 @@ class TaskGroup(TaskGroupMixin, DAGNode):
           traversal, O((V + E) log V), avoids the O(N²) blowup the sweep would hit.
 
         Both branches produce the same emission order: level-by-legacy-pass, ties broken by
-        children insertion order.
+        children insertion order. If task-level edges produce a cyclic sibling projection,
+        strongly connected children retain insertion order while dependencies between those
+        components are still respected.
         """
         children = self.children
         if not children:
@@ -657,7 +659,7 @@ class TaskGroup(TaskGroupMixin, DAGNode):
                 emitted[i] = 1
                 order_append(nodes[i])
             if len(next_pending) == len(pending):
-                raise AirflowDagCycleException(f"A cyclic dependency occurred in dag: {self.dag_id}")
+                return self._sort_cyclic_projection(nodes, projected)
             pending = next_pending
         return order
 
@@ -697,10 +699,20 @@ class TaskGroup(TaskGroupMixin, DAGNode):
                     queue.append(s)
 
         if processed != n:
-            raise AirflowDagCycleException(f"A cyclic dependency occurred in dag: {self.dag_id}")
+            return self._sort_cyclic_projection(nodes, projected)
 
         sorted_indices = sorted(range(n), key=lambda i: (pass_of[i], i))
         return [nodes[i] for i in sorted_indices]
+
+    def _sort_cyclic_projection(
+        self, nodes: list[DAGNode], projected: list[tuple[int, ...]]
+    ) -> list[DAGNode]:
+        downstream_ids_by_task = {
+            task_id: task.downstream_task_ids for task_id, task in self.dag.task_dict.items()
+        }
+        if has_task_cycle(downstream_ids_by_task):
+            raise AirflowDagCycleException(f"A cyclic dependency occurred in dag: {self.dag_id}")
+        return [nodes[i] for i in sort_projected_indices(projected)]
 
     def iter_mapped_task_groups(self) -> Iterator[MappedTaskGroup]:
         """

--- a/task-sdk/tests/task_sdk/definitions/test_taskgroup.py
+++ b/task-sdk/tests/task_sdk/definitions/test_taskgroup.py
@@ -31,7 +31,7 @@ from airflow.sdk import (
     timezone,
 )
 from airflow.sdk.definitions.taskgroup import TaskGroup
-from airflow.sdk.exceptions import TaskAlreadyInTaskGroup
+from airflow.sdk.exceptions import AirflowDagCycleException, TaskAlreadyInTaskGroup
 
 from tests_common.test_utils.compat import BashOperator, EmptyOperator, PythonOperator
 
@@ -1101,6 +1101,36 @@ def test_topological_sort_reverse_declared_order_matches_sweep():
     pass_number_order = [node.node_id for node in group._sort_via_pass_numbering(nodes, projected)]
 
     assert pass_number_order == sweep_order
+
+
+@pytest.mark.parametrize("group_count", [2, 3])
+def test_topological_sort_bidirectional_task_level_cross_group_deps(group_count):
+    """Sibling projection cycles do not imply a cycle in the task-level Dag."""
+    outbound = {}
+    inbound = {}
+    with DAG("test_bidirectional_cross_group_deps", schedule=None, start_date=DEFAULT_DATE) as dag:
+        for group_idx in range(group_count):
+            with TaskGroup(f"group_{group_idx}"):
+                for other_idx in range(group_count):
+                    if group_idx == other_idx:
+                        continue
+                    outbound[group_idx, other_idx] = EmptyOperator(task_id=f"to_{other_idx}")
+                    inbound[group_idx, other_idx] = EmptyOperator(task_id=f"from_{other_idx}")
+
+        for source_idx in range(group_count):
+            for target_idx in range(group_count):
+                if source_idx != target_idx:
+                    outbound[source_idx, target_idx] >> inbound[target_idx, source_idx]
+
+    dag.check_cycle()
+
+    assert [node.node_id for node in dag.task_group.topological_sort()] == [
+        f"group_{idx}" for idx in range(group_count)
+    ]
+
+    inbound[1, 0] >> outbound[0, 1]
+    with pytest.raises(AirflowDagCycleException, match="A cyclic dependency occurred"):
+        dag.task_group.topological_sort()
 
 
 def test_topological_sort_padded_reverse_chain_uses_pass_numbering(monkeypatch):


### PR DESCRIPTION
Valid Dags can contain independent task dependencies that cross between sibling TaskGroups in both directions. The current sibling-level projection treats those edges as a TaskGroup cycle even when the task graph itself is acyclic. This causes serialized Grid and Graph endpoints to return 500 responses.

This change falls back to strongly connected component ordering when the sibling projection is cyclic. It preserves child insertion order within each component, keeps dependencies between components topologically ordered, and continues to reject genuine task-level cycles. The behavior is shared by the Task SDK and serialized TaskGroup implementations.

before:
<img width="2551" height="1028" alt="image" src="https://github.com/user-attachments/assets/e609bcf3-0111-4280-9953-050bb739b265" />

<img width="2558" height="1023" alt="image" src="https://github.com/user-attachments/assets/a8a6ccef-a06d-42db-9af5-efde58f80475" />


Fixed:
<img width="2555" height="1125" alt="image" src="https://github.com/user-attachments/assets/f2cd83d3-2017-47fb-b528-88d5758bef52" />


---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
