### PR TITLE
Reject non-numeric --limit values in airflow dags list-jobs

### DIFF
--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -294,7 +294,7 @@ ARG_DR_STATE = Arg(
 
 # list_jobs
 ARG_DAG_ID_OPT = Arg(("-d", "--dag-id"), help="The id of the dag")
-ARG_LIMIT = Arg(("--limit",), help="Return a limited number of records")
+ARG_LIMIT = Arg(("--limit",), type=positive_int(allow_zero=True), help="Return a limited number of records")
 job_states = tuple(state.value for state in JobState)
 ARG_JOB_STATE = Arg(
     ("--state",),

--- a/airflow-core/tests/unit/cli/test_cli_parser.py
+++ b/airflow-core/tests/unit/cli/test_cli_parser.py
@@ -635,6 +635,15 @@ class TestCli:
         assert e.value.code == 2
         assert "unrecognized arguments: --output json" in stderr.getvalue()
 
+    @pytest.mark.parametrize("bad_value", ["abc", "-1"])
+    def test_dags_list_jobs_rejects_invalid_limit(self, bad_value):
+        with contextlib.redirect_stderr(StringIO()) as stderr:
+            parser = cli_parser.get_parser()
+            with pytest.raises(SystemExit) as e:
+                parser.parse_args(["dags", "list-jobs", "--limit", bad_value])
+        assert e.value.code == 2
+        assert f"argument --limit: invalid positive int value: '{bad_value}'" in stderr.getvalue()
+
     @pytest.mark.parametrize(
         "action_cmd",
         [


### PR DESCRIPTION
`airflow dags list-jobs --limit <not-a-number>` now fails with a normal argparse usage error instead of a SQLAlchemy traceback.

### Why

`ARG_LIMIT`, the `--limit` option of `airflow dags list-jobs`, was declared without an argparse `type=`, so whatever the user typed was kept as a string and handed straight to `select(...).limit(args.limit)`. SQLAlchemy then tried to coerce it and the command died deep inside `sqlalchemy/util/langhelpers.py`:

    $ airflow dags list-jobs --limit abc
    ...
      File ".../sqlalchemy/util/langhelpers.py", line 1348, in asint
        return int(value)
    ValueError: invalid literal for int() with base 10: 'abc'
    (exit code 1)

Nothing in that output tells the user that `--limit` was the problem. A negative value was even worse: SQLite treats `LIMIT -1` as "no limit" while PostgreSQL rejects it, so the same invocation behaved differently per backend. It is the only numeric option in `cli_config.py` that had no type.

### What

`ARG_LIMIT` now uses the existing `positive_int(allow_zero=True)` validator, so non-numeric and negative values are rejected by argparse before any database access, with the standard message and exit code 2:

    $ airflow dags list-jobs --limit abc
    airflow dags list-jobs: error: argument --limit: invalid positive int value: 'abc'
    (exit code 2)

`allow_zero=True` is deliberate: `--limit 0` was accepted before this change (it compiled to `LIMIT 0` and printed an empty table with exit code 0) and keeps working exactly the same way, and it matches the sibling `airflow jobs check --limit`, which also accepts 0. Omitting `--limit` is unchanged too (`args.limit` stays `None`, no `LIMIT` clause). The only behaviour that changes is for inputs that previously produced a traceback.

The CLI reference docs are generated from the parser via the `argparse` Sphinx directive, so no doc edits are needed.

### How to test

Automated, `airflow-core/tests/unit/cli/test_cli_parser.py`:

- `TestCli::test_dags_list_jobs_rejects_invalid_limit[abc]` and `[-1]` assert exit code 2 and the `argument --limit: invalid positive int value` message on stderr.
- `uv run --project airflow-core pytest airflow-core/tests/unit/cli/test_cli_parser.py -xvs` (whole file: 46 passed with the change; the two new cases fail on `main`, where argparse accepts the strings and no `SystemExit` is raised).
- `airflow-core/tests/unit/cli/commands/test_dag_command.py` was run in full to confirm the existing `list-jobs` tests (`--limit 100` and no `--limit`) still pass.

Manual, against a fresh `airflow db migrate` SQLite database:

- `airflow dags list-jobs --limit abc` and `--limit -1` now exit 2 with the usage error shown above (before: `ValueError` traceback, exit 1).
- `airflow dags list-jobs --limit 0` and `--limit 5` print `No data found` and exit 0, same as before.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5.1)

Generated-by: Claude Code (Fable 5.1) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
