### PR TITLE
Fix pickling in EcsTaskFailToStart and add unit tests for Amazon exceptions

### DIFF
--- a/airflow-core/tests/unit/always/test_project_structure.py
+++ b/airflow-core/tests/unit/always/test_project_structure.py
@@ -169,7 +169,6 @@ class TestProjectStructure:
             "providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_adls.py",
             "providers/snowflake/tests/unit/snowflake/triggers/test_snowflake_trigger.py",
             "providers/standard/tests/unit/standard/operators/test_branch.py",
-            "providers/standard/tests/unit/standard/operators/test_empty.py",
             "providers/standard/tests/unit/standard/operators/test_latest_only.py",
             "providers/standard/tests/unit/standard/sensors/test_external_task.py",
             "providers/sftp/tests/unit/sftp/test_exceptions.py",

--- a/airflow-core/tests/unit/always/test_project_structure.py
+++ b/airflow-core/tests/unit/always/test_project_structure.py
@@ -72,7 +72,6 @@ class TestProjectStructure:
             "providers/amazon/tests/unit/amazon/aws/operators/test_sagemaker.py",
             "providers/amazon/tests/unit/amazon/aws/sensors/test_emr.py",
             "providers/amazon/tests/unit/amazon/aws/sensors/test_sagemaker.py",
-            "providers/amazon/tests/unit/amazon/aws/test_exceptions.py",
             "providers/amazon/tests/unit/amazon/aws/triggers/test_sagemaker_unified_studio.py",
             "providers/amazon/tests/unit/amazon/aws/triggers/test_step_function.py",
             "providers/amazon/tests/unit/amazon/aws/utils/test_rds.py",

--- a/providers/amazon/src/airflow/providers/amazon/aws/exceptions.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/exceptions.py
@@ -34,7 +34,7 @@ class EcsTaskFailToStart(Exception):
 
     def __reduce__(self):
         """Return ECSTask state and its message."""
-        return EcsTaskFailToStart, (self.message)
+        return EcsTaskFailToStart, (self.message,)
 
 
 class EcsOperatorError(Exception):

--- a/providers/amazon/tests/unit/amazon/aws/test_exceptions.py
+++ b/providers/amazon/tests/unit/amazon/aws/test_exceptions.py
@@ -1,0 +1,160 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pickle
+
+import pytest
+
+from airflow.providers.amazon.aws.exceptions import (
+    DataSyncLocationNotFoundError,
+    DataSyncMultipleLocationsError,
+    DataSyncMultipleTasksError,
+    DataSyncTaskCreationError,
+    DataSyncTaskExecutionFailedError,
+    DataSyncTaskNotFoundError,
+    EcsOperatorError,
+    EcsTaskFailToStart,
+    GlueJobRunStoppedError,
+    NeptuneGraphCreationFailedError,
+    NeptuneGraphDeletionFailedError,
+    NeptuneImportTaskCancellationFailedError,
+    NeptuneImportTaskFailedError,
+    NeptunePrivateEndpointCreationFailedError,
+    NeptunePrivateEndpointDeletionFailedError,
+    S3HookPathTraversalError,
+    S3HookUriParseFailure,
+    WaiterMaxAttemptsError,
+    WaiterTerminalFailure,
+)
+from airflow.providers.common.compat.sdk import AirflowException
+
+
+class TestEcsExceptions:
+    def test_ecs_task_fail_to_start(self):
+        msg = "Task failed to start due to resource constraints"
+        exc = EcsTaskFailToStart(msg)
+        assert exc.message == msg
+        assert str(exc) == msg
+        assert isinstance(exc, Exception)
+        assert not isinstance(exc, AirflowException)
+
+        # Verify pickle / unpickle via __reduce__
+        pickled = pickle.dumps(exc)
+        restored = pickle.loads(pickled)
+        assert isinstance(restored, EcsTaskFailToStart)
+        assert restored.message == msg
+
+    def test_ecs_operator_error(self):
+        failures = [{"arn": "arn:aws:ecs:123", "reason": "RESOURCE:CPU"}]
+        msg = "ECS run task error"
+        exc = EcsOperatorError(failures=failures, message=msg)
+        assert exc.failures == failures
+        assert exc.message == msg
+        assert str(exc) == msg
+        assert isinstance(exc, Exception)
+        assert not isinstance(exc, AirflowException)
+
+        # Verify pickle / unpickle via __reduce__
+        pickled = pickle.dumps(exc)
+        restored = pickle.loads(pickled)
+        assert isinstance(restored, EcsOperatorError)
+        assert restored.failures == failures
+        assert restored.message == msg
+
+
+class TestS3Exceptions:
+    def test_s3_hook_uri_parse_failure(self):
+        with pytest.raises(S3HookUriParseFailure, match="Invalid S3 URI"):
+            raise S3HookUriParseFailure("Invalid S3 URI")
+
+        assert issubclass(S3HookUriParseFailure, AirflowException)
+
+    def test_s3_hook_path_traversal_error(self):
+        with pytest.raises(S3HookPathTraversalError, match="Path traversal detected"):
+            raise S3HookPathTraversalError("Path traversal detected")
+
+        assert issubclass(S3HookPathTraversalError, AirflowException)
+
+
+class TestNeptuneExceptions:
+    @pytest.mark.parametrize(
+        "exc_class",
+        [
+            NeptuneGraphCreationFailedError,
+            NeptunePrivateEndpointCreationFailedError,
+            NeptunePrivateEndpointDeletionFailedError,
+            NeptuneGraphDeletionFailedError,
+            NeptuneImportTaskCancellationFailedError,
+            NeptuneImportTaskFailedError,
+        ],
+    )
+    def test_neptune_exceptions(self, exc_class):
+        msg = f"Test error for {exc_class.__name__}"
+        with pytest.raises(exc_class, match=msg):
+            raise exc_class(msg)
+
+        assert issubclass(exc_class, AirflowException)
+
+
+class TestGlueExceptions:
+    def test_glue_job_run_stopped_error(self):
+        with pytest.raises(GlueJobRunStoppedError, match="Glue job stopped"):
+            raise GlueJobRunStoppedError("Glue job stopped")
+
+        assert issubclass(GlueJobRunStoppedError, AirflowException)
+
+
+class TestDataSyncExceptions:
+    @pytest.mark.parametrize(
+        "exc_class",
+        [
+            DataSyncTaskNotFoundError,
+            DataSyncMultipleTasksError,
+            DataSyncMultipleLocationsError,
+            DataSyncLocationNotFoundError,
+            DataSyncTaskCreationError,
+            DataSyncTaskExecutionFailedError,
+        ],
+    )
+    def test_datasync_exceptions(self, exc_class):
+        msg = f"DataSync failure for {exc_class.__name__}"
+        with pytest.raises(exc_class, match=msg):
+            raise exc_class(msg)
+
+        assert issubclass(exc_class, AirflowException)
+
+
+class TestWaiterExceptions:
+    def test_waiter_terminal_failure(self):
+        last_response = {"Status": "FAILED", "Error": "ResourceNotFound"}
+        msg = "Waiter entered terminal failure"
+        exc = WaiterTerminalFailure(message=msg, last_response=last_response)
+
+        assert str(exc) == msg
+        assert exc.last_response == last_response
+        assert isinstance(exc, AirflowException)
+
+        with pytest.raises(WaiterTerminalFailure, match="Waiter entered terminal failure"):
+            raise exc
+
+    def test_waiter_max_attempts_error(self):
+        with pytest.raises(WaiterMaxAttemptsError, match="Max attempts exceeded"):
+            raise WaiterMaxAttemptsError("Max attempts exceeded")
+
+        assert issubclass(WaiterMaxAttemptsError, AirflowException)

--- a/providers/standard/tests/unit/standard/operators/test_empty.py
+++ b/providers/standard/tests/unit/standard/operators/test_empty.py
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from airflow.providers.standard.operators.empty import EmptyOperator
+from airflow.providers.standard.version_compat import BaseOperator
+
+
+class TestEmptyOperator:
+    def test_empty_operator_init(self):
+        op = EmptyOperator(task_id="test_empty")
+        assert op.task_id == "test_empty"
+        assert op.inherits_from_empty_operator is True
+        assert op.ui_color == "#e8f7e4"
+        assert isinstance(op, BaseOperator)
+
+    def test_empty_operator_execute_none(self):
+        op = EmptyOperator(task_id="test_empty_none")
+        result = op.execute(None)
+        assert result is None
+
+    def test_empty_operator_execute_with_context(self):
+        op = EmptyOperator(task_id="test_empty_context")
+        mock_context = MagicMock()
+        result = op.execute(context=mock_context)
+        assert result is None


### PR DESCRIPTION
### Why

1. `providers/amazon/src/airflow/providers/amazon/aws/exceptions.py` was on the `OVERLOOKED_TESTS` allowlist in `airflow-core/tests/unit/always/test_project_structure.py`, tracked under meta-issue #35442.
2. In `EcsTaskFailToStart`, the `__reduce__` method returned `EcsTaskFailToStart, (self.message)`. In Python, `(self.message)` is evaluated as a parenthesized string expression rather than a 1-element tuple, which causes `pickle.dumps()` across multiprocessing/Celery worker boundaries to fail with `_pickle.PicklingError: second item of the tuple returned by __reduce__ must be a tuple`.

### How

1. Fixed `EcsTaskFailToStart.__reduce__` to return a proper 1-element tuple: `(self.message,)`, matching the reduce pattern used in `EcsOperatorError`.
2. Created `providers/amazon/tests/unit/amazon/aws/test_exceptions.py` with 19 test cases covering:
   - `EcsTaskFailToStart` initialization, string conversion, and pickle serialization roundtrip via `__reduce__`.
   - `EcsOperatorError` failures list preservation, message handling, and pickle serialization roundtrip.
   - S3 exceptions (`S3HookUriParseFailure`, `S3HookPathTraversalError`) and `AirflowException` inheritance.
   - Neptune graph and endpoint exceptions (6 classes).
   - Glue exception (`GlueJobRunStoppedError`).
   - DataSync exceptions (6 classes).
   - Waiter exceptions (`WaiterTerminalFailure` with `last_response` attribute, `WaiterMaxAttemptsError`).
3. Removed `providers/amazon/tests/unit/amazon/aws/test_exceptions.py` from `OVERLOOKED_TESTS`.

### What

19 unit tests added and 1 bugfix in `EcsTaskFailToStart`.

Verified locally:
```
uv run --project providers/amazon pytest providers/amazon/tests/unit/amazon/aws/test_exceptions.py -v
# 19 passed, 1 warning in 1.31s

uv run --project airflow-core pytest airflow-core/tests/unit/always/test_project_structure.py -k test_providers_modules_should_have_tests -v
# 1 passed, 10 deselected in 1.78s
```

related: #35442

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
