### PR TITLE
Show a clean error when airflow backfill create targets an unknown Dag

### DIFF
--- a/airflow-core/src/airflow/cli/commands/backfill_command.py
+++ b/airflow-core/src/airflow/cli/commands/backfill_command.py
@@ -27,7 +27,7 @@ from airflow import settings
 from airflow.api_fastapi.common.dagbag import resolve_run_on_latest_version
 from airflow.cli.simple_table import AirflowConsole
 from airflow.cli.utils import deprecated_for_airflowctl
-from airflow.exceptions import AirflowConfigException
+from airflow.exceptions import AirflowConfigException, DagNotFound
 from airflow.models.backfill import NoBackfillRunsToCreate, ReprocessBehavior, _create_backfill, _do_dry_run
 from airflow.utils import cli as cli_utils
 from airflow.utils.cli import sigint_handler
@@ -83,15 +83,20 @@ def create_backfill(args) -> None:
         for k, v in params.items():
             console.print(f"    - {k} = {v}")
         with create_session() as session:
-            infos = _do_dry_run(
-                dag_id=args.dag_id,
-                from_date=args.from_date,
-                to_date=args.to_date,
-                reverse=args.run_backwards,
-                reprocess_behavior=reprocess_behavior or ReprocessBehavior.NONE,
-                dag_run_conf=dag_run_conf,
-                session=session,
-            )
+            try:
+                infos = list(
+                    _do_dry_run(
+                        dag_id=args.dag_id,
+                        from_date=args.from_date,
+                        to_date=args.to_date,
+                        reverse=args.run_backwards,
+                        reprocess_behavior=reprocess_behavior or ReprocessBehavior.NONE,
+                        dag_run_conf=dag_run_conf,
+                        session=session,
+                    )
+                )
+            except DagNotFound as e:
+                raise SystemExit(str(e))
         console.print("Runs to be attempted:")
         rows = [
             dict(logical_date=d.logical_date, partition_key=d.partition_key, partition_date=d.partition_date)
@@ -119,6 +124,8 @@ def create_backfill(args) -> None:
             reprocess_behavior=reprocess_behavior,
             run_on_latest_version=resolved_run_on_latest,
         )
+    except DagNotFound as e:
+        raise SystemExit(str(e))
     except NoBackfillRunsToCreate as e:
         console.print(f"[yellow]Warning:[/yellow] {e}")
         raise SystemExit(1)

--- a/airflow-core/tests/unit/cli/commands/test_backfill_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_backfill_command.py
@@ -321,3 +321,20 @@ class TestCliBackfill:
         with pytest.raises(SystemExit) as exc_info:
             airflow.cli.commands.backfill_command.create_backfill(self.parser.parse_args(args))
         assert exc_info.value.code == 1
+
+    @pytest.mark.parametrize("dry_run", [False, True])
+    def test_backfill_unknown_dag_shows_friendly_message(self, dry_run):
+        args = [
+            "backfill",
+            "create",
+            "--dag-id",
+            "does_not_exist",
+            "--from-date",
+            DEFAULT_DATE.isoformat(),
+            "--to-date",
+            DEFAULT_DATE.isoformat(),
+        ]
+        if dry_run:
+            args.append("--dry-run")
+        with pytest.raises(SystemExit, match="does_not_exist"):
+            airflow.cli.commands.backfill_command.create_backfill(self.parser.parse_args(args))


### PR DESCRIPTION
`airflow backfill create --dag-id <unknown>` now prints a one-line error and exits 1 instead of dumping a `DagNotFound` traceback, in both the normal and `--dry-run` paths.

### Why

Mistyping the Dag id is the most ordinary user error this command can see, and today it looks like a crash:

    $ airflow backfill create --dag-id does_not_exist --from-date 2025-01-01 --to-date 2025-01-02
    Traceback (most recent call last):
      ...
      File ".../airflow/models/backfill.py", line 641, in _create_backfill
        raise DagNotFound(f"Could not find dag {dag_id}")
    airflow.exceptions.DagNotFound: Could not find dag does_not_exist

The model layer raises `DagNotFound` on purpose (it serves both the REST API and the CLI), and the REST route already maps it to a 404. The CLI handler only caught `NoBackfillRunsToCreate`, so this exception escaped untranslated. Every other CLI "Dag does not exist" path (`dags list-jobs`, `dags list-runs`, `dags state`, ...) already reports it as a plain message on stderr.

The `--dry-run` path had a second wrinkle: `_do_dry_run` is a generator, so its body (including the Dag lookup that raises) only ran when the result was iterated, which happened after the `create_session()` block had exited and outside any `try`.

### What

- Catch `DagNotFound` at the CLI boundary and re-raise it as `SystemExit(str(e))`, which writes the message to stderr and exits 1, the same idiom the other CLI "not found" paths use. The exit code is unchanged from the traceback case, so scripts checking `$?` see no difference.
- In the dry-run branch, consume `_do_dry_run(...)` with `list(...)` inside the session block and the `try`. Without this the new handler would be unreachable, because the exception surfaces on iteration, not on the call. As a side effect the generator now runs while the session it was given is still open; previously it ran after `session.close()`.

Deliberately out of scope: the sibling validation errors from the same two model calls (`AlreadyRunningBackfill`, `DagNonPeriodicScheduleException`, `DagRunTypeNotAllowed`, `InvalidBackfillDateRange`, ...) still surface as tracebacks. They share the root cause but each needs its own message and test; this PR only fixes the missing-Dag case. Happy to follow up with the rest if reviewers prefer one PR.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5.1)

Generated-by: Claude Code (Fable 5.1) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

