### PR TITLE
Honor API server worker timeout configuration

### DIFF
--- a/airflow-core/newsfragments/72859.bugfix.rst
+++ b/airflow-core/newsfragments/72859.bugfix.rst
@@ -1,0 +1,1 @@
+The API server now honors the ``[api] worker_timeout`` configuration setting.

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -751,7 +751,7 @@ ARG_API_SERVER_WORKERS = Arg(
 )
 ARG_API_SERVER_WORKER_TIMEOUT = Arg(
     ("-t", "--worker-timeout"),
-    default=120,
+    default=conf.get("api", "worker_timeout"),
     type=int,
     help="The timeout for waiting on API server workers",
 )

--- a/airflow-core/tests/unit/cli/commands/test_api_server_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_api_server_command.py
@@ -16,7 +16,9 @@
 # under the License.
 from __future__ import annotations
 
+import os
 import ssl
+import subprocess
 import sys
 from unittest import mock
 
@@ -29,6 +31,23 @@ from airflow.exceptions import AirflowConfigException
 from unit.cli.commands._common_cli_classes import _CommonCLIUvicornTestClass
 
 console = Console(width=400, color_system="standard")
+
+
+def test_uses_worker_timeout_config_as_cli_default():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from airflow.cli.cli_parser import get_parser; "
+            "print(f\"worker_timeout={get_parser().parse_args(['api-server']).worker_timeout}\")",
+        ],
+        env={**os.environ, "AIRFLOW__API__WORKER_TIMEOUT": "321"},
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "worker_timeout=321" in result.stdout.splitlines()
 
 
 @pytest.mark.db_test


### PR DESCRIPTION
The `airflow api-server` command hard-codes its worker timeout default, so the documented `[api] worker_timeout` setting and `AIRFLOW__API__WORKER_TIMEOUT` environment variable do not affect the server.

This change uses the configured value as the CLI default while preserving an explicit `--worker-timeout` override. It also adds a regression test that evaluates the parser in a fresh process.

Reference:

- [api] worker_timeout setting: https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#worker-timeout

Validation:

- `airflow-core/tests/unit/cli/commands/test_api_server_command.py`: 37 passed
- Selective core tests: `Always` and `CLI` passed
- Ruff, mypy, fast Prek checks, and manual Prek checks passed

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes - Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)