### PR TITLE
Remove a misleading connection type warning and explain lookup failures

### DIFF
--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -287,11 +287,19 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
 
         Note that the URI returned by this method is **not** SQLAlchemy-compatible, if you need a SQLAlchemy-compatible URI, use the :attr:`~airflow.providers.common.sql.hooks.sql.DbApiHook.sqlalchemy_url`
         """
-        conn_type = getattr(self, "_prenormalized_conn_type", self.conn_type) or ""
-        if "_" in conn_type:
+        conn_type = self.conn_type or ""
+        if "-" in conn_type:
+            # '-' is how '_' is encoded in a URI scheme, since RFC 3986 forbids '_' there.
+            # A literal '-' in conn_type is therefore indistinguishable from an encoded '_'
+            # once serialized, and _normalize_conn_type decodes it back to '_' on read, so
+            # the hook registered under the hyphenated name can never be found again.
             self.log.warning(
-                "Connection schemes (type: %s) shall not contain '_' according to RFC3986.",
+                "Connection type %r contains '-', which does not survive URI serialization: "
+                "'-' is the URI-scheme encoding of '_', so this connection resolves back to %r. "
+                "A connection type has to be declared with '_' in the provider's "
+                "connection-type, and the connection has to use that same form.",
                 conn_type,
+                conn_type.lower().replace("-", "_"),
             )
 
         if self.conn_type:
@@ -393,7 +401,19 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
         hook = ProvidersManager().hooks.get(self.conn_type, None)
 
         if hook is None:
-            raise AirflowException(f'Unknown hook type "{self.conn_type}"')
+            if not self.conn_type:
+                # A URI scheme cannot contain '_' (RFC 3986), so "foo_bar://h" parses with no
+                # scheme at all and leaves conn_type empty. Name that, instead of reporting an
+                # unknown hook type of "".
+                message = (
+                    f"Connection {self.conn_id!r} has no connection type, so no hook could be "
+                    "looked up. If it was defined as a URI, note that a URI scheme cannot "
+                    "contain '_' (RFC 3986) and such a URI parses with no scheme at all: use "
+                    "'-' in the URI instead, which is decoded back to '_' on read."
+                )
+            else:
+                message = f'Unknown hook type "{self.conn_type}"'
+            raise AirflowException(message)
         try:
             hook_class = import_string(hook.hook_class_name)
         except ImportError:

--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -399,18 +399,20 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
                 )
             else:
                 message = f'Unknown hook type "{self.conn_type}"'
-                # To a URI scheme '-' and '_' are the same character: get_uri() encodes '_' as
-                # '-' because RFC 3986 forbids '_' in a scheme, and reading a connection back
-                # from a URI or from JSON decodes it again. A connection type spelled one way
-                # therefore cannot resolve a hook registered the other way. Hooks register under
-                # the connection-type verbatim, so look the other spelling up rather than
-                # asserting which one is right.
+                # get_uri() encodes '_' as '-' because RFC 3986 forbids '_' in a scheme, and
+                # reading a connection back from a URI or from JSON decodes it again, so both
+                # characters serialize to '-' and a connection type spelled one way cannot
+                # resolve a hook registered the other way. Hooks register under the
+                # connection-type verbatim, so look the other spelling up rather than asserting
+                # which one is right, and resolve it rather than testing for membership: a
+                # registered connection type maps to None when its hook cannot be imported, and
+                # naming a spelling that still will not resolve is worse than naming none.
                 alternative = (
                     self.conn_type.replace("-", "_")
                     if "-" in self.conn_type
                     else self.conn_type.replace("_", "-")
                 )
-                if alternative != self.conn_type and alternative in hooks:
+                if alternative != self.conn_type and hooks.get(alternative) is not None:
                     message += f", but a hook is registered for {alternative!r}. "
                     if "-" in self.conn_type:
                         message += "Spell this connection's type with '_' to reach it."

--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -287,21 +287,6 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
 
         Note that the URI returned by this method is **not** SQLAlchemy-compatible, if you need a SQLAlchemy-compatible URI, use the :attr:`~airflow.providers.common.sql.hooks.sql.DbApiHook.sqlalchemy_url`
         """
-        conn_type = self.conn_type or ""
-        if "-" in conn_type:
-            # '-' is how '_' is encoded in a URI scheme, since RFC 3986 forbids '_' there.
-            # A literal '-' in conn_type is therefore indistinguishable from an encoded '_'
-            # once serialized, and _normalize_conn_type decodes it back to '_' on read, so a
-            # hook registered under the hyphenated name is unreachable from that point on.
-            self.log.warning(
-                "Connection type %r contains '-', which does not survive URI serialization: "
-                "'-' is the URI-scheme encoding of '_', so this connection resolves back to %r. "
-                "Only a connection type spelled with '_' round-trips through a URI, so the "
-                "provider's connection-type and this connection both have to use that form.",
-                conn_type,
-                conn_type.lower().replace("-", "_"),
-            )
-
         if self.conn_type:
             uri = f"{self.conn_type.lower().replace('_', '-')}://"
         else:

--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -291,13 +291,13 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
         if "-" in conn_type:
             # '-' is how '_' is encoded in a URI scheme, since RFC 3986 forbids '_' there.
             # A literal '-' in conn_type is therefore indistinguishable from an encoded '_'
-            # once serialized, and _normalize_conn_type decodes it back to '_' on read, so
-            # the hook registered under the hyphenated name can never be found again.
+            # once serialized, and _normalize_conn_type decodes it back to '_' on read, so a
+            # hook registered under the hyphenated name is unreachable from that point on.
             self.log.warning(
                 "Connection type %r contains '-', which does not survive URI serialization: "
                 "'-' is the URI-scheme encoding of '_', so this connection resolves back to %r. "
-                "A connection type has to be declared with '_' in the provider's "
-                "connection-type, and the connection has to use that same form.",
+                "Only a connection type spelled with '_' round-trips through a URI, so the "
+                "provider's connection-type and this connection both have to use that form.",
                 conn_type,
                 conn_type.lower().replace("-", "_"),
             )
@@ -398,7 +398,8 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
         """Return hook based on conn_type."""
         from airflow.providers_manager import ProvidersManager
 
-        hook = ProvidersManager().hooks.get(self.conn_type, None)
+        hooks = ProvidersManager().hooks
+        hook = hooks.get(self.conn_type, None)
 
         if hook is None:
             if not self.conn_type:
@@ -411,18 +412,29 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
                     "contain '_' (RFC 3986) and such a URI parses with no scheme at all: use "
                     "'-' in the URI instead, which is decoded back to '_' on read."
                 )
-            elif "-" in self.conn_type:
-                # A hyphenated conn_type is the configuration this cannot ever resolve for,
-                # because '-' is the URI-scheme encoding of '_'. Say so, but as a hint rather
-                # than a diagnosis: the provider may simply not be installed.
-                message = (
-                    f"Unknown hook type \"{self.conn_type}\". Note that it contains '-', which is "
-                    "the URI-scheme encoding of '_', so a connection type spelled with '-' cannot "
-                    f"be resolved; the registered name is likely {self.conn_type.replace('-', '_')!r}. "
-                    "Otherwise the provider supplying this connection type may not be installed."
-                )
             else:
                 message = f'Unknown hook type "{self.conn_type}"'
+                # To a URI scheme '-' and '_' are the same character: get_uri() encodes '_' as
+                # '-' because RFC 3986 forbids '_' in a scheme, and reading a connection back
+                # from a URI or from JSON decodes it again. A connection type spelled one way
+                # therefore cannot resolve a hook registered the other way. Hooks register under
+                # the connection-type verbatim, so look the other spelling up rather than
+                # asserting which one is right.
+                alternative = (
+                    self.conn_type.replace("-", "_")
+                    if "-" in self.conn_type
+                    else self.conn_type.replace("_", "-")
+                )
+                if alternative != self.conn_type and alternative in hooks:
+                    message += f", but a hook is registered for {alternative!r}. "
+                    if "-" in self.conn_type:
+                        message += "Spell this connection's type with '_' to reach it."
+                    else:
+                        message += (
+                            "Reading a connection from a URI or from JSON decodes '-' back to "
+                            "'_', so this connection cannot reach that hook; the provider has "
+                            "to declare its connection-type with '_'."
+                        )
             raise AirflowException(message)
         try:
             hook_class = import_string(hook.hook_class_name)

--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -411,6 +411,16 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
                     "contain '_' (RFC 3986) and such a URI parses with no scheme at all: use "
                     "'-' in the URI instead, which is decoded back to '_' on read."
                 )
+            elif "-" in self.conn_type:
+                # A hyphenated conn_type is the configuration this cannot ever resolve for,
+                # because '-' is the URI-scheme encoding of '_'. Say so, but as a hint rather
+                # than a diagnosis: the provider may simply not be installed.
+                message = (
+                    f"Unknown hook type \"{self.conn_type}\". Note that it contains '-', which is "
+                    "the URI-scheme encoding of '_', so a connection type spelled with '-' cannot "
+                    f"be resolved; the registered name is likely {self.conn_type.replace('-', '_')!r}. "
+                    "Otherwise the provider supplying this connection type may not be installed."
+                )
             else:
                 message = f'Unknown hook type "{self.conn_type}"'
             raise AirflowException(message)

--- a/airflow-core/tests/unit/models/test_connection.py
+++ b/airflow-core/tests/unit/models/test_connection.py
@@ -271,11 +271,29 @@ class TestConnection:
     def test_get_uri(self, connection, expected_uri):
         assert connection.get_uri() == expected_uri
 
+    def test_get_hook_explains_a_uri_whose_scheme_was_dropped(self):
+        """
+        A URI scheme cannot contain '_' (RFC 3986), so ``foo_bar://h`` parses with no scheme
+        at all and leaves conn_type empty. The resulting failure used to read
+        ``Unknown hook type ""``, which named neither the cause nor the fix.
+        """
+        conn = Connection(conn_id="c", uri="pydanticai_azure://h")
+        assert conn.conn_type == ""
+
+        with pytest.raises(AirflowException, match="has no connection type") as exc_info:
+            conn.get_hook()
+
+        assert "RFC 3986" in str(exc_info.value)
+
     @pytest.mark.parametrize(
         ("connection", "expected_warned"),
         [
+            # Parsed from a URI: _normalize_conn_type has already decoded '-' to '_', so the
+            # conn_type is the canonical form and there is nothing to warn about.
             (Connection(conn_id="test-uri-1", uri="google-cloud-platform://testlogin:testpassword@"), False),
             (Connection(conn_id="test-uri-2", uri="amazon://test:test@"), False),
+            # Set directly with a hyphen: this is the configuration that cannot round-trip,
+            # because '-' is the URI-scheme encoding of '_'. This is what must warn.
             (
                 Connection(
                     conn_id="test-non-uri-1",
@@ -283,8 +301,10 @@ class TestConnection:
                     login="testlogin",
                     password="testpassword",
                 ),
-                False,
+                True,
             ),
+            # The canonical underscore form. It serializes to 'google-cloud-platform://' and
+            # decodes back unchanged, so it is correct and must stay silent.
             (
                 Connection(
                     conn_id="test-non-uri-2",
@@ -292,7 +312,7 @@ class TestConnection:
                     login="testlogin",
                     password="testpassword",
                 ),
-                True,
+                False,
             ),
             (
                 Connection(
@@ -302,22 +322,22 @@ class TestConnection:
             ),
         ],
     )
-    def test_get_uri_conn_type_warning(self, connection: Connection, expected_warned: bool):
+    def test_get_uri_warns_only_for_a_conn_type_that_cannot_round_trip(
+        self, connection: Connection, expected_warned: bool
+    ):
         with capture_logs() as captured_logs:
             connection.get_uri()
-        conn_type_warnings = list(
-            filter(
-                lambda captured_log: (
-                    captured_log["log_level"] == "warning" and "RFC3986" in captured_log["event"]
-                ),
-                captured_logs,
-            )
-        )
+        conn_type_warnings = [
+            captured_log
+            for captured_log in captured_logs
+            if captured_log["log_level"] == "warning"
+            and "does not survive URI serialization" in captured_log["event"]
+        ]
         if expected_warned:
-            assert conn_type_warnings, f"RFC3986 warning expected for connection '{connection.conn_id}'."
+            assert conn_type_warnings, f"expected a hyphenated-conn_type warning for '{connection.conn_id}'."
         else:
             assert not conn_type_warnings, (
-                f"RFC3986 warning not expected for connection '{connection.conn_id}'."
+                f"unexpected hyphenated-conn_type warning for '{connection.conn_id}'."
             )
 
     @pytest.mark.parametrize(

--- a/airflow-core/tests/unit/models/test_connection.py
+++ b/airflow-core/tests/unit/models/test_connection.py
@@ -271,20 +271,63 @@ class TestConnection:
     def test_get_uri(self, connection, expected_uri):
         assert connection.get_uri() == expected_uri
 
-    def test_get_hook_explains_a_hyphenated_conn_type(self):
+    @pytest.mark.parametrize(
+        ("conn_type", "registered", "expected_remedy"),
+        [
+            # Typed with '-' where the provider registers '_': the connection is the thing to
+            # fix, so say which spelling reaches the hook.
+            pytest.param(
+                "google-cloud-platform",
+                "google_cloud_platform",
+                "Spell this connection's type with '_' to reach it.",
+                id="hyphenated-conn-type",
+            ),
+            # The reverse, which is what a hyphenated connection-type actually produces: a
+            # connection read from a URI or from JSON normalizes to '_' and cannot reach the
+            # registered name, so there is nothing that connection can do and the provider
+            # has to rename. A metadata-DB row keeps the hyphen and does resolve.
+            pytest.param(
+                "pydanticai_vertex",
+                "pydanticai-vertex",
+                "so this connection cannot reach that hook",
+                id="hyphenated-registration",
+            ),
+        ],
+    )
+    def test_get_hook_names_the_other_spelling_when_it_is_the_registered_one(
+        self, conn_type, registered, expected_remedy
+    ):
         """
-        A conn_type set directly with a hyphen, as a metadata-DB row can be, never round-trips
-        through get_uri(), so it reaches get_hook() unchanged and can never resolve. The bare
-        'Unknown hook type' told the user nothing about why.
+        '-' and '_' are the same character to a URI scheme, so a connection type spelled one
+        way cannot resolve a hook registered the other way. The bare 'Unknown hook type' named
+        neither the cause nor which spelling would work.
+        """
+        conn = Connection(conn_id="c", conn_type=conn_type)
+
+        with mock.patch("airflow.providers_manager.ProvidersManager") as mock_manager:
+            mock_manager.return_value.hooks = {registered: mock.MagicMock()}
+            with pytest.raises(AirflowException, match="Unknown hook type") as exc_info:
+                conn.get_hook()
+
+        message = str(exc_info.value)
+        assert conn_type in message
+        assert registered in message
+        assert expected_remedy in message
+
+    def test_get_hook_does_not_guess_an_unregistered_spelling(self):
+        """
+        A hyphenated connection-type registers verbatim and resolves for a connection built
+        with that type directly, so an unresolved hyphenated type is not evidence that the
+        underscored name exists. With nothing registered either way, say only what is known.
         """
         conn = Connection(conn_id="c", conn_type="google-cloud-platform")
 
-        with pytest.raises(AirflowException, match="Unknown hook type") as exc_info:
-            conn.get_hook()
+        with mock.patch("airflow.providers_manager.ProvidersManager") as mock_manager:
+            mock_manager.return_value.hooks = {}
+            with pytest.raises(AirflowException) as exc_info:
+                conn.get_hook()
 
-        message = str(exc_info.value)
-        assert "google-cloud-platform" in message
-        assert "google_cloud_platform" in message
+        assert str(exc_info.value) == 'Unknown hook type "google-cloud-platform"'
 
     def test_get_hook_explains_a_uri_whose_scheme_was_dropped(self):
         """

--- a/airflow-core/tests/unit/models/test_connection.py
+++ b/airflow-core/tests/unit/models/test_connection.py
@@ -344,59 +344,47 @@ class TestConnection:
         assert "RFC 3986" in str(exc_info.value)
 
     @pytest.mark.parametrize(
-        ("connection", "expected_warned"),
+        "connection",
         [
-            # Parsed from a URI: _normalize_conn_type has already decoded '-' to '_', so the
-            # conn_type is the canonical form and there is nothing to warn about.
-            (Connection(conn_id="test-uri-1", uri="google-cloud-platform://testlogin:testpassword@"), False),
-            (Connection(conn_id="test-uri-2", uri="amazon://test:test@"), False),
-            # Set directly with a hyphen: this is the configuration that cannot round-trip,
-            # because '-' is the URI-scheme encoding of '_'. This is what must warn.
-            (
-                Connection(
-                    conn_id="test-non-uri-1",
-                    conn_type="google-cloud-platform",
-                    login="testlogin",
-                    password="testpassword",
-                ),
-                True,
+            # Parsed from a URI, so _normalize_conn_type has already decoded '-' to '_'.
+            Connection(conn_id="test-uri-1", uri="google-cloud-platform://testlogin:testpassword@"),
+            Connection(conn_id="test-uri-2", uri="amazon://test:test@"),
+            # Set directly with a hyphen, which is the spelling that cannot round-trip.
+            Connection(
+                conn_id="test-non-uri-1",
+                conn_type="google-cloud-platform",
+                login="testlogin",
+                password="testpassword",
             ),
-            # The canonical underscore form. It serializes to 'google-cloud-platform://' and
-            # decodes back unchanged, so it is correct and must stay silent.
-            (
-                Connection(
-                    conn_id="test-non-uri-2",
-                    conn_type="google_cloud_platform",
-                    login="testlogin",
-                    password="testpassword",
-                ),
-                False,
+            # The canonical underscore form, which serializes to 'google-cloud-platform://'
+            # and decodes back unchanged.
+            Connection(
+                conn_id="test-non-uri-2",
+                conn_type="google_cloud_platform",
+                login="testlogin",
+                password="testpassword",
             ),
-            (
-                Connection(
-                    conn_id="test-non-uri-3", conn_type="amazon", login="testlogin", password="testpassword"
-                ),
-                False,
+            Connection(
+                conn_id="test-non-uri-3", conn_type="amazon", login="testlogin", password="testpassword"
             ),
         ],
     )
-    def test_get_uri_warns_only_for_a_conn_type_that_cannot_round_trip(
-        self, connection: Connection, expected_warned: bool
-    ):
+    def test_get_uri_does_not_warn_about_the_connection_type(self, connection: Connection):
+        """
+        get_uri() serializes a connection; it does not validate one.
+
+        It used to warn that a conn_type containing '_' broke RFC 3986. That is the one
+        spelling which survives the round trip, since get_uri() encodes '_' as '-' and
+        reading a connection back decodes it, and the warning fired on every uncached
+        connection fetch. A connection type that cannot round-trip is reported where it
+        fails, by get_hook(), and is rejected by the provider schema.
+        """
         with capture_logs() as captured_logs:
             connection.get_uri()
-        conn_type_warnings = [
-            captured_log
-            for captured_log in captured_logs
-            if captured_log["log_level"] == "warning"
-            and "does not survive URI serialization" in captured_log["event"]
-        ]
-        if expected_warned:
-            assert conn_type_warnings, f"expected a hyphenated-conn_type warning for '{connection.conn_id}'."
-        else:
-            assert not conn_type_warnings, (
-                f"unexpected hyphenated-conn_type warning for '{connection.conn_id}'."
-            )
+
+        assert [
+            captured_log for captured_log in captured_logs if captured_log["log_level"] == "warning"
+        ] == []
 
     @pytest.mark.parametrize(
         ("connection", "expected_conn_id"),

--- a/airflow-core/tests/unit/models/test_connection.py
+++ b/airflow-core/tests/unit/models/test_connection.py
@@ -329,6 +329,21 @@ class TestConnection:
 
         assert str(exc_info.value) == 'Unknown hook type "google-cloud-platform"'
 
+    def test_get_hook_does_not_advise_a_spelling_whose_hook_cannot_be_imported(self):
+        """
+        ProvidersManager.hooks holds None for a connection type whose hook could not be
+        imported, so membership alone does not mean the other spelling would resolve. Advice
+        that still fails when followed is worse than no advice.
+        """
+        conn = Connection(conn_id="c", conn_type="google-cloud-platform")
+
+        with mock.patch("airflow.providers_manager.ProvidersManager") as mock_manager:
+            mock_manager.return_value.hooks = {"google_cloud_platform": None}
+            with pytest.raises(AirflowException) as exc_info:
+                conn.get_hook()
+
+        assert str(exc_info.value) == 'Unknown hook type "google-cloud-platform"'
+
     def test_get_hook_explains_a_uri_whose_scheme_was_dropped(self):
         """
         A URI scheme cannot contain '_' (RFC 3986), so ``foo_bar://h`` parses with no scheme

--- a/airflow-core/tests/unit/models/test_connection.py
+++ b/airflow-core/tests/unit/models/test_connection.py
@@ -271,6 +271,21 @@ class TestConnection:
     def test_get_uri(self, connection, expected_uri):
         assert connection.get_uri() == expected_uri
 
+    def test_get_hook_explains_a_hyphenated_conn_type(self):
+        """
+        A conn_type set directly with a hyphen, as a metadata-DB row can be, never round-trips
+        through get_uri(), so it reaches get_hook() unchanged and can never resolve. The bare
+        'Unknown hook type' told the user nothing about why.
+        """
+        conn = Connection(conn_id="c", conn_type="google-cloud-platform")
+
+        with pytest.raises(AirflowException, match="Unknown hook type") as exc_info:
+            conn.get_hook()
+
+        message = str(exc_info.value)
+        assert "google-cloud-platform" in message
+        assert "google_cloud_platform" in message
+
     def test_get_hook_explains_a_uri_whose_scheme_was_dropped(self):
         """
         A URI scheme cannot contain '_' (RFC 3986), so ``foo_bar://h`` parses with no scheme

--- a/task-sdk/src/airflow/sdk/definitions/connection.py
+++ b/task-sdk/src/airflow/sdk/definitions/connection.py
@@ -220,7 +220,19 @@ class Connection:
         hook = ProvidersManagerTaskRuntime().hooks.get(self.conn_type, None)
 
         if hook is None:
-            raise AirflowException(f'Unknown hook type "{self.conn_type}"')
+            if not self.conn_type:
+                # A URI scheme cannot contain '_' (RFC 3986), so "foo_bar://h" parses with no
+                # scheme at all and leaves conn_type empty. Name that, instead of reporting an
+                # unknown hook type of "".
+                message = (
+                    f"Connection {self.conn_id!r} has no connection type, so no hook could be "
+                    "looked up. If it was defined as a URI, note that a URI scheme cannot "
+                    "contain '_' (RFC 3986) and such a URI parses with no scheme at all: use "
+                    "'-' in the URI instead, which is decoded back to '_' on read."
+                )
+            else:
+                message = f'Unknown hook type "{self.conn_type}"'
+            raise AirflowException(message)
         try:
             hook_class = import_string(hook.hook_class_name)
         except ImportError:

--- a/task-sdk/src/airflow/sdk/definitions/connection.py
+++ b/task-sdk/src/airflow/sdk/definitions/connection.py
@@ -230,6 +230,16 @@ class Connection:
                     "contain '_' (RFC 3986) and such a URI parses with no scheme at all: use "
                     "'-' in the URI instead, which is decoded back to '_' on read."
                 )
+            elif "-" in self.conn_type:
+                # A hyphenated conn_type is the configuration this cannot ever resolve for,
+                # because '-' is the URI-scheme encoding of '_'. Say so, but as a hint rather
+                # than a diagnosis: the provider may simply not be installed.
+                message = (
+                    f"Unknown hook type \"{self.conn_type}\". Note that it contains '-', which is "
+                    "the URI-scheme encoding of '_', so a connection type spelled with '-' cannot "
+                    f"be resolved; the registered name is likely {self.conn_type.replace('-', '_')!r}. "
+                    "Otherwise the provider supplying this connection type may not be installed."
+                )
             else:
                 message = f'Unknown hook type "{self.conn_type}"'
             raise AirflowException(message)

--- a/task-sdk/src/airflow/sdk/definitions/connection.py
+++ b/task-sdk/src/airflow/sdk/definitions/connection.py
@@ -217,7 +217,8 @@ class Connection:
         """Return hook based on conn_type."""
         from airflow.sdk._shared.module_loading import import_string
 
-        hook = ProvidersManagerTaskRuntime().hooks.get(self.conn_type, None)
+        hooks = ProvidersManagerTaskRuntime().hooks
+        hook = hooks.get(self.conn_type, None)
 
         if hook is None:
             if not self.conn_type:
@@ -230,18 +231,29 @@ class Connection:
                     "contain '_' (RFC 3986) and such a URI parses with no scheme at all: use "
                     "'-' in the URI instead, which is decoded back to '_' on read."
                 )
-            elif "-" in self.conn_type:
-                # A hyphenated conn_type is the configuration this cannot ever resolve for,
-                # because '-' is the URI-scheme encoding of '_'. Say so, but as a hint rather
-                # than a diagnosis: the provider may simply not be installed.
-                message = (
-                    f"Unknown hook type \"{self.conn_type}\". Note that it contains '-', which is "
-                    "the URI-scheme encoding of '_', so a connection type spelled with '-' cannot "
-                    f"be resolved; the registered name is likely {self.conn_type.replace('-', '_')!r}. "
-                    "Otherwise the provider supplying this connection type may not be installed."
-                )
             else:
                 message = f'Unknown hook type "{self.conn_type}"'
+                # To a URI scheme '-' and '_' are the same character: get_uri() encodes '_' as
+                # '-' because RFC 3986 forbids '_' in a scheme, and reading a connection back
+                # from a URI or from JSON decodes it again. A connection type spelled one way
+                # therefore cannot resolve a hook registered the other way. Hooks register under
+                # the connection-type verbatim, so look the other spelling up rather than
+                # asserting which one is right.
+                alternative = (
+                    self.conn_type.replace("-", "_")
+                    if "-" in self.conn_type
+                    else self.conn_type.replace("_", "-")
+                )
+                if alternative != self.conn_type and alternative in hooks:
+                    message += f", but a hook is registered for {alternative!r}. "
+                    if "-" in self.conn_type:
+                        message += "Spell this connection's type with '_' to reach it."
+                    else:
+                        message += (
+                            "Reading a connection from a URI or from JSON decodes '-' back to "
+                            "'_', so this connection cannot reach that hook; the provider has "
+                            "to declare its connection-type with '_'."
+                        )
             raise AirflowException(message)
         try:
             hook_class = import_string(hook.hook_class_name)

--- a/task-sdk/src/airflow/sdk/definitions/connection.py
+++ b/task-sdk/src/airflow/sdk/definitions/connection.py
@@ -233,18 +233,20 @@ class Connection:
                 )
             else:
                 message = f'Unknown hook type "{self.conn_type}"'
-                # To a URI scheme '-' and '_' are the same character: get_uri() encodes '_' as
-                # '-' because RFC 3986 forbids '_' in a scheme, and reading a connection back
-                # from a URI or from JSON decodes it again. A connection type spelled one way
-                # therefore cannot resolve a hook registered the other way. Hooks register under
-                # the connection-type verbatim, so look the other spelling up rather than
-                # asserting which one is right.
+                # get_uri() encodes '_' as '-' because RFC 3986 forbids '_' in a scheme, and
+                # reading a connection back from a URI or from JSON decodes it again, so both
+                # characters serialize to '-' and a connection type spelled one way cannot
+                # resolve a hook registered the other way. Hooks register under the
+                # connection-type verbatim, so look the other spelling up rather than asserting
+                # which one is right, and resolve it rather than testing for membership: a
+                # registered connection type maps to None when its hook cannot be imported, and
+                # naming a spelling that still will not resolve is worse than naming none.
                 alternative = (
                     self.conn_type.replace("-", "_")
                     if "-" in self.conn_type
                     else self.conn_type.replace("_", "-")
                 )
-                if alternative != self.conn_type and alternative in hooks:
+                if alternative != self.conn_type and hooks.get(alternative) is not None:
                     message += f", but a hook is registered for {alternative!r}. "
                     if "-" in self.conn_type:
                         message += "Spell this connection's type with '_' to reach it."

--- a/task-sdk/tests/task_sdk/definitions/test_connection.py
+++ b/task-sdk/tests/task_sdk/definitions/test_connection.py
@@ -78,6 +78,21 @@ class TestConnections:
         with pytest.raises(AirflowException, match='Unknown hook type "unknown_type"'):
             conn.get_hook()
 
+    def test_get_hook_explains_a_uri_whose_scheme_was_dropped(self, mock_providers_manager):
+        """
+        A URI scheme cannot contain '_' (RFC 3986), so ``foo_bar://h`` parses with no scheme at
+        all and leaves conn_type empty. This is the worker-side copy of that failure, which
+        used to read ``Unknown hook type ""`` and named neither the cause nor the fix.
+        """
+        mock_providers_manager.return_value.hooks = {}
+        conn = Connection(conn_id="test_conn", uri="pydanticai_azure://h")
+        assert conn.conn_type == ""
+
+        with pytest.raises(AirflowException, match="has no connection type") as exc_info:
+            conn.get_hook()
+
+        assert "RFC 3986" in str(exc_info.value)
+
     def test_get_uri(self):
         """Test that get_uri generates the correct URI based on connection attributes."""
 

--- a/task-sdk/tests/task_sdk/definitions/test_connection.py
+++ b/task-sdk/tests/task_sdk/definitions/test_connection.py
@@ -120,6 +120,16 @@ class TestConnections:
 
         assert str(exc_info.value) == 'Unknown hook type "google-cloud-platform"'
 
+    def test_get_hook_does_not_advise_a_spelling_whose_hook_cannot_be_imported(self, mock_providers_manager):
+        """A registered connection type maps to None when its hook cannot be imported."""
+        mock_providers_manager.return_value.hooks = {"google_cloud_platform": None}
+        conn = Connection(conn_id="test_conn", conn_type="google-cloud-platform")
+
+        with pytest.raises(AirflowException) as exc_info:
+            conn.get_hook()
+
+        assert str(exc_info.value) == 'Unknown hook type "google-cloud-platform"'
+
     def test_get_hook_explains_a_uri_whose_scheme_was_dropped(self, mock_providers_manager):
         """
         A URI scheme cannot contain '_' (RFC 3986), so ``foo_bar://h`` parses with no scheme at

--- a/task-sdk/tests/task_sdk/definitions/test_connection.py
+++ b/task-sdk/tests/task_sdk/definitions/test_connection.py
@@ -78,6 +78,18 @@ class TestConnections:
         with pytest.raises(AirflowException, match='Unknown hook type "unknown_type"'):
             conn.get_hook()
 
+    def test_get_hook_explains_a_hyphenated_conn_type(self, mock_providers_manager):
+        """Worker-side copy of the hyphenated-conn_type hint."""
+        mock_providers_manager.return_value.hooks = {}
+        conn = Connection(conn_id="test_conn", conn_type="google-cloud-platform")
+
+        with pytest.raises(AirflowException, match="Unknown hook type") as exc_info:
+            conn.get_hook()
+
+        message = str(exc_info.value)
+        assert "google-cloud-platform" in message
+        assert "google_cloud_platform" in message
+
     def test_get_hook_explains_a_uri_whose_scheme_was_dropped(self, mock_providers_manager):
         """
         A URI scheme cannot contain '_' (RFC 3986), so ``foo_bar://h`` parses with no scheme at

--- a/task-sdk/tests/task_sdk/definitions/test_connection.py
+++ b/task-sdk/tests/task_sdk/definitions/test_connection.py
@@ -78,17 +78,47 @@ class TestConnections:
         with pytest.raises(AirflowException, match='Unknown hook type "unknown_type"'):
             conn.get_hook()
 
-    def test_get_hook_explains_a_hyphenated_conn_type(self, mock_providers_manager):
-        """Worker-side copy of the hyphenated-conn_type hint."""
-        mock_providers_manager.return_value.hooks = {}
-        conn = Connection(conn_id="test_conn", conn_type="google-cloud-platform")
+    @pytest.mark.parametrize(
+        ("conn_type", "registered", "expected_remedy"),
+        [
+            pytest.param(
+                "google-cloud-platform",
+                "google_cloud_platform",
+                "Spell this connection's type with '_' to reach it.",
+                id="hyphenated-conn-type",
+            ),
+            pytest.param(
+                "pydanticai_vertex",
+                "pydanticai-vertex",
+                "so this connection cannot reach that hook",
+                id="hyphenated-registration",
+            ),
+        ],
+    )
+    def test_get_hook_names_the_other_spelling_when_it_is_the_registered_one(
+        self, mock_providers_manager, conn_type, registered, expected_remedy
+    ):
+        """Worker-side copy: this is the path a task actually raises from."""
+        mock_providers_manager.return_value.hooks = {registered: mock.MagicMock()}
+        conn = Connection(conn_id="test_conn", conn_type=conn_type)
 
         with pytest.raises(AirflowException, match="Unknown hook type") as exc_info:
             conn.get_hook()
 
         message = str(exc_info.value)
-        assert "google-cloud-platform" in message
-        assert "google_cloud_platform" in message
+        assert conn_type in message
+        assert registered in message
+        assert expected_remedy in message
+
+    def test_get_hook_does_not_guess_an_unregistered_spelling(self, mock_providers_manager):
+        """With neither spelling registered, say only what is known."""
+        mock_providers_manager.return_value.hooks = {}
+        conn = Connection(conn_id="test_conn", conn_type="google-cloud-platform")
+
+        with pytest.raises(AirflowException) as exc_info:
+            conn.get_hook()
+
+        assert str(exc_info.value) == 'Unknown hook type "google-cloud-platform"'
 
     def test_get_hook_explains_a_uri_whose_scheme_was_dropped(self, mock_providers_manager):
         """


### PR DESCRIPTION
## Summary

`Connection.get_uri()` warned that a `conn_type` containing `_` violates RFC 3986. That is the one spelling which survives a round trip, so the warning fired on the correct form and stayed silent on the broken one. This removes it, and reports a connection type that cannot resolve at the point where it actually fails.

## The mechanics

A URI scheme cannot contain `_` (RFC 3986 section 3.1 permits ALPHA, DIGIT, `+`, `-` and `.`), so [`get_uri()`](https://github.com/apache/airflow/blob/bdf2abcbc6/airflow-core/src/airflow/models/connection.py#L297) writes the scheme as `conn_type.lower().replace('_', '-')` and [`_normalize_conn_type`](https://github.com/apache/airflow/blob/bdf2abcbc6/airflow-core/src/airflow/models/connection.py#L228-L233) decodes `-` back to `_` on read. That substitution covers the one forbidden character Airflow itself introduces, and it is a substitution rather than validation: a connection type containing a space or a leading digit still yields a scheme that is not compliant. The encoding is also lossy in one direction:

| `conn_type` | URI emitted | read back as |
|---|---|---|
| `google_cloud_platform` | `google-cloud-platform://` | `google_cloud_platform`, unchanged |
| `google-cloud-platform` | `google-cloud-platform://` | `google_cloud_platform`, changed |

Both rows emit the same URI. `-` and `_` collapse onto `-` on the way out and the decode can only pick one preimage, so a connection type spelled with `-` is not discouraged, it is unrepresentable: it returns as a different type, and a hook registered under the hyphenated name is then not found.

RFC 3986 is why the encoding exists. It is not why either spelling fails.

## Why the warning goes rather than flipping

The [old guard](https://github.com/apache/airflow/blob/bdf2abcbc6/airflow-core/src/airflow/models/connection.py#L290-L295) read `_prenormalized_conn_type` when the connection was parsed from a URI, and `conn_type` otherwise. That attribute holds a parsed URI scheme, and an underscore scheme parses with no scheme at all:

```python
>>> urlsplit("foo_bar://h").scheme
''
```

So it could suppress the warning but never trigger it. A connection parsed from a URI never warned; the warning fired for a metadata-DB row, `from_json`, or kwargs. Since `get_uri()` removes every `_` before the URI exists, it was warning about a violation it had already prevented, on the input side of its own encoder.

32 registered connection types contain `_`, and the warning was not gated on the secrets cache. `conn.get_uri()` is evaluated as an argument to [`save_connection_uri()`](https://github.com/apache/airflow/blob/bdf2abcbc6/airflow-core/src/airflow/models/connection.py#L525) and the cache-enabled check sits inside [`_save`](https://github.com/apache/airflow/blob/bdf2abcbc6/task-sdk/src/airflow/sdk/execution_time/cache.py#L158), so it ran after every successful backend fetch even where the cache was never initialized. [`SecretCache.init()`](https://github.com/apache/airflow/blob/bdf2abcbc6/airflow-core/src/airflow/dag_processing/manager.py#L562) is called only by the dag processor.

It also advised the wrong thing. #62817 renamed `pydantic_ai` to `pydanticai` specifically to silence it, and the vendor types added in #62816 then followed the same instinct and used hyphens, which is the bug fixed in #72853.

Inverting the condition to flag `-` would say something true in the wrong place. It fires per fetch for what is static configuration, and its audience is whoever reads the logs rather than the provider author who declares the `connection-type`. An invariant with no valid instance belongs in validation, and it now has two better homes: the failure is explained where it fails, and #72853 rejects a hyphenated `connection-type` in the authoring schema.

## What replaces it

`get_hook()` explained neither of its two failures.

An underscore scheme parses with no scheme, which left `conn_type` empty and surfaced as `Unknown hook type ""`. It now names the empty connection type and the scheme rule behind it.

A lookup that misses now names the other spelling when that is the registered one. Hooks register under the provider's `connection-type` verbatim, so a hyphenated type does register and does resolve for a connection built with that type directly; the two spellings only diverge once a connection is read back:

```
Unknown hook type "pydanticai_vertex", but a hook is registered for 'pydanticai-vertex'.
Reading a connection from a URI or from JSON decodes '-' back to '_', so this connection
cannot reach that hook; the provider has to declare its connection-type with '_'.
```

```
Unknown hook type "google-cloud-platform", but a hook is registered for
'google_cloud_platform'. Spell this connection's type with '_' to reach it.
```

The first is #72316's own failure, which reports the underscored form because the connection normalized on the way in. The other spelling is resolved in the registry rather than guessed at, and named only when it yields a usable hook. A registered connection type maps to None when its hook cannot be imported, so mere presence would have produced advice that still fails when followed. With neither spelling usable the message is unchanged. Both `airflow.models.Connection` and the Task SDK copy raise this, so both carry it. The existing `raise` is reused rather than adding one, to respect `check-no-new-airflow-exceptions`.

## Alternatives considered

Allowing `-` requires the decode to stop rewriting it, which breaks all 32 underscore types to save the 3 hyphenated ones. Not encoding on write emits `google_cloud_platform://`, which `urlsplit` reads as having no scheme, so `conn_type` arrives empty. An encoding that escapes both characters rather than mapping one onto the other would let both spellings coexist, and would change the URI spelling of every connection already written down. Mapping `_` to `--` alone does not achieve it, since `foo_bar` and `foo--bar` then collide. Decoding conditionally, rewriting `-` only when the hyphenated name is absent from the registry, would fix #72316 with no rename, at the cost of consulting `ProvidersManager` during connection parsing and making the same URI mean different things depending on which providers happen to be installed.

## Relationship to #72853

The three hyphenated `connection-type` values in the tree are `pydanticai-azure`, `pydanticai-bedrock` and `pydanticai-vertex`, and `ProvidersManager` registers those strings verbatim. How they fail depends on where the connection is stored. From a secrets backend serving a URI or JSON they never resolve, because `Connection(uri=...)` and `from_json` both normalize; a custom backend that constructs a `Connection` itself is the exception, since it bypasses both parsers. From a metadata-DB row the hyphen survives into the object and the hook does resolve, until the secrets cache is enabled and a cache hit rebuilds the connection from the cached URI. #72853 renames all three and forbids a hyphenated `connection-type` in the authoring schema. This PR is independent of it and does not depend on the order the two merge.

## Known gap this does not close

Where two providers register the two spellings of one name, a connection resolves a different
provider's hook after a round trip, and nothing raises:

```
stored directly      conn_type='foo-bar'  -> provider_a.HookA
after URI round trip conn_type='foo_bar'  -> provider_b.HookB
```

`get_hook()` only speaks when a lookup fails, so no message in this PR can reach that case, and
an inverted `get_uri()` warning would not have described it either. It predates this change and
is unaffected by it. The right place for it is a once-per-discovery advisory in the provider
registration path, naming the declared type, the name it normalizes to, and any collision, which
also covers third-party wheels that the authoring schema never sees. That belongs in its own
change rather than here.

## Note on the Task SDK

Only `airflow-core`'s `Connection` ever had the `get_uri()` warning, so the worker path that raises in practice was silent throughout. That is not because `get_uri()` is off the SDK's path, since it is called there after every successful backend fetch as well, but because the SDK's copy carries no warning code. The improved error messages apply to both copies.
