### PR TITLE
Avoid repeated pod deletion in KubernetesExecutor

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -29,7 +29,7 @@ import json
 import logging
 import multiprocessing
 import time
-from collections import Counter, defaultdict
+from collections import Counter, OrderedDict, defaultdict
 from collections.abc import Iterable
 from contextlib import suppress
 from dataclasses import dataclass
@@ -102,6 +102,7 @@ class KubernetesExecutor(BaseExecutor):
     """Executor for Kubernetes."""
 
     RUNNING_POD_LOG_LINES = 100
+    _MAX_DELETED_PODS = 10_000
     supports_ad_hoc_ti_run: bool = True
     supports_multi_team: bool = True
 
@@ -170,6 +171,7 @@ class KubernetesExecutor(BaseExecutor):
                 f"got {self.RUNNING_POD_LOG_LINES}."
             )
         self.completed: dict[tuple[str, str], KubernetesResults] = {}
+        self._deleted_pods: OrderedDict[tuple[str, str, str | None], None] = OrderedDict()
         self.create_pods_after: datetime | None = None
 
         # Maintain compatibility with older Airflow releases that do not define team_name.
@@ -740,13 +742,22 @@ class KubernetesExecutor(BaseExecutor):
 
         if self.kube_config.delete_worker_pods:
             if state != TaskInstanceState.FAILED or self.kube_config.delete_worker_pods_on_failure:
-                self.kube_scheduler.delete_pod(pod_name=pod_name, namespace=namespace)
-                self.log.info(
-                    "Deleted pod associated with the TI %s. Pod name: %s. Namespace: %s",
-                    key,
-                    pod_name,
-                    namespace,
-                )
+                # A task key can have several pods (including pre-execution retries), so
+                # deduplicate successful deletions by pod rather than membership in running.
+                pod_key = (namespace, pod_name, results.pod_uid)
+                if pod_key in self._deleted_pods:
+                    self._deleted_pods.move_to_end(pod_key)
+                else:
+                    self.kube_scheduler.delete_pod(pod_name=pod_name, namespace=namespace)
+                    self._deleted_pods[pod_key] = None
+                    if len(self._deleted_pods) > self._MAX_DELETED_PODS:
+                        self._deleted_pods.popitem(last=False)
+                    self.log.info(
+                        "Deleted pod associated with the TI %s. Pod name: %s. Namespace: %s",
+                        key,
+                        pod_name,
+                        namespace,
+                    )
         else:
             self.kube_scheduler.patch_pod_executor_done(pod_name=pod_name, namespace=namespace)
             self.log.info("Patched pod %s in namespace %s to mark it as done", key, namespace)
@@ -1196,6 +1207,7 @@ class KubernetesExecutor(BaseExecutor):
                 namespace=namespace,
                 resource_version=pod.metadata.resource_version,
                 failure_details=None,
+                pod_uid=pod.metadata.uid,
             )
 
     def _flush_task_queue(self) -> None:

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_types.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_types.py
@@ -51,6 +51,7 @@ class KubernetesResults(NamedTuple):
     namespace: str
     resource_version: str
     failure_details: FailureDetails | None
+    pod_uid: str | None = None
 
 
 class KubernetesWatch(NamedTuple):
@@ -62,6 +63,7 @@ class KubernetesWatch(NamedTuple):
     annotations: dict[str, str]
     resource_version: str
     failure_details: FailureDetails | None
+    pod_uid: str | None = None
 
 
 # TODO: Remove after Airflow 2 support is removed

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py
@@ -225,7 +225,15 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
             # However, need to free the executor slot from the current executor.
             self.log.info("Event: pod %s adopted, annotations: %s", pod_name, annotations_string)
             self.watcher_queue.put(
-                KubernetesWatch(pod_name, namespace, ADOPTED, annotations, resource_version, None)
+                KubernetesWatch(
+                    pod_name,
+                    namespace,
+                    ADOPTED,
+                    annotations,
+                    resource_version,
+                    None,
+                    pod_uid=pod.metadata.uid,
+                )
             )
         elif hasattr(pod.status, "reason") and pod.status.reason == "ProviderFailed":
             # Most likely this happens due to Kubernetes setup (virtual kubelet, virtual nodes, etc.)
@@ -245,6 +253,7 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
                     annotations,
                     resource_version,
                     None,
+                    pod_uid=pod.metadata.uid,
                 )
             )
         elif status == "Pending":
@@ -292,6 +301,7 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
                                     annotations,
                                     resource_version,
                                     None,
+                                    pod_uid=pod.metadata.uid,
                                 )
                             )
                             break
@@ -321,12 +331,15 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
                     annotations,
                     resource_version,
                     failure_details,
+                    pod_uid=pod.metadata.uid,
                 )
             )
         elif status == "Succeeded":
             self.log.info("Event: %s Succeeded, annotations: %s", pod_name, annotations_string)
             self.watcher_queue.put(
-                KubernetesWatch(pod_name, namespace, None, annotations, resource_version, None)
+                KubernetesWatch(
+                    pod_name, namespace, None, annotations, resource_version, None, pod_uid=pod.metadata.uid
+                )
             )
         elif status == "Running":
             # deletion_timestamp is set by kube server when a graceful deletion is requested.
@@ -345,6 +358,7 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
                         annotations,
                         resource_version,
                         None,
+                        pod_uid=pod.metadata.uid,
                     )
                 )
             else:
@@ -844,6 +858,7 @@ class AirflowKubernetesScheduler(LoggingMixin):
                     task.namespace,
                     task.resource_version,
                     task.failure_details,
+                    pod_uid=task.pod_uid,
                 )
             )
 

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -27,7 +27,7 @@ from unittest import mock
 import pytest
 import yaml
 from aiohttp import ClientConnectionError
-from kubernetes.client import models as k8s
+from kubernetes.client import CoreV1Api, models as k8s
 from kubernetes.client.rest import ApiException
 from sqlalchemy import inspect
 from urllib3 import HTTPConnectionPool, HTTPResponse
@@ -1992,6 +1992,164 @@ class TestKubernetesExecutor:
             executor.end()
 
     @pytest.mark.db_test
+    @pytest.mark.parametrize("map_index", [-1, 3])
+    @pytest.mark.parametrize("state", [State.SUCCESS, None])
+    @pytest.mark.parametrize("already_deleted", [False, True])
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.KubernetesJobWatcher",
+        autospec=True,
+    )
+    @mock.patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client", autospec=True)
+    @mock.patch.object(
+        KubernetesExecutor, "_get_task_instance_state", autospec=True, return_value=State.SUCCESS
+    )
+    def test_change_state_deletes_same_pod_once(
+        self,
+        mock_lookup,
+        mock_get_kube_client,
+        mock_kubernetes_job_watcher,
+        map_index,
+        state,
+        already_deleted,
+    ):
+        kube_client = mock.create_autospec(CoreV1Api, instance=True)
+        kube_client.delete_namespaced_pod.return_value = k8s.V1Status(status="Success")
+        if already_deleted:
+            kube_client.delete_namespaced_pod.side_effect = ApiException(status=404)
+        mock_get_kube_client.return_value = kube_client
+        executor = self.kubernetes_executor
+        executor.start()
+        try:
+            key = TaskInstanceKey("dag_id", "task_id", "run_id", 1, map_index)
+            executor.running = {key}
+            result = KubernetesResults(key, state, "finished-pod", "default", "1", None, pod_uid="pod-uid")
+            annotations = {
+                "dag_id": key.dag_id,
+                "task_id": key.task_id,
+                "run_id": key.run_id,
+                "try_number": str(key.try_number),
+                "map_index": str(map_index),
+            }
+            for resource_version in ("1", "2", "3"):
+                executor.kube_scheduler.process_watcher_task(
+                    KubernetesWatch(
+                        "finished-pod",
+                        "default",
+                        state,
+                        annotations,
+                        resource_version,
+                        None,
+                        pod_uid="pod-uid",
+                    )
+                )
+                received = executor.result_queue.get(timeout=5)
+                executor.result_queue.task_done()
+                assert received == result._replace(resource_version=resource_version)
+                executor._change_state(received)
+
+            assert executor.event_buffer[key] == (State.SUCCESS, None)
+            assert executor.running == set()
+            kube_client.delete_namespaced_pod.assert_called_once_with(
+                "finished-pod", "default", body=k8s.V1DeleteOptions()
+            )
+        finally:
+            executor.end()
+
+    @pytest.mark.db_test
+    @pytest.mark.parametrize("running", [False, True])
+    @pytest.mark.parametrize(
+        "other_pod",
+        [
+            {"pod_name": "other-pod", "pod_uid": "other-uid"},
+            {"namespace": "other-namespace", "pod_uid": "other-uid"},
+            {"pod_uid": "other-uid"},
+        ],
+        ids=["different-name", "different-namespace", "reused-name"],
+    )
+    def test_change_state_deletes_distinct_pods_for_same_key(self, running, other_pod):
+        executor = self.kubernetes_executor
+        executor.kube_scheduler = mock.create_autospec(AirflowKubernetesScheduler, instance=True)
+        key = TaskInstanceKey("dag", "task", "run", 1, 3)
+        executor.running = {key} if running else set()
+        first = KubernetesResults(key, State.SUCCESS, "pod", "default", "1", None, pod_uid="first-uid")
+        second = first._replace(**other_pod, resource_version="2")
+
+        for result in (first, second, first, second):
+            executor._change_state(result)
+
+        assert executor.kube_scheduler.delete_pod.call_args_list == [
+            mock.call(pod_name=first.pod_name, namespace=first.namespace),
+            mock.call(pod_name=second.pod_name, namespace=second.namespace),
+        ]
+        assert executor.running == set()
+        assert executor.event_buffer == ({key: (State.SUCCESS, None)} if running else {})
+
+    @pytest.mark.db_test
+    def test_change_state_tracks_pod_deletions_per_executor(self):
+        key = TaskInstanceKey("dag", "task", "run", 1, 3)
+        result = KubernetesResults(key, State.SUCCESS, "pod", "default", "1", None, pod_uid="pod-uid")
+        for executor in (self.kubernetes_executor, KubernetesExecutor()):
+            executor.kube_scheduler = mock.create_autospec(AirflowKubernetesScheduler, instance=True)
+            executor._change_state(result)
+            executor._change_state(result)
+            executor.kube_scheduler.delete_pod.assert_called_once_with(pod_name="pod", namespace="default")
+
+    @pytest.mark.db_test
+    def test_change_state_retries_unsuccessful_pod_deletion(self):
+        executor = self.kubernetes_executor
+        executor.kube_scheduler = mock.create_autospec(AirflowKubernetesScheduler, instance=True)
+        executor.kube_scheduler.delete_pod.side_effect = [ApiException(status=500), None]
+        key = TaskInstanceKey("dag", "task", "run", 1, 3)
+        executor.running = {key}
+        result = KubernetesResults(key, State.SUCCESS, "pod", "default", "1", None, pod_uid="pod-uid")
+
+        with pytest.raises(ApiException):
+            executor._change_state(result)
+        assert executor.running == {key}
+        assert executor.event_buffer == {}
+
+        executor._change_state(result)
+        executor._change_state(result)
+        assert executor.kube_scheduler.delete_pod.call_count == 2
+        assert executor.running == set()
+        assert executor.event_buffer == {key: (State.SUCCESS, None)}
+
+    @pytest.mark.db_test
+    @mock.patch.object(KubernetesExecutor, "_MAX_DELETED_PODS", 2)
+    def test_change_state_bounds_recent_pod_deletions(self):
+        executor = self.kubernetes_executor
+        executor.kube_scheduler = mock.create_autospec(AirflowKubernetesScheduler, instance=True)
+        key = TaskInstanceKey("dag", "task", "run", 1)
+        results = [KubernetesResults(key, State.SUCCESS, name, "default", "1", None) for name in "abc"]
+
+        for result in (results[0], results[1], results[0], results[2], results[0]):
+            executor._change_state(result)
+        assert executor.kube_scheduler.delete_pod.call_count == 3
+        assert len(executor._deleted_pods) == 2
+
+        executor._change_state(results[1])
+        assert executor.kube_scheduler.delete_pod.call_count == 4
+        assert len(executor._deleted_pods) == 2
+
+    @pytest.mark.db_test
+    @pytest.mark.parametrize("adopted_first", [False, True])
+    @mock.patch.object(
+        KubernetesExecutor, "_get_task_instance_state", autospec=True, return_value=State.SUCCESS
+    )
+    def test_change_state_deduplicates_adopted_and_watched_pod(self, mock_lookup, adopted_first):
+        executor = self.kubernetes_executor
+        executor.kube_scheduler = mock.create_autospec(AirflowKubernetesScheduler, instance=True)
+        key = TaskInstanceKey("dag", "task", "run", 1, 3)
+        watched = KubernetesResults(key, None, "pod", "default", "1", None, pod_uid="pod-uid")
+        adopted = watched._replace(state="completed", resource_version="2")
+
+        for result in (adopted, watched) if adopted_first else (watched, adopted):
+            executor._change_state(result)
+
+        executor.kube_scheduler.delete_pod.assert_called_once_with(pod_name="pod", namespace="default")
+        assert executor.event_buffer == {}
+
+    @pytest.mark.db_test
     @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.KubernetesJobWatcher")
     @mock.patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")
     @mock.patch(
@@ -2307,6 +2465,7 @@ class TestKubernetesExecutor:
     ):
         """Repeated Failed events for one pod requeue once; a new pod requeues again."""
         executor = self.kubernetes_executor
+        executor.kube_config.delete_worker_pods_on_failure = True
         executor.pod_launch_failure_max_retries = 5
         executor.start()
         try:
@@ -2330,11 +2489,13 @@ class TestKubernetesExecutor:
             executor._change_state(_failed("pod_a"))
             executor._change_state(_failed("pod_a"))
             executor._change_state(_failed("pod_a"))
+            mock_get_kube_client.return_value.delete_namespaced_pod.assert_called_once()
             assert executor.pod_launch_attempts[key].attempts == 1
             assert executor.pod_launch_attempts[key].requeued_for_pod == "pod_a"
 
             # A failure of the requeued (distinct) pod requeues again.
             executor._change_state(_failed("pod_b"))
+            assert mock_get_kube_client.return_value.delete_namespaced_pod.call_count == 2
             assert executor.pod_launch_attempts[key].attempts == 2
             assert executor.pod_launch_attempts[key].requeued_for_pod == "pod_b"
             assert key in executor.running
@@ -2728,6 +2889,7 @@ class TestKubernetesExecutor:
                     labels={"airflow-worker": pod_name},
                     annotations=get_annotations(pod_name),
                     namespace="somens",
+                    uid=f"uid-{pod_name}",
                 )
             )
             for pod_name in pod_names
@@ -2755,6 +2917,7 @@ class TestKubernetesExecutor:
             any_order=True,
         )
         assert {k8s_res.key for k8s_res in executor.completed.values()} == expected_running_ti_keys
+        assert {result.pod_uid for result in executor.completed.values()} == {"uid-one", "uid-two"}
 
     @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor.DynamicClient")
     @mock.patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")
@@ -3351,6 +3514,7 @@ class TestKubernetesJobWatcher:
                 annotations={"airflow-worker": "bar", **self.core_annotations},
                 namespace="airflow",
                 resource_version="456",
+                uid="pod-uid",
                 labels={},
             ),
             status=k8s.V1PodStatus(phase="Pending"),
@@ -3395,6 +3559,7 @@ class TestKubernetesJobWatcher:
                 self.core_annotations,
                 self.pod.metadata.resource_version,
                 mock.ANY,  # failure_details can be any value including None
+                pod_uid="pod-uid",
             )
         )
 
@@ -3652,6 +3817,7 @@ class TestKubernetesJobWatcher:
                 self.core_annotations,
                 self.pod.metadata.resource_version,
                 None,  # failure_details is None for ADOPTED state
+                pod_uid="pod-uid",
             )
         )
 

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -30,6 +30,7 @@ from aiohttp import ClientConnectionError
 from kubernetes.client import CoreV1Api, models as k8s
 from kubernetes.client.rest import ApiException
 from sqlalchemy import inspect
+from sqlalchemy.exc import OperationalError
 from urllib3 import HTTPConnectionPool, HTTPResponse
 from urllib3.exceptions import MaxRetryError, ProtocolError
 
@@ -2113,6 +2114,74 @@ class TestKubernetesExecutor:
         assert executor.kube_scheduler.delete_pod.call_count == 2
         assert executor.running == set()
         assert executor.event_buffer == {key: (State.SUCCESS, None)}
+
+    @pytest.mark.db_test
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.KubernetesJobWatcher",
+        autospec=True,
+    )
+    @mock.patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client", autospec=True)
+    def test_change_state_retries_processing_after_successful_pod_deletion(
+        self, mock_get_kube_client, mock_kubernetes_job_watcher, create_task_instance, dag_maker
+    ):
+        """A metadata lookup failure must not lose the retry after the pod was deleted."""
+        kube_client = mock.create_autospec(CoreV1Api, instance=True)
+        kube_client.delete_namespaced_pod.return_value = k8s.V1Status(status="Success")
+        mock_get_kube_client.return_value = kube_client
+        executor = self.kubernetes_executor
+        executor.kube_config.delete_worker_pods = True
+        executor.kube_config.delete_worker_pods_on_failure = True
+        executor.pod_launch_failure_max_retries = 2
+        executor.start()
+        try:
+            ti = create_task_instance(state=TaskInstanceState.QUEUED)
+            key = ti.key
+            # Persist the queued state before the simulated transaction failure.
+            dag_maker.session.commit()
+            job = KubernetesJob(key, ["airflow", "tasks", "run"], {}, None)
+            executor.running = {key}
+            executor.pod_launch_attempts[key] = _PodLaunchAttempt(job=job)
+            results = KubernetesResults(
+                key,
+                State.FAILED,
+                "pod_name",
+                "default",
+                "1",
+                {"container_reason": "ContainerStatusUnknown", "exit_code": 137},
+                pod_uid="pod-uid",
+            )
+            real_lookup = executor._get_task_instance_state
+            lookup_failed = False
+
+            def lookup_after_outage(key, *, session):
+                nonlocal lookup_failed
+                if not lookup_failed:
+                    lookup_failed = True
+                    raise OperationalError("SELECT state", {}, RuntimeError("temporary metadata failure"))
+                return real_lookup(key, session=session)
+
+            with mock.patch.object(
+                executor, "_get_task_instance_state", autospec=True, side_effect=lookup_after_outage
+            ) as lookup:
+                with pytest.raises(OperationalError):
+                    executor._change_state(results)
+                kube_client.delete_namespaced_pod.assert_called_once()
+                assert executor.task_queue.empty()
+                assert executor.running == {key}
+
+                executor._change_state(results._replace(resource_version="2"))
+
+                requeued_job = executor.task_queue.get(timeout=5)
+                executor.task_queue.task_done()
+                assert requeued_job == job
+                assert lookup.call_count == 2
+                kube_client.delete_namespaced_pod.assert_called_once_with(
+                    "pod_name", "default", body=k8s.V1DeleteOptions()
+                )
+                assert executor.running == {key}
+                assert key not in executor.event_buffer
+        finally:
+            executor.end()
 
     @pytest.mark.db_test
     @mock.patch.object(KubernetesExecutor, "_MAX_DELETED_PODS", 2)


### PR DESCRIPTION
Repeated Kubernetes watch events for a completed pod currently issue repeated DELETE requests. Remember recently deleted pod identities in the executor so duplicate results skip the DELETE while retaining task-state handling, adoption, and pre-execution retries. Carry the Kubernetes UID through watcher and adoption results so a newly created pod reusing the same name can still be deleted.

The deletion history is local to one executor and limited to 10,000 identities. Events received after eviction or executor restart may issue another DELETE. Legacy result producers that omit the optional UID cannot distinguish reused pod names.

Fixes #72803.

Validation:

- The regression reproduced three DELETE calls on the original implementation, where one was expected.
- Python 3.12: 61 focused executor/watcher/adoption tests passed on `f59c353`, including repeated success/404 events, failed deletion retry, distinct pod UIDs, and pre-execution retries. Production code and those tests are unchanged in the follow-up commit.
- On `16f34d8`, the new regression test passed: after a successful DELETE and a temporary metadata lookup failure, processing the repeated result requeues the actual job without a second DELETE. An additional local negative control rejected an incorrect early return on a cache hit. The complete 62-test selection was not rerun.
- The follow-up test passed Ruff, formatting, and all applicable pre-commit/commit-msg hooks.
- `prek run --stage pre-commit` on the four staged files: 43 hooks passed; pre-commit and commit-msg hooks also passed during commit.
- Manual hooks: three passed; `mypy-providers` initially stopped before type checking because `breeze` was not on PATH. Breeze was subsequently run in an isolated environment for selective-check only. Provider mypy still requires the unavailable Docker daemon and remains unverified locally.
- `breeze ci selective-check --commit-ref HEAD --github-event-name pull_request` completed; its broader provider, compatibility, and Kubernetes selections were not all executed locally.
- No live Kubernetes cluster or full supported-version matrix was run; upstream CI remains necessary.

Original 61-test selection (Python 3.12, frozen Kubernetes provider environment):

```shell
pytest providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py \
  -k 'change_state or sync_processes_completed_pods or adopt_completed_pods or process_status' --tb=short
```

Follow-up regression command:

```shell
pytest providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py::TestKubernetesExecutor::test_change_state_retries_processing_after_successful_pod_deletion --tb=short
```
