### PR TITLE
Fix clipping of Last run state badge (#72459)

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/FilterBar/filters/SelectFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FilterBar/filters/SelectFilter.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { createListCollection, Box, Text } from "@chakra-ui/react";
+import type { ReactNode } from "react";
 
 import { Select } from "src/components/ui";
 
@@ -24,7 +25,7 @@ import { FilterPill } from "../FilterPill";
 import type { FilterPluginProps, FilterConfig } from "../types";
 
 type SelectOption = {
-  label: string;
+  label: ReactNode;
   value: string;
 };
 
@@ -52,6 +53,8 @@ export const SelectFilter = ({ filter, onChange, onRemove }: FilterPluginProps) 
   const displayValue = config.options.find(
     (option) => option.value === (typeof filter.value === "string" ? filter.value : ""),
   )?.label;
+  // Chakra line-clamps value text by default, which clips padded elements such as state badges.
+  const hasRichDisplayValue = displayValue !== undefined && typeof displayValue !== "string";
 
   return (
     <FilterPill
@@ -95,7 +98,11 @@ export const SelectFilter = ({ filter, onChange, onRemove }: FilterPluginProps) 
             value={hasValue && typeof filter.value === "string" ? [filter.value] : []}
           >
             <Select.Trigger dataTestId="select-filter-trigger" triggerProps={{ border: "none" }}>
-              <Select.ValueText placeholder={filter.config.placeholder} />
+              <Select.ValueText
+                lineClamp={hasRichDisplayValue ? "none" : undefined}
+                overflow={hasRichDisplayValue ? "visible" : undefined}
+                placeholder={filter.config.placeholder}
+              />
             </Select.Trigger>
             <Select.Content>
               {config.options.map((option) => (


### PR DESCRIPTION
Backport of #72459 to `v3-3-test` for the 3.3.2 release.

Fixes state badges being clipped by Chakra's default line-clamping in filter value text. v3-3-test's `SelectFilter.tsx` is structurally older, so the fix (ReactNode label type, `hasRichDisplayValue`, `lineClamp`/`overflow`) was adapted onto it while keeping v3-3-test's `dataTestId`. Confirmed the clipping scenario is live on v3-3-test (`filterConfigs.tsx` passes `StateBadge` as option labels). `FilterBar.test.tsx` removed (not on v3-3-test). eslint + tsc clean.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)