### PR TITLE
Fix PydanticAI vendor connections not resolving from secrets backends

### DIFF
--- a/airflow-core/src/airflow/provider.yaml.schema.json
+++ b/airflow-core/src/airflow/provider.yaml.schema.json
@@ -428,9 +428,9 @@
                 "type": "object",
                 "properties": {
                     "connection-type": {
-                        "description": "Type of connection defined by the provider. Must not contain '-': the hook is registered under this exact string, but Connection.from_uri/from_json rewrite '-' to '_', which would leave the hook unreachable from every secrets backend.",
+                        "description": "Type of connection defined by the provider. Lowercase letters, digits and '_' only, starting with a letter. The hook is registered under this exact string, while Connection.get_uri() encodes '_' as '-' and from_uri/from_json decode '-' back to '_'. A '-' here is therefore indistinguishable from an encoded '_' and leaves the hook unresolvable for any connection stored as a URI or JSON; uppercase is lost to get_uri()'s lowercasing; and a leading digit is not a valid URI scheme under RFC 3986.",
                         "type": "string",
-                        "pattern": "^[a-z0-9_]+$"
+                        "pattern": "^[a-z][a-z0-9_]*$"
                     },
                     "hook-class-name": {
                         "description": "Hook class name that implements the connection type",

--- a/airflow-core/src/airflow/provider.yaml.schema.json
+++ b/airflow-core/src/airflow/provider.yaml.schema.json
@@ -428,8 +428,9 @@
                 "type": "object",
                 "properties": {
                     "connection-type": {
-                        "description": "Type of connection defined by the provider",
-                        "type": "string"
+                        "description": "Type of connection defined by the provider. Must not contain '-': the hook is registered under this exact string, but Connection.from_uri/from_json rewrite '-' to '_', which would leave the hook unreachable from every secrets backend.",
+                        "type": "string",
+                        "pattern": "^[a-z0-9_]+$"
                     },
                     "hook-class-name": {
                         "description": "Hook class name that implements the connection type",

--- a/airflow-core/src/airflow/provider.yaml.schema.json
+++ b/airflow-core/src/airflow/provider.yaml.schema.json
@@ -428,9 +428,9 @@
                 "type": "object",
                 "properties": {
                     "connection-type": {
-                        "description": "Type of connection defined by the provider. Lowercase letters, digits and '_' only, starting with a letter. The hook is registered under this exact string, while Connection.get_uri() encodes '_' as '-' and from_uri/from_json decode '-' back to '_'. A '-' here is therefore indistinguishable from an encoded '_' and leaves the hook unresolvable for any connection stored as a URI or JSON; uppercase is lost to get_uri()'s lowercasing; and a leading digit is not a valid URI scheme under RFC 3986.",
+                        "description": "Type of connection defined by the provider. Lowercase letters, digits and '_' only, starting with a letter. The hook is registered under this exact string, while Connection.get_uri() encodes '_' as '-' and from_uri/from_json decode '-' back to '_'. A '-' here is therefore indistinguishable from an encoded '_' and leaves the hook unresolvable for any connection stored as a URI or JSON; uppercase is lost to get_uri()'s lowercasing; and a leading digit is not a valid URI scheme under RFC 3986. The trailing lookahead is load-bearing: a pattern is matched with re.search, where '$' also matches before a trailing newline, which is what a YAML block scalar produces.",
                         "type": "string",
-                        "pattern": "^[a-z][a-z0-9_]*$"
+                        "pattern": "^[a-z][a-z0-9_]*$(?!\\n)"
                     },
                     "hook-class-name": {
                         "description": "Hook class name that implements the connection type",

--- a/airflow-core/src/airflow/provider_info.schema.json
+++ b/airflow-core/src/airflow/provider_info.schema.json
@@ -292,9 +292,8 @@
                 "type": "object",
                 "properties": {
                     "connection-type": {
-                        "description": "Type of connection defined by the provider. Must not contain '-': the hook is registered under this exact string, but Connection.from_uri/from_json rewrite '-' to '_', which would leave the hook unreachable from every secrets backend.",
-                        "type": "string",
-                        "pattern": "^[a-z0-9_]+$"
+                        "description": "Type of connection defined by the provider",
+                        "type": "string"
                     },
                     "hook-class-name": {
                         "description": "Hook class name that implements the connection type",

--- a/airflow-core/src/airflow/provider_info.schema.json
+++ b/airflow-core/src/airflow/provider_info.schema.json
@@ -292,8 +292,9 @@
                 "type": "object",
                 "properties": {
                     "connection-type": {
-                        "description": "Type of connection defined by the provider",
-                        "type": "string"
+                        "description": "Type of connection defined by the provider. Must not contain '-': the hook is registered under this exact string, but Connection.from_uri/from_json rewrite '-' to '_', which would leave the hook unreachable from every secrets backend.",
+                        "type": "string",
+                        "pattern": "^[a-z0-9_]+$"
                     },
                     "hook-class-name": {
                         "description": "Hook class name that implements the connection type",

--- a/airflow-core/tests/unit/always/test_provider_yaml_schema.py
+++ b/airflow-core/tests/unit/always/test_provider_yaml_schema.py
@@ -1,0 +1,73 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+import yaml
+
+import airflow
+
+SCHEMA_PATH = Path(airflow.__file__).parent / "provider.yaml.schema.json"
+
+# A connection type is registered under this exact string, so the authoring schema constrains
+# it to the one spelling that can be reached again: get_uri() lowercases and encodes '_' as
+# '-', and reading a connection back decodes '-' to '_'.
+CONNECTION_TYPE_SCHEMA = json.loads(SCHEMA_PATH.read_text())["properties"]["connection-types"]["items"][
+    "properties"
+]["connection-type"]
+
+# A YAML block scalar keeps a trailing newline, which is the value most easily written by
+# accident. It is built here through the parser rather than hard-coded, so the case documents
+# how such a value reaches the schema at all.
+BLOCK_SCALAR_VALUE = yaml.safe_load("connection-type: |\n  pydanticai_vertex\n")["connection-type"]
+
+
+@pytest.mark.parametrize(
+    "connection_type",
+    ["pydanticai", "google_cloud_platform", "pagerduty_events", "a", "s3"],
+)
+def test_schema_accepts_a_registrable_connection_type(connection_type):
+    jsonschema.validate(connection_type, schema=CONNECTION_TYPE_SCHEMA)
+
+
+@pytest.mark.parametrize(
+    ("connection_type", "reason"),
+    [
+        pytest.param("pydanticai-vertex", "'-' is the URI encoding of '_'", id="hyphen"),
+        pytest.param(BLOCK_SCALAR_VALUE, "a trailing newline is not part of the name", id="block-scalar"),
+        pytest.param("pydanticai-vertex\n", "hyphen and trailing newline", id="hyphen-and-newline"),
+        pytest.param("PydanticAI", "get_uri() lowercases the scheme", id="uppercase"),
+        pytest.param("1password", "a URI scheme cannot start with a digit", id="leading-digit"),
+        pytest.param("pydantic ai", "a space cannot appear in a scheme", id="space"),
+        pytest.param("pydantic\nai", "an embedded newline is not a scheme", id="embedded-newline"),
+        pytest.param("", "a connection type is required to be non-empty", id="empty"),
+    ],
+)
+def test_schema_rejects_a_connection_type_that_cannot_be_resolved(connection_type, reason):
+    """
+    The trailing-newline cases are why the pattern carries a lookahead rather than ending at
+    '$'. A schema pattern is matched with ``re.search``, and Python's '$' matches before a
+    trailing newline as well as at the end of the string, so ``^[a-z][a-z0-9_]*$`` alone
+    accepts a value written as a YAML block scalar.
+    """
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(connection_type, schema=CONNECTION_TYPE_SCHEMA)

--- a/contributing-docs/23_provider_hook_migration_to_yaml.rst
+++ b/contributing-docs/23_provider_hook_migration_to_yaml.rst
@@ -82,7 +82,7 @@ no effect on docs generation, logos, or tags.
     connection-types:
       - hook-class-name: airflow.providers.common.ai.hooks.pydantic_ai.PydanticAIAzureHook
         hook-name: "Pydantic AI (Azure OpenAI)"
-        connection-type: pydanticai-azure
+        connection-type: pydanticai_azure
         external-services:
           - Azure OpenAI
 

--- a/providers/MANAGING_PROVIDERS_LIFECYCLE.rst
+++ b/providers/MANAGING_PROVIDERS_LIFECYCLE.rst
@@ -270,7 +270,7 @@ your provider:
 
     connection-types:
       - hook-class-name: airflow.providers.<PROVIDER>.hooks.<PROVIDER>.NewProviderHook
-      - connection-type: provider-connection-type
+        connection-type: provider_connection_type
 
 
 Building documentation locally

--- a/providers/common/ai/docs/connections/pydantic_ai_azure.rst
+++ b/providers/common/ai/docs/connections/pydantic_ai_azure.rst
@@ -29,11 +29,26 @@ that the generic :doc:`pydantic_ai` connection assumes).
 
 .. note::
 
-    This connection type was previously named ``pydanticai-azure``. A connection stored
-    with the old hyphenated type will not resolve; update its type to
-    ``pydanticai_azure``. Hyphens are not usable here because a hook is registered
-    under this exact string while ``Connection.from_uri`` and ``from_json`` rewrite
-    ``-`` to ``_``, which left the hook unreachable from every secrets backend.
+    This connection type was previously named ``pydanticai-azure``.
+
+    Connections stored as a URI or as JSON need no change: ``-`` is how ``_`` is
+    encoded in a URI scheme, so ``pydanticai-azure`` is decoded to ``pydanticai_azure``
+    on read and resolves as before. That covers ``AIRFLOW_CONN_*`` environment
+    variables and secrets backends such as HashiCorp Vault, AWS Secrets Manager and
+    GCP Secret Manager.
+
+    A connection whose type is stored verbatim does need updating, because the
+    hyphen is preserved and no longer matches a registered hook. That means rows in
+    the metadata database, including any created through the UI, and connections
+    imported in object form from a local file:
+
+    .. code-block:: bash
+
+        airflow connections get <conn_id> -o json    # confirm conn_type is 'pydanticai-azure'
+        airflow connections delete <conn_id>
+        airflow connections add <conn_id> --conn-type pydanticai_azure ...
+
+    In the UI, edit the connection and re-pick its type.
 
 Default Connection IDs
 ----------------------

--- a/providers/common/ai/docs/connections/pydantic_ai_azure.rst
+++ b/providers/common/ai/docs/connections/pydantic_ai_azure.rst
@@ -15,12 +15,12 @@
     specific language governing permissions and limitations
     under the License.
 
-.. _howto/connection:pydanticai-azure:
+.. _howto/connection:pydanticai_azure:
 
 Pydantic AI (Azure OpenAI) Connection
 ======================================
 
-The ``pydanticai-azure`` connection type configures access to
+The ``pydanticai_azure`` connection type configures access to
 `Azure OpenAI <https://azure.microsoft.com/en-us/products/ai-services/openai-service>`__
 via the pydantic-ai framework. It backs ``PydanticAIAzureHook``, the dedicated
 subclass of ``PydanticAIHook`` for Azure's non-standard auth (an endpoint URL
@@ -60,7 +60,7 @@ Examples
 .. code-block:: json
 
     {
-        "conn_type": "pydanticai-azure",
+        "conn_type": "pydanticai_azure",
         "password": "<azure-api-key>",
         "host": "https://<resource>.openai.azure.com",
         "extra": "{\"model\": \"azure:gpt-4o\", \"api_version\": \"2024-07-01-preview\"}"

--- a/providers/common/ai/docs/connections/pydantic_ai_azure.rst
+++ b/providers/common/ai/docs/connections/pydantic_ai_azure.rst
@@ -27,6 +27,14 @@ subclass of ``PydanticAIHook`` for Azure's non-standard auth (an endpoint URL
 plus an API version, rather than the plain ``api_key`` + optional ``base_url``
 that the generic :doc:`pydantic_ai` connection assumes).
 
+.. note::
+
+    This connection type was previously named ``pydanticai-azure``. A connection stored
+    with the old hyphenated type will not resolve; update its type to
+    ``pydanticai_azure``. Hyphens are not usable here because a hook is registered
+    under this exact string while ``Connection.from_uri`` and ``from_json`` rewrite
+    ``-`` to ``_``, which left the hook unreachable from every secrets backend.
+
 Default Connection IDs
 ----------------------
 

--- a/providers/common/ai/docs/connections/pydantic_ai_bedrock.rst
+++ b/providers/common/ai/docs/connections/pydantic_ai_bedrock.rst
@@ -30,11 +30,26 @@ that the generic :doc:`pydantic_ai` connection assumes. All fields live in
 
 .. note::
 
-    This connection type was previously named ``pydanticai-bedrock``. A connection stored
-    with the old hyphenated type will not resolve; update its type to
-    ``pydanticai_bedrock``. Hyphens are not usable here because a hook is registered
-    under this exact string while ``Connection.from_uri`` and ``from_json`` rewrite
-    ``-`` to ``_``, which left the hook unreachable from every secrets backend.
+    This connection type was previously named ``pydanticai-bedrock``.
+
+    Connections stored as a URI or as JSON need no change: ``-`` is how ``_`` is
+    encoded in a URI scheme, so ``pydanticai-bedrock`` is decoded to ``pydanticai_bedrock``
+    on read and resolves as before. That covers ``AIRFLOW_CONN_*`` environment
+    variables and secrets backends such as HashiCorp Vault, AWS Secrets Manager and
+    GCP Secret Manager.
+
+    A connection whose type is stored verbatim does need updating, because the
+    hyphen is preserved and no longer matches a registered hook. That means rows in
+    the metadata database, including any created through the UI, and connections
+    imported in object form from a local file:
+
+    .. code-block:: bash
+
+        airflow connections get <conn_id> -o json    # confirm conn_type is 'pydanticai-bedrock'
+        airflow connections delete <conn_id>
+        airflow connections add <conn_id> --conn-type pydanticai_bedrock ...
+
+    In the UI, edit the connection and re-pick its type.
 
 Default Connection IDs
 ----------------------

--- a/providers/common/ai/docs/connections/pydantic_ai_bedrock.rst
+++ b/providers/common/ai/docs/connections/pydantic_ai_bedrock.rst
@@ -15,12 +15,12 @@
     specific language governing permissions and limitations
     under the License.
 
-.. _howto/connection:pydanticai-bedrock:
+.. _howto/connection:pydanticai_bedrock:
 
 Pydantic AI (AWS Bedrock) Connection
 =======================================
 
-The ``pydanticai-bedrock`` connection type configures access to
+The ``pydanticai_bedrock`` connection type configures access to
 `AWS Bedrock <https://aws.amazon.com/bedrock/>`__ via the pydantic-ai framework.
 It backs ``PydanticAIBedrockHook``, the dedicated subclass of ``PydanticAIHook``
 for Bedrock's AWS-style credentials — IAM keys, a bearer token, or the default
@@ -95,7 +95,7 @@ the instance role or environment:
 .. code-block:: json
 
     {
-        "conn_type": "pydanticai-bedrock",
+        "conn_type": "pydanticai_bedrock",
         "extra": "{\"model\": \"bedrock:us.anthropic.claude-opus-4-5\", \"region_name\": \"us-east-1\"}"
     }
 
@@ -104,7 +104,7 @@ the instance role or environment:
 .. code-block:: json
 
     {
-        "conn_type": "pydanticai-bedrock",
+        "conn_type": "pydanticai_bedrock",
         "extra": "{\"model\": \"bedrock:us.anthropic.claude-opus-4-5\", \"region_name\": \"us-east-1\", \"aws_access_key_id\": \"AKIA...\", \"aws_secret_access_key\": \"...\"}"
     }
 
@@ -113,6 +113,6 @@ the instance role or environment:
 .. code-block:: json
 
     {
-        "conn_type": "pydanticai-bedrock",
+        "conn_type": "pydanticai_bedrock",
         "extra": "{\"model\": \"bedrock:us.anthropic.claude-opus-4-5\", \"api_key\": \"<bearer-token>\"}"
     }

--- a/providers/common/ai/docs/connections/pydantic_ai_bedrock.rst
+++ b/providers/common/ai/docs/connections/pydantic_ai_bedrock.rst
@@ -28,6 +28,14 @@ credential chain — none of which fit the plain ``api_key`` + ``base_url`` shap
 that the generic :doc:`pydantic_ai` connection assumes. All fields live in
 ``extra``; the ``password`` and ``host`` fields are hidden in the connection form.
 
+.. note::
+
+    This connection type was previously named ``pydanticai-bedrock``. A connection stored
+    with the old hyphenated type will not resolve; update its type to
+    ``pydanticai_bedrock``. Hyphens are not usable here because a hook is registered
+    under this exact string while ``Connection.from_uri`` and ``from_json`` rewrite
+    ``-`` to ``_``, which left the hook unreachable from every secrets backend.
+
 Default Connection IDs
 ----------------------
 

--- a/providers/common/ai/docs/connections/pydantic_ai_vertex.rst
+++ b/providers/common/ai/docs/connections/pydantic_ai_vertex.rst
@@ -15,12 +15,12 @@
     specific language governing permissions and limitations
     under the License.
 
-.. _howto/connection:pydanticai-vertex:
+.. _howto/connection:pydanticai_vertex:
 
 Pydantic AI (Google Vertex AI) Connection
 ============================================
 
-The ``pydanticai-vertex`` connection type configures access to
+The ``pydanticai_vertex`` connection type configures access to
 `Google Vertex AI <https://cloud.google.com/vertex-ai>`__ via the pydantic-ai
 framework. It backs ``PydanticAIVertexHook``, the dedicated subclass of
 ``PydanticAIHook`` for Google Cloud's project/location/service-account
@@ -114,7 +114,7 @@ environment:
 .. code-block:: json
 
     {
-        "conn_type": "pydanticai-vertex",
+        "conn_type": "pydanticai_vertex",
         "extra": "{\"model\": \"google-cloud:gemini-2.0-flash\", \"project\": \"my-gcp-project\", \"location\": \"us-central1\"}"
     }
 
@@ -123,6 +123,6 @@ environment:
 .. code-block:: json
 
     {
-        "conn_type": "pydanticai-vertex",
+        "conn_type": "pydanticai_vertex",
         "extra": "{\"model\": \"google-cloud:gemini-2.0-flash\", \"project\": \"my-gcp-project\", \"location\": \"us-central1\", \"service_account_info\": {\"type\": \"service_account\", \"project_id\": \"my-gcp-project\", \"private_key\": \"<contents of the service account JSON key's private_key field>\", \"client_email\": \"sa@my-gcp-project.iam.gserviceaccount.com\"}}"
     }

--- a/providers/common/ai/docs/connections/pydantic_ai_vertex.rst
+++ b/providers/common/ai/docs/connections/pydantic_ai_vertex.rst
@@ -29,6 +29,14 @@ shape that the generic :doc:`pydantic_ai` connection assumes. All fields live
 in ``extra``; the ``password`` and ``host`` fields are hidden in the connection
 form.
 
+.. note::
+
+    This connection type was previously named ``pydanticai-vertex``. A connection stored
+    with the old hyphenated type will not resolve; update its type to
+    ``pydanticai_vertex``. Hyphens are not usable here because a hook is registered
+    under this exact string while ``Connection.from_uri`` and ``from_json`` rewrite
+    ``-`` to ``_``, which left the hook unreachable from every secrets backend.
+
 Default Connection IDs
 ----------------------
 

--- a/providers/common/ai/docs/connections/pydantic_ai_vertex.rst
+++ b/providers/common/ai/docs/connections/pydantic_ai_vertex.rst
@@ -31,11 +31,26 @@ form.
 
 .. note::
 
-    This connection type was previously named ``pydanticai-vertex``. A connection stored
-    with the old hyphenated type will not resolve; update its type to
-    ``pydanticai_vertex``. Hyphens are not usable here because a hook is registered
-    under this exact string while ``Connection.from_uri`` and ``from_json`` rewrite
-    ``-`` to ``_``, which left the hook unreachable from every secrets backend.
+    This connection type was previously named ``pydanticai-vertex``.
+
+    Connections stored as a URI or as JSON need no change: ``-`` is how ``_`` is
+    encoded in a URI scheme, so ``pydanticai-vertex`` is decoded to ``pydanticai_vertex``
+    on read and resolves as before. That covers ``AIRFLOW_CONN_*`` environment
+    variables and secrets backends such as HashiCorp Vault, AWS Secrets Manager and
+    GCP Secret Manager.
+
+    A connection whose type is stored verbatim does need updating, because the
+    hyphen is preserved and no longer matches a registered hook. That means rows in
+    the metadata database, including any created through the UI, and connections
+    imported in object form from a local file:
+
+    .. code-block:: bash
+
+        airflow connections get <conn_id> -o json    # confirm conn_type is 'pydanticai-vertex'
+        airflow connections delete <conn_id>
+        airflow connections add <conn_id> --conn-type pydanticai_vertex ...
+
+    In the UI, edit the connection and re-pick its type.
 
 Default Connection IDs
 ----------------------

--- a/providers/common/ai/docs/index.rst
+++ b/providers/common/ai/docs/index.rst
@@ -48,7 +48,7 @@ When to use this provider
 (OpenAI, Anthropic, Google, Bedrock, …) is picked by the connection ``llm_conn_id`` points
 at — switching providers later is a connection change, not a Dag rewrite. Most connections
 use the generic ``pydanticai`` type, but Azure OpenAI, Bedrock, and Vertex AI also have their
-own connection types (``pydanticai-azure``, ``pydanticai-bedrock``, ``pydanticai-vertex``) for
+own connection types (``pydanticai_azure``, ``pydanticai_bedrock``, ``pydanticai_vertex``) for
 provider-specific authentication. Existing LangChain
 tools aren't locked out either: pydantic-ai ships ``pydantic_ai.ext.langchain.LangChainToolset``
 upstream, which wraps LangChain tools for a common.ai agent, and the provider's own

--- a/providers/common/ai/provider.yaml
+++ b/providers/common/ai/provider.yaml
@@ -181,7 +181,7 @@ connection-types:
             - 'null'
   - hook-class-name: airflow.providers.common.ai.hooks.pydantic_ai.PydanticAIAzureHook
     hook-name: "Pydantic AI (Azure OpenAI)"
-    connection-type: pydanticai-azure
+    connection-type: pydanticai_azure
     external-services:
       - Azure OpenAI
     ui-field-behaviour:
@@ -212,7 +212,7 @@ connection-types:
             - 'null'
   - hook-class-name: airflow.providers.common.ai.hooks.pydantic_ai.PydanticAIBedrockHook
     hook-name: "Pydantic AI (AWS Bedrock)"
-    connection-type: pydanticai-bedrock
+    connection-type: pydanticai_bedrock
     external-services:
       - AWS Bedrock
     ui-field-behaviour:
@@ -299,7 +299,7 @@ connection-types:
             - 'null'
   - hook-class-name: airflow.providers.common.ai.hooks.pydantic_ai.PydanticAIVertexHook
     hook-name: "Pydantic AI (Google Vertex AI)"
-    connection-type: pydanticai-vertex
+    connection-type: pydanticai_vertex
     external-services:
       - Google Vertex AI
     ui-field-behaviour:

--- a/providers/common/ai/src/airflow/providers/common/ai/get_provider_info.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/get_provider_info.py
@@ -155,7 +155,7 @@ def get_provider_info():
             {
                 "hook-class-name": "airflow.providers.common.ai.hooks.pydantic_ai.PydanticAIAzureHook",
                 "hook-name": "Pydantic AI (Azure OpenAI)",
-                "connection-type": "pydanticai-azure",
+                "connection-type": "pydanticai_azure",
                 "external-services": ["Azure OpenAI"],
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port", "login"],
@@ -181,7 +181,7 @@ def get_provider_info():
             {
                 "hook-class-name": "airflow.providers.common.ai.hooks.pydantic_ai.PydanticAIBedrockHook",
                 "hook-name": "Pydantic AI (AWS Bedrock)",
-                "connection-type": "pydanticai-bedrock",
+                "connection-type": "pydanticai_bedrock",
                 "external-services": ["AWS Bedrock"],
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port", "login", "host", "password"],
@@ -246,7 +246,7 @@ def get_provider_info():
             {
                 "hook-class-name": "airflow.providers.common.ai.hooks.pydantic_ai.PydanticAIVertexHook",
                 "hook-name": "Pydantic AI (Google Vertex AI)",
-                "connection-type": "pydanticai-vertex",
+                "connection-type": "pydanticai_vertex",
                 "external-services": ["Google Vertex AI"],
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port", "login", "host", "password"],

--- a/providers/common/ai/src/airflow/providers/common/ai/hooks/pydantic_ai.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/hooks/pydantic_ai.py
@@ -317,7 +317,7 @@ class PydanticAIAzureHook(PydanticAIHook):
     :param model_id: Model identifier, e.g. ``"azure:gpt-4o"``.
     """
 
-    conn_type = "pydanticai-azure"
+    conn_type = "pydanticai_azure"
     default_conn_name = "pydanticai_azure_default"
     hook_name = "Pydantic AI (Azure OpenAI)"
 
@@ -385,7 +385,7 @@ class PydanticAIBedrockHook(PydanticAIHook):
     :param model_id: Model identifier, e.g. ``"bedrock:us.anthropic.claude-opus-4-5"``.
     """
 
-    conn_type = "pydanticai-bedrock"
+    conn_type = "pydanticai_bedrock"
     default_conn_name = "pydanticai_bedrock_default"
     hook_name = "Pydantic AI (AWS Bedrock)"
 
@@ -477,7 +477,7 @@ class PydanticAIVertexHook(PydanticAIHook):
     :param model_id: Model identifier, e.g. ``"google-cloud:gemini-2.0-flash"``.
     """
 
-    conn_type = "pydanticai-vertex"
+    conn_type = "pydanticai_vertex"
     default_conn_name = "pydanticai_vertex_default"
     hook_name = "Pydantic AI (Google Vertex AI)"
 

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/llm.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/llm.py
@@ -147,7 +147,7 @@ class LLMOperator(BaseOperator, LLMApprovalMixin):
         Delegates to :meth:`~PydanticAIHook.get_hook` which looks up
         the connection's ``conn_type`` and instantiates the matching subclass
         (e.g. :class:`~airflow.providers.common.ai.hooks.pydantic_ai.PydanticAIAzureHook`
-        for ``pydanticai-azure`` connections).
+        for ``pydanticai_azure`` connections).
         """
         hook_params = {
             "model_id": self.model_id,

--- a/providers/common/ai/tests/unit/common/ai/hooks/test_pydantic_ai.py
+++ b/providers/common/ai/tests/unit/common/ai/hooks/test_pydantic_ai.py
@@ -1050,7 +1050,7 @@ class TestConnTypeResolution:
         round_tripped = Connection(conn_id="c", uri=conn.get_uri())
 
         assert round_tripped.conn_type == hook_class.conn_type
-        assert isinstance(round_tripped.get_hook(), hook_class)
+        assert type(round_tripped.get_hook()) is hook_class
 
     @pytest.mark.parametrize("hook_class", ALL_HOOKS, ids=lambda c: c.__name__)
     def test_hook_resolves_from_json(self, hook_class):
@@ -1059,7 +1059,7 @@ class TestConnTypeResolution:
         round_tripped = Connection.from_json(conn.as_json(), conn_id="c")
 
         assert round_tripped.conn_type == hook_class.conn_type
-        assert isinstance(round_tripped.get_hook(), hook_class)
+        assert type(round_tripped.get_hook()) is hook_class
 
     @pytest.mark.parametrize("hook_class", ALL_HOOKS, ids=lambda c: c.__name__)
     @pytest.mark.parametrize("serializer", ["uri", "json"])
@@ -1069,11 +1069,12 @@ class TestConnTypeResolution:
         connections, so it is the widest blast radius for a conn_type that does not
         round-trip.
         """
-        conn = Connection(conn_id="c", conn_type=hook_class.conn_type, host="example.com")
+        conn_id = f"vendor_{hook_class.conn_type}_{serializer}"
+        conn = Connection(conn_id=conn_id, conn_type=hook_class.conn_type, host="example.com")
         serialized = conn.get_uri() if serializer == "uri" else conn.as_json()
-        monkeypatch.setenv("AIRFLOW_CONN_VENDOR_CONN", serialized)
+        monkeypatch.setenv(f"AIRFLOW_CONN_{conn_id.upper()}", serialized)
 
-        resolved = Connection.get_connection_from_secrets("vendor_conn")
+        resolved = Connection.get_connection_from_secrets(conn_id)
 
         assert resolved.conn_type == hook_class.conn_type
-        assert isinstance(resolved.get_hook(), hook_class)
+        assert type(resolved.get_hook()) is hook_class

--- a/providers/common/ai/tests/unit/common/ai/hooks/test_pydantic_ai.py
+++ b/providers/common/ai/tests/unit/common/ai/hooks/test_pydantic_ai.py
@@ -1014,6 +1014,7 @@ class TestPydanticAIVertexHook:
 
 
 ALL_HOOKS = [PydanticAIHook, PydanticAIAzureHook, PydanticAIBedrockHook, PydanticAIVertexHook]
+DECLARED_CONNECTION_TYPES = [c["connection-type"] for c in get_provider_info()["connection-types"]]
 
 
 class TestConnTypeResolution:
@@ -1026,18 +1027,21 @@ class TestConnTypeResolution:
     metadata DB kept its hyphen and resolved.
     """
 
-    def test_declared_connection_types_survive_a_uri_round_trip(self):
+    def test_provider_declares_connection_types(self):
+        """Keeps the round-trip guard below from passing vacuously."""
+        assert DECLARED_CONNECTION_TYPES
+
+    @pytest.mark.parametrize("conn_type", DECLARED_CONNECTION_TYPES)
+    def test_declared_connection_type_survives_a_uri_round_trip(self, conn_type):
         """Guards every connection-type this provider declares, current and future."""
-        for entry in get_provider_info()["connection-types"]:
-            conn_type = entry["connection-type"]
-            source = Connection(conn_id="c", conn_type=conn_type)
+        source = Connection(conn_id="c", conn_type=conn_type)
 
-            parsed = Connection(conn_id="c", uri=source.get_uri())
+        parsed = Connection(conn_id="c", uri=source.get_uri())
 
-            assert parsed.conn_type == conn_type, (
-                f"connection-type {conn_type!r} does not survive URI serialization, so its hook "
-                "cannot be looked up from any secrets backend; declare it with underscores"
-            )
+        assert parsed.conn_type == conn_type, (
+            f"connection-type {conn_type!r} does not survive URI serialization, so its hook "
+            "cannot be looked up from any secrets backend; declare it with underscores"
+        )
 
     @pytest.mark.parametrize("hook_class", ALL_HOOKS, ids=lambda c: c.__name__)
     def test_hook_resolves_from_uri(self, hook_class):

--- a/providers/common/ai/tests/unit/common/ai/hooks/test_pydantic_ai.py
+++ b/providers/common/ai/tests/unit/common/ai/hooks/test_pydantic_ai.py
@@ -520,7 +520,7 @@ class TestPydanticAIAzureHook:
     """Tests for PydanticAIAzureHook."""
 
     def test_conn_type(self):
-        assert PydanticAIAzureHook.conn_type == "pydanticai-azure"
+        assert PydanticAIAzureHook.conn_type == "pydanticai_azure"
 
     def test_hook_name(self):
         assert "Azure" in PydanticAIAzureHook.hook_name
@@ -581,7 +581,7 @@ class TestPydanticAIAzureHook:
         hook = PydanticAIAzureHook(llm_conn_id="azure_test")
         conn = Connection(
             conn_id="azure_test",
-            conn_type="pydanticai-azure",
+            conn_type="pydanticai_azure",
             password="azure-key",
             host="https://myresource.openai.azure.com",
             extra=json.dumps({"model": "azure:gpt-4o", "api_version": "2024-07-01-preview"}),
@@ -604,7 +604,7 @@ class TestPydanticAIAzureHook:
         hook = PydanticAIAzureHook(llm_conn_id="azure_test")
         conn = Connection(
             conn_id="azure_test",
-            conn_type="pydanticai-azure",
+            conn_type="pydanticai_azure",
             extra=json.dumps({"model": "azure:gpt-4o"}),
         )
         with patch.object(hook, "get_connection", return_value=conn):
@@ -617,7 +617,7 @@ class TestPydanticAIBedrockHook:
     """Tests for PydanticAIBedrockHook."""
 
     def test_conn_type(self):
-        assert PydanticAIBedrockHook.conn_type == "pydanticai-bedrock"
+        assert PydanticAIBedrockHook.conn_type == "pydanticai_bedrock"
 
     def test_hook_name(self):
         assert "Bedrock" in PydanticAIBedrockHook.hook_name
@@ -657,7 +657,7 @@ class TestPydanticAIBedrockHook:
         hook = PydanticAIBedrockHook(llm_conn_id="bedrock_test")
         conn = Connection(
             conn_id="bedrock_test",
-            conn_type="pydanticai-bedrock",
+            conn_type="pydanticai_bedrock",
             extra=json.dumps({"model": "bedrock:us.anthropic.claude-opus-4-5"}),
         )
         with patch.object(hook, "get_connection", return_value=conn):
@@ -675,7 +675,7 @@ class TestPydanticAIBedrockHook:
         hook = PydanticAIBedrockHook(llm_conn_id="bedrock_test")
         conn = Connection(
             conn_id="bedrock_test",
-            conn_type="pydanticai-bedrock",
+            conn_type="pydanticai_bedrock",
             extra=json.dumps(
                 {
                     "model": "bedrock:us.anthropic.claude-opus-4-5",
@@ -747,7 +747,7 @@ class TestPydanticAIVertexHook:
     """Tests for PydanticAIVertexHook."""
 
     def test_conn_type(self):
-        assert PydanticAIVertexHook.conn_type == "pydanticai-vertex"
+        assert PydanticAIVertexHook.conn_type == "pydanticai_vertex"
 
     def test_hook_name(self):
         assert "Vertex" in PydanticAIVertexHook.hook_name
@@ -858,7 +858,7 @@ class TestPydanticAIVertexHook:
         hook = PydanticAIVertexHook(llm_conn_id="vertex_test")
         conn = Connection(
             conn_id="vertex_test",
-            conn_type="pydanticai-vertex",
+            conn_type="pydanticai_vertex",
             extra=json.dumps({"model": "google-cloud:gemini-2.0-flash"}),
         )
         with patch.object(hook, "get_connection", return_value=conn):
@@ -876,7 +876,7 @@ class TestPydanticAIVertexHook:
         hook = PydanticAIVertexHook(llm_conn_id="vertex_test")
         conn = Connection(
             conn_id="vertex_test",
-            conn_type="pydanticai-vertex",
+            conn_type="pydanticai_vertex",
             extra=json.dumps(
                 {
                     "model": "google-cloud:gemini-2.0-flash",
@@ -934,7 +934,7 @@ class TestPydanticAIVertexHook:
         hook = PydanticAIVertexHook(llm_conn_id="vertex_test")
         conn = Connection(
             conn_id="vertex_test",
-            conn_type="pydanticai-vertex",
+            conn_type="pydanticai_vertex",
             extra=json.dumps(
                 {
                     "model": "google-cloud:gemini-2.0-flash",
@@ -976,7 +976,7 @@ class TestPydanticAIVertexHook:
         """
         connection_types = get_provider_info()["connection-types"]
         vertex_conn_fields = next(
-            c["conn-fields"] for c in connection_types if c["connection-type"] == "pydanticai-vertex"
+            c["conn-fields"] for c in connection_types if c["connection-type"] == "pydanticai_vertex"
         )
         description = vertex_conn_fields["model"]["description"]
         prefix = _extract_google_cloud_prefix(description)
@@ -994,7 +994,7 @@ class TestPydanticAIVertexHook:
         """
         connection_types = get_provider_info()["connection-types"]
         vertex_connection_type = next(
-            c for c in connection_types if c["connection-type"] == "pydanticai-vertex"
+            c for c in connection_types if c["connection-type"] == "pydanticai_vertex"
         )
         placeholder = vertex_connection_type["ui-field-behaviour"]["placeholders"]["extra"]
         prefix = _extract_google_cloud_prefix(placeholder)
@@ -1011,3 +1011,65 @@ class TestPydanticAIVertexHook:
         placeholder = PydanticAIVertexHook.get_ui_field_behaviour()["placeholders"]["extra"]
         prefix = _extract_google_cloud_prefix(placeholder)
         _assert_prefix_is_known_provider(prefix)
+
+
+ALL_HOOKS = [PydanticAIHook, PydanticAIAzureHook, PydanticAIBedrockHook, PydanticAIVertexHook]
+
+
+class TestConnTypeResolution:
+    """
+    Every hook is registered under the literal ``connection-type`` string from
+    ``provider.yaml``, but ``Connection.from_uri`` and ``Connection.from_json`` rewrite
+    ``-`` to ``_`` before the lookup happens. A hyphen in ``conn_type`` therefore makes
+    the hook unreachable from every secrets backend, which is what happened to the three
+    vendor types (apache/airflow#72316): only a connection read straight out of the
+    metadata DB kept its hyphen and resolved.
+    """
+
+    def test_declared_connection_types_survive_a_uri_round_trip(self):
+        """Guards every connection-type this provider declares, current and future."""
+        for entry in get_provider_info()["connection-types"]:
+            conn_type = entry["connection-type"]
+            source = Connection(conn_id="c", conn_type=conn_type)
+
+            parsed = Connection(conn_id="c", uri=source.get_uri())
+
+            assert parsed.conn_type == conn_type, (
+                f"connection-type {conn_type!r} does not survive URI serialization, so its hook "
+                "cannot be looked up from any secrets backend; declare it with underscores"
+            )
+
+    @pytest.mark.parametrize("hook_class", ALL_HOOKS, ids=lambda c: c.__name__)
+    def test_hook_resolves_from_uri(self, hook_class):
+        conn = Connection(conn_id="c", conn_type=hook_class.conn_type, host="example.com")
+
+        round_tripped = Connection(conn_id="c", uri=conn.get_uri())
+
+        assert round_tripped.conn_type == hook_class.conn_type
+        assert isinstance(round_tripped.get_hook(), hook_class)
+
+    @pytest.mark.parametrize("hook_class", ALL_HOOKS, ids=lambda c: c.__name__)
+    def test_hook_resolves_from_json(self, hook_class):
+        conn = Connection(conn_id="c", conn_type=hook_class.conn_type, host="example.com")
+
+        round_tripped = Connection.from_json(conn.as_json(), conn_id="c")
+
+        assert round_tripped.conn_type == hook_class.conn_type
+        assert isinstance(round_tripped.get_hook(), hook_class)
+
+    @pytest.mark.parametrize("hook_class", ALL_HOOKS, ids=lambda c: c.__name__)
+    @pytest.mark.parametrize("serializer", ["uri", "json"])
+    def test_hook_resolves_from_environment_variable(self, hook_class, serializer, monkeypatch):
+        """
+        ``AIRFLOW_CONN_*`` is enabled by default and is how most deployments define
+        connections, so it is the widest blast radius for a conn_type that does not
+        round-trip.
+        """
+        conn = Connection(conn_id="c", conn_type=hook_class.conn_type, host="example.com")
+        serialized = conn.get_uri() if serializer == "uri" else conn.as_json()
+        monkeypatch.setenv("AIRFLOW_CONN_VENDOR_CONN", serialized)
+
+        resolved = Connection.get_connection_from_secrets("vendor_conn")
+
+        assert resolved.conn_type == hook_class.conn_type
+        assert isinstance(resolved.get_hook(), hook_class)


### PR DESCRIPTION
## Summary

The three PydanticAI vendor hooks declared their `conn_type` with hyphens, which made them unreachable from any secrets backend that stores a connection as a URI or as JSON. A hook is registered under the literal `connection-type` string from `provider.yaml`, but [`Connection.from_uri`](https://github.com/apache/airflow/blob/251cd91bb2/airflow-core/src/airflow/models/connection.py#L235) and `Connection.from_json` both run [`_normalize_conn_type`](https://github.com/apache/airflow/blob/251cd91bb2/airflow-core/src/airflow/models/connection.py#L228-L233), which rewrites `-` to `_` before the lookup. The key the hook is [registered under](https://github.com/apache/airflow/blob/251cd91bb2/airflow-core/src/airflow/providers_manager.py#L679-L706) could therefore never be produced by either parse path, so any connection stored as a URI or as JSON failed with:

```
AirflowException: Unknown hook type "pydanticai_azure"
  File ".../airflow/sdk/definitions/connection.py", line 223 in get_hook
```

A connection read straight out of the metadata DB kept its hyphen and resolved, which is why this went unnoticed. Even that path was only reliable with the secret cache off: [`get_connection_from_secrets`](https://github.com/apache/airflow/blob/251cd91bb2/airflow-core/src/airflow/models/connection.py#L521) caches `conn.get_uri()` and rebuilds the connection from that URI on the next read, so with `secrets.use_cache = True` a DB-stored hyphenated connection worked on first use and failed on every subsequent one.

Closes #72316. Supersedes #72341, which identified the same root cause.

## The blast radius is wider than the report

The report describes URI-valued backends such as HashiCorp Vault. `from_json` normalizes identically, and so does the `AIRFLOW_CONN_*` environment-variable backend, which is enabled by default and is how most deployments define connections. All six combinations below failed before this change and resolve after it:

![Task log showing all three vendor connection types resolving from the environment-variable secrets backend in both JSON and URI form](https://github.com/user-attachments/assets/440dc0c4-1490-448d-adad-087435ddf1ba)

Both stored shapes are exercised because both occur in the wild. JSON carries the canonical underscore `conn_type`; a URI's scheme is hyphenated because RFC 3986 forbids `_` in a scheme, so `Connection.get_uri()` writes hyphens and `_normalize_conn_type` converts back on read. Hyphenated URIs already sitting in a secrets backend keep working.

## Why rename rather than also register the hyphenated form

Three ways to close this, and why the rename wins:

- **Add the hyphenated names to `_normalize_conn_type`'s alias table**, where `postgresql` → `postgres` lives. That puts provider-specific names in airflow-core, for one provider's benefit.
- **Register a second hook class per vendor under the hyphenated key.** This does not fix the reported path at all: a hyphenated URI or JSON value already normalizes onto the underscore key, so the extra registration only serves connections sitting hyphenated in the metadata DB. It also adds three unlabelled entries to the connection-type dropdown, because a `connection-types` entry with no `hook-name` falls back to the raw slug.
- **Rename**, which matches every other multi-word hook in the tree (`azure_data_factory`, `google_cloud_platform`, `spark_connect`, `hive_cli`) and leaves exactly one canonical name per type.

One entry per type after the rename, each with its own label:

![Add Connection dialog with the connection-type list filtered to Pydantic, showing four entries each with a descriptive label](https://github.com/user-attachments/assets/4dcf2f73-7ee2-488f-b68b-c13a6b4acde4)

## Migration, and who actually has to do anything

`default_conn_name` values were already underscored (`pydanticai_azure_default`) and are unchanged, so only `conn_type` moves.

Most users need no change at all, because the same decoding that caused the bug now works in their favour. A stored `pydanticai-azure` is decoded to `pydanticai_azure` on read, so it lands on the new key:

| where the connection is stored | after this change |
|---|---|
| `AIRFLOW_CONN_*`, Vault, AWS Secrets Manager, GCP Secret Manager (URI or JSON) | resolves, no action |
| metadata DB row, including anything created in the UI | needs its type updated |
| object-form import from a local file | needs its type updated |

For the two that do need it:

```bash
airflow connections get <conn_id> -o json      # confirm conn_type is 'pydanticai-azure'
airflow connections delete <conn_id>
airflow connections add <conn_id> --conn-type pydanticai_azure ...
```

In the UI, edit the connection and re-pick its type. The same note is now in each of the three connection docs, so a user who never reads this PR still finds it.

No compatibility shim is included: these three types are recent, the provider is pre-1.0, and a permanent second registration per vendor is not worth the dropdown noise it costs every user.

## Tradeoff worth stating

Underscores bring back a warning whenever a connection is serialized to a URI:

```
Connection schemes (type: pydanticai_azure) shall not contain '_' according to RFC3986.
```

That warning is exactly why `pydantic_ai` became `pydanticai` in #62817, which is how these three types ended up hyphenated in the first place. It is a log line only, the hyphenated URI it emits is valid and still round-trips, and 32 other connection types in the tree have carried the same warning for years.

The warning is also misdirected, and worth fixing separately. It inspects `conn_type`, which is required to be underscored, while the URI it is warning about is hyphenated and compliant by construction. So it fires on correct configuration and is silent on the broken kind: `airflow-core/tests/unit/models/test_connection.py::test_get_uri_conn_type_warning` currently pins warned=True for `google_cloud_platform` and warned=False for `google-cloud-platform`. Inverting it to flag `-` would both remove this PR's added noise and give the metadata-DB users named above an actionable message. That touches core `Connection` behaviour for every provider, so it belongs in its own change rather than here.

## Guard against a repeat

Nothing stopped a hyphen getting in: `connection-type` was declared as a bare `{"type": "string"}`. This adds `"pattern": "^[a-z][a-z0-9_]*$"` to `provider.yaml.schema.json`, so the same mistake now fails `check-provider-yaml-valid` at authoring time for any in-tree provider rather than at a user's first task run. All 142 `connection-type` values across the tree already satisfy it, so it lands green.

The pattern is deliberately narrower than RFC 3986 allows for a scheme, and it is confined to the authoring schema:

- `-` is rejected because it is the encoding of `_`, so it cannot also be a literal.
- Uppercase is rejected because `get_uri()` lowercases the scheme, so it does not survive the round trip.
- A leading digit is rejected because RFC 3986 requires a scheme to start with a letter, and Python does not agree with itself about it: `urlsplit("1acme://h").scheme` is `"1acme"` on 3.10 and `""` on 3.14.
- `.` and `+` are excluded even though they are legal in a scheme and do round-trip cleanly. No connection type in the tree uses either, so the pattern is deliberately restricted to the shape all 142 already have rather than widening the accepted surface on a bugfix.
- The pattern is **not** added to `provider_info.schema.json`. That is the runtime schema, validated against every installed provider including third-party ones, and its `validate()` call is unwrapped in provider discovery, so one non-conforming provider would break discovery for all of them. Every released `common-ai` wheel declares the hyphenated types, so tightening the runtime schema would stop a released provider importing at all. #71104 declined the same change for the same reason.

Two smaller guards alongside it. `TestConnTypeResolution` asserts that every `connection-type` this provider declares survives a URI round-trip, parametrized so it names every offender rather than aborting at the first. And both author-facing `connection-types` examples used the hyphenated form as their illustration, which is what a new provider author copies, so `contributing-docs/23_provider_hook_migration_to_yaml.rst` and `providers/MANAGING_PROVIDERS_LIFECYCLE.rst` are corrected too. The latter also had `connection-type` mis-nested as its own sequence item, which yields two entries each missing one required key.
