### PR TITLE
Add Stats.observable_gauge for callback-based OTel gauges

### DIFF
--- a/airflow-core/newsfragments/72887.feature.rst
+++ b/airflow-core/newsfragments/72887.feature.rst
@@ -1,0 +1,1 @@
+Add ``Stats.observable_gauge()`` for callback-based gauge metrics collected at OpenTelemetry export time.

--- a/airflow-core/src/airflow/observability/stats.py
+++ b/airflow-core/src/airflow/observability/stats.py
@@ -26,6 +26,7 @@ from airflow._shared.observability.metrics.stats import (
     incr,
     initialize,
     normalize_name_for_stats,
+    observable_gauge,
     timer,
     timing,
 )
@@ -37,6 +38,7 @@ __all__ = [
     "incr",
     "initialize",
     "normalize_name_for_stats",
+    "observable_gauge",
     "timer",
     "timing",
 ]

--- a/scripts/ci/prek/check_metrics_synced_with_the_registry.py
+++ b/scripts/ci/prek/check_metrics_synced_with_the_registry.py
@@ -48,6 +48,7 @@ STATS_METHOD_TO_TYPE: dict[str, str] = {
     "incr": "counter",
     "decr": "counter",
     "gauge": "gauge",
+    "observable_gauge": "gauge",
     "timing": "timer",
     "timer": "timer",
 }

--- a/shared/observability/src/airflow_shared/observability/metrics/base_stats_logger.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/base_stats_logger.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any, Protocol
 
 from .protocols import Timer
@@ -86,6 +86,16 @@ class StatsLogger(Protocol):
         """Timer metric that can be cancelled."""
         raise NotImplementedError()
 
+    @classmethod
+    def observable_gauge(
+        cls,
+        stat: str,
+        callback: Callable[..., Iterable[Any]],
+        *,
+        description: str = "",
+    ) -> None:
+        """Register a callback-based gauge whose values are collected at export time."""
+
 
 class NoStatsLogger:
     """If no StatsLogger is configured, NoStatsLogger is used as a fallback."""
@@ -126,3 +136,13 @@ class NoStatsLogger:
     def timer(cls, *args, **kwargs) -> Timer:
         """Timer metric that can be cancelled."""
         return Timer()
+
+    @classmethod
+    def observable_gauge(
+        cls,
+        stat: str,
+        callback: Callable[..., Iterable[Any]],
+        *,
+        description: str = "",
+    ) -> None:
+        """Observable gauge is a no-op when no backend is configured."""

--- a/shared/observability/src/airflow_shared/observability/metrics/datadog_logger.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/datadog_logger.py
@@ -142,6 +142,15 @@ class SafeDogStatsdLogger:
             return Timer(self.dogstatsd.timed(stat, tags=tags_list, **kwargs))
         return Timer()
 
+    def observable_gauge(
+        self,
+        stat: str,
+        callback,
+        *,
+        description: str = "",
+    ) -> None:
+        """Observable gauges are not supported by the Datadog backend; this is a no-op."""
+
 
 def get_dogstatsd_logger(
     *,

--- a/shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
@@ -26,6 +26,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from opentelemetry import metrics
+from opentelemetry.metrics import CallbackOptions, Observation
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics._internal.export import (
     ConsoleMetricExporter,
@@ -319,6 +320,40 @@ class SafeOtelLogger:
         """Timer context manager returns the duration and can be cancelled."""
         safe_stat = stat if self._is_recordable(stat) else None
         return _OtelTimer(self, safe_stat, tags)
+
+    def observable_gauge(
+        self,
+        stat: str,
+        callback,
+        *,
+        description: str = "",
+    ) -> None:
+        """
+        Register a callback-based gauge whose values are collected at export time.
+
+        The callback is invoked by the OTel SDK during metric collection (in the
+        export thread), not during registration.  It receives a single
+        ``timeout_millis`` argument (a ``float``) and must yield
+        ``(value, attributes)`` tuples where *value* is numeric and
+        *attributes* is an optional ``dict``.  The tuples are converted to
+        :class:`~opentelemetry.metrics.Observation` objects internally.
+
+        :param stat: The metric name.
+        :param callback: A callable that yields ``(value, attributes)`` tuples.
+        :param description: Optional human-readable description of the metric.
+        """
+        if not self._is_recordable(stat):
+            return
+
+        def _otel_callback(options: CallbackOptions):
+            for value, attributes in callback(options.timeout_millis):
+                yield Observation(value=value, attributes=attributes)
+
+        self.meter.create_observable_gauge(
+            name=_get_otel_safe_name(full_name(prefix=self.prefix, name=stat)),
+            callbacks=[_otel_callback],
+            description=description,
+        )
 
 
 class InternalGauge:

--- a/shared/observability/src/airflow_shared/observability/metrics/stats.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/stats.py
@@ -260,6 +260,27 @@ def gauge(
     backend.gauge(stat, value, **_defined(rate=rate, delta=delta, tags=tags))
 
 
+def observable_gauge(
+    stat: str,
+    callback: Callable[..., Iterable[Any]],
+    *,
+    description: str = "",
+) -> None:
+    """
+    Register a callback-based gauge whose values are collected at export time.
+
+    The callback is invoked by the metrics SDK during periodic collection (in the
+    export thread), not during registration.  It receives a single ``timeout_millis``
+    argument (a ``float``) and must yield ``(value, attributes)`` tuples where
+    *value* is numeric and *attributes* is an optional ``dict``.
+
+    On backends that do not support observable instruments (StatsD, Datadog),
+    this is a no-op.
+    """
+    backend = _get_backend()
+    backend.observable_gauge(stat, callback, description=description)
+
+
 def timing(
     stat: str,
     dt: DeltaType,
@@ -354,5 +375,6 @@ class Stats:
     incr = staticmethod(incr)
     decr = staticmethod(decr)
     gauge = staticmethod(gauge)
+    observable_gauge = staticmethod(observable_gauge)
     timing = staticmethod(timing)
     timer = staticmethod(timer)

--- a/shared/observability/src/airflow_shared/observability/metrics/statsd_logger.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/statsd_logger.py
@@ -155,6 +155,15 @@ class SafeStatsdLogger:
             return Timer(self.statsd.timer(stat, *args, **kwargs))
         return Timer()
 
+    def observable_gauge(
+        self,
+        stat: str,
+        callback,
+        *,
+        description: str = "",
+    ) -> None:
+        """Observable gauges are not supported by the StatsD backend; this is a no-op."""
+
 
 def _make_safe_statsd_logger(
     statsd_client: StatsClient,

--- a/shared/observability/tests/observability/metrics/test_otel_logger.py
+++ b/shared/observability/tests/observability/metrics/test_otel_logger.py
@@ -304,6 +304,97 @@ class TestOtelMetrics:
 
         assert self.map[full_name(name)].value == 1
 
+    def test_observable_gauge_registers_callback(self, name):
+        def my_callback(timeout_millis):
+            yield (42.0, {"key": "value"})
+
+        self.stats.observable_gauge(name, my_callback, description="test gauge")
+
+        self.meter.get_meter().create_observable_gauge.assert_called_once()
+        call_kwargs = self.meter.get_meter().create_observable_gauge.call_args
+        assert call_kwargs.kwargs["name"] == full_name(name)
+        assert call_kwargs.kwargs["description"] == "test gauge"
+        assert len(call_kwargs.kwargs["callbacks"]) == 1
+
+    def test_observable_gauge_callback_is_invoked(self, name):
+        """Verify the wrapper yields Observation objects when the callback is invoked."""
+        from opentelemetry.metrics import Observation
+
+        def my_callback(timeout_millis):
+            yield (10.0, {"pool": "default"})
+            yield (20.0, {"pool": "secondary"})
+
+        self.stats.observable_gauge(name, my_callback)
+
+        call_kwargs = self.meter.get_meter().create_observable_gauge.call_args
+        otel_callback = call_kwargs.kwargs["callbacks"][0]
+
+        results = list(otel_callback(mock.Mock(timeout_millis=5000.0)))
+        assert len(results) == 2
+        assert isinstance(results[0], Observation)
+        assert results[0].value == 10.0
+        assert results[0].attributes == {"pool": "default"}
+        assert results[1].value == 20.0
+        assert results[1].attributes == {"pool": "secondary"}
+
+    def test_observable_gauge_callback_exception_does_not_crash(self, name):
+        """OTel SDK catches callback exceptions; verify our wrapper propagates them cleanly."""
+
+        def bad_callback(timeout_millis):
+            raise ValueError("boom")
+
+        self.stats.observable_gauge(name, bad_callback)
+
+        call_kwargs = self.meter.get_meter().create_observable_gauge.call_args
+        otel_callback = call_kwargs.kwargs["callbacks"][0]
+
+        with pytest.raises(ValueError, match="boom"):
+            list(otel_callback(mock.Mock(timeout_millis=5000.0)))
+
+    def test_observable_gauge_invalid_stat_name_skipped(self):
+        def my_callback(timeout_millis):
+            yield (1.0, None)
+
+        self.stats.observable_gauge("invalid/$tats", my_callback)
+
+        self.meter.get_meter().create_observable_gauge.assert_not_called()
+
+    def test_observable_gauge_empty_stat_name_skipped(self):
+        def my_callback(timeout_millis):
+            yield (1.0, None)
+
+        self.stats.observable_gauge("", my_callback)
+
+        self.meter.get_meter().create_observable_gauge.assert_not_called()
+
+    def test_observable_gauge_empty_callback_yields_no_observations(self, name):
+        def empty_callback(timeout_millis):
+            return []
+
+        self.stats.observable_gauge(name, empty_callback)
+
+        call_kwargs = self.meter.get_meter().create_observable_gauge.call_args
+        otel_callback = call_kwargs.kwargs["callbacks"][0]
+
+        results = list(otel_callback(mock.Mock(timeout_millis=5000.0)))
+        assert results == []
+
+    def test_observable_gauge_timeout_millis_forwarded(self, name):
+        """Verify that the OTel CallbackOptions.timeout_millis is forwarded to the user callback."""
+        received_timeout = []
+
+        def my_callback(timeout_millis):
+            received_timeout.append(timeout_millis)
+            yield (1.0, None)
+
+        self.stats.observable_gauge(name, my_callback)
+
+        call_kwargs = self.meter.get_meter().create_observable_gauge.call_args
+        otel_callback = call_kwargs.kwargs["callbacks"][0]
+
+        list(otel_callback(mock.Mock(timeout_millis=3000.0)))
+        assert received_timeout == [3000.0]
+
     def test_timing_new_metric(self, name):
         import datetime
 

--- a/shared/observability/tests/observability/metrics/test_stats.py
+++ b/shared/observability/tests/observability/metrics/test_stats.py
@@ -131,6 +131,14 @@ class TestStats:
         self.stats.gauge("empty", 123)
         self.statsd_client.gauge.assert_called_once_with("empty", 123, 1, False)
 
+    def test_observable_gauge_is_noop(self):
+        def my_callback(timeout_millis):
+            yield (1.0, None)
+
+        self.stats.observable_gauge("some_metric", my_callback)
+        self.statsd_client.gauge.assert_not_called()
+        self.statsd_client.assert_not_called()
+
     def test_decr(self):
         self.stats.decr("empty")
         self.statsd_client.decr.assert_called_once_with("empty", 1, 1)
@@ -279,6 +287,14 @@ class TestDogStats:
     def test_gauge(self):
         self.dogstatsd.gauge("empty", 123)
         self.dogstatsd_client.gauge.assert_called_once_with(metric="empty", sample_rate=1, value=123, tags=[])
+
+    def test_observable_gauge_is_noop(self):
+        def my_callback(timeout_millis):
+            yield (1.0, None)
+
+        self.dogstatsd.observable_gauge("some_metric", my_callback)
+        self.dogstatsd_client.gauge.assert_not_called()
+        self.dogstatsd_client.assert_not_called()
 
     def test_decr(self):
         self.dogstatsd.decr("empty")
@@ -765,6 +781,31 @@ class TestLegacyExport:
         assert mock_backend.timer.call_count == 2
         mock_backend.timer.assert_any_call("operator_failures_EmptyOperator")
         mock_backend.timer.assert_any_call("operator_failures", tags={"operator_name": "EmptyOperator"})
+
+    def test_observable_gauge_delegates_to_backend(self, mock_backend):
+        def my_callback(timeout_millis):
+            yield (1.0, None)
+
+        airflow_shared.observability.metrics.stats.observable_gauge("some_metric", my_callback)
+        mock_backend.observable_gauge.assert_called_once_with("some_metric", my_callback, description="")
+
+    def test_observable_gauge_class_delegates_to_backend(self, mock_backend):
+        def my_callback(timeout_millis):
+            yield (1.0, None)
+
+        airflow_shared.observability.metrics.stats.Stats.observable_gauge("some_metric", my_callback)
+        mock_backend.observable_gauge.assert_called_once_with("some_metric", my_callback, description="")
+
+    def test_observable_gauge_with_description(self, mock_backend):
+        def my_callback(timeout_millis):
+            yield (1.0, None)
+
+        airflow_shared.observability.metrics.stats.observable_gauge(
+            "some_metric", my_callback, description="A test gauge"
+        )
+        mock_backend.observable_gauge.assert_called_once_with(
+            "some_metric", my_callback, description="A test gauge"
+        )
 
 
 class TestCustomStatsName:

--- a/task-sdk/src/airflow/sdk/observability/stats.py
+++ b/task-sdk/src/airflow/sdk/observability/stats.py
@@ -26,6 +26,7 @@ from airflow.sdk._shared.observability.metrics.stats import (
     incr,
     initialize,
     normalize_name_for_stats,
+    observable_gauge,
     timer,
     timing,
 )
@@ -37,6 +38,7 @@ __all__ = [
     "incr",
     "initialize",
     "normalize_name_for_stats",
+    "observable_gauge",
     "timer",
     "timing",
 ]


### PR DESCRIPTION
Add a callback-based ``Stats.observable_gauge(name, callback, description=...)`` API to the Stats observability interface. Instead of a caller pushing a value at a moment in time (the existing ``Stats.gauge``), a callback is registered once and the metrics SDK invokes it on its own export/collection cadence, guaranteeing a fresh "current state" sample every collection cycle.

Implemented in the OpenTelemetry backend (`SafeOtelLogger`) via `create_observable_gauge`: the user callback receives the collection timeout and yields `(value, attributes)` tuples, which are converted to OTel `Observation` objects internally. Callback exceptions are handled by the OTel SDK (logged, do not crash collection). `Stats.gauge` and all other existing Stats methods are unchanged and fully backward compatible.

On non-OTel backends (StatsD, Datadog) and when no backend is configured, `observable_gauge` is a silent no-op — those backends do not support observable instruments. The prek metrics-registry hook is updated to classify `observable_gauge` as type `gauge`.

Validation:
- OTel backend tests: 7 new (registration, callback invocation, exception propagation, invalid/empty names, empty callback, timeout forwarding) — all pass
- Stats facade/StatsD/Datadog tests: 5 new (delegation via module + `Stats` class, description passthrough, no-op behavior) — all pass
- prek registry hook tests: 106 pass
- ruff, mypy, `git diff --check`: clean

closes: #72885

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — big-pickle

Generated-by: big-pickle following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)