### PR TITLE
Keep date-only range ends inclusive

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/FilterBar/filters/DateRangeFilter.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FilterBar/filters/DateRangeFilter.test.tsx
@@ -148,6 +148,33 @@ describe("DateRangeFilter", () => {
     cleanup();
   });
 
+  it("includes the whole end date when its time is empty", async () => {
+    const onChange = vi.fn();
+
+    renderFilter({ ...defaultProps, onChange });
+    const { endDateInput } = getInputs();
+
+    changeDateInput(endDateInput, "2024/01/15");
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith({
+        endDate: "2024-01-15T23:59:59.999Z",
+        startDate: undefined,
+      });
+    });
+  });
+
+  it("accepts a start time on the end date when the end time is empty", async () => {
+    renderFilter();
+    const { endDateInput, startDateInput, startTimeInput } = getInputs();
+
+    changeDateInput(startDateInput, "2024/01/15");
+    changeTimeInput(startTimeInput, "10:00");
+    changeDateInput(endDateInput, "2024/01/15");
+
+    await waitForNoError("Start date/time must be before end date/time");
+  });
+
   describe("Input Validation", () => {
     it("validates date and time formats", async () => {
       renderFilter();

--- a/airflow-core/src/airflow/ui/src/hooks/useDateRangeFilter.ts
+++ b/airflow-core/src/airflow/ui/src/hooks/useDateRangeFilter.ts
@@ -189,7 +189,10 @@ export const useDateRangeFilter = ({ onChange, translate, value }: UseDateRangeF
       const startDateTime = combineDateAndTime(inputs.start, inputs.startTime, {
         timezone: selectedTimezone,
       });
-      const endDateTime = combineDateAndTime(inputs.end, inputs.endTime, { timezone: selectedTimezone });
+      const endDateTime = combineDateAndTime(inputs.end, inputs.endTime, {
+        endOfDay: true,
+        timezone: selectedTimezone,
+      });
 
       if (Boolean(startDateTime) && Boolean(endDateTime) && !validateDateRange(startDateTime, endDateTime)) {
         errors.push({
@@ -276,7 +279,10 @@ export const useDateRangeFilter = ({ onChange, translate, value }: UseDateRangeF
         const timeStr = field === "start" ? newInputs.startTime : newInputs.endTime;
 
         if (dayjs(dateStr, DATE_INPUT_FORMAT, true).isValid()) {
-          const combinedDateTime = combineDateAndTime(dateStr, timeStr, { timezone: selectedTimezone });
+          const combinedDateTime = combineDateAndTime(dateStr, timeStr, {
+            endOfDay: field === "end",
+            timezone: selectedTimezone,
+          });
 
           if (Boolean(combinedDateTime)) {
             onChange({


### PR DESCRIPTION
Entering an end date without a time currently emits midnight at the start of that day. This excludes the rest of the end date and can also report a range error when the start time is later on the same day.

Use the existing end-of-day option when emitting and validating the range's end value. Add regression tests for both cases.

Validation: both regression tests fail before the fix. All 18 related tests, TypeScript checking, regular prek checks, and the manual UI build pass.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes, Codex (GPT-6)

Generated-by: Codex (GPT-6) following the [contribution guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions).
