### PR TITLE
Add job_name support to DataflowJobStatusSensor and DataflowJobStatusTrigger

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/hooks/dataflow.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/dataflow.py
@@ -1174,6 +1174,33 @@ class DataflowHook(GoogleBaseHook):
         return jobs_controller.fetch_job_by_id(job_id)
 
     @GoogleBaseHook.fallback_to_default_project_id
+    def fetch_job_by_name(
+        self,
+        job_name: str,
+        project_id: str = PROVIDE_PROJECT_ID,
+        location: str = DEFAULT_DATAFLOW_LOCATION,
+    ) -> dict | None:
+        """
+        Fetch the most recently created job matching the given job name.
+
+        :param job_name: The exact name of the job to look up.
+        :param project_id: Optional, the Google Cloud project ID in which to look for the job.
+        :param location: The location of the Dataflow job (for example europe-west1).
+        :return: the most recent matching Job dict, or None if no job matches.
+        """
+        jobs_controller = _DataflowJobsController(
+            dataflow=self.get_conn(),
+            project_number=project_id,
+            location=location,
+        )
+        all_jobs = jobs_controller._fetch_all_jobs()
+        matching_jobs = [job for job in all_jobs if job.get("name") == job_name]
+        if not matching_jobs:
+            return None
+        matching_jobs.sort(key=lambda job: job.get("createTime", ""), reverse=True)
+        return matching_jobs[0]
+
+    @GoogleBaseHook.fallback_to_default_project_id
     def fetch_job_metrics_by_id(
         self,
         job_id: str,
@@ -1548,6 +1575,27 @@ class AsyncDataflowHook(GoogleBaseAsyncHook, DataflowJobTerminalStateHelper):
         )
         page_result: ListJobsAsyncPager = await client.list_jobs(request=request)
         return page_result
+
+    async def get_job_by_name(
+        self,
+        job_name: str,
+        project_id: str | None = PROVIDE_PROJECT_ID,
+        location: str | None = DEFAULT_DATAFLOW_LOCATION,
+    ) -> Job | None:
+        """
+        Fetch the most recently created job matching the given job name.
+
+        :param job_name: The exact name of the job to look up.
+        :param project_id: Optional. The Google Cloud project ID in which to look for the job.
+        :param location: Optional. The location of the Dataflow job (for example europe-west1).
+        :return: the most recent matching Job, or None if no job matches.
+        """
+        page_result = await self.list_jobs(project_id=project_id, location=location)
+        matching_jobs = [job async for job in page_result if job.name == job_name]
+        if not matching_jobs:
+            return None
+        matching_jobs.sort(key=lambda job: job.create_time, reverse=True)
+        return matching_jobs[0]
 
     async def list_job_messages(
         self,

--- a/providers/google/src/airflow/providers/google/cloud/sensors/dataflow.py
+++ b/providers/google/src/airflow/providers/google/cloud/sensors/dataflow.py
@@ -36,6 +36,7 @@ from airflow.providers.google.cloud.triggers.dataflow import (
     DataflowJobStatusTrigger,
 )
 from airflow.providers.google.common.hooks.base_google import PROVIDE_PROJECT_ID
+from airflow.utils.helpers import exactly_one
 
 if TYPE_CHECKING:
     from airflow.providers.common.compat.sdk import Context
@@ -49,7 +50,10 @@ class DataflowJobStatusSensor(BaseSensorOperator):
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:DataflowJobStatusSensor`
 
-    :param job_id: ID of the job to be checked.
+    :param job_id: ID of the job to be checked. Mutually exclusive with ``job_name``.
+    :param job_name: Name of the job to be checked. Mutually exclusive with ``job_id``.
+        Since job names are not globally unique, the most recently created matching job
+        within the given project/location is targeted.
     :param expected_statuses: The expected state(s) of the operation.
         See:
         https://cloud.google.com/dataflow/docs/reference/rest/v1b3/projects.jobs#Job.JobState
@@ -70,12 +74,13 @@ class DataflowJobStatusSensor(BaseSensorOperator):
     :param poll_interval: Time (seconds) to wait between two consecutive calls to check the job.
     """
 
-    template_fields: Sequence[str] = ("job_id",)
+    template_fields: Sequence[str] = ("job_id", "job_name")
 
     def __init__(
         self,
         *,
-        job_id: str,
+        job_id: str | None = None,
+        job_name: str | None = None,
         expected_statuses: set[str] | str,
         project_id: str = PROVIDE_PROJECT_ID,
         location: str = DEFAULT_DATAFLOW_LOCATION,
@@ -86,7 +91,10 @@ class DataflowJobStatusSensor(BaseSensorOperator):
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
+        if not exactly_one(job_id, job_name):
+            raise AirflowException("Exactly one of 'job_id' or 'job_name' must be provided.")
         self.job_id = job_id
+        self.job_name = job_name
         self.expected_statuses = (
             {expected_statuses} if isinstance(expected_statuses, str) else expected_statuses
         )
@@ -100,15 +108,25 @@ class DataflowJobStatusSensor(BaseSensorOperator):
     def poke(self, context: Context) -> bool:
         self.log.info(
             "Waiting for job %s to be in one of the states: %s.",
-            self.job_id,
+            self.job_id or self.job_name,
             ", ".join(self.expected_statuses),
         )
 
-        job = self.hook.get_job(
-            job_id=self.job_id,
-            project_id=self.project_id,
-            location=self.location,
-        )
+        if self.job_name is not None:
+            job = self.hook.fetch_job_by_name(
+                job_name=self.job_name,
+                project_id=self.project_id,
+                location=self.location,
+            )
+            if job is None:
+                return False
+            self.job_id = job["id"]
+        else:
+            job = self.hook.get_job(
+                job_id=self.job_id,
+                project_id=self.project_id,
+                location=self.location,
+            )
 
         job_status = job["currentState"]
         self.log.debug("Current job status for job %s: %s.", self.job_id, job_status)
@@ -130,6 +148,7 @@ class DataflowJobStatusSensor(BaseSensorOperator):
                 timeout=self.execution_timeout,
                 trigger=DataflowJobStatusTrigger(
                     job_id=self.job_id,
+                    job_name=self.job_name if self.job_id is None else None,
                     expected_statuses=self.expected_statuses,
                     project_id=self.project_id,
                     location=self.location,

--- a/providers/google/src/airflow/providers/google/cloud/triggers/dataflow.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/dataflow.py
@@ -33,8 +33,10 @@ from google.cloud.dataflow_v1beta3.types import (
     MetricUpdate,
 )
 
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.dataflow import AsyncDataflowHook, DataflowJobStatus
 from airflow.triggers.base import BaseTrigger, TriggerEvent
+from airflow.utils.helpers import exactly_one
 
 if TYPE_CHECKING:
     from google.cloud.dataflow_v1beta3.services.messages_v1_beta3.pagers import ListJobMessagesAsyncPager
@@ -169,7 +171,9 @@ class DataflowJobStatusTrigger(BaseTrigger):
     """
     Trigger that monitors if a Dataflow job has reached any of the expected statuses.
 
-    :param job_id: Required. ID of the job.
+    :param job_id: ID of the job. Mutually exclusive with ``job_name``.
+    :param job_name: Name of the job. Mutually exclusive with ``job_id``. Since job names
+        are not globally unique, the newest matching job is targeted, re-resolved each poll.
     :param expected_statuses: The expected state(s) of the operation.
         See: https://cloud.google.com/dataflow/docs/reference/rest/v1b3/projects.jobs#Job.JobState
     :param project_id: Required. The Google Cloud project ID in which the job was started.
@@ -189,16 +193,21 @@ class DataflowJobStatusTrigger(BaseTrigger):
 
     def __init__(
         self,
-        job_id: str,
+        *,
         expected_statuses: set[str],
         project_id: str | None,
+        job_id: str | None = None,
+        job_name: str | None = None,
         location: str = DEFAULT_DATAFLOW_LOCATION,
         gcp_conn_id: str = "google_cloud_default",
         poll_sleep: int = 10,
         impersonation_chain: str | Sequence[str] | None = None,
     ):
         super().__init__()
+        if not exactly_one(job_id, job_name):
+            raise AirflowException("Exactly one of 'job_id' or 'job_name' must be provided.")
         self.job_id = job_id
+        self.job_name = job_name
         self.expected_statuses = expected_statuses
         self.project_id = project_id
         self.location = location
@@ -212,6 +221,7 @@ class DataflowJobStatusTrigger(BaseTrigger):
             "airflow.providers.google.cloud.triggers.dataflow.DataflowJobStatusTrigger",
             {
                 "job_id": self.job_id,
+                "job_name": self.job_name,
                 "expected_statuses": self.expected_statuses,
                 "project_id": self.project_id,
                 "location": self.location,
@@ -235,11 +245,23 @@ class DataflowJobStatusTrigger(BaseTrigger):
         """
         try:
             while True:
-                job_status = await self.async_hook.get_job_status(
-                    job_id=self.job_id,
-                    project_id=self.project_id,
-                    location=self.location,
-                )
+                if self.job_name is not None and self.job_id is None:
+                    job = await self.async_hook.get_job_by_name(
+                        job_name=self.job_name,
+                        project_id=self.project_id,
+                        location=self.location,
+                    )
+                    if job is None:
+                        await asyncio.sleep(self.poll_sleep)
+                        continue
+                    self.job_id = job.id
+                    job_status = job.current_state
+                else:
+                    job_status = await self.async_hook.get_job_status(
+                        job_id=self.job_id,
+                        project_id=self.project_id,
+                        location=self.location,
+                    )
                 if job_status.name in self.expected_statuses:
                     yield TriggerEvent(
                         {


### PR DESCRIPTION
Summary

DataflowJobStatusSensor (and its trigger, DataflowJobStatusTrigger) previously
required a job_id, forcing users who don't have the job ID readily available
(e.g. jobs launched by external tools that don't push it to XCom) to write
custom operators just to look it up. This PR adds an alternative job_name
parameter so the sensor/trigger can locate and monitor a job by name instead.

Root cause

Dataflow job names are not globally unique, so simply exposing job_name as a
drop-in replacement for job_id isn't safe — multiple jobs (across retries/
backfills) can share a name. The sensor and trigger had no mechanism to
disambiguate between same-named jobs or to handle the case where the named
job hasn't been created yet.

Fix

- DataflowJobStatusSensor and DataflowJobStatusTrigger now accept job_id or
  job_name (exactly one required, enforced via exactly_one(), raising
  AirflowException otherwise).
- Added DataflowHook.fetch_job_by_name() (sync) and
  AsyncDataflowHook.get_job_by_name() (async), which list jobs in the given
  project/location, filter to exact name matches, and return the one with
  the latest createTime/create_time.
- If no job matching job_name exists yet, the sensor's poke() returns False
  and the trigger's run() sleeps and retries, so both keep sensing until the
  job appears or the task times out.
- Once resolved, job_id is pinned internally so subsequent logging/polling
  is unambiguous.
- job_name added to template_fields so it can be templated
  (e.g. job_name="daily-etl-{{ ds_nodash }}").

closes: #72875


Was generative AI tooling used ?

- [X] Yes - Claude

Generated-by: Claude following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)