### PR TITLE
Return 404 instead of 500 when ti_run cannot find the DagRun

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -276,7 +276,7 @@ def ti_run(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail={
                     "reason": "not_found",
-                    "message": f"DagRun with dag_id={ti.dag_id} and run_id={ti.run_id} not found.",
+                    "message": f"DagRun with dag_id={ti.dag_id} and run_id={ti.run_id} not found",
                 },
             )
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -272,7 +272,13 @@ def ti_run(
 
         if not dr:
             log.error("DagRun not found", dag_id=ti.dag_id, run_id=ti.run_id)
-            raise ValueError(f"DagRun with dag_id={ti.dag_id} and run_id={ti.run_id} not found.")
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={
+                    "reason": "not_found",
+                    "message": f"DagRun with dag_id={ti.dag_id} and run_id={ti.run_id} not found.",
+                },
+            )
 
         # Send the keys to the SDK so that the client requests to clear those XComs from the server.
         # The reason we cannot do this here in the server is because we need to issue a purge on custom XCom backends

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -237,7 +237,7 @@ class TestTIRunState:
         assert response.status_code == 404
         assert response.json()["detail"] == {
             "reason": "not_found",
-            "message": f"DagRun with dag_id={ti.dag_id} and run_id={ti.run_id} not found.",
+            "message": f"DagRun with dag_id={ti.dag_id} and run_id={ti.run_id} not found",
         }
 
     @pytest.mark.parametrize(

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -216,8 +216,7 @@ class TestTIRunState:
         events = response.json()["dag_run"]["consumed_asset_events"]
         assert [e["partition_key"] for e in events] == ["2024-01-15"]
 
-    @mock.patch("sqlalchemy.orm.Session.scalars")
-    def test_ti_run_missing_dagrun_returns_404(self, mock_scalars, client, session, create_task_instance):
+    def test_ti_run_missing_dagrun_returns_404(self, client, session, create_task_instance):
         """A missing DagRun must surface as a clean 404, not an internal 500."""
         ti = create_task_instance(
             task_id="test_ti_run_missing_dagrun",
@@ -226,13 +225,14 @@ class TestTIRunState:
         )
         session.commit()
 
-        # Force the DagRun lookup (the only scalars() call before the guard) to return None.
-        mock_scalars.return_value.unique.return_value.one_or_none.return_value = None
-
-        response = client.patch(
-            f"/execution/task-instances/{ti.id}/run",
-            json=self.RUN_PAYLOAD,
-        )
+        # Patch only around the request so fixture setup above is untouched; force the DagRun
+        # lookup (the only scalars() call before the guard) to return None.
+        with mock.patch("sqlalchemy.orm.Session.scalars", autospec=True) as mock_scalars:
+            mock_scalars.return_value.unique.return_value.one_or_none.return_value = None
+            response = client.patch(
+                f"/execution/task-instances/{ti.id}/run",
+                json=self.RUN_PAYLOAD,
+            )
 
         assert response.status_code == 404
         assert response.json()["detail"] == {

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -216,6 +216,30 @@ class TestTIRunState:
         events = response.json()["dag_run"]["consumed_asset_events"]
         assert [e["partition_key"] for e in events] == ["2024-01-15"]
 
+    @mock.patch("sqlalchemy.orm.Session.scalars")
+    def test_ti_run_missing_dagrun_returns_404(self, mock_scalars, client, session, create_task_instance):
+        """A missing DagRun must surface as a clean 404, not an internal 500."""
+        ti = create_task_instance(
+            task_id="test_ti_run_missing_dagrun",
+            state=State.QUEUED,
+            session=session,
+        )
+        session.commit()
+
+        # Force the DagRun lookup (the only scalars() call before the guard) to return None.
+        mock_scalars.return_value.unique.return_value.one_or_none.return_value = None
+
+        response = client.patch(
+            f"/execution/task-instances/{ti.id}/run",
+            json=self.RUN_PAYLOAD,
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == {
+            "reason": "not_found",
+            "message": f"DagRun with dag_id={ti.dag_id} and run_id={ti.run_id} not found.",
+        }
+
     @pytest.mark.parametrize(
         ("max_tries", "should_retry"),
         [


### PR DESCRIPTION
The Execution API `ti_run` route raised a bare `ValueError` when the DagRun for a task instance could not be found. That `try` block only guards `DataError` and `SQLAlchemyError`, so the `ValueError` escaped to the app-level `Exception` handler and the caller received an opaque `500 {"message": "Internal server error"}`.

A missing resource should be reported as a `404`. This replaces the `ValueError` with an `HTTPException(404, ...)` whose RFC 9457-style `{"reason": "not_found", "message": ...}` detail matches the other not-found responses in this route, so Starlette's `HTTPException` handler renders a clean 404.

This is a defensive branch (a task instance's `run_id` is FK-bound to a DagRun, so `dr is None` should not occur in a consistent DB), so it is a low-blast-radius error-path correctness fix with a regression test.

closes: #69392

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)