### PR TITLE
Run short CI bookkeeping jobs on ubuntu-slim runners

### DIFF
--- a/.github/workflows/automatic-backport.yml
+++ b/.github/workflows/automatic-backport.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   get-pr-info:
     name: "Get PR information"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       branches: ${{ steps.pr-info.outputs.branches }}
       commit-sha: ${{ github.sha }}

--- a/.github/workflows/check-newsfragment-pr-number.yml
+++ b/.github/workflows/check-newsfragment-pr-number.yml
@@ -34,7 +34,7 @@ concurrency:
 jobs:
   check-newsfragment-pr-number:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip newsfragment check') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     steps:
       - name: Check newsfragment PR number

--- a/.github/workflows/ci-amd.yml
+++ b/.github/workflows/ci-amd.yml
@@ -238,7 +238,7 @@ jobs:
   print-platform:
     name: "Platform: AMD"
     needs: [build-info]
-    runs-on: ["ubuntu-22.04"]
+    runs-on: ["ubuntu-slim"]
     steps:
       - name: "Print architecture"
         run: "echo '## Architecture: AMD' >> $GITHUB_STEP_SUMMARY"
@@ -1201,7 +1201,7 @@ jobs:
       !cancelled() &&
       github.event_name == 'schedule' &&
       github.run_attempt == 1
-    runs-on: ["ubuntu-22.04"]
+    runs-on: ["ubuntu-slim"]
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/ci-arm.yml
+++ b/.github/workflows/ci-arm.yml
@@ -227,7 +227,7 @@ jobs:
   print-platform:
     name: "Platform: ARM"
     needs: [build-info]
-    runs-on: ["ubuntu-22.04"]
+    runs-on: ["ubuntu-slim"]
     steps:
       - name: "Print architecture"
         run: "echo '## Architecture: ARM' >> $GITHUB_STEP_SUMMARY"
@@ -1190,7 +1190,7 @@ jobs:
       !cancelled() &&
       github.event_name == 'schedule' &&
       github.run_attempt == 1
-    runs-on: ["ubuntu-22.04"]
+    runs-on: ["ubuntu-slim"]
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/ci-duration-monitor.yml
+++ b/.github/workflows/ci-duration-monitor.yml
@@ -34,7 +34,7 @@ jobs:
 
   monitor-ci-durations:
     name: "Monitor CI durations on main"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/ci-notification.yml
+++ b/.github/workflows/ci-notification.yml
@@ -40,18 +40,21 @@ jobs:
         # Track AMD; ARM is the canary slot and is reported separately by
         # `ci-arm.yml`'s notify-slack job on schedule events.
         workflow-id: ["ci-amd.yml"]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
 
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
+        with:
+          version-file: uv.lock
+
       - name: "Find workflow run status"
         id: find-workflow-run-status
-        run: |
-          python3 -m pip install uv
-          uv run ./dev/breeze/src/airflow_breeze/utils/workflow_status.py
+        run: uv run ./dev/breeze/src/airflow_breeze/utils/workflow_status.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           workflow_branch: ${{ matrix.branch }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,7 +49,7 @@ concurrency:
 jobs:
   detect-languages:
     name: Detect languages to scan
-    runs-on: ["ubuntu-22.04"]
+    runs-on: ["ubuntu-slim"]
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/e2e-flaky-tests-report.yml
+++ b/.github/workflows/e2e-flaky-tests-report.yml
@@ -33,7 +33,7 @@ jobs:
 
   analyze-flaky-tests:
     name: "Analyze E2E flaky tests"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/java-sdk-dependency-security.yml
+++ b/.github/workflows/java-sdk-dependency-security.yml
@@ -42,7 +42,7 @@ jobs:
   dependency-review:
     name: Reject vulnerable dependency changes
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Review dependency changes
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0

--- a/.github/workflows/milestone-tag-assistant.yml
+++ b/.github/workflows/milestone-tag-assistant.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   get-pr-info:
     name: "Get PR information"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       should-run: ${{ steps.pr-info.outputs.should-run }}
       pr-number: ${{ steps.pr-info.outputs.pr-number }}

--- a/.github/workflows/notify-uv-lock-conflicts.yml
+++ b/.github/workflows/notify-uv-lock-conflicts.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   notify:
     name: "Notify open PRs that conflict on uv.lock"
-    runs-on: ["ubuntu-22.04"]
+    runs-on: ["ubuntu-slim"]
     timeout-minutes: 10
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
@@ -37,16 +37,9 @@ jobs:
         with:
           persist-credentials: false
       - name: "Install uv"
-        # Extract uv version from uv.lock. The format is stable: the line
-        # immediately after `name = "uv"` is `version = "<X.Y.Z>"`.
-        run: |
-          UV_VERSION=$(sed -n '/^name = "uv"$/{n;s/^version = "\(.*\)"$/\1/p;}' uv.lock)
-          if [[ -z "${UV_VERSION}" ]]; then
-            echo "Failed to extract uv version from uv.lock" >&2
-            exit 1
-          fi
-          echo "Installing uv==${UV_VERSION}"
-          pip install "uv==${UV_VERSION}"
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
+        with:
+          version-file: uv.lock
       - name: "Notify open PRs"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/recheck-old-bug-report.yml
+++ b/.github/workflows/recheck-old-bug-report.yml
@@ -26,7 +26,7 @@ permissions:
   issues: write
 jobs:
   recheck-old-bug-report:
-    runs-on: ["ubuntu-22.04"]
+    runs-on: ["ubuntu-slim"]
     steps:
       - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93  # v11.0.0
         with:

--- a/.github/workflows/registry-backfill.yml
+++ b/.github/workflows/registry-backfill.yml
@@ -79,7 +79,7 @@ jobs:
       disable-airflow-repo-cache: "false"
 
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       bucket: ${{ steps.destination.outputs.bucket }}

--- a/.github/workflows/registry-tests.yml
+++ b/.github/workflows/registry-tests.yml
@@ -45,8 +45,10 @@ concurrency:
 jobs:
   registry-tests:
     name: "Registry extraction tests"
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
+    runs-on: ubuntu-slim
+    # ubuntu-slim is single-core, so the uv sync plus the suite need more headroom than
+    # the 5 minutes that sufficed on a 2-core runner.
+    timeout-minutes: 10
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/scheduled-verify-release-calendar.yml
+++ b/.github/workflows/scheduled-verify-release-calendar.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   verify-release-calendar:
     name: "Verify release calendar"
-    runs-on: ["ubuntu-22.04"]
+    runs-on: ["ubuntu-slim"]
     timeout-minutes: 10
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
@@ -35,16 +35,9 @@ jobs:
         with:
           persist-credentials: false
       - name: "Install uv"
-        # Extract uv version from uv.lock. The format is stable: the line
-        # immediately after `name = "uv"` is `version = "<X.Y.Z>"`.
-        run: |
-          UV_VERSION=$(sed -n '/^name = "uv"$/{n;s/^version = "\(.*\)"$/\1/p;}' uv.lock)
-          if [[ -z "${UV_VERSION}" ]]; then
-            echo "Failed to extract uv version from uv.lock" >&2
-            exit 1
-          fi
-          echo "Installing uv==${UV_VERSION}"
-          pip install "uv==${UV_VERSION}"
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
+        with:
+          version-file: uv.lock
       - name: "Verify release calendar"
         run: uv run dev/verify_release_calendar.py
       # yamllint disable rule:line-length

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,7 +27,7 @@ permissions:
   issues: write
 jobs:
   stale:
-    runs-on: ["ubuntu-22.04"]
+    runs-on: ["ubuntu-slim"]
     steps:
       # Handle all PRs (45-day stale) and pending-response issues (14-day stale)
       - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93  # v11.0.0

--- a/.github/workflows/ts-sdk-dependency-review.yml
+++ b/.github/workflows/ts-sdk-dependency-review.yml
@@ -36,7 +36,7 @@ concurrency:
 jobs:
   dependency-review:
     name: Reject vulnerable dependency changes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Review dependency changes
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0

--- a/.github/workflows/update-constraints-on-push-stable.yml
+++ b/.github/workflows/update-constraints-on-push-stable.yml
@@ -159,7 +159,7 @@ jobs:
 
   notify-on-failure:
     name: "Notify on failure"
-    runs-on: ["ubuntu-22.04"]
+    runs-on: ["ubuntu-slim"]
     needs: [build-info, build-ci-images, generate-constraints, update-constraints]
     if: failure()
     env:

--- a/.github/workflows/update-constraints-on-push.yml
+++ b/.github/workflows/update-constraints-on-push.yml
@@ -234,7 +234,7 @@ jobs:
 
   notify-on-failure:
     name: "Notify on failure"
-    runs-on: ["ubuntu-22.04"]
+    runs-on: ["ubuntu-slim"]
     needs: [build-info, build-ci-images, generate-constraints, update-constraints]
     if: failure()
     env:

--- a/dev/breeze/doc/ci/05_workflows.md
+++ b/dev/breeze/doc/ci/05_workflows.md
@@ -28,6 +28,7 @@
   - [Workflow Architecture Overview](#workflow-architecture-overview)
   - [Branch-Specific Behavior](#branch-specific-behavior)
   - [Tests Workflow Structure](#tests-workflow-structure)
+  - [Runners](#runners)
   - [Implementation Details](#implementation-details)
   - [CodeQL scan](#codeql-scan)
   - [Publishing documentation](#publishing-documentation)
@@ -310,6 +311,36 @@ Special tests (integration and system tests) run selectively:
 - When complete test coverage is required for thorough validation
 - In canary runs for scheduled quality checks
 - When dependency upgrades require thorough testing
+
+## Runners
+
+Two kinds of GitHub-hosted runner are used, and which one a job gets depends on what
+the job actually needs.
+
+**`ubuntu-22.04` / `ubuntu-22.04-arm`** (2 cores, 7-16 GB RAM, privileged) is the
+default for anything that builds or runs a container, installs Airflow, or runs a real
+test suite. Jobs that get their runner from selective checks (`amd-runners` /
+`arm-runners`, see [04_selective_checks.md](04_selective_checks.md)) always land here.
+
+**`ubuntu-slim`** (1 core, 5 GB RAM, 14 GB disk) is used for the short bookkeeping jobs
+around the edges of CI — computing a matrix, posting a Slack notification, closing stale
+issues, checking a newsfragment name. It is a container rather than a VM and runs
+unprivileged, which constrains what can go on it:
+
+- **No Docker daemon.** The Docker *client* is on the image, but nothing can build an
+  image, start a container, or use a Docker-container action. Anything touching Breeze
+  is out.
+- **`python3` is Ubuntu's system interpreter**, so it is PEP 668 externally managed and
+  a bare `pip install` fails. Stdlib-only scripts are fine; a job that needs
+  dependencies must bring its own interpreter. For anything driven by `uv run`, use
+  `astral-sh/setup-uv` with `version-file: uv.lock` — that installs the uv version the
+  workspace is locked to, and `uv run` then provisions its own Python.
+- **Minimal toolset** — `git`, `gh`, `jq`, `node`, `curl` are present; Java and Go are
+  not. `actions/setup-*` still works, since those actions download into the tool cache.
+- **One core**, so give a job that does real work a timeout with some slack in it.
+
+When adding a job, reach for `ubuntu-slim` if it only shuffles metadata around, and
+`ubuntu-22.04` otherwise.
 
 ## Implementation Details
 

--- a/dev/breeze/doc/ci/05_workflows.md
+++ b/dev/breeze/doc/ci/05_workflows.md
@@ -330,7 +330,7 @@ unprivileged, which constrains what can go on it:
 - **No Docker daemon.** The Docker *client* is on the image, but nothing can build an
   image, start a container, or use a Docker-container action. Anything touching Breeze
   is out.
-- **`python3` is Ubuntu's system interpreter**, so it is PEP 668 externally managed and
+- **`python3` is Ubuntu's system interpreter**, so it is [PEP 668](https://peps.python.org/pep-0668/) externally managed and
   a bare `pip install` fails. Stdlib-only scripts are fine; a job that needs
   dependencies must bring its own interpreter. For anything driven by `uv run`, use
   `astral-sh/setup-uv` with `version-file: uv.lock` — that installs the uv version the


### PR DESCRIPTION
A large share of our workflow jobs never build an image, never install Airflow
and never run a test suite — they compute a matrix, post a Slack message, close
a stale issue, check a newsfragment name. They were holding a 2-core runner for
their whole (short) lifetime, competing with the builds and test shards that
genuinely need one.

`ubuntu-slim` (1 core, 5 GB RAM, 14 GB disk, unprivileged container) is the right
size for that class of work. 22 jobs across 19 workflows move onto it.

### What decided the cut

`ubuntu-slim`'s constraints, verified against the runner image rather than assumed:

* **No Docker daemon** — client only, unprivileged, no DinD. Everything touching
  Breeze, image builds or Docker-container actions stays put.
* **`python3` is Ubuntu's system interpreter** — PEP 668 externally managed, so a
  bare `pip install` fails.
* **Minimal toolset** — `git`, `gh`, `jq`, `node`, `curl` present; no Java, no Go.
  `actions/setup-*` still works (tool-cache downloads).
* **One core** — jobs doing real work need timeout headroom.

So every moved job is one that only shuffles metadata: matrix computation
(`detect-languages`, `registry-backfill`'s `prepare`), notifications (`notify-slack`,
`notify-on-failure`, the CI-duration and flaky-test reports), issue/PR housekeeping
(`stale`, `recheck-old-bug-report`, `milestone-tag-assistant`, `automatic-backport`),
and cheap guards (`check-newsfragment-pr-number`, the two `dependency-review` jobs,
`registry-tests`). I checked that every Python script involved is stdlib-only.

### uv installs

Three moved jobs installed uv by `sed`-ing the version out of `uv.lock` and
pip-installing it into the system interpreter — which this image refuses. They now use:

```yaml
- uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
  with:
    version-file: uv.lock
```

`setup-uv`'s `uv.lock` parser finds the package named `uv` and returns its version —
exactly what the `sed` did — so the pin is preserved. `ci-notification` was previously
installing *unpinned* uv, so it gains determinism here. All three scripts carry PEP 723
inline metadata, so `uv run` provisions its own Python; no `setup-python` needed. The
pinned SHA is already used in `registry-tests.yml` and is on the ASF approved allowlist.

### Not moved

`asf-allowlist-check` is the one obvious candidate left behind: the blocker is inside
the upstream `apache/infrastructure-actions/allowlist-check` composite, which does a
bare `pip install ruyaml` with no `setup-python`. Fixing that belongs upstream — PR to
follow.

`registry-tests` is the only moved job doing real work, so its timeout goes 5 → 10 min
for the single core.

Also documents the two runner tiers and the slim constraints in
`dev/breeze/doc/ci/05_workflows.md`, so new jobs land on the right one.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UL4HBX63zq4um1L4XBcJYy
