### PR TITLE
Show detailed API error messages in UI toasters

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/ErrorAlert.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ErrorAlert.tsx
@@ -22,6 +22,8 @@ import type { HTTPExceptionResponse, HTTPValidationError } from "openapi-gen/req
 
 import { Alert } from "src/system-components";
 
+import { getErrorDetail } from "src/utils/errorHandling";
+
 export type ExpandedApiError = {
   body: HTTPExceptionResponse | HTTPValidationError | undefined;
 } & ApiError;
@@ -37,18 +39,7 @@ export const ErrorAlert = ({ error: err }: Props) => {
     return undefined;
   }
 
-  const details = error.body?.detail;
-  let detailMessage;
-
-  if (details !== undefined) {
-    if (typeof details === "string") {
-      detailMessage = details;
-    } else if (Array.isArray(details)) {
-      detailMessage = details.map((detail) => `${detail.loc.join(".")} ${detail.msg}`);
-    } else {
-      detailMessage = Object.keys(details).map((key) => `${key}: ${details[key] as string}`);
-    }
-  }
+  const detailMessage = getErrorDetail(error);
 
   return (
     <Alert data-testid="error-alert" status="error">

--- a/airflow-core/src/airflow/ui/src/utils/errorHandling.ts
+++ b/airflow-core/src/airflow/ui/src/utils/errorHandling.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import type { TFunction } from "i18next";
+import type { HTTPExceptionResponse, HTTPValidationError } from "openapi-gen/requests/types.gen";
 
 import { toaster } from "src/system-components";
 
@@ -24,6 +25,7 @@ import { toaster } from "src/system-components";
  * Type guard to check if an error has a status property
  */
 type ErrorWithStatus = {
+  body?: HTTPExceptionResponse | HTTPValidationError;
   message?: string;
   response?: {
     status?: number;
@@ -44,6 +46,30 @@ export const getErrorStatus = (error: unknown): number | undefined => {
   return errorObj.status ?? errorObj.response?.status;
 };
 
+export const getErrorDetail = (error: unknown): string | undefined => {
+  if (typeof error !== "object" || error === null) {
+    return undefined;
+  }
+
+  const detail = (error as ErrorWithStatus).body?.detail;
+
+  if (detail === undefined) {
+    return undefined;
+  }
+
+  if (typeof detail === "string") {
+    return detail;
+  }
+
+  if (Array.isArray(detail)) {
+    return detail.map((item) => `${item.loc.join(".")} ${item.msg}`).join("\n");
+  }
+
+  return Object.keys(detail)
+    .map((key) => `${key}: ${detail[key] as string}`)
+    .join("\n");
+};
+
 /**
  * Safely extracts the error message from an error object
  */
@@ -54,7 +80,7 @@ const getErrorMessage = (error: unknown): string => {
 
   const errorObj = error as ErrorWithStatus;
 
-  return errorObj.message ?? "An error occurred";
+  return getErrorDetail(error) ?? errorObj.message ?? "An error occurred";
 };
 
 /**


### PR DESCRIPTION
### Sumarry

Error toasters raised by `createErrorToaster()` reported only the HTTP status phrase, so a user who hit a rejected action saw `Conflict` or `Bad Request` instead of the reason the API had already sent them.

`getErrorMessage()` in `errorHandling.ts` read `error.message`, and for the generated client that field never carries the API's own explanation: it comes from the status-code table in `openapi-gen/requests/core/request.ts`, which maps every response to a bare phrase. The reason lives in `error.body.detail`, which was dropped.

`ErrorAlert` already knew how to render that field in all three shapes FastAPI returns it in (a plain string, a list of validation errors, an object keyed by field). This extracts that logic into a shared `getErrorDetail()` and has both `ErrorAlert` and `createErrorToaster()` use it, so every screen that reports errors through a toaster gains the real message.

### Before / after

Deleting a Dag run that is still running returns:
- Before: the toaster said `Conflict`.

<img width="1592" height="871" alt="image" src="https://github.com/user-attachments/assets/1ef5fe1f-b6d4-4c37-8e0d-93f99e602da7" />

- After: the toaster says why the run cannot be deleted.
<img width="1690" height="858" alt="image" src="https://github.com/user-attachments/assets/55fcb7fd-9aef-4294-ac14-ace05e6b9df9" />

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)