### PR TITLE
Reduce XCom requests when resolving mapped task inputs

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/xcom.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/xcom.py
@@ -30,6 +30,21 @@ class XComResponse(BaseModel):
     """The returned XCom value in a JSON-compatible format."""
 
 
+class XComBatchItemResponse(BaseModel):
+    """One XCom value returned from a batch Runtime request."""
+
+    task_id: str
+    value: JsonValue | None
+    """The returned XCom value in a JSON-compatible format."""
+
+
+class XComBatchResponse(BaseModel):
+    """XCom values returned from a batch Runtime request."""
+
+    key: str
+    values: list[XComBatchItemResponse]
+
+
 class XComSequenceIndexResponse(RootModel):
     """XCom schema with minimal structure for index-based access."""
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/__init__.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/__init__.py
@@ -62,6 +62,7 @@ authenticated_router.include_router(
     task_reschedules.router, prefix="/task-reschedules", tags=["Task Reschedules"]
 )
 authenticated_router.include_router(variables.router, prefix="/variables", tags=["Variables"])
+authenticated_router.include_router(xcoms.batch_router, prefix="/xcoms", tags=["XComs"])
 authenticated_router.include_router(xcoms.router, prefix="/xcoms", tags=["XComs"])
 authenticated_router.include_router(hitl.router, prefix="/hitlDetails", tags=["Human in the Loop"])
 authenticated_router.include_router(task_state_store.router, prefix="/store/ti", tags=["Task State Store"])

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -28,6 +28,8 @@ from sqlalchemy.sql.selectable import Select
 from airflow.api_fastapi.common.db.common import SessionDep
 from airflow.api_fastapi.core_api.base import BaseModel
 from airflow.api_fastapi.execution_api.datamodels.xcom import (
+    XComBatchItemResponse,
+    XComBatchResponse,
     XComResponse,
     XComSequenceIndexResponse,
     XComSequenceSliceResponse,
@@ -38,36 +40,17 @@ from airflow.models.xcom import XComModel
 from airflow.utils.db import get_query_count
 
 
-def has_xcom_access(
+def _check_xcom_access(
     dag_id: str,
-    run_id: str,
-    task_id: str,
-    xcom_key: Annotated[str, Path(alias="key", min_length=1)],
+    xcom_key: str,
     request: Request,
+    *,
     session: SessionDep,
-    token=CurrentTIToken,
+    token,
+    write: bool,
 ) -> bool:
-    """
-    Check whether the requesting task may access the XCom for ``dag_id``.
-
-    In multi-team mode, XCom access is scoped by team ownership (resolved via the
-    ``dag -> bundle -> team`` chain). There is no cross-team XCom sharing:
-
-    * reads (``GET``/``HEAD``) are allowed for the requester's own team or for
-      global (teamless) dags;
-    * writes and deletes are allowed only for the requester's own team; a team
-      task may not mutate a global dag's XCom, mirroring how team-scoped
-      Variables and Connections behave.
-
-    When multi-team mode is disabled this is a no-op and all access is allowed,
-    consistent with Airflow's single-team security model where workers within a
-    deployment trust each other. Note this enforces the boundary at the Execution
-    API only; it does not constrain code paths with direct database access (e.g.
-    the Dag File Processor or Triggerer).
-    """
+    """Check whether the requesting task may read or write the XCom for ``dag_id``."""
     from airflow.configuration import conf
-
-    write = request.method not in {"GET", "HEAD", "OPTIONS"}
 
     log.debug(
         "Checking %s XCom access for task instance '%s' to XCom '%s' on dag '%s'",
@@ -104,6 +87,44 @@ def has_xcom_access(
     )
 
 
+def has_xcom_access(
+    dag_id: str,
+    run_id: str,
+    task_id: str,
+    xcom_key: Annotated[str, Path(alias="key", min_length=1)],
+    request: Request,
+    *,
+    session: SessionDep,
+    token=CurrentTIToken,
+) -> bool:
+    """
+    Check whether the requesting task may access the XCom for ``dag_id``.
+
+    In multi-team mode, XCom access is scoped by team ownership (resolved via the
+    ``dag -> bundle -> team`` chain). There is no cross-team XCom sharing:
+
+    * reads (``GET``/``HEAD``) are allowed for the requester's own team or for
+      global (teamless) dags;
+    * writes and deletes are allowed only for the requester's own team; a team
+      task may not mutate a global dag's XCom, mirroring how team-scoped
+      Variables and Connections behave.
+
+    When multi-team mode is disabled this is a no-op and all access is allowed,
+    consistent with Airflow's single-team security model where workers within a
+    deployment trust each other. Note this enforces the boundary at the Execution
+    API only; it does not constrain code paths with direct database access (e.g.
+    the Dag File Processor or Triggerer).
+    """
+    return _check_xcom_access(
+        dag_id,
+        xcom_key,
+        request,
+        session=session,
+        token=token,
+        write=request.method not in {"GET", "HEAD", "OPTIONS"},
+    )
+
+
 router = APIRouter(
     responses={
         status.HTTP_401_UNAUTHORIZED: {"description": "Unauthorized"},
@@ -114,6 +135,72 @@ router = APIRouter(
 )
 
 log = logging.getLogger(__name__)
+
+
+batch_router = APIRouter(
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {"description": "Unauthorized"},
+        status.HTTP_403_FORBIDDEN: {"description": "Task does not have access to the XCom"},
+        status.HTTP_404_NOT_FOUND: {"description": "XCom not found"},
+    },
+)
+
+
+class XComBatchRequest(BaseModel):
+    """Request body for batch XCom fetches."""
+
+    dag_id: str
+    run_id: str
+    key: str
+    task_ids: list[str]
+    map_index: int = -1
+    include_prior_dates: bool = False
+
+
+@batch_router.post(
+    "/batch",
+    description="Get multiple XCom values for the same Dag run, key, and map index",
+)
+def get_xcom_batch(
+    body: XComBatchRequest,
+    request: Request,
+    *,
+    session: SessionDep,
+    token=CurrentTIToken,
+) -> XComBatchResponse:
+    """Get several Airflow XComs from database - not other XCom Backends."""
+    if not body.task_ids or any(not task_id for task_id in body.task_ids) or not body.key:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "reason": "invalid_request",
+                "message": "Key and at least one non-empty task_id are required.",
+            },
+        )
+
+    _check_xcom_access(body.dag_id, body.key, request, session=session, token=token, write=False)
+
+    query = XComModel.get_many(
+        run_id=body.run_id,
+        key=body.key,
+        task_ids=body.task_ids,
+        dag_ids=body.dag_id,
+        map_indexes=body.map_index,
+        include_prior_dates=body.include_prior_dates,
+    )
+    rows = session.execute(query.with_only_columns(XComModel.task_id, XComModel.value)).all()
+
+    values_by_task_id: dict[str, JsonValue | None] = {}
+    for task_id, value in rows:
+        values_by_task_id.setdefault(task_id, value)
+
+    return XComBatchResponse(
+        key=body.key,
+        values=[
+            XComBatchItemResponse(task_id=task_id, value=values_by_task_id.get(task_id))
+            for task_id in body.task_ids
+        ],
+    )
 
 
 async def xcom_query(

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
@@ -53,12 +53,13 @@ from airflow.api_fastapi.execution_api.versions.v2026_06_30 import (
 )
 from airflow.api_fastapi.execution_api.versions.v2026_10_30 import (
     AddArgBindingsToTIRunContext,
+    AddBatchXComEndpoint,
     AddCallbackRunEndpoint,
 )
 
 bundle = VersionBundle(
     HeadVersion(),
-    Version("2026-10-30", AddArgBindingsToTIRunContext, AddCallbackRunEndpoint),
+    Version("2026-10-30", AddArgBindingsToTIRunContext, AddCallbackRunEndpoint, AddBatchXComEndpoint),
     Version(
         "2026-06-30",
         AddVariableKeysEndpoint,

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_10_30.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_10_30.py
@@ -52,3 +52,11 @@ class AddCallbackRunEndpoint(VersionChange):
     instructions_to_migrate_to_previous_version = (
         endpoint("/callbacks/{callback_id}/run", ["PATCH"]).didnt_exist,
     )
+
+
+class AddBatchXComEndpoint(VersionChange):
+    """Add the xcoms/batch endpoint workers use to fetch multiple mapped inputs together."""
+
+    description = __doc__
+
+    instructions_to_migrate_to_previous_version = (endpoint("/xcoms/batch", ["POST"]).didnt_exist,)

--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -55,6 +55,7 @@ from airflow.sdk.execution_time.comms import (
     GetVariableKeys,
     GetXCom,
     GetXComCount,
+    GetXComs,
     GetXComSequenceItem,
     GetXComSequenceSlice,
     MaskSecret,
@@ -66,6 +67,7 @@ from airflow.sdk.execution_time.comms import (
     TaskStatesResult,
     VariableKeysResult,
     VariableResult,
+    XComBatchResult,
     XComCountResponse,
     XComResult,
     XComSequenceIndexResult,
@@ -83,6 +85,7 @@ from airflow.sdk.execution_time.request_handlers import (
     handle_get_xcom_count,
     handle_get_xcom_sequence_item,
     handle_get_xcom_sequence_slice,
+    handle_get_xcoms,
     handle_mask_secret,
     handle_put_variable,
 )
@@ -158,6 +161,7 @@ ToManager = Annotated[
     | GetPreviousDagRun
     | GetPreviousTI
     | GetXCom
+    | GetXComs
     | GetXComCount
     | GetXComSequenceItem
     | GetXComSequenceSlice
@@ -170,6 +174,7 @@ ToDagProcessor = Annotated[
     | ConnectionResult
     | VariableResult
     | VariableKeysResult
+    | XComBatchResult
     | TaskStatesResult
     | PreviousDagRunResult
     | PreviousTIResult
@@ -718,6 +723,8 @@ class DagFileProcessorProcess(WatchedSubprocess, LoggingMixin):
             resp, dump_opts = handle_get_prev_successful_dag_run(self.client, self.id)
         elif isinstance(msg, GetXCom):
             resp, dump_opts = handle_get_xcom(self.client, msg)
+        elif isinstance(msg, GetXComs):
+            resp, dump_opts = handle_get_xcoms(self.client, msg)
         elif isinstance(msg, GetXComCount):
             resp, dump_opts = handle_get_xcom_count(self.client, msg)
         elif isinstance(msg, GetXComSequenceItem):

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -86,6 +86,7 @@ from airflow.sdk.execution_time.comms import (
     GetVariable,
     GetVariableKeys,
     GetXCom,
+    GetXComs,
     MaskSecret,
     OKResponse,
     PutVariable,
@@ -97,6 +98,7 @@ from airflow.sdk.execution_time.comms import (
     UpdateHITLDetail,
     VariableKeysResult,
     VariableResult,
+    XComBatchResult,
     XComResult,
     _new_encoder,
     _RequestFrame,
@@ -120,6 +122,7 @@ from airflow.sdk.execution_time.request_handlers import (
     handle_get_variable,
     handle_get_variable_keys,
     handle_get_xcom,
+    handle_get_xcoms,
     handle_mask_secret,
     handle_put_variable,
     handle_set_asset_state_store_by_name,
@@ -366,6 +369,7 @@ ToTriggerRunner = Annotated[
     | ConnectionResult
     | VariableResult
     | VariableKeysResult
+    | XComBatchResult
     | XComResult
     | DagRunStateResult
     | DRCount
@@ -392,6 +396,7 @@ ToTriggerSupervisor = Annotated[
     | PutVariable
     | DeleteXCom
     | GetXCom
+    | GetXComs
     | SetXCom
     | GetTICount
     | GetTaskStates
@@ -634,6 +639,8 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
             resp, dump_opts = handle_delete_xcom(self.client, msg)
         elif isinstance(msg, GetXCom):
             resp, dump_opts = handle_get_xcom(self.client, msg)
+        elif isinstance(msg, GetXComs):
+            resp, dump_opts = handle_get_xcoms(self.client, msg)
         elif isinstance(msg, SetXCom):
             resp, dump_opts = handle_set_xcom(self.client, msg)
         elif isinstance(msg, GetDRCount):

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
@@ -70,7 +70,7 @@ def access_denied(client):
         token=CurrentTIToken,
     ):
         with create_session() as session:
-            has_xcom_access(dag_id, run_id, task_id, xcom_key, request, session, token)
+            has_xcom_access(dag_id, run_id, task_id, xcom_key, request, session=session, token=token)
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail={

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2025_04_28/test_xcom.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2025_04_28/test_xcom.py
@@ -105,3 +105,46 @@ class TestXComsGetEndpoint:
         response = client.get(f"/execution/xcoms/dag/runid/task/xcom_1?offset={offset}")
         assert response.status_code == expected_status
         assert response.json() == expected_json
+
+    def test_xcom_batch_get(self, client, dag_maker, session):
+        with dag_maker(dag_id="dag"):
+            EmptyOperator(task_id="task_1")
+            EmptyOperator(task_id="task_2")
+            EmptyOperator(task_id="task_3")
+
+        dag_run = dag_maker.create_dagrun(run_id="runid")
+        tis = {ti.task_id: ti for ti in dag_run.task_instances}
+        for task_id, value in {"task_1": "one", "task_2": "two"}.items():
+            ti = tis[task_id]
+            session.add(
+                XComModel(
+                    key="return_value",
+                    value=value,
+                    dag_run_id=ti.dag_run.id,
+                    run_id=ti.run_id,
+                    task_id=ti.task_id,
+                    dag_id=ti.dag_id,
+                    map_index=-1,
+                )
+            )
+        session.commit()
+
+        response = client.post(
+            "/execution/xcoms/batch",
+            json={
+                "dag_id": "dag",
+                "run_id": "runid",
+                "key": "return_value",
+                "task_ids": ["task_2", "task_3", "task_1"],
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "key": "return_value",
+            "values": [
+                {"task_id": "task_2", "value": "two"},
+                {"task_id": "task_3", "value": None},
+                {"task_id": "task_1", "value": "one"},
+            ],
+        }

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2026_10_30/test_xcoms.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2026_10_30/test_xcoms.py
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.db_test
+
+BATCH_XCOM_URL = "/execution/xcoms/batch"
+
+
+class TestBatchXComEndpointVersioning:
+    """The xcoms/batch endpoint didn't exist before the 2026-10-30 API version."""
+
+    def test_old_version_returns_404(self, client):
+        client.headers["Airflow-API-Version"] = "2026-06-30"
+
+        response = client.post(
+            BATCH_XCOM_URL,
+            json={"dag_id": "dag", "run_id": "runid", "key": "return_value", "task_ids": ["task"]},
+        )
+
+        assert response.status_code == 404
+        assert response.json() == {"detail": "Not Found"}
+
+    def test_head_version_routes_to_endpoint(self, client):
+        response = client.post(
+            BATCH_XCOM_URL,
+            json={"dag_id": "dag", "run_id": "runid", "key": "return_value", "task_ids": ["task"]},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "key": "return_value",
+            "values": [{"task_id": "task", "value": None}],
+        }

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -85,6 +85,7 @@ from airflow.sdk.api.datamodels._generated import (
     VariableKeysResponse,
     VariablePostBody,
     VariableResponse,
+    XComBatchResponse,
     XComResponse,
     XComSequenceIndexResponse,
     XComSequenceSliceResponse,
@@ -612,6 +613,24 @@ class XComOperations:
                 return XComResponse(key=key, value=None)
             raise
         return XComResponse.model_validate_json(resp.read())
+
+    def get_batch(
+        self,
+        dag_id: str,
+        run_id: str,
+        task_ids: list[str],
+        key: str,
+        map_index: int | None = None,
+        include_prior_dates: bool = False,
+    ) -> XComBatchResponse:
+        """Get multiple XCom values from the API server."""
+        body: dict[str, Any] = {"dag_id": dag_id, "run_id": run_id, "key": key, "task_ids": task_ids}
+        if map_index is not None and map_index >= 0:
+            body["map_index"] = map_index
+        if include_prior_dates:
+            body["include_prior_dates"] = include_prior_dates
+        resp = self.client.post("xcoms/batch", json=body)
+        return XComBatchResponse.model_validate_json(resp.read())
 
     def set(
         self,

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -513,6 +513,37 @@ class VariableResponse(BaseModel):
     value: Annotated[str | None, Field(title="Value")]
 
 
+class XComBatchItemResponse(BaseModel):
+    """
+    One XCom value returned from a batch Runtime request.
+    """
+
+    task_id: Annotated[str, Field(title="Task Id")]
+    value: JsonValue | None
+
+
+class XComBatchRequest(BaseModel):
+    """
+    Request body for batch XCom fetches.
+    """
+
+    dag_id: Annotated[str, Field(title="Dag Id")]
+    run_id: Annotated[str, Field(title="Run Id")]
+    key: Annotated[str, Field(title="Key")]
+    task_ids: Annotated[list[str], Field(title="Task Ids")]
+    map_index: Annotated[int | None, Field(title="Map Index")] = -1
+    include_prior_dates: Annotated[bool | None, Field(title="Include Prior Dates")] = False
+
+
+class XComBatchResponse(BaseModel):
+    """
+    XCom values returned from a batch Runtime request.
+    """
+
+    key: Annotated[str, Field(title="Key")]
+    values: Annotated[list[XComBatchItemResponse], Field(title="Values")]
+
+
 class XComResponse(BaseModel):
     """
     XCom schema for responses with fields that are needed for Runtime.

--- a/task-sdk/src/airflow/sdk/bases/xcom.py
+++ b/task-sdk/src/airflow/sdk/bases/xcom.py
@@ -25,8 +25,10 @@ import structlog
 from airflow.sdk.execution_time.comms import (
     DeleteXCom,
     GetXCom,
+    GetXComs,
     GetXComSequenceSlice,
     SetXCom,
+    XComBatchResult,
     XComResult,
     XComSequenceSliceResult,
 )
@@ -348,6 +350,41 @@ class BaseXCom:
             map_index=map_index,
         )
         return None
+
+    @classmethod
+    def get_many(
+        cls,
+        *,
+        key: str,
+        dag_id: str,
+        task_ids: list[str],
+        run_id: str,
+        map_index: int | None = None,
+        include_prior_dates: bool = False,
+    ) -> dict[str, Any | None]:
+        """Retrieve multiple XCom values for one Dag run, key, and map index."""
+        from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
+
+        msg = SUPERVISOR_COMMS.send(
+            GetXComs(
+                key=key,
+                dag_id=dag_id,
+                task_ids=task_ids,
+                run_id=run_id,
+                map_index=map_index,
+                include_prior_dates=include_prior_dates,
+            ),
+        )
+
+        if not isinstance(msg, XComBatchResult):
+            raise TypeError(f"Expected XComBatchResult, received: {type(msg)} {msg}")
+
+        return {
+            item.task_id: cls.deserialize_value(_XComValueWrapper(item.value))
+            if item.value is not None
+            else None
+            for item in msg.values
+        }
 
     @classmethod
     async def aget_one(

--- a/task-sdk/src/airflow/sdk/definitions/_internal/expandinput.py
+++ b/task-sdk/src/airflow/sdk/definitions/_internal/expandinput.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence, Sized
+from itertools import groupby
 from typing import TYPE_CHECKING, Any, ClassVar, Union
 
 import attrs
@@ -184,6 +185,71 @@ class DictOfListsExpandInput(ResolveMixin):
             if isinstance(x, XComArg):
                 yield from x.iter_references()
 
+    def _iter_batch_resolvable_plain_xcomargs(
+        self, context: Mapping[str, Any], upstream_map_indexes: dict[str, int]
+    ) -> Iterable[tuple[str, str, str, str, int | None]]:
+        from airflow.sdk.bases.xcom import BaseXCom
+        from airflow.sdk.definitions.xcom_arg import PlainXComArg
+
+        ti = context["ti"]
+        for key, value in self.value.items():
+            if not isinstance(value, PlainXComArg):
+                continue
+            if value.key != BaseXCom.XCOM_RETURN_KEY or value.operator.is_mapped:
+                continue
+            tg = value.operator.get_closest_mapped_task_group()
+            if tg is None:
+                map_index = None
+            elif value.operator.task_id in upstream_map_indexes:
+                map_index = upstream_map_indexes[value.operator.task_id]
+            else:
+                cached_context = getattr(ti, "_cached_template_context", None)
+                ti_count = cached_context.get("expanded_ti_count") if cached_context else None
+                map_index = ti.get_relevant_upstream_map_indexes(
+                    upstream=value.operator,
+                    ti_count=ti_count,
+                    session=None,
+                )
+                if map_index is None:
+                    continue
+            if isinstance(map_index, range):
+                continue
+            yield key, ti.dag_id, value.operator.task_id, value.key, map_index
+
+    def _resolve_batch_resolvable_plain_xcomargs(
+        self, context: Mapping[str, Any], upstream_map_indexes: dict[str, int]
+    ) -> dict[str, Any]:
+        from airflow.sdk.bases.xcom import BaseXCom
+        from airflow.sdk.execution_time import task_runner
+        from airflow.sdk.execution_time.xcom import XCom
+
+        if XCom is not BaseXCom or getattr(task_runner, "SUPERVISOR_COMMS", None) is None:
+            return {}
+
+        def batch_key(item: tuple[str, str, str, str, int | None]) -> tuple[str, str, int | None]:
+            return item[1], item[3], item[4]
+
+        def sort_key(item: tuple[str, str, str, str, int | None]) -> tuple[str, str, bool, int]:
+            map_index = item[4]
+            return item[1], item[3], map_index is not None, -1 if map_index is None else map_index
+
+        entries = sorted(
+            self._iter_batch_resolvable_plain_xcomargs(context, upstream_map_indexes), key=sort_key
+        )
+        resolved: dict[str, Any] = {}
+        for (dag_id, key, map_index), group in groupby(entries, key=batch_key):
+            grouped_entries = list(group)
+            values = XCom.get_many(
+                key=key,
+                dag_id=dag_id,
+                task_ids=[task_id for _, _, task_id, _, _ in grouped_entries],
+                run_id=context["ti"].run_id,
+                map_index=map_index,
+            )
+            for mapped_key, _, task_id, _, _ in grouped_entries:
+                resolved[mapped_key] = values.get(task_id)
+        return resolved
+
     def resolve(self, context: Mapping[str, Any]) -> tuple[Mapping[str, Any], set[int]]:
         map_index: int | None = context["ti"].map_index
         if map_index is None or map_index < 0:
@@ -193,11 +259,15 @@ class DictOfListsExpandInput(ResolveMixin):
         # When empty, individual XComArgs will compute their map_indexes lazily in xcom_arg.py.
         upstream_map_indexes = getattr(context["ti"], "_upstream_map_indexes", None) or {}
 
-        # TODO: This initiates one API call for each XComArg. Would it be
-        # more efficient to do one single call and unpack the value here?
+        resolved_plain_xcomargs = self._resolve_batch_resolvable_plain_xcomargs(context, upstream_map_indexes)
 
         resolved = {
-            k: v.resolve(context) if _needs_run_time_resolution(v) else v for k, v in self.value.items()
+            k: resolved_plain_xcomargs[k]
+            if k in resolved_plain_xcomargs
+            else v.resolve(context)
+            if _needs_run_time_resolution(v)
+            else v
+            for k, v in self.value.items()
         }
 
         sized_resolved = {k: v for k, v in resolved.items() if isinstance(v, Sized)}

--- a/task-sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task-sdk/src/airflow/sdk/execution_time/comms.py
@@ -96,6 +96,7 @@ from airflow.sdk.api.datamodels._generated import (
     TriggerDAGRunPayload,
     UpdateHITLDetailPayload,
     VariableResponse,
+    XComBatchResponse,
     XComResponse,
     XComSequenceIndexResponse,
     XComSequenceSliceResponse,
@@ -556,6 +557,23 @@ class XComResult(XComResponse):
         return cls(**xcom_response.model_dump(exclude_defaults=True), type="XComResult")
 
 
+class XComBatchItemResult(BaseModel):
+    task_id: str
+    value: JsonValue | None
+
+
+class XComBatchResult(BaseModel):
+    """Response to batch ReadXCom request."""
+
+    key: str
+    values: list[XComBatchItemResult]
+    type: Literal["XComBatchResult"] = "XComBatchResult"
+
+    @classmethod
+    def from_xcom_batch_response(cls, xcom_response: XComBatchResponse) -> XComBatchResult:
+        return cls(**xcom_response.model_dump(exclude_defaults=True), type="XComBatchResult")
+
+
 class XComCountResponse(BaseModel):
     len: int
     type: Literal["XComCountResponse"] = "XComCountResponse"
@@ -839,6 +857,7 @@ ToTask = Annotated[
     | TaskStatesResult
     | VariableResult
     | VariableKeysResult
+    | XComBatchResult
     | XComCountResponse
     | XComResult
     | XComSequenceIndexResult
@@ -915,6 +934,16 @@ class GetXCom(BaseModel):
     map_index: int | None = None
     include_prior_dates: bool = False
     type: Literal["GetXCom"] = "GetXCom"
+
+
+class GetXComs(BaseModel):
+    key: str
+    dag_id: str
+    run_id: str
+    task_ids: list[str]
+    map_index: int | None = None
+    include_prior_dates: bool = False
+    type: Literal["GetXComs"] = "GetXComs"
 
 
 class GetXComCount(BaseModel):
@@ -1282,6 +1311,7 @@ ToSupervisor = Annotated[
     | GetVariable
     | GetVariableKeys
     | GetXCom
+    | GetXComs
     | GetXComCount
     | GetXComSequenceItem
     | GetXComSequenceSlice

--- a/task-sdk/src/airflow/sdk/execution_time/request_handlers.py
+++ b/task-sdk/src/airflow/sdk/execution_time/request_handlers.py
@@ -36,6 +36,7 @@ from airflow.sdk.api.datamodels._generated import (
     DagRunStateResponse,
     TaskStatesResponse,
     VariableResponse,
+    XComBatchResponse,
     XComResponse,
     XComSequenceIndexResponse,
     XComSequenceSliceResponse,
@@ -63,6 +64,7 @@ from airflow.sdk.execution_time.comms import (
     GetVariableKeys,
     GetXCom,
     GetXComCount,
+    GetXComs,
     GetXComSequenceItem,
     GetXComSequenceSlice,
     MaskSecret,
@@ -74,6 +76,7 @@ from airflow.sdk.execution_time.comms import (
     TaskStatesResult,
     VariableKeysResult,
     VariableResult,
+    XComBatchResult,
     XComResult,
     XComSequenceIndexResult,
     XComSequenceSliceResult,
@@ -280,6 +283,17 @@ def handle_get_xcom(client: Client, msg: GetXCom) -> tuple[BaseModel | None, dic
     )
     if isinstance(xcom, XComResponse):
         xcom_result = XComResult.from_xcom_response(xcom)
+        return xcom_result, {"exclude_unset": True}
+    return xcom, {}
+
+
+def handle_get_xcoms(client: Client, msg: GetXComs) -> tuple[BaseModel | None, dict[str, bool]]:
+    """Fetch multiple XComs and normalize them for supervisor response handling."""
+    xcom = client.xcoms.get_batch(
+        msg.dag_id, msg.run_id, msg.task_ids, msg.key, msg.map_index, msg.include_prior_dates
+    )
+    if isinstance(xcom, XComBatchResponse):
+        xcom_result = XComBatchResult.from_xcom_batch_response(xcom)
         return xcom_result, {"exclude_unset": True}
     return xcom, {}
 

--- a/task-sdk/src/airflow/sdk/execution_time/schema/schema.json
+++ b/task-sdk/src/airflow/sdk/execution_time/schema/schema.json
@@ -3001,6 +3001,60 @@
       "title": "GetXComSequenceSlice",
       "type": "object"
     },
+    "GetXComs": {
+      "properties": {
+        "key": {
+          "title": "Key",
+          "type": "string"
+        },
+        "dag_id": {
+          "title": "Dag Id",
+          "type": "string"
+        },
+        "run_id": {
+          "title": "Run Id",
+          "type": "string"
+        },
+        "task_ids": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Task Ids",
+          "type": "array"
+        },
+        "map_index": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Map Index"
+        },
+        "include_prior_dates": {
+          "default": false,
+          "title": "Include Prior Dates",
+          "type": "boolean"
+        },
+        "type": {
+          "const": "GetXComs",
+          "default": "GetXComs",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "key",
+        "dag_id",
+        "run_id",
+        "task_ids"
+      ],
+      "title": "GetXComs",
+      "type": "object"
+    },
     "HITLDetailRequestResult": {
       "description": "Response to CreateHITLDetailPayload request.",
       "properties": {
@@ -4505,6 +4559,58 @@
         "value"
       ],
       "title": "VariableResult",
+      "type": "object"
+    },
+    "XComBatchItemResult": {
+      "properties": {
+        "task_id": {
+          "title": "Task Id",
+          "type": "string"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/JsonValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "task_id",
+        "value"
+      ],
+      "title": "XComBatchItemResult",
+      "type": "object"
+    },
+    "XComBatchResult": {
+      "description": "Response to batch ReadXCom request.",
+      "properties": {
+        "key": {
+          "title": "Key",
+          "type": "string"
+        },
+        "values": {
+          "items": {
+            "$ref": "#/$defs/XComBatchItemResult"
+          },
+          "title": "Values",
+          "type": "array"
+        },
+        "type": {
+          "const": "XComBatchResult",
+          "default": "XComBatchResult",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "key",
+        "values"
+      ],
+      "title": "XComBatchResult",
       "type": "object"
     },
     "XComCountResponse": {

--- a/task-sdk/src/airflow/sdk/execution_time/schema/versions/__init__.py
+++ b/task-sdk/src/airflow/sdk/execution_time/schema/versions/__init__.py
@@ -39,11 +39,12 @@ def get_bundle() -> VersionBundle:
 
     from airflow.sdk.execution_time.schema.versions.v2026_10_30 import (
         AddArgBindingsToSupervisorTIRunContext,
+        AddBatchXComSupervisorMessages,
     )
 
     return VersionBundle(
         HeadVersion(),
-        Version("2026-10-30", AddArgBindingsToSupervisorTIRunContext),
+        Version("2026-10-30", AddArgBindingsToSupervisorTIRunContext, AddBatchXComSupervisorMessages),
         Version("2026-06-16"),
     )
 

--- a/task-sdk/src/airflow/sdk/execution_time/schema/versions/v2026_10_30.py
+++ b/task-sdk/src/airflow/sdk/execution_time/schema/versions/v2026_10_30.py
@@ -34,3 +34,11 @@ class AddArgBindingsToSupervisorTIRunContext(VersionChange):
     description = __doc__
 
     instructions_to_migrate_to_previous_version = (schema(TIRunContext).field("arg_bindings").didnt_exist,)
+
+
+class AddBatchXComSupervisorMessages(VersionChange):
+    """Add supervisor messages for fetching multiple XCom values together."""
+
+    description = __doc__
+
+    instructions_to_migrate_to_previous_version = ()

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -103,6 +103,7 @@ from airflow.sdk.execution_time.comms import (
     GetVariableKeys,
     GetXCom,
     GetXComCount,
+    GetXComs,
     GetXComSequenceItem,
     GetXComSequenceSlice,
     HITLDetailRequestResult,
@@ -150,6 +151,7 @@ from airflow.sdk.execution_time.request_handlers import (
     handle_get_xcom_count,
     handle_get_xcom_sequence_item,
     handle_get_xcom_sequence_slice,
+    handle_get_xcoms,
     handle_mask_secret,
     handle_put_variable,
     handle_set_xcom,
@@ -1779,6 +1781,8 @@ class ActivitySubprocess(WatchedSubprocess):
             resp, dump_opts = handle_get_variable_keys(self.client, msg)
         elif isinstance(msg, GetXCom):
             resp, dump_opts = handle_get_xcom(self.client, msg)
+        elif isinstance(msg, GetXComs):
+            resp, dump_opts = handle_get_xcoms(self.client, msg)
         elif isinstance(msg, GetXComSequenceItem):
             resp, dump_opts = handle_get_xcom_sequence_item(self.client, msg)
         elif isinstance(msg, GetXComSequenceSlice):

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -48,6 +48,7 @@ from airflow.sdk.api.datamodels._generated import (
     TaskStateStoreResponse,
     TerminalTIState,
     VariableResponse,
+    XComBatchResponse,
     XComResponse,
 )
 from airflow.sdk.exceptions import ErrorType, TaskAlreadyRunningError
@@ -1020,6 +1021,44 @@ class TestXCOMOperations:
         assert isinstance(result, XComResponse)
         assert result.key == "test_key"
         assert result.value == "test_value"
+
+    def test_xcom_get_batch_success(self):
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/xcoms/batch"
+            assert json.loads(request.content) == {
+                "dag_id": "dag_id",
+                "run_id": "run_id",
+                "task_ids": ["task_1", "task_2"],
+                "key": "key",
+                "map_index": 2,
+                "include_prior_dates": True,
+            }
+            return httpx.Response(
+                status_code=201,
+                json={
+                    "key": "key",
+                    "values": [
+                        {"task_id": "task_1", "value": "value_1"},
+                        {"task_id": "task_2", "value": None},
+                    ],
+                },
+            )
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        result = client.xcoms.get_batch(
+            dag_id="dag_id",
+            run_id="run_id",
+            task_ids=["task_1", "task_2"],
+            key="key",
+            map_index=2,
+            include_prior_dates=True,
+        )
+        assert isinstance(result, XComBatchResponse)
+        assert result.key == "key"
+        assert [(item.task_id, item.value) for item in result.values] == [
+            ("task_1", "value_1"),
+            ("task_2", None),
+        ]
 
     def test_xcom_get_500_error(self):
         with time_machine.travel("2023-01-01T00:00:00Z", tick=False):

--- a/task-sdk/tests/task_sdk/definitions/test_mappedoperator.py
+++ b/task-sdk/tests/task_sdk/definitions/test_mappedoperator.py
@@ -35,10 +35,13 @@ from airflow.sdk.execution_time.comms import (
     ErrorResponse,
     GetTICount,
     GetXCom,
+    GetXComs,
     GetXComSequenceItem,
     GetXComSequenceSlice,
     SetXCom,
     TICount,
+    XComBatchItemResult,
+    XComBatchResult,
     XComResult,
     XComSequenceIndexResult,
     XComSequenceSliceResult,
@@ -264,6 +267,11 @@ def test_mapped_render_template_fields_validating_operator(
         mapped = callable(mapped, task1.output)
 
     def mock_comms(msg):
+        if isinstance(msg, GetXComs):
+            return XComBatchResult(
+                key=BaseXCom.XCOM_RETURN_KEY,
+                values=[XComBatchItemResult(task_id=task_id, value=["{{ ds }}"]) for task_id in msg.task_ids],
+            )
         if isinstance(msg, GetXCom):
             return XComResult(key=BaseXCom.XCOM_RETURN_KEY, value=["{{ ds }}"])
         if isinstance(msg, GetXComSequenceSlice):
@@ -461,6 +469,14 @@ def test_map_cross_product(run_ti: RunTI, mock_supervisor_comms):
     letters = {"a": "x", "b": "y", "c": "z"}
 
     def mock_comms(msg):
+        if isinstance(msg, GetXComs):
+            values = {"emit_numbers": numbers, "emit_letters": letters}
+            return XComBatchResult(
+                key=BaseXCom.XCOM_RETURN_KEY,
+                values=[
+                    XComBatchItemResult(task_id=task_id, value=values[task_id]) for task_id in msg.task_ids
+                ],
+            )
         if isinstance(msg, GetXCom):
             if msg.task_id == "emit_numbers":
                 return XComResult(key=BaseXCom.XCOM_RETURN_KEY, value=numbers)
@@ -482,6 +498,19 @@ def test_map_cross_product(run_ti: RunTI, mock_supervisor_comms):
     mock_supervisor_comms.send.side_effect = mock_comms
 
     states = [run_ti(dag, "show", map_index) for map_index in range(6)]
+    batch_requests = [
+        call.args[0]
+        for call in mock_supervisor_comms.send.call_args_list
+        if call.args and isinstance(call.args[0], GetXComs)
+    ]
+    assert batch_requests
+    assert all(request.task_ids == ["emit_numbers", "emit_letters"] for request in batch_requests)
+    direct_xcom_requests = [
+        call.args[0]
+        for call in mock_supervisor_comms.send.call_args_list
+        if call.args and isinstance(call.args[0], GetXCom)
+    ]
+    assert direct_xcom_requests == []
     assert states == [TaskInstanceState.SUCCESS] * 6
     assert outputs == [
         (1, ("a", "x")),
@@ -513,6 +542,11 @@ def test_map_product_same(run_ti: RunTI, mock_supervisor_comms):
     numbers = [1, 2]
 
     def mock_comms(msg):
+        if isinstance(msg, GetXComs):
+            return XComBatchResult(
+                key=BaseXCom.XCOM_RETURN_KEY,
+                values=[XComBatchItemResult(task_id=task_id, value=numbers) for task_id in msg.task_ids],
+            )
         if isinstance(msg, GetXCom):
             if msg.task_id == "emit_numbers":
                 return XComResult(key=BaseXCom.XCOM_RETURN_KEY, value=numbers)
@@ -529,6 +563,19 @@ def test_map_product_same(run_ti: RunTI, mock_supervisor_comms):
     mock_supervisor_comms.send.side_effect = mock_comms
 
     states = [run_ti(dag, "show", map_index) for map_index in range(4)]
+    batch_requests = [
+        call.args[0]
+        for call in mock_supervisor_comms.send.call_args_list
+        if call.args and isinstance(call.args[0], GetXComs)
+    ]
+    assert batch_requests
+    assert all(request.task_ids == ["emit_numbers", "emit_numbers"] for request in batch_requests)
+    direct_xcom_requests = [
+        call.args[0]
+        for call in mock_supervisor_comms.send.call_args_list
+        if call.args and isinstance(call.args[0], GetXCom)
+    ]
+    assert direct_xcom_requests == []
     assert states == [TaskInstanceState.SUCCESS] * 4
     assert outputs == [(1, 1), (1, 2), (2, 1), (2, 2)]
 

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -118,6 +118,7 @@ from airflow.sdk.execution_time.comms import (
     GetVariableKeys,
     GetXCom,
     GetXComCount,
+    GetXComs,
     GetXComSequenceItem,
     GetXComSequenceSlice,
     HITLDetailRequestResult,
@@ -152,6 +153,8 @@ from airflow.sdk.execution_time.comms import (
     ValidateInletsAndOutlets,
     VariableKeysResult,
     VariableResult,
+    XComBatchItemResult,
+    XComBatchResult,
     XComCountResponse,
     XComResult,
     XComSequenceIndexResult,
@@ -1913,6 +1916,36 @@ REQUEST_TEST_CASES = [
             response=XComResult(key="test_key", value=None, type="XComResult"),
         ),
         expected_body={"key": "test_key", "value": None, "type": "XComResult"},
+    ),
+    RequestTestCase(
+        message=GetXComs(
+            dag_id="test_dag",
+            run_id="test_run",
+            task_ids=["task_1", "task_2"],
+            key="test_key",
+            map_index=2,
+            include_prior_dates=True,
+        ),
+        test_id="get_xcoms",
+        client_mock=ClientMock(
+            method_path="xcoms.get_batch",
+            args=("test_dag", "test_run", ["task_1", "task_2"], "test_key", 2, True),
+            response=XComBatchResult(
+                key="test_key",
+                values=[
+                    XComBatchItemResult(task_id="task_1", value="value_1"),
+                    XComBatchItemResult(task_id="task_2", value=None),
+                ],
+            ),
+        ),
+        expected_body={
+            "key": "test_key",
+            "values": [
+                {"task_id": "task_1", "value": "value_1"},
+                {"task_id": "task_2", "value": None},
+            ],
+            "type": "XComBatchResult",
+        },
     ),
     RequestTestCase(
         message=SetXCom(


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Summary

This adds a batch XCom read path for mapped task input resolution.

When `DictOfListsExpandInput.resolve()` sees multiple direct return-key `PlainXComArg` inputs that can be safely batched, it now fetches them through one grouped Execution API request instead of resolving each `XComArg` one by one.

The old resolution path is preserved as a fallback for cases that are not batched, including mapped upstreams, range map indexes, non-return keys, transformed/combined XComArgs, and custom XCom backends.

## Changes

- Add `POST /execution/xcoms/batch` for fetching multiple XCom values for the same Dag run, key, and map index.
- Add Task SDK client, supervisor comms, request handler, and `BaseXCom.get_many()` support for batch XCom fetches.
- Use the batch path in `expandinput.py` for eligible direct `PlainXComArg` inputs.
- Add Cadwyn version gating for the new Execution API endpoint and supervisor schema changes.
- Regenerate Task SDK generated API models and supervisor schema snapshot.
- Add tests for the API endpoint, version gating, client method, supervisor message handling, and mapped operator batching behavior.

## Tests

- `uv run ruff format ...`
- `uv run ruff check --fix ...`
- `git diff --check`
- `prek run mypy-airflow-core --all-files`
- `uv run --project scripts python scripts/ci/prek/check_execution_api_versions.py`
- `uv run --project scripts python scripts/ci/prek/generate_supervisor_schemas_snapshot.py`
- `uv run --project scripts python scripts/ci/prek/check_supervisor_schemas_versions.py`
- `uv run --project task-sdk pytest task-sdk/tests/task_sdk/api/test_client.py::TestXCOMOperations task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest task-sdk/tests/task_sdk/definitions/test_mappedoperator.py::test_map_cross_product task-sdk/tests/task_sdk/definitions/test_mappedoperator.py::test_map_product_same -xvs`
- `uv run --project airflow-core pytest airflow-core/tests/unit/api_fastapi/execution_api/versions/v2025_04_28/test_xcom.py airflow-core/tests/unit/api_fastapi/execution_api/versions/v2026_10_30/test_xcoms.py -xvs`


##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

-  `[X]`  Yes (please specify the tool below)


Generated-by: [Codex] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
