### PR TITLE
Fix td_format to correctly handle negative durations

### DIFF
--- a/shared/timezones/src/airflow_shared/timezones/timezone.py
+++ b/shared/timezones/src/airflow_shared/timezones/timezone.py
@@ -231,13 +231,21 @@ def td_format(td_object: None | dt.timedelta | float | int) -> str | None:
 
     For example timedelta(seconds=3752) would become `1h:2M:32s`.
     If the time is less than a second, the return will be `<1s`.
+    Negative durations are prefixed with a `-` sign, e.g. `-1h:2M:32s`.
     """
     if td_object is None:
         return None
     if isinstance(td_object, dt.timedelta):
-        delta = relativedelta() + td_object
+        total_seconds = td_object.total_seconds()
     else:
-        delta = relativedelta(seconds=int(td_object))
+        total_seconds = td_object
+
+    is_negative = total_seconds < 0
+
+    if isinstance(td_object, dt.timedelta):
+        delta = relativedelta() + (abs(td_object) if is_negative else td_object)
+    else:
+        delta = relativedelta(seconds=abs(int(td_object)))
     # relativedelta for timedelta cannot convert days to months
     # so calculate months by assuming 30 day months and normalize
     months, delta.days = divmod(delta.days, 30)
@@ -258,8 +266,7 @@ def td_format(td_object: None | dt.timedelta | float | int) -> str | None:
     joined = ":".join(part for part in parts if part)
     if not joined:
         return "<1s"
-    return joined
-
+    return f"-{joined}" if is_negative else joined
 
 def parse_timezone(name: str | int) -> FixedTimezone | Timezone:
     """

--- a/shared/timezones/tests/timezones/test_timezone.py
+++ b/shared/timezones/tests/timezones/test_timezone.py
@@ -96,6 +96,16 @@ class TestTimezone:
         assert timezone.td_format(td) == "3d:11h:32M:32s"
         td = 434343600.0
         assert timezone.td_format(td) == "13y:11m:17d:3h"
+        td = datetime.timedelta(seconds=-3752)
+        assert timezone.td_format(td) == "-1h:2M:32s"
+        td = -3200.0
+        assert timezone.td_format(td) == "-53M:20s"
+        td = -3200
+        assert timezone.td_format(td) == "-53M:20s"
+        td = datetime.timedelta(days=-5)
+        assert timezone.td_format(td) == "-5d"
+        td = -0.5
+        assert timezone.td_format(td) == "<1s"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What
`td_format` incorrectly rendered negative durations as large positive-looking values (e.g. `timedelta(seconds=-3752)` returned `29d:22h:57M:28s` instead of a negative representation).

## Why
Python's internal `timedelta`/`relativedelta` normalization mixes signs (e.g. `days=-1, seconds=82048`), and the subsequent `divmod(delta.days, 30)` month calculation flipped the sign further, silently dropping the negative months field due to the `if value < 1: return ""` check in `_format_part`. The negative sign information was lost entirely.

## Fix
- Detect whether the input duration is negative up front.
- Perform all relativedelta/formatting math on the absolute value.
- Prepend a `-` sign to the final formatted string if the original duration was negative.

## Testing
Added test cases to `test_td_format` covering negative `timedelta`, negative `float`, and negative `int` inputs, including a sub-second negative duration (`<1s` case). All 30 existing tests in `test_timezone.py` pass.
