### PR TITLE
Release scheduler locks between Dag runs

### DIFF
--- a/airflow-core/docs/administration-and-deployment/scheduler.rst
+++ b/airflow-core/docs/administration-and-deployment/scheduler.rst
@@ -240,12 +240,17 @@ However, you can also look at other non-performance-related scheduler configurat
 
 - :ref:`config:scheduler__max_dagruns_per_loop_to_schedule`
 
-  How many DagRuns should a scheduler examine (and lock) when scheduling
-  and queuing tasks. Increasing this limit will allow more throughput for
-  smaller Dags but will likely slow down throughput for larger (>500
-  tasks for example) Dags. Setting this too high when using multiple
-  schedulers could also lead to one scheduler taking all the Dag runs
-  leaving no work for the others.
+  How many Dag runs a scheduler considers per scheduling loop. Candidates
+  are selected together, then each is locked and revalidated immediately
+  before scheduling. Runs already claimed or examined by another scheduler
+  are skipped. Each run's scheduling transaction commits before the next
+  candidate is processed, releasing its locks so an expensive run does not
+  retain locks from previously scheduled runs.
+
+  Increasing this limit allows more runs to be examined before queuing tasks
+  to executors. Each run requires a claim query and a separate commit, so
+  account for database round-trip and commit costs when tuning this value.
+  Expansion of a large mapped task still happens within its run's transaction.
 
 - :ref:`config:scheduler__use_row_level_locking`
 

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -2846,8 +2846,9 @@ scheduler:
       see_also: ":ref:`scheduler:ha:tunables`"
     max_dagruns_per_loop_to_schedule:
       description: |
-        How many DagRuns should a scheduler examine (and lock) when scheduling
-        and queuing tasks.
+        How many Dag runs a scheduler considers per scheduling loop. Each candidate
+        is locked and revalidated immediately before scheduling, then committed
+        separately so its locks are released before processing the next candidate.
       example: ~
       version_added: 2.0.0
       type: integer

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -51,7 +51,7 @@ from sqlalchemy import (
     update,
 )
 from sqlalchemy.exc import DBAPIError, OperationalError
-from sqlalchemy.orm import joinedload, lazyload, load_only, make_transient, selectinload
+from sqlalchemy.orm import contains_eager, joinedload, lazyload, load_only, make_transient, selectinload
 from sqlalchemy.sql import expression
 
 from airflow import settings
@@ -2007,10 +2007,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
           By "next oldest", we mean hasn't been examined/scheduled in the most time.
 
-          We don't select all dagruns at once, because the rows are selected with row locks, meaning
-          that only one scheduler can "process them", even it is waiting behind other dags. Increasing this
-          limit will allow more throughput for smaller DAGs but will likely slow down throughput for larger
-          (>500 tasks.) DAGs
+          Each candidate is locked and scheduled in its own transaction, so an expensive Dag run
+          does not retain locks acquired while scheduling other runs.
 
         - Then, via a Critical Section (locking the rows of the Pool model) we queue tasks, and then send them
           to the executor.
@@ -2027,27 +2025,22 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             self._start_queued_dagruns(session)
             guard.commit()
 
-            # Bulk fetch the currently active dag runs for the dags we are
-            # examining, rather than making one query per DagRun.
-            # Materialize into a list because the multi-team block below iterates
-            # the result and ScalarResult is a one-pass iterator.
+            # Team stamping and scheduling both consume the candidates, so materialize the iterator.
             dag_runs = list(
                 DagRun.get_running_dag_runs_to_examine(
-                    session=session, eagerly_load_dag_tags=self._dag_tags_in_metrics
+                    session=session, eagerly_load_dag_tags=self._dag_tags_in_metrics, lock_rows=False
                 )
             )
 
             # Team name should be added before listeners are called in _schedule_all_dag_runs()
             self._stamp_team_names(dag_runs, session)
 
-            callback_tuples = self._schedule_all_dag_runs(guard, dag_runs, session)
-
         # Send the callbacks after we commit to ensure the context is up to date when it gets run
         # cache saves time during scheduling of many dag_runs for same dag
         cached_get_dag: Callable[[DagRun], SerializedDAG | None] = lru_cache()(
             partial(self.scheduler_dag_bag.get_dag_for_run, session=session)
         )
-        for dag_run, callback_to_run in callback_tuples:
+        for dag_run, callback_to_run in self._schedule_all_dag_runs(dag_runs, session=session):
             dag = cached_get_dag(dag_run)
             if dag:
                 # Sending callbacks to the database, so it must be done outside of prohibit_commit.
@@ -2910,25 +2903,67 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             _update_state(dag, dag_run)
             dag_run.notify_dagrun_state_changed(msg="started")
 
-    @retry_db_transaction
     def _schedule_all_dag_runs(
         self,
-        guard: CommitProhibitorGuard,
         dag_runs: Iterable[DagRun],
+        *,
         session: Session,
-    ) -> list[tuple[DagRun, DagCallbackRequest | None]]:
+    ) -> Iterator[tuple[DagRun, DagCallbackRequest | None]]:
         """Make scheduling decisions for all `dag_runs`."""
-        callback_tuples = []
-        for run in dag_runs:
+        candidates = [(run.id, run.dag_id, run.run_id, run.last_scheduling_decision) for run in dag_runs]
+        for dag_run_id, dag_id, run_id, last_scheduling_decision in candidates:
             try:
-                callback = self._schedule_dag_run(run, session=session)
-                callback_tuples.append((run, callback))
+                result = self._schedule_dag_run_with_lock(
+                    dag_run_id, last_scheduling_decision, session=session
+                )
             except DBAPIError:
-                raise  # let @retry_db_transaction handle DB errors
+                raise  # Earlier runs have committed and must not be retried.
             except Exception:
-                self.log.exception("Error scheduling DAG run %s of %s", run.run_id, run.dag_id)
-        guard.commit()
-        return callback_tuples
+                session.rollback()
+                self.log.exception("Error scheduling Dag run %s of %s", run_id, dag_id)
+            else:
+                if result is not None:
+                    # Deliver a committed run's callback before a later run can exhaust its retries.
+                    yield result
+
+    @retry_db_transaction
+    def _schedule_dag_run_with_lock(
+        self,
+        dag_run_id: int,
+        last_scheduling_decision: datetime | None,
+        *,
+        session: Session,
+    ) -> tuple[DagRun, DagCallbackRequest | None] | None:
+        """Claim and schedule one unchanged candidate, releasing its locks before returning."""
+        with prohibit_commit(session) as guard:
+            query = (
+                select(DagRun)
+                .join(DM, DM.dag_id == DagRun.dag_id)
+                .where(
+                    DagRun.id == dag_run_id,
+                    DagRun.state == DagRunState.RUNNING,
+                    DagRun.last_scheduling_decision.is_not_distinct_from(last_scheduling_decision),
+                    DagRun.run_after <= func.now(),
+                    DM.is_paused == expression.false(),
+                    DM.is_stale == expression.false(),
+                )
+                .execution_options(populate_existing=True)
+            )
+            dag_model_loader = contains_eager(DagRun.dag_model)
+            if self._dag_tags_in_metrics:
+                dag_model_loader = dag_model_loader.selectinload(DM.tags)
+            query = query.options(dag_model_loader)
+            run = (
+                session.scalars(with_row_locks(query, of=DagRun, session=session, skip_locked=True))
+                .unique()
+                .one_or_none()
+            )
+            if run is None:
+                guard.commit()
+                return None
+            callback = self._schedule_dag_run(run, session=session)
+            guard.commit()
+            return run, callback
 
     def _schedule_dag_run(
         self,

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -745,7 +745,7 @@ class DagRun(Base, LoggingMixin):
     @classmethod
     @retry_db_transaction
     def get_running_dag_runs_to_examine(
-        cls, *, session: Session, eagerly_load_dag_tags: bool
+        cls, *, session: Session, eagerly_load_dag_tags: bool, lock_rows: bool = True
     ) -> ScalarResult[DagRun]:
         """
         Return the next DagRuns that the scheduler should attempt to schedule.
@@ -753,6 +753,8 @@ class DagRun(Base, LoggingMixin):
         This will return zero or more DagRun rows that are row-level-locked with a "SELECT ... FOR UPDATE"
         query, you should ensure that any scheduling decisions are made in a single transaction -- as soon as
         the transaction is committed it will be unlocked.
+
+        With ``lock_rows=False``, return candidates that must be locked and revalidated before scheduling.
 
         :meta private:
         """
@@ -785,7 +787,9 @@ class DagRun(Base, LoggingMixin):
 
         query = query.where(DagRun.run_after <= func.now())
 
-        result = session.scalars(with_row_locks(query, of=cls, session=session, skip_locked=True)).unique()
+        if lock_rows:
+            query = with_row_locks(query, of=cls, session=session, skip_locked=True)
+        result = session.scalars(query).unique()
         return result
 
     @classmethod

--- a/airflow-core/tests/unit/jobs/test_scheduler_dag_run_transactions.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_dag_run_transactions.py
@@ -1,0 +1,256 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest import mock
+
+import pytest
+from sqlalchemy import delete, func, inspect, select, update
+from sqlalchemy.exc import DBAPIError
+from sqlalchemy.orm import Session
+from tenacity import Retrying, retry_if_exception_type, stop_after_attempt, wait_none
+
+from airflow._shared.timezones import timezone
+from airflow.callbacks.callback_requests import DagCallbackRequest
+from airflow.jobs.job import Job
+from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
+from airflow.models.dag import DagModel
+from airflow.models.dagrun import DagRun
+from airflow.providers.standard.operators.empty import EmptyOperator
+from airflow.utils.sqlalchemy import UtcDateTime, with_row_locks
+from airflow.utils.state import DagRunState
+
+from tests_common.test_utils.mock_executor import MockExecutor
+
+pytestmark = [pytest.mark.db_test, pytest.mark.need_serialized_dag]
+
+DECISION_DATE = timezone.datetime(2026, 9, 9)
+
+
+@pytest.fixture
+def dag_runs(dag_maker, session):
+    runs = []
+    for index in range(3):
+        with dag_maker(f"transaction_dag_{index}", session=session, tags=["env:test"]):
+            EmptyOperator(task_id="task")
+        runs.append(dag_maker.create_dagrun(state=DagRunState.RUNNING))
+    session.commit()
+    return runs
+
+
+@pytest.fixture
+def runner():
+    return SchedulerJobRunner(job=Job(), executors=[MockExecutor(do_update=False)])
+
+
+@pytest.fixture
+def immediate_db_retries():
+    def get_retries(**kwargs):
+        return Retrying(
+            retry=retry_if_exception_type(DBAPIError),
+            stop=stop_after_attempt(2),
+            wait=wait_none(),
+            reraise=True,
+        )
+
+    with mock.patch("airflow.utils.retries.run_with_db_retries", autospec=True, side_effect=get_retries):
+        yield
+
+
+@pytest.mark.parametrize("eager_tags", [False, True])
+@mock.patch.object(SchedulerJobRunner, "_schedule_dag_run", autospec=True)
+def test_schedule_locks_only_current_dag_run(schedule, runner, dag_runs, session, monkeypatch, eager_tags):
+    if session.bind.dialect.name == "sqlite":
+        pytest.skip("SQLite does not support row locks")
+    run_ids = {run.id for run in dag_runs}
+    monkeypatch.setattr(runner, "_dag_tags_in_metrics", eager_tags)
+    candidates = list(
+        DagRun.get_running_dag_runs_to_examine(
+            session=session, eagerly_load_dag_tags=eager_tags, lock_rows=False
+        )
+    )
+    assert {run.id for run in candidates} == run_ids
+
+    def get_available_ids():
+        with Session(bind=session.get_bind()) as other:
+            return set(
+                other.scalars(
+                    with_row_locks(
+                        select(DagRun.id).where(DagRun.id.in_(run_ids)),
+                        session=other,
+                        of=DagRun,
+                        skip_locked=True,
+                    )
+                )
+            )
+
+    assert get_available_ids() == run_ids
+
+    def schedule_run(self, run, *, session):
+        assert get_available_ids() == run_ids - {run.id}
+        if eager_tags:
+            assert "tags" not in inspect(run.dag_model).unloaded
+        run.last_scheduling_decision = DECISION_DATE
+
+    schedule.side_effect = schedule_run
+    completed = []
+    for run, callback in runner._schedule_all_dag_runs(candidates, session=session):
+        completed.append(run.id)
+        assert callback is None
+        assert get_available_ids() == run_ids
+    assert set(completed) == run_ids
+
+
+@mock.patch.object(SchedulerJobRunner, "_schedule_dag_run", autospec=True)
+def test_schedule_skips_run_claimed_by_another_scheduler(schedule, runner, dag_runs, session):
+    if session.bind.dialect.name == "sqlite":
+        pytest.skip("SQLite does not support row locks")
+    run_id = dag_runs[0].id
+    with Session(bind=session.get_bind()) as other:
+        other.scalar(with_row_locks(select(DagRun.id).where(DagRun.id == run_id), session=other, of=DagRun))
+        assert list(runner._schedule_all_dag_runs(dag_runs[:1], session=session)) == []
+    schedule.assert_not_called()
+
+
+@pytest.mark.parametrize("change", ["paused", "stale", "finished", "scheduled", "deleted", "future"])
+@mock.patch.object(SchedulerJobRunner, "_schedule_dag_run", autospec=True)
+def test_schedule_revalidates_candidate(schedule, runner, dag_runs, session, change):
+    run = dag_runs[0]
+    with Session(bind=session.get_bind()) as other:
+        if change in {"paused", "stale"}:
+            other.execute(
+                update(DagModel).where(DagModel.dag_id == run.dag_id).values({f"is_{change}": True})
+            )
+        elif change == "deleted":
+            other.execute(delete(DagRun).where(DagRun.id == run.id))
+        elif change == "future":
+            other.execute(
+                update(DagRun)
+                .where(DagRun.id == run.id)
+                .values(run_after=other.scalar(select(func.now(type_=UtcDateTime))) + timedelta(days=1))
+            )
+        else:
+            values = {
+                "finished": {"state": DagRunState.SUCCESS},
+                "scheduled": {"last_scheduling_decision": DECISION_DATE},
+            }[change]
+            other.execute(update(DagRun).where(DagRun.id == run.id).values(**values))
+        other.commit()
+
+    assert list(runner._schedule_all_dag_runs([run], session=session)) == []
+    schedule.assert_not_called()
+
+
+@mock.patch.object(SchedulerJobRunner, "_schedule_dag_run", autospec=True)
+def test_schedule_refreshes_candidate_before_scheduling(schedule, runner, dag_runs, session):
+    run = dag_runs[0]
+    max_active_tasks = run.dag_model.max_active_tasks + 1
+    with Session(bind=session.get_bind()) as other:
+        other.execute(update(DagRun).where(DagRun.id == run.id).values(conf={"updated": True}))
+        other.execute(
+            update(DagModel).where(DagModel.dag_id == run.dag_id).values(max_active_tasks=max_active_tasks)
+        )
+        other.commit()
+
+    def schedule_run(self, run, *, session):
+        assert run.conf == {"updated": True}
+        assert "dag_model" not in inspect(run).unloaded
+        assert run.dag_model.max_active_tasks == max_active_tasks
+
+    schedule.side_effect = schedule_run
+    assert len(list(runner._schedule_all_dag_runs([run], session=session))) == 1
+    schedule.assert_called_once()
+
+
+@pytest.mark.parametrize("failures", [1, 2])
+@mock.patch.object(SchedulerJobRunner, "_schedule_dag_run", autospec=True)
+def test_retry_does_not_repeat_committed_runs(
+    schedule, runner, dag_runs, session, immediate_db_retries, failures
+):
+    first_id, second_id = (run.id for run in dag_runs[:2])
+    attempts = []
+    error = DBAPIError("update dag_run", None, Exception("retry transaction"))
+
+    def schedule_run(self, run, *, session):
+        attempts.append(run.id)
+        run.last_scheduling_decision = DECISION_DATE
+        session.flush()
+        if run.id == second_id and attempts.count(second_id) <= failures:
+            raise error
+
+    schedule.side_effect = schedule_run
+    results = runner._schedule_all_dag_runs(dag_runs[:2], session=session)
+    first, callback = next(results)
+    assert first.id == first_id
+    assert callback is None
+    with Session(bind=session.get_bind()) as other:
+        assert other.get(DagRun, first_id).last_scheduling_decision == DECISION_DATE
+
+    if failures == 1:
+        assert [run.id for run, _ in results] == [second_id]
+    else:
+        with pytest.raises(DBAPIError):
+            next(results)
+        with Session(bind=session.get_bind()) as other:
+            assert other.get(DagRun, second_id).last_scheduling_decision is None
+    assert attempts == [first_id, second_id, second_id]
+
+
+@mock.patch.object(SchedulerJobRunner, "_schedule_dag_run", autospec=True)
+def test_unexpected_error_rolls_back_only_failed_run(schedule, runner, dag_runs, session):
+    failed_id = dag_runs[0].id
+
+    def schedule_run(self, run, *, session):
+        run.state = DagRunState.SUCCESS
+        session.flush()
+        if run.id == failed_id:
+            raise ValueError("invalid scheduling state")
+
+    schedule.side_effect = schedule_run
+    assert [run.id for run, _ in runner._schedule_all_dag_runs(dag_runs, session=session)] == [
+        run.id for run in dag_runs[1:]
+    ]
+    with Session(bind=session.get_bind()) as other:
+        assert other.get(DagRun, failed_id).state == DagRunState.RUNNING
+        assert all(other.get(DagRun, run.id).state == DagRunState.SUCCESS for run in dag_runs[1:])
+
+
+@mock.patch.object(SchedulerJobRunner, "_send_dag_callbacks_to_processor", autospec=True)
+@mock.patch.object(SchedulerJobRunner, "_schedule_dag_run", autospec=True)
+def test_committed_callback_is_sent_before_later_run_fails(
+    schedule, send_callback, runner, dag_runs, session, immediate_db_retries, monkeypatch
+):
+    monkeypatch.setattr(runner, "_scheduler_use_job_schedule", False)
+    callback = mock.Mock(spec=DagCallbackRequest)
+    scheduled_ids = []
+
+    def schedule_run(self, run, *, session):
+        scheduled_ids.append(run.id)
+        if len(scheduled_ids) == 1:
+            run.last_scheduling_decision = DECISION_DATE
+            return callback
+        send_callback.assert_called_once()
+        assert send_callback.call_args.args[2] is callback
+        raise DBAPIError("update dag_run", None, Exception("retry transaction"))
+
+    schedule.side_effect = schedule_run
+    with pytest.raises(DBAPIError):
+        runner._do_scheduling(session)
+    assert len(scheduled_ids) == 3
+    assert scheduled_ids[0] != scheduled_ids[1] == scheduled_ids[2]

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -6487,19 +6487,7 @@ class TestSchedulerJob:
             )
 
     def test_schedule_all_dag_runs_does_not_crash_on_single_dag_run_error(self, dag_maker, caplog, session):
-        """Test that _schedule_all_dag_runs continues processing other DAG runs
-        when one DAG run raises an exception during scheduling.
-
-        Previously, _schedule_all_dag_runs used a list comprehension that would
-        abort entirely if any single _schedule_dag_run call raised, crashing
-        the entire scheduler and stopping scheduling for ALL DAGs.
-
-        While the specific scenario used to reproduce this (a TaskInstance with
-        state=UP_FOR_RETRY and end_date=NULL) is nearly impossible under normal
-        operation, the lack of per-dag-run fault isolation means ANY unexpected
-        exception from ANY dag run would have the same catastrophic effect.
-        """
-        # Create two DAGs with running DAG runs
+        """An unexpected error scheduling one Dag run does not prevent scheduling another."""
         with dag_maker(dag_id="good_dag", schedule="@once"):
             EmptyOperator(task_id="good_task")
         good_run = dag_maker.create_dagrun(state=DagRunState.RUNNING)
@@ -6508,7 +6496,7 @@ class TestSchedulerJob:
             EmptyOperator(task_id="bad_task")
         bad_run = dag_maker.create_dagrun(state=DagRunState.RUNNING)
 
-        session.flush()
+        session.commit()
 
         scheduler_job = Job()
         self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
@@ -6526,10 +6514,7 @@ class TestSchedulerJob:
                 ],
             ) as mock_schedule,
         ):
-            from airflow.utils.sqlalchemy import prohibit_commit
-
-            with prohibit_commit(session) as guard:
-                result = self.job_runner._schedule_all_dag_runs(guard, [bad_run, good_run], session=session)
+            result = list(self.job_runner._schedule_all_dag_runs([bad_run, good_run], session=session))
 
             # The good DAG run should have been processed despite the bad one failing
             assert len(result) == 1
@@ -6538,17 +6523,10 @@ class TestSchedulerJob:
             # Both dag runs should have been attempted
             assert mock_schedule.call_count == 2
 
-            # The error should have been logged
-            error_messages = [r.message for r in caplog.records if r.levelno >= logging.ERROR]
-            assert any(
-                msg == f"Error scheduling DAG run {bad_run.run_id} of {bad_run.dag_id}"
-                for msg in error_messages
-            )
+            assert f"Error scheduling Dag run {bad_run.run_id} of {bad_run.dag_id}" in caplog
 
-    def test_schedule_all_dag_runs_reraises_db_errors(self, dag_maker, session):
-        """Test that _schedule_all_dag_runs does not catch DBAPIError, allowing
-        it to propagate to @retry_db_transaction for proper retry handling.
-        """
+    def test_schedule_dag_run_with_lock_reraises_db_errors(self, dag_maker, session):
+        """Database errors escape the scheduling transaction for retry handling."""
         from sqlalchemy.exc import DBAPIError
 
         with dag_maker(dag_id="db_error_dag", schedule="@once"):
@@ -6565,15 +6543,10 @@ class TestSchedulerJob:
             autospec=True,
             side_effect=DBAPIError("select 1", None, Exception("connection lost")),
         ) as mock_schedule:
-            from airflow.utils.sqlalchemy import prohibit_commit
-
-            with prohibit_commit(session) as guard:
-                # Bypass @retry_db_transaction to verify the exception escapes
-                # the inner function rather than being swallowed by except Exception.
-                with pytest.raises(DBAPIError):
-                    self.job_runner._schedule_all_dag_runs.__wrapped__(
-                        self.job_runner, guard, [run], session=session
-                    )
+            with pytest.raises(DBAPIError):
+                self.job_runner._schedule_dag_run_with_lock.__wrapped__(
+                    self.job_runner, run.id, run.last_scheduling_decision, session=session
+                )
 
             assert mock_schedule.call_count == 1
 
@@ -6783,8 +6756,7 @@ class TestSchedulerJob:
         assert num_queued == 1
 
         session.flush()
-        ti = run1.task_instances[0]
-        ti.refresh_from_db(session=session)
+        ti = run1.get_task_instance("dummy1", session=session)
         assert ti.state == State.QUEUED
 
     def test_more_runs_are_not_created_when_max_active_runs_is_reached(self, dag_maker, caplog, session):
@@ -11072,33 +11044,33 @@ class TestSchedulerJobQueriesCount:
             # One DAG with one task per DAG file.
             ([10, 10, 10, 10], 1, 1, "1d", "None", "no_structure"),
             ([10, 10, 10, 10], 1, 1, "1d", "None", "linear"),
-            ([24, 14, 14, 14], 1, 1, "1d", "@once", "no_structure"),
-            ([24, 14, 14, 14], 1, 1, "1d", "@once", "linear"),
-            ([24, 26, 29, 32], 1, 1, "1d", "30m", "no_structure"),
-            ([24, 26, 29, 32], 1, 1, "1d", "30m", "linear"),
-            ([24, 26, 29, 32], 1, 1, "1d", "30m", "binary_tree"),
-            ([24, 26, 29, 32], 1, 1, "1d", "30m", "star"),
-            ([24, 26, 29, 32], 1, 1, "1d", "30m", "grid"),
+            ([25, 14, 14, 14], 1, 1, "1d", "@once", "no_structure"),
+            ([25, 14, 14, 14], 1, 1, "1d", "@once", "linear"),
+            ([25, 26, 29, 32], 1, 1, "1d", "30m", "no_structure"),
+            ([25, 26, 29, 32], 1, 1, "1d", "30m", "linear"),
+            ([25, 26, 29, 32], 1, 1, "1d", "30m", "binary_tree"),
+            ([25, 26, 29, 32], 1, 1, "1d", "30m", "star"),
+            ([25, 26, 29, 32], 1, 1, "1d", "30m", "grid"),
             # One DAG with five tasks per DAG file.
             ([10, 10, 10, 10], 1, 5, "1d", "None", "no_structure"),
             ([10, 10, 10, 10], 1, 5, "1d", "None", "linear"),
-            ([24, 14, 14, 14], 1, 5, "1d", "@once", "no_structure"),
-            ([25, 15, 15, 15], 1, 5, "1d", "@once", "linear"),
-            ([24, 26, 29, 32], 1, 5, "1d", "30m", "no_structure"),
-            ([25, 28, 32, 36], 1, 5, "1d", "30m", "linear"),
-            ([25, 28, 32, 36], 1, 5, "1d", "30m", "binary_tree"),
-            ([25, 28, 32, 36], 1, 5, "1d", "30m", "star"),
-            ([25, 28, 32, 36], 1, 5, "1d", "30m", "grid"),
+            ([25, 14, 14, 14], 1, 5, "1d", "@once", "no_structure"),
+            ([26, 15, 15, 15], 1, 5, "1d", "@once", "linear"),
+            ([25, 26, 29, 32], 1, 5, "1d", "30m", "no_structure"),
+            ([26, 28, 32, 36], 1, 5, "1d", "30m", "linear"),
+            ([26, 28, 32, 36], 1, 5, "1d", "30m", "binary_tree"),
+            ([26, 28, 32, 36], 1, 5, "1d", "30m", "star"),
+            ([26, 28, 32, 36], 1, 5, "1d", "30m", "grid"),
             # 10 DAGs with 10 tasks per DAG file.
             ([10, 10, 10, 10], 10, 10, "1d", "None", "no_structure"),
             ([10, 10, 10, 10], 10, 10, "1d", "None", "linear"),
-            ([218, 69, 69, 69], 10, 10, "1d", "@once", "no_structure"),
-            ([228, 84, 84, 84], 10, 10, "1d", "@once", "linear"),
-            ([217, 119, 119, 119], 10, 10, "1d", "30m", "no_structure"),
+            ([238, 86, 79, 79], 10, 10, "1d", "@once", "no_structure"),
+            ([248, 93, 93, 93], 10, 10, "1d", "@once", "linear"),
+            ([238, 119, 119, 119], 10, 10, "1d", "30m", "no_structure"),
             ([2227, 145, 145, 145], 10, 10, "1d", "30m", "linear"),
-            ([227, 139, 139, 139], 10, 10, "1d", "30m", "binary_tree"),
-            ([227, 139, 139, 139], 10, 10, "1d", "30m", "star"),
-            ([227, 259, 259, 259], 10, 10, "1d", "30m", "grid"),
+            ([248, 139, 139, 139], 10, 10, "1d", "30m", "binary_tree"),
+            ([248, 139, 139, 139], 10, 10, "1d", "30m", "star"),
+            ([248, 259, 259, 259], 10, 10, "1d", "30m", "grid"),
         ],
     )
     def test_process_dags_queries_count(


### PR DESCRIPTION
An expensive mapped-task expansion currently keeps scheduling locks on every Dag run selected in the same batch. For example, an update to run A can wait for a 10,000-instance expansion in run B even after the scheduler has finished examining A.

Select scheduling candidates without locking the whole batch, then claim, revalidate, schedule, and commit each run separately. A scheduler skips candidates that another scheduler has locked or examined in the meantime. Database retries apply only to the current run, and callbacks for committed runs are delivered before scheduling the next candidate.

The intended benefit is shorter lock waits across Dag runs. This adds a claim query and a transaction boundary per candidate, and prevents some updates from being batched together. It can increase database round trips and commit overhead. Multiple schedulers can also reach other candidates sooner, potentially increasing concurrent expansion work. This does not bound aggregate database load or claim improved scheduler throughput.

Task-instance creation remains eager, including full expansion of a mapped task. This PR does **not** defer creation across scheduler loops or impose a creation budget. Scheduling changes for each running Dag run become visible when that run commits, before the scheduler finishes the remaining candidates. Existing mapped-task semantics and `task_instance_mutation_hook` behavior are preserved. Dag-run creation and the pool-lock critical section for queuing tasks retain their existing transaction boundaries.

### PostgreSQL 14 contention experiment

Local PostgreSQL 14.24, 20 running Dags, a real 10,000-instance expansion in the middle of the batch, and a concurrent connection updating a previously examined run. Three repetitions per variant; no artificial delay holds locks open.

| Measurement | Batch transaction | Transaction per run |
| --- | ---: | ---: |
| Conflicting update latency, median | 2.431 s | 1.251 ms |
| Conflicting update latency, range | 2.234–2.829 s | 1.172–2.600 ms |
| Workload duration, median | 2.430 s | 2.409 s |
| Scheduler commits | 1 | 20 |
| Scheduler driver SELECT calls | 6 | 26 |
| Scheduler driver UPDATE calls | 3 | 21 |
| Scheduler driver INSERT calls | 1 | 1 |

The baseline writer waited on `Lock/transactionid`, with the scheduler PID reported by `pg_blocking_pids`. With separate transactions, that update finished during the expansion and had no blocker. Cluster WAL deltas were approximately 11 MB for both variants; these measurements do not establish reduced WAL production.

This is a controlled transaction-boundary experiment using the existing `TaskMap.expand_mapped_task`, not a full scheduler throughput benchmark. Other scheduling work is replaced by a timestamp update. Driver calls were counted with SQLAlchemy cursor events; one `executemany` call may represent multiple server operations. Broader workload measurements are still needed to assess the extra query/commit cost under multiple schedulers.

### Validation

- PostgreSQL 14: 42 transaction, query-count, and scheduler regressions passed; the final future-run fixture and six contention runs also passed.
- MySQL 8.0: all 15 targeted regressions passed after correcting the future-run test fixture's timestamp range and UTC handling.
- SQLite: 13,039 passed across API (3,949), Other (2,016), CLI (930), Serialization (593), Always (2,105), models (1,464), triggerer/dependencies/utilities (1,088), and the scheduler/Core/executor subset (894).
- The combined Core run was killed with exit 137 on the local 1.9 GB VM. All Core tests subsequently completed in smaller processes. Standard backend-specific, system, and long-running exclusions still apply.
- Fast static checks, including mypy, commit hooks, manual checks, and CI test selection completed.

The full local suites ran before the final rebase onto current `main`. Upstream changes did not touch the six files in this PR; the rebased patch is identical. Static checks were repeated after rebasing.

Related: #71967. This change starts from `main` and has no dependency on that PR.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-6)

Generated-by: Codex (GPT-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---
Drafted-by: Codex (GPT-6) (no human review before posting)
