### PR TITLE
Mark task-group aggregate bars on Gantt with a diagonal stripe

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/GanttTimeline.test.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/GanttTimeline.test.tsx
@@ -329,4 +329,50 @@ describe("GanttTimeline segment bars", () => {
     // Only the execution bar should be rendered; scheduled and queued are too narrow.
     expect(screen.getAllByRole("link")).toHaveLength(1);
   });
+
+  it("hatches a task-group aggregate bar so it does not read as a single long task", () => {
+    const groupNode: GridTask = {
+      depth: 0,
+      id: "group_1",
+      is_mapped: false,
+      isGroup: true,
+      label: "group_1",
+    };
+    const groupSegment: GanttDataItem = {
+      queued_when: null,
+      scheduled_when: null,
+      state: "success",
+      taskId: "group_1",
+      tryNumber: undefined,
+      x: [new Date("2024-03-14T10:00:00Z").getTime(), new Date("2024-03-14T10:05:00Z").getTime()],
+      y: "group_1",
+    };
+    const leafSegment: GanttDataItem = {
+      queued_when: null,
+      scheduled_when: null,
+      state: "success",
+      taskId: "task_1",
+      tryNumber: 1,
+      x: [new Date("2024-03-14T10:00:00Z").getTime(), new Date("2024-03-14T10:05:00Z").getTime()],
+      y: "task_1",
+    };
+
+    render(
+      <GanttTimeline
+        {...defaultProps}
+        flatNodes={[groupNode, BASE_NODE]}
+        ganttDataItems={[groupSegment, leafSegment]}
+        rowSegments={[[groupSegment], [leafSegment]]}
+        scrollContainerRef={makeScrollRef()}
+      />,
+      { wrapper: TestWrapper },
+    );
+
+    const bars = screen.getAllByRole("link");
+
+    // Group aggregate bar carries the diagonal-stripe overlay.
+    expect(bars[0]?.querySelector('[style*="repeating-linear-gradient"]')).not.toBeNull();
+    // Regular task bar does not.
+    expect(bars[1]?.querySelector('[style*="repeating-linear-gradient"]')).toBeNull();
+  });
 });

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/GanttTimeline.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/GanttTimeline.tsx
@@ -385,6 +385,18 @@ export const GanttTimeline = ({
                               justifyContent="center"
                               minH={0}
                               p={0}
+                              // Aggregate task-group bars are the envelope of their children's
+                              // runtime, not a real running task. Overlay a diagonal stripe so
+                              // they read as an aggregate at a glance and don't get mistaken for
+                              // a single long-running task.
+                              style={
+                                node.isGroup === true
+                                  ? {
+                                      backgroundImage:
+                                        "repeating-linear-gradient(45deg, rgba(255,255,255,0.4) 0px, rgba(255,255,255,0.4) 3px, transparent 3px, transparent 6px)",
+                                    }
+                                  : undefined
+                              }
                               variant="solid"
                               w="100%"
                             >


### PR DESCRIPTION
A collapsed TaskGroup renders on the Gantt chart as a single bar spanning the
envelope of its children's runtime. That bar looks identical to a real task and
reads as one very long-running task at a glance — the confusion the linked
issue describes.

Overlay a diagonal stripe (`repeating-linear-gradient`) on group aggregate bars
so they are visually distinct from real task bars while keeping their duration
and position (so groups still line up with the sidebar for organisation). The
gradient composes on top of the badge's solid state color, so state remains
legible.

The stripe is applied via a `style` prop on the existing `<Badge>` rather than
an overlay element, keeping the diff tiny (one file, 12 source lines) and
preserving existing tooltip and click behavior unchanged.

Regression test in `GanttTimeline.test.tsx` — mounts a group node next to a
regular task node and asserts the group bar carries the diagonal-stripe
overlay while the regular bar does not. Verified locally: fails on `main`,
passes on this branch.

closes: #72434

Supersedes #72435 (thanks to @Kunal8954 for the earlier exploration and to
@jroachgolf84 for suggesting the hatch approach in that thread).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)