### PR TITLE
Expose a translated navigation landmark in the sidebar

### DIFF
--- a/airflow-core/newsfragments/72844.improvement.rst
+++ b/airflow-core/newsfragments/72844.improvement.rst
@@ -1,0 +1,1 @@
+Expose the sidebar as a navigation landmark with a translated accessible name.

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.test.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.test.tsx
@@ -20,11 +20,15 @@ import type { PropsWithChildren } from "react";
 
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { BaseWrapper } from "src/utils/Wrapper";
 
+import enCommon from "../../../public/i18n/locales/en/common.json";
+import zhTWCommon from "../../../public/i18n/locales/zh-TW/common.json";
 import { Nav } from "./Nav";
 
 vi.mock("openapi/queries", () => ({
@@ -47,6 +51,23 @@ vi.mock("./UserSettingsButton", () => ({ UserSettingsButton: () => <div /> }));
 vi.mock("./PluginMenus", () => ({ PluginMenus: () => <div /> }));
 vi.mock("./TimezoneModal", () => ({ default: () => <div /> }));
 
+beforeAll(async () => {
+  await i18n.use(initReactI18next).init({
+    defaultNS: "common",
+    fallbackLng: "en",
+    interpolation: { escapeValue: false },
+    lng: "en",
+    resources: {
+      en: { common: enCommon },
+      "zh-TW": { common: zhTWCommon },
+    },
+  });
+});
+
+beforeEach(async () => {
+  await i18n.changeLanguage("en");
+});
+
 const wrapperAt = (path: string) => {
   const wrapper = ({ children }: PropsWithChildren) => (
     <BaseWrapper>
@@ -56,6 +77,18 @@ const wrapperAt = (path: string) => {
 
   return wrapper;
 };
+
+describe("Nav landmark", () => {
+  it.each([
+    { language: "en", name: "Navigation" },
+    { language: "zh-TW", name: "導覽" },
+  ])("exposes a translated navigation landmark in $language", async ({ language, name }) => {
+    await i18n.changeLanguage(language);
+    render(<Nav />, { wrapper: wrapperAt("/") });
+
+    expect(screen.getByRole("navigation", { name })).toBeInTheDocument();
+  });
+});
 
 describe("Nav dashboard button", () => {
   it("links to the dashboard at /home", () => {

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -150,6 +150,8 @@ export const Nav = () => {
         right: 0,
       }}
       alignItems="center"
+      aria-label={translate("shortcuts.categories.navigation")}
+      as="nav"
       bg="brand.muted"
       data-testid="nav-sidebar"
       height="100%"


### PR DESCRIPTION
## Summary

Render the sidebar as a navigation landmark with an accessible name from the existing translations. Regression tests use the real English and Traditional Chinese resources, so an unresolved translation key cannot satisfy the assertions.

Addresses the navigation-landmark portion of #54587. This changes accessibility semantics, not the visual layout.

## Development and review

Developed with Codex assistance. Astra independently reviewed the correction and assisted with final integration and validation. I thoroughly reviewed the code before submission and take responsibility for the contribution. The automated checks below were run by the coding assistant, not personally by me.

## Validation

- Rebased onto the latest fetched upstream main.
- Required regular and manual hooks passed in Ubuntu 22.04 under WSL, including the production UI build. Only the three documented manual-hook exclusions were used: `compile-ui-assets-dev`, `view-skill-eval`, and `run-skill-eval-codex`.
- All five tests in `Nav.test.tsx` passed, covering English and Traditional Chinese landmark names and the existing dashboard navigation behavior.
- `git diff --check` passed.

No manual screen-reader testing or full UI-suite result is claimed. The Airflow checks used WSL, not Docker.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes, Codex, including Astra (gpt-6-astra) for review and final integration.

Generated-by: Codex (Astra, gpt-6-astra) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

Drafted-by: Codex (Astra, gpt-6-astra); reviewed by John Finnerty after initial posting.
