### PR TITLE
Add redis_conn_id to RedisPublishOperator template_fields

### DIFF
--- a/providers/redis/src/airflow/providers/redis/operators/redis_publish.py
+++ b/providers/redis/src/airflow/providers/redis/operators/redis_publish.py
@@ -33,10 +33,10 @@ class RedisPublishOperator(BaseOperator):
 
     :param channel: redis channel to which the message is published (templated)
     :param message: the message to publish (templated)
-    :param redis_conn_id: redis connection to use
+    :param redis_conn_id: redis connection to use (templated)
     """
 
-    template_fields: Sequence[str] = ("channel", "message")
+    template_fields: Sequence[str] = ("channel", "message", "redis_conn_id")
 
     def __init__(self, *, channel: str, message: str, redis_conn_id: str = "redis_default", **kwargs) -> None:
         super().__init__(**kwargs)

--- a/providers/redis/tests/unit/redis/operators/test_redis_publish.py
+++ b/providers/redis/tests/unit/redis/operators/test_redis_publish.py
@@ -47,16 +47,3 @@ class TestRedisPublishOperator:
 
         mock_redis_conn.assert_called_once_with()
         mock_redis_conn().publish.assert_called_once_with(channel="test_channel", message="test_message")
-
-    def test_redis_conn_id_is_templated(self):
-        operator = RedisPublishOperator(
-            task_id="test_task",
-            dag=self.dag,
-            channel="test_channel",
-            message="test_message",
-            redis_conn_id="{{ conn_id }}",
-        )
-
-        assert "redis_conn_id" in operator.template_fields
-        operator.render_template_fields({"conn_id": "redis_custom"})
-        assert operator.redis_conn_id == "redis_custom"

--- a/providers/redis/tests/unit/redis/operators/test_redis_publish.py
+++ b/providers/redis/tests/unit/redis/operators/test_redis_publish.py
@@ -47,3 +47,16 @@ class TestRedisPublishOperator:
 
         mock_redis_conn.assert_called_once_with()
         mock_redis_conn().publish.assert_called_once_with(channel="test_channel", message="test_message")
+
+    def test_redis_conn_id_is_templated(self):
+        operator = RedisPublishOperator(
+            task_id="test_task",
+            dag=self.dag,
+            channel="test_channel",
+            message="test_message",
+            redis_conn_id="{{ conn_id }}",
+        )
+
+        assert "redis_conn_id" in operator.template_fields
+        operator.render_template_fields({"conn_id": "redis_custom"})
+        assert operator.redis_conn_id == "redis_custom"


### PR DESCRIPTION
`RedisPublishOperator` currently does not include `redis_conn_id` in
`template_fields`, so Jinja templates used for Redis connection IDs are not
rendered.

This PR adds `redis_conn_id` to `RedisPublishOperator.template_fields` and marks
it as templated in the operator documentation.

related: #35259

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-6 and GPT-5)

Generated-by: Codex (GPT-6 and GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

Drafted-by: Codex (GPT-6 and GPT-5) (no human review before posting)
