### PR TITLE
Fix pickle round-trip of Amazon provider exceptions and add their tests

### DIFF
--- a/airflow-core/tests/unit/always/test_project_structure.py
+++ b/airflow-core/tests/unit/always/test_project_structure.py
@@ -72,7 +72,6 @@ class TestProjectStructure:
             "providers/amazon/tests/unit/amazon/aws/operators/test_sagemaker.py",
             "providers/amazon/tests/unit/amazon/aws/sensors/test_emr.py",
             "providers/amazon/tests/unit/amazon/aws/sensors/test_sagemaker.py",
-            "providers/amazon/tests/unit/amazon/aws/test_exceptions.py",
             "providers/amazon/tests/unit/amazon/aws/triggers/test_sagemaker_unified_studio.py",
             "providers/amazon/tests/unit/amazon/aws/utils/test_rds.py",
             "providers/amazon/tests/unit/amazon/aws/utils/test_sagemaker.py",

--- a/providers/amazon/src/airflow/providers/amazon/aws/exceptions.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/exceptions.py
@@ -34,7 +34,7 @@ class EcsTaskFailToStart(Exception):
 
     def __reduce__(self):
         """Return ECSTask state and its message."""
-        return EcsTaskFailToStart, (self.message)
+        return EcsTaskFailToStart, (self.message,)
 
 
 class EcsOperatorError(Exception):
@@ -115,7 +115,12 @@ class WaiterTerminalFailure(AirflowException):
 
     def __init__(self, message: str, last_response: dict[str, Any]):
         super().__init__(message)
+        self.message = message
         self.last_response = last_response
+
+    def __reduce__(self):
+        """Return the waiter failure state as its message and the last waiter response."""
+        return WaiterTerminalFailure, (self.message, self.last_response)
 
 
 class WaiterMaxAttemptsError(AirflowException):

--- a/providers/amazon/tests/unit/amazon/aws/test_exceptions.py
+++ b/providers/amazon/tests/unit/amazon/aws/test_exceptions.py
@@ -1,0 +1,137 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pickle
+
+import pytest
+
+from airflow.providers.amazon.aws.exceptions import (
+    DataSyncLocationNotFoundError,
+    DataSyncMultipleLocationsError,
+    DataSyncMultipleTasksError,
+    DataSyncTaskCreationError,
+    DataSyncTaskExecutionFailedError,
+    DataSyncTaskNotFoundError,
+    EcsOperatorError,
+    EcsTaskFailToStart,
+    GlueJobRunStoppedError,
+    NeptuneGraphCreationFailedError,
+    NeptuneGraphDeletionFailedError,
+    NeptuneImportTaskCancellationFailedError,
+    NeptuneImportTaskFailedError,
+    NeptunePrivateEndpointCreationFailedError,
+    NeptunePrivateEndpointDeletionFailedError,
+    S3HookPathTraversalError,
+    S3HookUriParseFailure,
+    WaiterMaxAttemptsError,
+    WaiterTerminalFailure,
+)
+from airflow.providers.common.compat.sdk import AirflowException
+
+ECS_FAILURES = [
+    {
+        "arn": "arn:aws:ecs:us-east-1:123456789012:container-instance/abc123",
+        "reason": "RESOURCE:MEMORY",
+    }
+]
+LAST_RESPONSE = {"Cluster": {"Status": "FAILED", "StatusReason": "Insufficient capacity"}}
+
+AIRFLOW_EXCEPTION_SUBCLASSES = [
+    S3HookUriParseFailure,
+    S3HookPathTraversalError,
+    NeptuneGraphCreationFailedError,
+    NeptunePrivateEndpointCreationFailedError,
+    NeptunePrivateEndpointDeletionFailedError,
+    NeptuneGraphDeletionFailedError,
+    NeptuneImportTaskCancellationFailedError,
+    NeptuneImportTaskFailedError,
+    GlueJobRunStoppedError,
+    DataSyncTaskNotFoundError,
+    DataSyncMultipleTasksError,
+    DataSyncMultipleLocationsError,
+    DataSyncLocationNotFoundError,
+    DataSyncTaskCreationError,
+    DataSyncTaskExecutionFailedError,
+    WaiterMaxAttemptsError,
+]
+
+
+class TestEcsTaskFailToStart:
+    def test_message(self):
+        exc = EcsTaskFailToStart("The task failed to start due to: OutOfMemoryError")
+
+        assert exc.message == "The task failed to start due to: OutOfMemoryError"
+        assert str(exc) == "The task failed to start due to: OutOfMemoryError"
+
+    def test_pickle_round_trip(self):
+        exc = EcsTaskFailToStart("The task failed to start due to: OutOfMemoryError")
+
+        restored = pickle.loads(pickle.dumps(exc))
+
+        assert isinstance(restored, EcsTaskFailToStart)
+        assert restored.message == exc.message
+        assert str(restored) == str(exc)
+
+
+class TestEcsOperatorError:
+    def test_failures_and_message(self):
+        exc = EcsOperatorError(ECS_FAILURES, "ECS could not run the task")
+
+        assert exc.failures == ECS_FAILURES
+        assert exc.message == "ECS could not run the task"
+        assert str(exc) == "ECS could not run the task"
+
+    def test_pickle_round_trip(self):
+        exc = EcsOperatorError(ECS_FAILURES, "ECS could not run the task")
+
+        restored = pickle.loads(pickle.dumps(exc))
+
+        assert isinstance(restored, EcsOperatorError)
+        assert restored.failures == ECS_FAILURES
+        assert restored.message == "ECS could not run the task"
+
+
+class TestWaiterTerminalFailure:
+    def test_message_and_last_response(self):
+        exc = WaiterTerminalFailure("Waiter reached a terminal failure state", LAST_RESPONSE)
+
+        assert isinstance(exc, AirflowException)
+        assert str(exc) == "Waiter reached a terminal failure state"
+        assert exc.last_response == LAST_RESPONSE
+
+    def test_pickle_round_trip(self):
+        exc = WaiterTerminalFailure("Waiter reached a terminal failure state", LAST_RESPONSE)
+
+        restored = pickle.loads(pickle.dumps(exc))
+
+        assert isinstance(restored, WaiterTerminalFailure)
+        assert str(restored) == "Waiter reached a terminal failure state"
+        assert restored.last_response == LAST_RESPONSE
+
+
+@pytest.mark.parametrize("exc_cls", AIRFLOW_EXCEPTION_SUBCLASSES)
+def test_airflow_exception_subclasses_keep_message(exc_cls):
+    exc = exc_cls("something went wrong")
+
+    assert isinstance(exc, AirflowException)
+    assert str(exc) == "something went wrong"
+
+    restored = pickle.loads(pickle.dumps(exc))
+
+    assert isinstance(restored, exc_cls)
+    assert str(restored) == "something went wrong"


### PR DESCRIPTION
While adding the missing unit tests for `airflow/providers/amazon/aws/exceptions.py` (listed in `OVERLOOKED_TESTS` in `test_project_structure.py`, tracked in #35442), the pickle round-trip tests failed for two of the exceptions:

- `EcsTaskFailToStart.__reduce__` returns `(EcsTaskFailToStart, (self.message))`. The second item is a plain string instead of a one-element tuple, so `pickle.dumps()` raises `PicklingError: second item of the tuple returned by __reduce__ must be a tuple`. The method was added in #22002, right after #21441 fixed the same problem for `EcsOperatorError`, and has never worked.
- `WaiterTerminalFailure` (added in #72455) keeps `last_response` outside `args`, so unpickling calls `WaiterTerminalFailure(message)` and fails with `TypeError: __init__() missing 1 required positional argument: 'last_response'`.

**Changes**

- `exceptions.py`: return a one-element tuple from `EcsTaskFailToStart.__reduce__`; give `WaiterTerminalFailure` a `__reduce__` that carries `last_response`, in the same style as the ECS exceptions
- `tests/unit/amazon/aws/test_exceptions.py` (new): message and attribute handling plus pickle round-trips for the exceptions that carry extra state, and inheritance, message, and round-trip checks for the plain `AirflowException` subclasses
- `test_project_structure.py`: remove the module from `OVERLOOKED_TESTS`

**Testing**

- `providers/amazon`: `tests/unit/amazon/aws/test_exceptions.py`, `tests/unit/amazon/aws/utils/test_waiter_with_logging.py`, `tests/unit/amazon/aws/hooks/test_ecs.py`, `tests/unit/amazon/aws/operators/test_ecs.py`
- `airflow-core`: `tests/unit/always/test_project_structure.py`
- prek hooks on the changed files

related: #35442

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Claude Fable 5.1) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions). I reviewed and understand all changes; the tests were run locally as listed above.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
