### PR TITLE
UI: Fix raw translation key showing as a Backfills column header

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dag/Backfills/BackfillDagRunsModal.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Backfills/BackfillDagRunsModal.tsx
@@ -142,7 +142,7 @@ const getColumns = (
 ];
 
 export const BackfillDagRunsModal = ({ backfillId, dagId, onClose, open }: BackfillDagRunsModalProps) => {
-  const { t: translate } = useTranslation();
+  const { t: translate } = useTranslation(["common", "components"]);
   const pageSize = (useConfig("fallback_page_limit") as number | undefined) ?? 100;
   const [pageIndex, setPageIndex] = useState(0);
   const tableState = {

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Backfills/Backfills.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Backfills/Backfills.tsx
@@ -143,7 +143,8 @@ const getColumns = (
 ];
 
 export const Backfills = () => {
-  const { t: translate } = useTranslation();
+  // `common` is listed explicitly because passing any namespace overrides defaultNS.
+  const { t: translate } = useTranslation(["common", "components"]);
   const { setTableURLState, tableURLState } = useTableURLState();
   const location = useLocation();
   const navigate = useNavigate();


### PR DESCRIPTION
There was a bug in the backfills header translations.

We also need to pass "components" for our backfill headers. Which means, we also need to add common to the array.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
