### PR TITLE
Count all failed task attempts in failure metrics

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -241,9 +241,6 @@ class RuntimeTaskInstance(TaskInstance):
     _terminal_state_send_failed: bool = False
     """True when the supervisor IPC send for a non-success terminal state raised; signals main() to sys.exit(1) after finalize() so the supervisor doesn't misclassify the run as SUCCESS via exit code 0."""
 
-    _failure_metrics_emitted: bool = False
-    """True once the failure counters have been recorded, so a second pass through the failure path (one attempt raised part-way through) does not count the same failure twice."""
-
     _ti_context_from_server: Annotated[TIRunContext | None, Field(repr=False)] = None
     """The Task Instance context from the API server, if any."""
 
@@ -1716,6 +1713,11 @@ def run(
         # skipping the retry decision and every callback in ``finalize()``.
         msg, state, error = _handle_handler_failure(ti, e, log, context)
     finally:
+        # Count the final outcome once, including failures that bypass the retry handler.
+        if state in (TaskInstanceState.FAILED, TaskInstanceState.UP_FOR_RETRY):
+            stats.incr("operator_failures", tags={**stats_tags, "operator_name": ti.task.__class__.__name__})
+            stats.incr("ti_failures", tags=stats_tags)
+
         # `state` may still be unset if an exception handler above raised before
         # binding it
         if state is not None:
@@ -1903,7 +1905,7 @@ def _finalize_task_failure(
     retry_reason: str | None = None,
 ) -> tuple[RetryTask, TaskInstanceState] | tuple[TaskState, TaskInstanceState]:
     """
-    Record failure metrics and build the standard retry-or-fail outcome.
+    Build the standard retry-or-fail outcome.
 
     Returns an ``UP_FOR_RETRY`` ``RetryTask`` when the server marked the task
     retry-eligible (optionally carrying a policy-supplied delay/reason), else a
@@ -1912,17 +1914,6 @@ def _finalize_task_failure(
     """
     end_date = datetime.now(tz=timezone.utc)
     ti.end_date = end_date
-
-    # Record operator and task instance failed metrics. One failure is one increment even
-    # if this runs twice, which happens when a first pass raised after counting -- see
-    # `_handle_handler_failure`.
-    if not ti._failure_metrics_emitted:
-        operator = ti.task.__class__.__name__
-        stats_tags = ti.stats_tags
-
-        stats.incr("operator_failures", tags={**stats_tags, "operator_name": operator})
-        stats.incr("ti_failures", tags=stats_tags)
-        ti._failure_metrics_emitted = True
 
     if ti._ti_context_from_server and ti._ti_context_from_server.should_retry:
         retry_kwargs: dict[str, Any] = {"end_date": end_date}

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -1046,8 +1046,9 @@ def test_defer_with_unserializable_kwargs_honours_retries_and_callbacks(
     assert callbacks_run == ["retry" if should_retry else "failure"]
 
 
+@mock.patch("airflow.sdk.execution_time.task_runner.stats.incr", autospec=True)
 def test_handler_failure_keeps_non_retryable_exceptions_non_retryable(
-    create_runtime_ti, mock_supervisor_comms
+    mock_incr, create_runtime_ti, mock_supervisor_comms
 ):
     """
     A handler that raises a non-retryable exception must still fail without retrying.
@@ -1085,6 +1086,16 @@ def test_handler_failure_keeps_non_retryable_exceptions_non_retryable(
     assert state == TaskInstanceState.FAILED
     assert isinstance(msg, TaskState)
     assert isinstance(error, AirflowFailException)
+    assert mock_incr.call_args_list.count(mock.call("ti_failures", tags=ti.stats_tags)) == 1
+    assert (
+        mock_incr.call_args_list.count(
+            mock.call(
+                "operator_failures",
+                tags={**ti.stats_tags, "operator_name": "_DeferWithFailingTrigger"},
+            )
+        )
+        == 1
+    )
 
 
 def test_handler_failure_lets_keyboard_interrupt_propagate(create_runtime_ti, mock_supervisor_comms):
@@ -1164,9 +1175,8 @@ def test_handler_failure_counts_the_failure_once(create_runtime_ti, mock_supervi
     """
     One failure is one increment, even when the failure path runs twice.
 
-    The first pass through `_finalize_task_failure` records the counters before the broken
-    retry delay makes it raise, so counting again on the second pass would report two
-    failures for a single task run.
+    A broken retry delay makes the failure handler run twice, but it must still report
+    only one failure for the task run.
     """
 
     class _BadDelayPolicy(RetryPolicy):
@@ -5892,26 +5902,64 @@ class TestTaskInstanceMetrics:
             )
             backend.incr.assert_any_call("ti_successes", tags=stats_tags)
 
-    def test_operator_failures_metrics_emitted(self, create_runtime_ti, mock_supervisor_comms):
-        """Test that operator_failures and ti_failures metrics are emitted on task failure."""
-        task = PythonOperator(task_id="test", python_callable=lambda: 1 / 0)
-        ti = create_runtime_ti(task=task)
+    @pytest.mark.parametrize("should_retry", [False, True])
+    @pytest.mark.parametrize(
+        ("exception", "policy_action"),
+        [
+            pytest.param(ValueError, None, id="ordinary-failure"),
+            pytest.param(AirflowFailException, None, id="forced-failure"),
+            pytest.param(AirflowSensorTimeout, None, id="sensor-timeout"),
+            pytest.param(AirflowTaskTerminated, None, id="terminated"),
+            pytest.param(ValueError, RetryAction.FAIL, id="retry-policy-fail"),
+        ],
+    )
+    @mock.patch("airflow.sdk._shared.observability.metrics.stats._get_backend", autospec=True)
+    def test_operator_failures_metrics_emitted(
+        self,
+        mock_get_backend,
+        exception,
+        policy_action,
+        should_retry,
+        create_runtime_ti,
+        mock_supervisor_comms,
+    ):
+        def fail():
+            raise exception("Task failed")
 
-        with mock.patch("airflow.sdk._shared.observability.metrics.stats._get_backend") as mock_get_backend:
-            backend = mock.MagicMock(spec=StatsLogger)
-            mock_get_backend.return_value = backend
-            run(ti, context=ti.get_template_context(), log=mock.MagicMock())
+        retry_policy = (
+            ExceptionRetryPolicy(rules=[RetryRule(exception=exception, action=policy_action)])
+            if policy_action
+            else None
+        )
+        task = PythonOperator(task_id="test", python_callable=fail, retry_policy=retry_policy)
+        ti = create_runtime_ti(task=task, should_retry=should_retry)
+        backend = mock.MagicMock(spec=StatsLogger)
+        mock_get_backend.return_value = backend
 
-            stats_tags = {"dag_id": ti.dag_id, "task_id": ti.task_id, "run_type": "manual"}
+        state, msg, error = run(
+            ti,
+            context=ti.get_template_context(),
+            log=mock.MagicMock(spec=structlog.typing.FilteringBoundLogger),
+        )
 
-            # verify operator_failures in legacy format
-            backend.incr.assert_any_call("operator_failures_PythonOperator", tags=stats_tags)
-            # verify operator_failures in tagged format
-            backend.incr.assert_any_call(
-                "operator_failures",
-                tags={**stats_tags, "operator_name": "PythonOperator"},
-            )
-            backend.incr.assert_any_call("ti_failures", tags=stats_tags)
+        expected_state = (
+            TaskInstanceState.UP_FOR_RETRY
+            if exception is ValueError and policy_action is None and should_retry
+            else TaskInstanceState.FAILED
+        )
+        assert state == expected_state
+        assert isinstance(msg, RetryTask if expected_state == TaskInstanceState.UP_FOR_RETRY else TaskState)
+        assert isinstance(error, exception)
+        failure_calls = [
+            c
+            for c in backend.incr.call_args_list
+            if c.args[0].startswith(("operator_failures", "ti_failures"))
+        ]
+        assert failure_calls == [
+            mock.call("operator_failures_PythonOperator", tags=ti.stats_tags),
+            mock.call("operator_failures", tags={**ti.stats_tags, "operator_name": "PythonOperator"}),
+            mock.call("ti_failures", tags=ti.stats_tags),
+        ]
 
     @pytest.mark.parametrize(
         ("team_name", "expected_tags_extra"),


### PR DESCRIPTION
Tasks that raise `AirflowFailException`, `AirflowSensorTimeout`, or `AirflowTaskTerminated`, and tasks whose retry policy returns `FAIL`, report a failed state but omit `ti_failures` and `operator_failures`. Non-retryable exceptions raised inside outcome handlers have the same gap.

Record the failure counters once in `run()` after the final outcome is known, for both `FAILED` and `UP_FOR_RETRY`. This restores emission through the shared metrics facade for StatsD and OpenTelemetry, including the registry-derived legacy operator counter. It also removes the per-instance deduplication flag: retry-handler recovery can run twice, but the final outcome is counted once. Retry decisions and terminal-state messages are unchanged.

Validation:

- Nine regression cases fail without the production change and pass with it. Coverage includes forced failure, sensor timeout, termination, retry-policy `FAIL`, both retry eligibility settings, and a non-retryable exception raised inside an outcome handler.
- All 543 task-runner tests pass, including the existing retry-handler double-fault and once-only counter tests.
- Ruff, Task SDK mypy, and both required prek stages pass.
- The broader Task SDK run recorded 2,822 passed and 7 skipped, plus two callback-log assertion failures and a provider-discovery worker crash. Both callback failures reproduced in the broader suite on unmodified upstream main (`a3bf92fe85`) and pass in isolation there. The run was interrupted after the worker crash stalled completion; the baseline run also lost its Sphinx subprocess to `SIGKILL`. The local Docker environment has about 2 GB RAM, so this is not a fully green suite result.
- Selective checks request the wider core, provider, and integration CI matrix; those suites were not run locally.

The separate queued-duration P1 is already covered by #67592 and is outside this PR.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-6)

Generated-by: Codex (GPT-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---
Drafted-by: Codex (GPT-6) (no human review before posting)
