### PR TITLE
Document Codespaces Docker troubleshooting for beginners

### DIFF
--- a/contributing-docs/03a_contributors_quick_start_beginners.rst
+++ b/contributing-docs/03a_contributors_quick_start_beginners.rst
@@ -189,9 +189,9 @@ Option B – One-Click GitHub Codespaces
 
       docker info
 
-   If ``docker info`` fails, try rebuilding the Codespace container
-   (Command Palette → *Codespaces: Rebuild Container*) or restarting
-   the Codespace from the GitHub Codespaces dashboard.
+   If ``docker info`` fails, see :ref:`troubleshooting_docker_in_codespaces`.
+   Do not rely on ``systemctl status docker`` in a Codespace: systemd is not
+   available there, so that command failing is expected.
 
 5. Install Breeze and start the development container
 
@@ -204,6 +204,9 @@ Option B – One-Click GitHub Codespaces
       ./scripts/tools/setup_breeze
       uv run dev/ide_setup/setup_vscode.py
       breeze start-airflow
+
+   If ``breeze start-airflow`` reports that Docker is not running even though
+   ``docker --version`` succeeds, follow :ref:`troubleshooting_docker_in_codespaces`.
 
 6. Edit a file in the editor, save, and commit via the Source Control sidebar.
    Push when prompted.

--- a/contributing-docs/quick-start-ide/contributors_quick_start_codespaces.rst
+++ b/contributing-docs/quick-start-ide/contributors_quick_start_codespaces.rst
@@ -46,10 +46,19 @@ Setup and develop using GitHub Codespaces
    as Codespaces use Visual Studio Code as interface.
 
 
+.. _troubleshooting_docker_in_codespaces:
+
 Troubleshooting Docker in Codespaces
 -------------------------------------
 
-If you see a "Docker is not running" error when running Breeze commands, try these steps:
+If you see a "Docker is not running" error when running Breeze commands (for
+example during ``breeze start-airflow``), the Docker CLI may be installed while
+the daemon is still unreachable from your Codespace session. This is separate
+from checking whether ``systemctl status docker`` works: Codespaces do not run
+systemd, so that command failing with "System has not been booted with systemd"
+is expected and does **not** by itself mean Docker is unavailable.
+
+Try these steps:
 
 1. Verify that Docker is accessible by running:
 


### PR DESCRIPTION
## Summary
- Clarify in the Codespaces troubleshooting guide that `systemctl status docker` failing is expected because Codespaces do not run systemd.
- Link the beginner quick-start Codespaces steps to the troubleshooting section when `docker info` or `breeze start-airflow` fails.

Fixes #62405

## Test plan
- [ ] Verified RST cross-reference `:ref:` target renders in docs build
- [ ] Confirmed wording matches the reporter's Codespaces scenario (Docker CLI installed, daemon unreachable, systemd unavailable)
