### PR TITLE
Drop the redundant OAuth2 branch from get_user and collect_request_tokens

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/auth.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/auth.py
@@ -67,18 +67,15 @@ def login(request: Request, auth_manager: AuthManagerDep, next: None | str = Non
 def logout(
     request: Request,
     auth_manager: AuthManagerDep,
-    oauth_token: str | None = Depends(oauth2_scheme),
+    # Kept for the OpenAPI security spec so ``/docs`` still renders the OAuth2 password
+    # login form. It resolves to the same ``Authorization: Bearer`` header
+    # ``bearer_scheme`` reads, so the value is unused at runtime.
+    _oauth_token: str | None = Depends(oauth2_scheme),
     bearer_credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
 ) -> RedirectResponse:
     """Logout the user."""
-    # Revoke every credential presented before any redirect or cookie deletion, so the
-    # JWT is invalidated even when the auth manager redirects to an external logout URL.
-    #
-    # This previously read only the `_token` cookie. A client that authenticates with an
-    # `Authorization: Bearer` header -- the documented way to call the API -- therefore
-    # got a successful logout response while its token was never revoked, and the token
-    # stayed valid until it expired.
-    for token_str in collect_request_tokens(request, oauth_token, bearer_credentials):
+    # Invalidate both tokens from the Authorization header and the _token cookie, if present.
+    for token_str in collect_request_tokens(request, bearer_credentials):
         auth_manager.revoke_token(token_str)
 
     logout_url = auth_manager.get_url_logout()

--- a/airflow-core/src/airflow/api_fastapi/core_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/security.py
@@ -144,14 +144,15 @@ USER_INJECTED_BY_TRUSTED_MIDDLEWARE = object()
 
 async def get_user(
     request: Request,
-    oauth_token: str | None = Depends(oauth2_scheme),
+    # Kept for the OpenAPI security spec so ``/docs`` still renders the OAuth2 password
+    # login form. It resolves to the same ``Authorization: Bearer`` header
+    # ``bearer_scheme`` reads, so the value is unused at runtime.
+    _oauth_token: str | None = Depends(oauth2_scheme),
     bearer_credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
 ) -> BaseUser:
     # An explicitly supplied credential always wins over the ambient session cookie.
     if bearer_credentials and bearer_credentials.scheme.lower() == "bearer":
         return await resolve_user_from_token(bearer_credentials.credentials)
-    if oauth_token:
-        return await resolve_user_from_token(oauth_token)
 
     # No explicit credential on this request, so the cookie is the caller's identity.
     # A user might have been already built by a trusted in-tree middleware (currently
@@ -168,7 +169,6 @@ async def get_user(
 
 def collect_request_tokens(
     request: Request,
-    oauth_token: str | None,
     bearer_credentials: HTTPAuthorizationCredentials | None,
 ) -> list[str]:
     """
@@ -183,7 +183,6 @@ def collect_request_tokens(
     candidates: list[str | None] = []
     if bearer_credentials and bearer_credentials.scheme.lower() == "bearer":
         candidates.append(bearer_credentials.credentials)
-    candidates.append(oauth_token)
     candidates.append(request.cookies.get(COOKIE_NAME_JWT_TOKEN))
 
     tokens: list[str] = []

--- a/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
@@ -206,17 +206,8 @@ class TestFastApiSecurity:
         assert result == resolved_user
         mock_resolve_user_from_token.assert_called_once_with("cookie_token")
 
-    @pytest.mark.parametrize(
-        ("oauth_token", "bearer_credentials_creds", "expected"),
-        [
-            pytest.param(None, "bearer_token", "bearer_token", id="bearer"),
-            pytest.param("oauth_token", None, "oauth_token", id="oauth"),
-        ],
-    )
     @patch("airflow.api_fastapi.core_api.security.resolve_user_from_token")
-    async def test_get_user_explicit_credential_beats_cookie_user(
-        self, mock_resolve_user_from_token, oauth_token, bearer_credentials_creds, expected
-    ):
+    async def test_get_user_explicit_credential_beats_cookie_user(self, mock_resolve_user_from_token):
         """An explicitly supplied credential wins over the cookie-derived session user.
 
         `JWTRefreshMiddleware` resolves a user from the `_token` cookie alone and stamps
@@ -236,29 +227,26 @@ class TestFastApiSecurity:
         request.state.user_authenticated_via = USER_INJECTED_BY_TRUSTED_MIDDLEWARE
         request.cookies = {COOKIE_NAME_JWT_TOKEN: "cookie_token"}
 
-        bearer_credentials = None
-        if bearer_credentials_creds:
-            bearer_credentials = Mock()
-            bearer_credentials.scheme = "bearer"
-            bearer_credentials.credentials = bearer_credentials_creds
+        bearer_credentials = Mock()
+        bearer_credentials.scheme = "bearer"
+        bearer_credentials.credentials = "bearer_token"
 
-        result = await get_user(request, oauth_token, bearer_credentials)
+        result = await get_user(request, None, bearer_credentials)
 
         assert result == token_user
         assert result != cookie_user
-        mock_resolve_user_from_token.assert_called_once_with(expected)
+        mock_resolve_user_from_token.assert_called_once_with("bearer_token")
 
     @pytest.mark.parametrize(
-        ("oauth_token", "bearer_credentials_creds", "cookies", "expected"),
+        ("bearer_credentials_creds", "cookies", "expected"),
         [
-            ("oauth_token", None, {}, "oauth_token"),
-            (None, "bearer_credentials_creds", {}, "bearer_credentials_creds"),
-            (None, None, {COOKIE_NAME_JWT_TOKEN: "cookie_token"}, "cookie_token"),
+            ("bearer_credentials_creds", {}, "bearer_credentials_creds"),
+            (None, {COOKIE_NAME_JWT_TOKEN: "cookie_token"}, "cookie_token"),
         ],
     )
     @patch("airflow.api_fastapi.core_api.security.resolve_user_from_token")
     async def test_get_user_with_token(
-        self, mock_resolve_user_from_token, oauth_token, bearer_credentials_creds, cookies, expected
+        self, mock_resolve_user_from_token, bearer_credentials_creds, cookies, expected
     ):
         user = Mock()
         mock_resolve_user_from_token.return_value = user
@@ -272,7 +260,7 @@ class TestFastApiSecurity:
             bearer_credentials.scheme = "bearer"
             bearer_credentials.credentials = bearer_credentials_creds
 
-        result = await get_user(request, oauth_token, bearer_credentials)
+        result = await get_user(request, None, bearer_credentials)
 
         assert result == user
         mock_resolve_user_from_token.assert_called_once_with(expected)


### PR DESCRIPTION
Follow-up to #72649, and stacked on it.

`HTTPBearer` and `OAuth2PasswordBearer` both extract the same `Authorization:
Bearer <token>` header. Declaring both as FastAPI dependencies produces the
same token string twice on every request, so:

- `get_user()` had a dead second branch: the OAuth2 branch never ran because
  the `HTTPBearer` branch above it always matched first for any valid bearer
  request.
- `collect_request_tokens()` (introduced by #72649) deduped the duplicate
  anyway.

Drop the runtime branch in both. `oauth2_scheme` stays declared as an unused
parameter on `get_user` and `logout` so the **OpenAPI security spec is
unchanged** and `/docs` still renders the OAuth2 password login form — this
is purely a runtime dead-code cleanup, no user-facing surface changes.

Verified locally: regenerated OpenAPI spec is byte-identical to the one on
#72649's HEAD; 130 tests pass in `test_security.py` + `test_auth.py`; ruff
and mypy clean.

This PR is stacked on #72649 and should be merged after it.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)