### PR TITLE
Document what a KubernetesExecutor worker pod runs on Airflow 3

### DIFF
--- a/providers/cncf/kubernetes/docs/kubernetes_executor.rst
+++ b/providers/cncf/kubernetes/docs/kubernetes_executor.rst
@@ -38,6 +38,42 @@ KubernetesExecutor requires a non-sqlite database in the backend.
 
 When a Dag submits a task, the KubernetesExecutor requests a worker pod from the Kubernetes API. The worker pod then runs the task, reports the result, and terminates.
 
+What the worker pod runs
+------------------------
+
+The executor sets the ``base`` container's ``args`` and the image's own entrypoint runs them.
+What it puts there depends on the Airflow version.
+
+On Airflow 2.11 it is the task CLI:
+
+.. code-block:: text
+
+    args:
+      - airflow
+      - tasks
+      - run
+      - example_bash_operator
+      - runme_0
+      - scheduled__2026-09-10T00:00:00+00:00
+      - --local
+      - --subdir
+      - DAGS_FOLDER/example_bash_operator.py
+
+On Airflow 3 there is no ``airflow worker`` command to call, so a serialized workload is handed
+to the Task SDK instead:
+
+.. code-block:: text
+
+    args:
+      - python
+      - -m
+      - airflow.sdk.execution_time.execute_workload
+      - --json-string
+      - '{"token": "...", "dag_rel_path": "...", "ti": {...}, "type": "ExecuteTask"}'
+
+In both cases, leave ``command`` unset on the ``base`` container: setting it replaces the
+entrypoint and the task never runs.
+
 .. image:: img/arch-diag-kubernetes.png
 
 


### PR DESCRIPTION
### Why

closes: #56008 asks what a worker image needs on Airflow 3 now that `airflow worker` is gone.
`kubernetes_executor.rst` doesn't answer it — the `Base image` section only says the image
"must be specified", and nothing on the page says what the container ends up running.

### How

Adds a short `What the worker pod runs` section: the executor injects the task into the
`base` container's `args` and the image entrypoint runs it, so `command` must stay unset.

Docs only.

### What

Captured from a worker pod on a local KinD cluster (Airflow 3.3.1, provider from `main`,
k8s v1.30.13, Python 3.10):

```
breeze k8s deploy-airflow --multi-namespace-mode --executor KubernetesExecutor
airflow dags trigger example_simplest_dag
kubectl get pod example-simplest-dag-my-task-<suffix> -n airflow -o yaml
```

```yaml
  - args:
    - python
    - -m
    - airflow.sdk.execution_time.execute_workload
    - --json-string
    - '{"token":"<redacted>","dag_rel_path":"example_simplest_dag.py",...,"type":"ExecuteTask"}'
    image: ghcr.io/apache/airflow/main/prod/python3.10-kubernetes:latest
    name: base
```

No `command` field on the container, so the image entrypoint consumes these `args`.

Docs build and spelling pass.

related: #56008

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
