### PR TITLE
Restore CLI commands from custom executors and auth managers

### DIFF
--- a/airflow-core/newsfragments/72858.bugfix.rst
+++ b/airflow-core/newsfragments/72858.bugfix.rst
@@ -1,0 +1,1 @@
+Fix missing ``airflow`` CLI commands from executors and auth managers that are configured by module path without being packaged as a provider.

--- a/airflow-core/src/airflow/cli/cli_parser.py
+++ b/airflow-core/src/airflow/cli/cli_parser.py
@@ -71,18 +71,18 @@ def _exclude_registered_commands(
     commands: Iterable[CLICommand], registered_names: set[str], source: str
 ) -> list[CLICommand]:
     """
-    Drop commands that a provider already registered through its ``cli`` section.
+    Drop commands whose name is already registered, and record the names of the commands kept.
 
-    A custom class subclassing a provider executor or auth manager inherits its ``get_cli_commands`` and
-    would otherwise re-register the same commands, which is reported as a conflict.
+    A subclass of a provider executor or auth manager inherits ``get_cli_commands``, so the same command can
+    come from a provider ``cli`` section and from an imported class, or from two imported classes. Only the
+    first one is kept, otherwise the duplicate is reported as a conflict.
     """
     result: list[CLICommand] = []
     for command in commands:
         if command.name in registered_names:
-            log.debug(
-                "Skipping CLI command '%s' from %s: already registered by a provider.", command.name, source
-            )
+            log.debug("Skipping CLI command '%s' from %s: already registered.", command.name, source)
             continue
+        registered_names.add(command.name)
         result.append(command)
     return result
 
@@ -104,8 +104,8 @@ if not os.environ.get("AIRFLOW_PACKAGE_NAME", None):
         log.warning("Failed to load CLI commands from providers: %s", e)
         # do not re-raise for the same reason as above
 
-    # Commands registered through a provider "cli" section take precedence over the compat loading below
-    provider_command_names = {command.name for command in airflow_commands} - {
+    # Core commands are left out so that a class redefining one still fails the conflict check below
+    registered_command_names = {command.name for command in airflow_commands} - {
         command.name for command in core_commands
     }
 
@@ -133,10 +133,8 @@ Providers with {component} missing 'cli' section in 'get_provider_info': {not_de
                 )
             )
         executors_defined_cli = {
-            executor_name
-            for executor_name, executor_provider in providers_manager.executor_without_check
-            if executor_provider in providers_manager.cli_command_providers
-        }
+            executor_name for executor_name, _ in providers_manager.executor_without_check
+        } - executors_not_defined_cli.keys()
 
         for executor_name in ExecutorLoader.get_executor_names(validate_teams=False):
             if executor_name.module_path in executors_defined_cli or executor_name.module_path.startswith(
@@ -152,7 +150,7 @@ Providers with {component} missing 'cli' section in 'get_provider_info': {not_de
                 executor, _ = ExecutorLoader.import_executor_cls(executor_name)
                 airflow_commands.extend(
                     _exclude_registered_commands(
-                        executor.get_cli_commands(), provider_command_names, executor_name.module_path
+                        executor.get_cli_commands(), registered_command_names, executor_name.module_path
                     )
                 )
             except Exception:
@@ -186,10 +184,8 @@ Providers with {component} missing 'cli' section in 'get_provider_info': {not_de
                 )
             )
         auth_managers_defined_cli = {
-            auth_manager_name
-            for auth_manager_name, auth_manager_provider in providers_manager.auth_manager_without_check
-            if auth_manager_provider in providers_manager.cli_command_providers
-        }
+            auth_manager_name for auth_manager_name, _ in providers_manager.auth_manager_without_check
+        } - auth_managers_not_defined_cli.keys()
 
         auth_manager_cls_path = conf.get(section="core", key="auth_manager")
 
@@ -206,7 +202,7 @@ Providers with {component} missing 'cli' section in 'get_provider_info': {not_de
                 auth_manager = auth_manager_cls()
                 airflow_commands.extend(
                     _exclude_registered_commands(
-                        auth_manager.get_cli_commands(), provider_command_names, auth_manager_cls_path
+                        auth_manager.get_cli_commands(), registered_command_names, auth_manager_cls_path
                     )
                 )
             except Exception:

--- a/airflow-core/src/airflow/cli/cli_parser.py
+++ b/airflow-core/src/airflow/cli/cli_parser.py
@@ -45,7 +45,9 @@ from airflow.cli.cli_config import (
     core_commands,
 )
 from airflow.cli.utils import CliConflictError
-from airflow.exceptions import AirflowException
+from airflow.configuration import conf
+from airflow.exceptions import AirflowConfigException, AirflowException
+from airflow.executors.executor_loader import ExecutorLoader
 from airflow.providers_manager import ProvidersManager
 from airflow.utils.helpers import partition
 
@@ -58,6 +60,32 @@ if TYPE_CHECKING:
 airflow_commands = core_commands.copy()  # make a copy to prevent bad interactions in tests
 
 log = logging.getLogger(__name__)
+
+# Executors and auth managers shipped in airflow-core define no CLI commands of their own. Skipping them
+# by module prefix keeps the default configuration from importing any executor or auth manager class.
+_CORE_EXECUTORS_PACKAGE = "airflow.executors."
+_CORE_AUTH_MANAGERS_PACKAGE = "airflow.api_fastapi.auth.managers."
+
+
+def _exclude_registered_commands(
+    commands: Iterable[CLICommand], registered_names: set[str], source: str
+) -> list[CLICommand]:
+    """
+    Drop commands that a provider already registered through its ``cli`` section.
+
+    A custom class subclassing a provider executor or auth manager inherits its ``get_cli_commands`` and
+    would otherwise re-register the same commands, which is reported as a conflict.
+    """
+    result: list[CLICommand] = []
+    for command in commands:
+        if command.name in registered_names:
+            log.debug(
+                "Skipping CLI command '%s' from %s: already registered by a provider.", command.name, source
+            )
+            continue
+        result.append(command)
+    return result
+
 
 # AIRFLOW_PACKAGE_NAME is set when generating docs and we don't want to load provider commands when generating airflow-core CLI docs
 if not os.environ.get("AIRFLOW_PACKAGE_NAME", None):
@@ -76,6 +104,11 @@ if not os.environ.get("AIRFLOW_PACKAGE_NAME", None):
         log.warning("Failed to load CLI commands from providers: %s", e)
         # do not re-raise for the same reason as above
 
+    # Commands registered through a provider "cli" section take precedence over the compat loading below
+    provider_command_names = {command.name for command in airflow_commands} - {
+        command.name for command in core_commands
+    }
+
     WARNING_TEMPLATE = """
 Please define the 'cli' section in the 'get_provider_info' for custom {component} to avoid this warning.
 For community providers, please update to the version that support 'cli' section.
@@ -84,10 +117,10 @@ For more details, see https://airflow.apache.org/docs/apache-airflow-providers/c
 Providers with {component} missing 'cli' section in 'get_provider_info': {not_defined_cli_dict}
     """
 
-    # compat loading for older providers that define get_cli_commands methods on Executors
+    # compat loading for executors that do not register CLI commands through a provider "cli" section:
+    # older providers, and custom executors configured by module path without being packaged as a provider
     try:
-        # if there is any executor_provider not in cli_provider, we have to do compat loading
-        # we use without check to avoid actual loading in this check
+        # warn about providers that still rely on compat loading; "without check" avoids importing them here
         executors_not_defined_cli = {
             executor_name: executor_provider
             for executor_name, executor_provider in providers_manager.executor_without_check
@@ -99,29 +132,38 @@ Providers with {component} missing 'cli' section in 'get_provider_info': {not_de
                     component="executors", not_defined_cli_dict=str(executors_not_defined_cli)
                 )
             )
-            from airflow.executors.executor_loader import ExecutorLoader
+        executors_defined_cli = {
+            executor_name
+            for executor_name, executor_provider in providers_manager.executor_without_check
+            if executor_provider in providers_manager.cli_command_providers
+        }
 
-            for executor_name in ExecutorLoader.get_executor_names(validate_teams=False):
-                # Skip if the executor already has CLI commands defined via the 'cli' section in provider.yaml
-                if executor_name.module_path not in executors_not_defined_cli:
-                    log.debug(
-                        "Skipping loading for '%s' as it is defined in 'cli' section.",
-                        executor_name.module_path,
-                    )
-                    continue
+        for executor_name in ExecutorLoader.get_executor_names(validate_teams=False):
+            if executor_name.module_path in executors_defined_cli or executor_name.module_path.startswith(
+                _CORE_EXECUTORS_PACKAGE
+            ):
+                log.debug(
+                    "Skipping loading for '%s' as its CLI commands are registered elsewhere.",
+                    executor_name.module_path,
+                )
+                continue
 
-                try:
-                    executor, _ = ExecutorLoader.import_executor_cls(executor_name)
-                    airflow_commands.extend(executor.get_cli_commands())
-                except Exception:
-                    log.exception("Failed to load CLI commands from executor: %s", executor_name)
-                    log.error(
-                        "Ensure all dependencies are met and try again. If using a Celery based executor install "
-                        "a 3.3.0+ version of the Celery provider. If using a Kubernetes executor, install a "
-                        "7.4.0+ version of the CNCF provider"
+            try:
+                executor, _ = ExecutorLoader.import_executor_cls(executor_name)
+                airflow_commands.extend(
+                    _exclude_registered_commands(
+                        executor.get_cli_commands(), provider_command_names, executor_name.module_path
                     )
-                    # Do not re-raise the exception since we want the CLI to still function for
-                    # other commands.
+                )
+            except Exception:
+                log.exception("Failed to load CLI commands from executor: %s", executor_name)
+                log.error(
+                    "Ensure all dependencies are met and try again. If using a Celery based executor install "
+                    "a 3.3.0+ version of the Celery provider. If using a Kubernetes executor, install a "
+                    "7.4.0+ version of the CNCF provider"
+                )
+                # Do not re-raise the exception since we want the CLI to still function for
+                # other commands.
 
     except Exception as e:
         log.warning(
@@ -129,10 +171,9 @@ Providers with {component} missing 'cli' section in 'get_provider_info': {not_de
             e,
         )
 
-    # compat loading for older providers that define get_cli_commands methods on AuthManagers
+    # compat loading for auth managers, following the same rules as for executors
     try:
-        # if there is any auth_manager not in cli_provider, we have to do compat loading
-        # we use without check to avoid actual loading in this check
+        # warn about providers that still rely on compat loading; "without check" avoids importing them here
         auth_managers_not_defined_cli = {
             auth_manager_name: auth_manager_provider
             for auth_manager_name, auth_manager_provider in providers_manager.auth_manager_without_check
@@ -144,27 +185,35 @@ Providers with {component} missing 'cli' section in 'get_provider_info': {not_de
                     component="auth manager", not_defined_cli_dict=str(auth_managers_not_defined_cli)
                 )
             )
+        auth_managers_defined_cli = {
+            auth_manager_name
+            for auth_manager_name, auth_manager_provider in providers_manager.auth_manager_without_check
+            if auth_manager_provider in providers_manager.cli_command_providers
+        }
 
-            from airflow.configuration import conf
-            from airflow.exceptions import AirflowConfigException
+        auth_manager_cls_path = conf.get(section="core", key="auth_manager")
 
-            auth_manager_cls_path = conf.get(section="core", key="auth_manager")
+        if not auth_manager_cls_path:
+            raise AirflowConfigException(
+                "No auth manager defined in the config. Please specify one using section/key [core/auth_manager]."
+            )
 
-            if not auth_manager_cls_path:
-                raise AirflowConfigException(
-                    "No auth manager defined in the config. Please specify one using section/key [core/auth_manager]."
+        if auth_manager_cls_path not in auth_managers_defined_cli and not auth_manager_cls_path.startswith(
+            _CORE_AUTH_MANAGERS_PACKAGE
+        ):
+            try:
+                auth_manager_cls = import_string(auth_manager_cls_path)
+                auth_manager = auth_manager_cls()
+                airflow_commands.extend(
+                    _exclude_registered_commands(
+                        auth_manager.get_cli_commands(), provider_command_names, auth_manager_cls_path
+                    )
                 )
-
-            if auth_manager_cls_path in auth_managers_not_defined_cli:
-                try:
-                    auth_manager_cls = import_string(auth_manager_cls_path)
-                    auth_manager = auth_manager_cls()
-                    airflow_commands.extend(auth_manager.get_cli_commands())
-                except Exception:
-                    log.exception("Failed to load CLI commands from auth manager: %s", auth_manager_cls)
-                    log.error("Ensure all dependencies are met and try again.")
-                    # Do not re-raise the exception since we want the CLI to still function for
-                    # other commands.
+            except Exception:
+                log.exception("Failed to load CLI commands from auth manager: %s", auth_manager_cls_path)
+                log.error("Ensure all dependencies are met and try again.")
+                # Do not re-raise the exception since we want the CLI to still function for
+                # other commands.
     except Exception as e:
         log.warning(
             "Failed to load CLI commands from auth managers that didn't define `get_cli_commands` in `.cli.definition`: %s",

--- a/airflow-core/tests/unit/cli/test_cli_parser.py
+++ b/airflow-core/tests/unit/cli/test_cli_parser.py
@@ -182,7 +182,7 @@ class TestCli:
         ["airflow.api_fastapi.auth.managers", "airflow.executors.base_executor"],
     )
     def test_should_not_import_in_cli_parser(self, module_pattern: str):
-        """Test that cli_parser does not import auth_managers or executor_loader at import time."""
+        """Test that cli_parser does not import any auth manager or executor class at import time."""
         # Remove the module from sys.modules if present to force a fresh import
         import sys
 
@@ -339,6 +339,28 @@ class TestCli:
         mock_import_executor_cls.assert_has_calls(expected_calls, any_order=True)
         assert mock_import_executor_cls.call_count == len(expected_calls)
 
+    @pytest.mark.parametrize(
+        ("cli_command_functions", "cli_command_providers", "executor_commands", "expected_celery_source"),
+        [
+            pytest.param(
+                [lambda: [ActionCommand(name="celery", help="provider", func=lambda: None, args=[])]],
+                {"apache-airflow-providers-celery"},
+                {"my.custom.module.CustomCeleryExecutor": ["celery", "custom-executor"]},
+                "provider",
+                id="already registered by a provider cli section",
+            ),
+            pytest.param(
+                [],
+                set(),
+                {
+                    "path.to.CeleryExecutor": ["celery"],
+                    "my.custom.module.CustomCeleryExecutor": ["celery", "custom-executor"],
+                },
+                "path.to.CeleryExecutor",
+                id="already registered by an earlier executor",
+            ),
+        ],
+    )
     @patch("airflow.executors.executor_loader.ExecutorLoader.import_executor_cls")
     @patch("airflow.executors.executor_loader.ExecutorLoader.get_executor_names")
     @patch(
@@ -353,35 +375,41 @@ class TestCli:
         "airflow.providers_manager.ProvidersManager.cli_command_functions",
         new_callable=mock.PropertyMock,
     )
-    def test_compat_cli_loading_skips_commands_registered_by_providers(
+    def test_compat_cli_loading_skips_already_registered_commands(
         self,
         mock_cli_command_functions: MagicMock,
         mock_cli_command_providers: MagicMock,
         mock_executor_without_check: MagicMock,
         mock_get_executor_names: MagicMock,
         mock_import_executor_cls: MagicMock,
+        cli_command_functions: list[Callable[[], list[ActionCommand | cli_parser.GroupCommand]]],
+        cli_command_providers: set[str],
+        executor_commands: dict[str, list[str]],
+        expected_celery_source: str,
     ):
-        """A subclass of a provider executor inherits get_cli_commands(); the provider registration must win."""
-        mock_cli_command_functions.return_value = [
-            lambda: [ActionCommand(name="celery", help="from provider", func=lambda: None, args=[])]
-        ]
-        mock_cli_command_providers.return_value = {"apache-airflow-providers-celery"}
+        """A subclass inherits get_cli_commands() from its provider executor. The first registration wins."""
+        mock_cli_command_functions.return_value = cli_command_functions
+        mock_cli_command_providers.return_value = cli_command_providers
         mock_executor_without_check.return_value = {
             ("path.to.CeleryExecutor", "apache-airflow-providers-celery"),
         }
         mock_get_executor_names.return_value = [
-            MagicMock(module_path="my.custom.module.CustomCeleryExecutor")
+            MagicMock(module_path=module_path) for module_path in executor_commands
         ]
-        mock_executor_cls = MagicMock()
-        mock_executor_cls.get_cli_commands.return_value = [
-            ActionCommand(name="celery", help="inherited", func=lambda: None, args=[]),
-            ActionCommand(name="custom-executor", help="", func=lambda: None, args=[]),
-        ]
-        mock_import_executor_cls.return_value = (mock_executor_cls, None)
+
+        def import_executor_cls(executor_name):
+            executor_cls = MagicMock()
+            executor_cls.get_cli_commands.return_value = [
+                ActionCommand(name=name, help=executor_name.module_path, func=lambda: None, args=[])
+                for name in executor_commands[executor_name.module_path]
+            ]
+            return executor_cls, None
+
+        mock_import_executor_cls.side_effect = import_executor_cls
 
         reload(cli_parser)
 
-        assert cli_parser.ALL_COMMANDS_DICT["celery"].help == "from provider"
+        assert cli_parser.ALL_COMMANDS_DICT["celery"].help == expected_celery_source
         assert "custom-executor" in cli_parser.ALL_COMMANDS_DICT
 
     @pytest.mark.parametrize(

--- a/airflow-core/tests/unit/cli/test_cli_parser.py
+++ b/airflow-core/tests/unit/cli/test_cli_parser.py
@@ -179,7 +179,7 @@ class TestCli:
 
     @pytest.mark.parametrize(
         "module_pattern",
-        ["airflow.auth.managers", "airflow.executors.executor_loader"],
+        ["airflow.api_fastapi.auth.managers", "airflow.executors.base_executor"],
     )
     def test_should_not_import_in_cli_parser(self, module_pattern: str):
         """Test that cli_parser does not import auth_managers or executor_loader at import time."""
@@ -208,6 +208,7 @@ class TestCli:
             "cli_command_functions",
             "cli_command_providers",
             "executor_without_check",
+            "executor_names",
             "expected_loaded_executors",
         ),
         [
@@ -218,6 +219,7 @@ class TestCli:
                     ("path.to.KubernetesExecutor", "apache-airflow-providers-cncf-kubernetes"),
                 },
                 ["path.to.KubernetesExecutor"],
+                ["path.to.KubernetesExecutor"],
                 id="empty cli section should load all the executors by ExecutorLoader",
             ),
             pytest.param(
@@ -227,6 +229,7 @@ class TestCli:
                     ("path.to.CeleryExecutor", "apache-airflow-providers-celery"),
                     ("path.to.KubernetesExecutor", "apache-airflow-providers-cncf-kubernetes"),
                 },
+                ["path.to.CeleryExecutor", "path.to.KubernetesExecutor"],
                 ["path.to.KubernetesExecutor"],
                 id="only partial executor define cli section in provider info, should load the rest by ExecutorLoader",
             ),
@@ -240,8 +243,25 @@ class TestCli:
                     ("path.to.CeleryExecutor", "apache-airflow-providers-celery"),
                     ("path.to.KubernetesExecutor", "apache-airflow-providers-cncf-kubernetes"),
                 },
+                ["path.to.CeleryExecutor", "path.to.KubernetesExecutor"],
                 [],
                 id="all executors define cli section in provider info, should not load any by ExecutorLoader",
+            ),
+            pytest.param(
+                [lambda: [ActionCommand(name="celery", help="", func=lambda: None, args=[])]],
+                {"apache-airflow-providers-celery"},
+                {("path.to.CeleryExecutor", "apache-airflow-providers-celery")},
+                ["my.custom.module.ExecutorClass"],
+                ["my.custom.module.ExecutorClass"],
+                id="custom executor not packaged as a provider should load by ExecutorLoader",
+            ),
+            pytest.param(
+                [lambda: [ActionCommand(name="celery", help="", func=lambda: None, args=[])]],
+                {"apache-airflow-providers-celery"},
+                {("path.to.CeleryExecutor", "apache-airflow-providers-celery")},
+                ["airflow.executors.local_executor.LocalExecutor"],
+                [],
+                id="core executor should not be imported",
             ),
         ],
     )
@@ -271,13 +291,14 @@ class TestCli:
         cli_command_functions: list[Callable[[], list[ActionCommand | cli_parser.GroupCommand]]],
         cli_command_providers: set[str],
         executor_without_check: set[tuple[str, str]],
+        executor_names: list[str],
         expected_loaded_executors: list[str],
         caplog,
     ):
         # Create mock ExecutorName objects
         mock_executor_names = [
             MagicMock(name=executor_name.split(".")[-1], module_path=executor_name)
-            for executor_name, _ in executor_without_check
+            for executor_name in executor_names
         ]
 
         # Create mock executor classes that return empty command lists
@@ -297,23 +318,71 @@ class TestCli:
 
         # assert
         expected_warning = "Please define the 'cli' section in the 'get_provider_info' for custom executors to avoid this warning."
-        if expected_loaded_executors:
+        executors_missing_cli = [
+            executor_path
+            for executor_path, executor_provider in executor_without_check
+            if executor_provider not in cli_command_providers
+        ]
+        if executors_missing_cli:
             assert expected_warning in caplog.text
-            for executor_path in expected_loaded_executors:
+            for executor_path in executors_missing_cli:
                 assert executor_path in caplog.text
         else:
             assert expected_warning not in caplog.text
 
-        # Verify import_executor_cls was called with correct ExecutorName objects
-        if expected_loaded_executors:
-            expected_calls = [
-                mock.call(executor_name)
-                for executor_name in mock_executor_names
-                if executor_name.module_path in expected_loaded_executors
-            ]
-            mock_import_executor_cls.assert_has_calls(expected_calls, any_order=True)
-        else:
-            mock_import_executor_cls.assert_not_called()
+        # Verify import_executor_cls was called with correct ExecutorName objects, and only with those
+        expected_calls = [
+            mock.call(executor_name)
+            for executor_name in mock_executor_names
+            if executor_name.module_path in expected_loaded_executors
+        ]
+        mock_import_executor_cls.assert_has_calls(expected_calls, any_order=True)
+        assert mock_import_executor_cls.call_count == len(expected_calls)
+
+    @patch("airflow.executors.executor_loader.ExecutorLoader.import_executor_cls")
+    @patch("airflow.executors.executor_loader.ExecutorLoader.get_executor_names")
+    @patch(
+        "airflow.providers_manager.ProvidersManager.executor_without_check",
+        new_callable=mock.PropertyMock,
+    )
+    @patch(
+        "airflow.providers_manager.ProvidersManager.cli_command_providers",
+        new_callable=mock.PropertyMock,
+    )
+    @patch(
+        "airflow.providers_manager.ProvidersManager.cli_command_functions",
+        new_callable=mock.PropertyMock,
+    )
+    def test_compat_cli_loading_skips_commands_registered_by_providers(
+        self,
+        mock_cli_command_functions: MagicMock,
+        mock_cli_command_providers: MagicMock,
+        mock_executor_without_check: MagicMock,
+        mock_get_executor_names: MagicMock,
+        mock_import_executor_cls: MagicMock,
+    ):
+        """A subclass of a provider executor inherits get_cli_commands(); the provider registration must win."""
+        mock_cli_command_functions.return_value = [
+            lambda: [ActionCommand(name="celery", help="from provider", func=lambda: None, args=[])]
+        ]
+        mock_cli_command_providers.return_value = {"apache-airflow-providers-celery"}
+        mock_executor_without_check.return_value = {
+            ("path.to.CeleryExecutor", "apache-airflow-providers-celery"),
+        }
+        mock_get_executor_names.return_value = [
+            MagicMock(module_path="my.custom.module.CustomCeleryExecutor")
+        ]
+        mock_executor_cls = MagicMock()
+        mock_executor_cls.get_cli_commands.return_value = [
+            ActionCommand(name="celery", help="inherited", func=lambda: None, args=[]),
+            ActionCommand(name="custom-executor", help="", func=lambda: None, args=[]),
+        ]
+        mock_import_executor_cls.return_value = (mock_executor_cls, None)
+
+        reload(cli_parser)
+
+        assert cli_parser.ALL_COMMANDS_DICT["celery"].help == "from provider"
+        assert "custom-executor" in cli_parser.ALL_COMMANDS_DICT
 
     @pytest.mark.parametrize(
         (
@@ -367,6 +436,32 @@ class TestCli:
                 True,
                 id="only configured auth manager should be loaded",
             ),
+            pytest.param(
+                [lambda: [ActionCommand(name="fab", help="", func=lambda: None, args=[])]],
+                {"apache-airflow-providers-fab"},
+                {
+                    (
+                        "airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager",
+                        "apache-airflow-providers-fab",
+                    ),
+                },
+                "my_company.auth_managers.MyCustomAuthManager",
+                True,
+                id="custom auth manager not packaged as a provider should load by import_string",
+            ),
+            pytest.param(
+                [lambda: [ActionCommand(name="fab", help="", func=lambda: None, args=[])]],
+                {"apache-airflow-providers-fab"},
+                {
+                    (
+                        "airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager",
+                        "apache-airflow-providers-fab",
+                    ),
+                },
+                "airflow.api_fastapi.auth.managers.simple.simple_auth_manager.SimpleAuthManager",
+                False,
+                id="core auth manager should not be imported",
+            ),
         ],
     )
     @patch(
@@ -417,21 +512,24 @@ class TestCli:
 
         # assert
         expected_warning = "Please define the 'cli' section in the 'get_provider_info' for custom auth manager to avoid this warning."
-        if expected_loaded:
+        auth_managers_missing_cli = [
+            auth_manager_path
+            for auth_manager_path, auth_manager_provider in auth_manager_without_check
+            if auth_manager_provider not in cli_command_providers
+        ]
+        if auth_managers_missing_cli:
             assert expected_warning in caplog.text
-            assert auth_manager_cls_path in caplog.text
+            for auth_manager_path in auth_managers_missing_cli:
+                assert auth_manager_path in caplog.text
+        else:
+            assert expected_warning not in caplog.text
+
+        if expected_loaded:
             mock_import_string.assert_called_once_with(auth_manager_cls_path)
             mock_auth_manager_cls.assert_called_once()
             mock_auth_manager_instance.get_cli_commands.assert_called_once()
         else:
-            if auth_manager_cls_path in [path for path, _ in auth_manager_without_check]:
-                # Auth manager is in the without_check but also in cli_providers, so warning should appear
-                # but import_string should NOT be called
-                assert expected_warning not in caplog.text
-                mock_import_string.assert_not_called()
-            else:
-                # Auth manager is not in the without_check, no warning
-                mock_import_string.assert_not_called()
+            mock_import_string.assert_not_called()
 
     def test_falsy_default_value(self):
         arg = cli_config.Arg(("--test",), default=0, type=int)


### PR DESCRIPTION
## Why

- An executor or auth manager configured by module path, without being packaged as a provider, loses every CLI command it defines in `get_cli_commands()`. The commands are missing with no warning and no error.
- Before the provider `cli` section was introduced (#59805), `cli_parser` looped over every configured executor and called the configured auth manager.
- `core-concepts/executor/index.rst` and `core-concepts/auth-manager/index.rst` still document `get_cli_commands()`, and the auth manager page still shows `[core] auth_manager = my_company.auth_managers.MyCustomAuthManager` as the way to configure a custom class.


## How

- Build the set of class paths a provider `cli` section already covers, skip those, and send everything else through the fallback.
- Skip classes shipped in airflow-core by module prefix, so the default configuration never imports them.
- Give commands registered by a provider priority over the fallback. A subclass of a provider executor or auth manager inherits `get_cli_commands()`. Without this, it registers the same names a second time. `cli_parser` raises `CliConflictError` on a duplicate name and the CLI fails to start.

## Verification

- Unit test: `uv run --project airflow-core pytest airflow-core/tests/unit/cli/test_cli_parser.py -q`
- Integration test:

1. Setup

```sh
mkdir -p files/demo/my_company
touch files/demo/my_company/__init__.py

cat > files/demo/my_company/executors.py <<'EOF'
from airflow.cli.cli_config import ActionCommand, GroupCommand
from airflow.executors.base_executor import BaseExecutor
from airflow.providers.celery.executors.celery_executor import CeleryExecutor


def ping(args):
    print("pong from MyExecutor")


class MyExecutor(BaseExecutor):
    """Plain custom executor: implements BaseExecutor, not packaged as a provider."""

    @staticmethod
    def get_cli_commands():
        return [
            GroupCommand(
                name="my-executor",
                help="Manage MyExecutor",
                subcommands=[ActionCommand(name="ping", help="Ping", func=ping, args=())],
            )
        ]


class MyCeleryExecutor(CeleryExecutor):
    """Custom executor built on a provider executor: inherits CeleryExecutor.get_cli_commands()."""
EOF

cat > files/demo/my_company/auth_managers.py <<'EOF'
from airflow.api_fastapi.auth.managers.simple.simple_auth_manager import SimpleAuthManager
from airflow.cli.cli_config import ActionCommand, GroupCommand
from airflow.providers.fab.auth_manager.fab_auth_manager import FabAuthManager


def whoami(args):
    print("hello from MyCustomAuthManager")


class MyCustomAuthManager(SimpleAuthManager):
    """Plain custom auth manager, not packaged as a provider."""

    @staticmethod
    def get_cli_commands():
        return [
            GroupCommand(
                name="my-auth",
                help="Manage MyCustomAuthManager",
                subcommands=[ActionCommand(name="whoami", help="Who am I", func=whoami, args=())],
            )
        ]


class MyFabAuthManager(FabAuthManager):
    """Custom auth manager built on a provider auth manager: inherits FabAuthManager.get_cli_commands()."""
EOF
```

```sh
uv sync --frozen --project airflow-core
export AIRFLOW_HOME="$(pwd)/files/demo/home"
export AIRFLOW__CORE__LOAD_EXAMPLES=False
export PYTHONPATH="$(pwd)/files/demo"
```

2. Check custom executor

```sh
AIRFLOW__CORE__EXECUTOR=my_company.executors.MyExecutor .venv/bin/airflow --help 2>/dev/null | grep -c my-executor
AIRFLOW__CORE__EXECUTOR=my_company.executors.MyExecutor .venv/bin/airflow my-executor ping
```

On main branch, the count is `0`. On this branch, it shows `1` and `pong from MyExecutor`.

3. Check custom auth manager

```sh
AIRFLOW__CORE__AUTH_MANAGER=my_company.auth_managers.MyCustomAuthManager .venv/bin/airflow --help 2>/dev/null | grep -c my-auth
AIRFLOW__CORE__AUTH_MANAGER=my_company.auth_managers.MyCustomAuthManager .venv/bin/airflow my-auth whoami
```

On main branch, the count is `0`. On this branch, it shows `1` and `hello from MyCustomAuthManager`.

4. Check classes inheriting from a provider

```
AIRFLOW__CORE__EXECUTOR=my_company.executors.MyCeleryExecutor .venv/bin/airflow --help 2>/dev/null | grep -cE '^\s+celery\s'
AIRFLOW__CORE__AUTH_MANAGER=my_company.auth_managers.MyFabAuthManager .venv/bin/airflow --help 2>/dev/null | grep -cE '^\s+users\s'
```

These two are regression guards rather than bug demos. On main they also print 1, because the fallback that imports the class and calls `get_cli_commands()` never runs there. What they prove is that re-opening that fallback does not start registering duplicate commands.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
