### PR TITLE
Update provider docs for the new discard-on-clear task state default

### DIFF
--- a/providers/amazon/docs/operators/glue.rst
+++ b/providers/amazon/docs/operators/glue.rst
@@ -203,11 +203,12 @@ id won't be there for the next retry, and the operator falls back to the XCom/sc
 above rather than reconnecting via task state store. Avoid running cleanup on a schedule shorter
 than your longest ``retry_delay``.
 
-Clearing a task is treated the same as a retry, which matters specifically for a task whose job
-already succeeded: clearing does not delete the stored run id, so the next attempt reads it back
-and returns immediately without submitting anything to Glue. See
+Clearing a task now discards the stored run id by default, so the next attempt submits a fresh Glue
+job instead of reconnecting to the one already run. To resume from the stored run id instead, pass
+``keep_task_state`` when clearing (or tick the corresponding box in the clear dialog). See
 :doc:`apache-airflow:core-concepts/resumable-tasks` for why, and for the
-``[state_store] clear_on_success`` setting that restores "clearing always resubmits."
+``[state_store] clear_on_success`` setting that discards the run id automatically as soon as the
+task succeeds.
 
 To opt out and always start a fresh run on retry, set ``durable=False``:
 

--- a/providers/amazon/docs/operators/redshift/redshift_data.rst
+++ b/providers/amazon/docs/operators/redshift/redshift_data.rst
@@ -99,11 +99,12 @@ the statement id won't be there for the next retry, and the operator will submit
 instead of reconnecting. Avoid running cleanup on a schedule shorter than your longest
 ``retry_delay``.
 
-Clearing a task is treated the same as a retry, which matters specifically for a task whose
-statement already succeeded: clearing does not delete the stored statement id, so the next attempt
-reads it back and returns immediately without submitting the SQL again. See
-:doc:`apache-airflow:core-concepts/resumable-tasks` for why, and for the
-``[state_store] clear_on_success`` setting that restores "clearing always resubmits."
+Clearing a task now discards the stored statement id by default, so the next attempt submits the
+SQL again instead of reconnecting to the statement already run. To resume from the stored statement
+id instead, pass ``keep_task_state`` when clearing (or tick the corresponding box in the clear
+dialog). See :doc:`apache-airflow:core-concepts/resumable-tasks` for why, and for the
+``[state_store] clear_on_success`` setting that discards the statement id automatically as soon as
+the task succeeds.
 
 This is most reliable for deferred tasks (``deferrable=True``); clearing a task that's actively
 polling synchronously can cancel the statement via ``on_kill`` before the next attempt gets a

--- a/providers/apache/spark/docs/operators.rst
+++ b/providers/apache/spark/docs/operators.rst
@@ -223,11 +223,12 @@ prerequisite each one needs before the operator can check driver status on retry
     immediately) still emits a deprecation warning on every Airflow version and maps onto
     ``durable``.
 
-Clearing a task is treated the same as a retry, which matters specifically for a task whose driver
-already succeeded: clearing does not delete the stored driver ID, so the next attempt reads it
-back and returns immediately without resubmitting. See
+Clearing a task now discards the stored driver ID by default, so the next attempt resubmits
+instead of reconnecting to the driver already run. To resume from the stored driver ID instead,
+pass ``keep_task_state`` when clearing (or tick the corresponding box in the clear dialog). See
 :doc:`apache-airflow:core-concepts/resumable-tasks` for why, and for the
-``[state_store] clear_on_success`` setting that restores "clearing always resubmits."
+``[state_store] clear_on_success`` setting that discards the driver ID automatically as soon as
+the task succeeds.
 
 This is most reliable for deferred tasks (``deferrable=True``); clearing a task that's actively
 polling synchronously can cancel the driver via ``on_kill`` before the next attempt gets a chance

--- a/providers/databricks/docs/operators/run_now.rst
+++ b/providers/databricks/docs/operators/run_now.rst
@@ -113,11 +113,12 @@ when someone runs ``airflow state-store clean``. If a task's ``retry_delay`` is 
 run id won't be there for the next retry, and the operator will trigger a fresh run instead of
 reconnecting. Avoid running cleanup on a schedule shorter than your longest ``retry_delay``.
 
-Clearing a task is treated the same as a retry, which matters specifically for a task whose run
-already succeeded: clearing does not delete the stored run id, so the next attempt reads it back
-and returns immediately without triggering a new run. See
+Clearing a task now discards the stored run id by default, so the next attempt triggers a new run
+instead of reconnecting to the one already run. To resume from the stored run id instead, pass
+``keep_task_state`` when clearing (or tick the corresponding box in the clear dialog). See
 :doc:`apache-airflow:core-concepts/resumable-tasks` for why, and for the
-``[state_store] clear_on_success`` setting that restores "clearing always resubmits."
+``[state_store] clear_on_success`` setting that discards the run id automatically as soon as the
+task succeeds.
 
 This is most reliable for deferred tasks (``deferrable=True``); clearing a task that's actively
 polling synchronously can cancel the run via ``on_kill`` before the next attempt gets a chance to

--- a/providers/databricks/docs/operators/submit_run.rst
+++ b/providers/databricks/docs/operators/submit_run.rst
@@ -191,11 +191,12 @@ when someone runs ``airflow state-store clean``. If a task's ``retry_delay`` is 
 run id won't be there for the next retry, and the operator will submit a fresh run instead of
 reconnecting. Avoid running cleanup on a schedule shorter than your longest ``retry_delay``.
 
-Clearing a task is treated the same as a retry, which matters specifically for a task whose run
-already succeeded: clearing does not delete the stored run id, so the next attempt reads it back
-and returns immediately without submitting a new run. See
+Clearing a task now discards the stored run id by default, so the next attempt submits a new run
+instead of reconnecting to the one already run. To resume from the stored run id instead, pass
+``keep_task_state`` when clearing (or tick the corresponding box in the clear dialog). See
 :doc:`apache-airflow:core-concepts/resumable-tasks` for why, and for the
-``[state_store] clear_on_success`` setting that restores "clearing always resubmits."
+``[state_store] clear_on_success`` setting that discards the run id automatically as soon as the
+task succeeds.
 
 This is most reliable for deferred tasks (``deferrable=True``); clearing a task that's actively
 polling synchronously can cancel the run via ``on_kill`` before the next attempt gets a chance to

--- a/providers/snowflake/docs/operators/snowflake.rst
+++ b/providers/snowflake/docs/operators/snowflake.rst
@@ -189,11 +189,12 @@ between, the handles won't be there for the next retry, and the operator will su
 fresh instead of reconnecting. Avoid running cleanup on a schedule shorter than your longest
 ``retry_delay``.
 
-Clearing a task is treated the same as a retry, which matters specifically for a task whose
-statements already succeeded: clearing does not delete the stored handles, so the next attempt
-reads them back and returns immediately without submitting the SQL again. See
-:doc:`apache-airflow:core-concepts/resumable-tasks` for why, and for the
-``[state_store] clear_on_success`` setting that restores "clearing always resubmits."
+Clearing a task now discards the stored handles by default, so the next attempt submits the SQL
+again instead of reconnecting to the statements already run. To resume from the stored handles
+instead, pass ``keep_task_state`` when clearing (or tick the corresponding box in the clear
+dialog). See :doc:`apache-airflow:core-concepts/resumable-tasks` for why, and for the
+``[state_store] clear_on_success`` setting that discards the handles automatically as soon as the
+task succeeds.
 
 This is most reliable for deferred tasks (``deferrable=True``); clearing a task that's actively
 polling synchronously can cancel the statements via ``on_kill`` before the next attempt gets a


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Clearing a task now discards its task_state_store entries by default, so the next attempt submits a fresh job/run/statement instead of reconnecting to the one already run (see #72100). The Glue, Redshift Data, Databricks, Snowflake, and Spark operator docs still described the old "clearing keeps the stored id" behavior, which is now backwards. Point them at
keep_task_state as the way to get the old reconnect behavior back.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
