### PR TITLE
Fix DeadlockImminentError when a connection is resolved inside an async task (#71890)

### DIFF
--- a/providers/ssh/tests/unit/ssh/hooks/test_ssh_async.py
+++ b/providers/ssh/tests/unit/ssh/hooks/test_ssh_async.py
@@ -125,9 +125,11 @@ class TestSSHHookAsync:
 
         mock_ssh_client = mock.AsyncMock()
 
-        with mock.patch("asgiref.sync.sync_to_async") as mock_sync:
-            mock_sync.return_value = mock.AsyncMock(return_value=mock_conn_obj)
-
+        with mock.patch(
+            "airflow.providers.ssh.hooks.ssh.get_async_connection",
+            new_callable=mock.AsyncMock,
+            return_value=mock_conn_obj,
+        ):
             with mock.patch("asyncssh.connect", new_callable=mock.AsyncMock) as mock_connect:
                 mock_connect.return_value = mock_ssh_client
                 result = await hook._get_conn()

--- a/task-sdk/docs/deferred-vs-async-operators.rst
+++ b/task-sdk/docs/deferred-vs-async-operators.rst
@@ -234,7 +234,7 @@ This allows multiple paginated requests to be performed efficiently within a sin
 
        @task
        async def get_users():
-           hook = KiotaRequestAdapterHook.get_hook(conn_id="msgraph_default")
+           hook = await KiotaRequestAdapterHook.aget_hook(conn_id="msgraph_default")
 
            return await hook.paginated_run(url="users")
 

--- a/task-sdk/src/airflow/sdk/definitions/connection.py
+++ b/task-sdk/src/airflow/sdk/definitions/connection.py
@@ -153,10 +153,13 @@ class Connection:
         else:
             self.__dict__.update(attrs.asdict(self.from_uri(uri, conn_id=conn_id), recurse=False))
 
-    def get_uri(self) -> str:
-        """Generate and return connection in URI format."""
-        from urllib.parse import parse_qsl
+    def _build_uri(self, extra_dejson: dict) -> str:
+        """
+        Build the connection URI given a pre-resolved extra_dejson dict.
 
+        Shared by ``get_uri`` (sync) and ``aget_uri`` (async) so the
+        URI-assembly logic lives in exactly one place.
+        """
         if self.conn_type:
             uri = f"{self.conn_type.lower().replace('_', '-')}://"
         else:
@@ -202,7 +205,6 @@ class Connection:
 
         if self.extra:
             try:
-                extra_dejson = self.extra_dejson
                 query: str | None = urlencode(extra_dejson)
             except TypeError:
                 query = None
@@ -212,6 +214,20 @@ class Connection:
                 uri += ("?" if self.schema else "/?") + urlencode({self.EXTRA_KEY: self.extra})
 
         return uri
+
+    def get_uri(self) -> str:
+        """Generate and return connection in URI format."""
+        return self._build_uri(self.extra_dejson)
+
+    async def aget_uri(self) -> str:
+        """
+        Async version of ``get_uri``, safe for use inside an async task.
+
+        Calls ``aextra_dejson`` so that secret masking uses ``asend()``
+        instead of the synchronous ``send()``, preventing
+        ``DeadlockImminentError`` when invoked from within an async context.
+        """
+        return self._build_uri(await self.aextra_dejson())
 
     def get_hook(self, *, hook_params=None):
         """Return hook based on conn_type."""
@@ -304,6 +320,25 @@ class Connection:
             else:
                 mask_secret(extra)
 
+        return extra
+
+    async def aextra_dejson(self) -> dict:
+        """
+        Async version of ``extra_dejson``, safe for use inside an async task.
+
+        Uses ``amask_secret`` instead of the synchronous ``mask_secret``, so calling
+        this from within an async context does not trigger ``DeadlockImminentError``.
+        """
+        from airflow.sdk.log import amask_secret
+
+        extra: dict = {}
+        if self.extra:
+            try:
+                extra = json.loads(self.extra)
+            except JSONDecodeError:
+                log.exception("Failed to deserialize extra property `extra`, returning empty dictionary")
+            else:
+                await amask_secret(extra)
         return extra
 
     def get_extra_dejson(self) -> dict:

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -269,7 +269,16 @@ async def _async_get_connection(conn_id: str) -> Connection:
                 conn = await sync_to_async(secrets_backend.get_connection)(conn_id)  # type: ignore[assignment]
 
             if conn:
-                SecretCache.save_connection_uri(conn_id, conn.get_uri())
+                # Use aget_uri if the returned connection object supports it (the SDK's own
+                # Connection class does); otherwise fall back to the sync get_uri, since backends
+                # can hand back other connection-shaped objects (e.g. MetastoreBackend returns
+                # airflow.models.Connection, which has no aget_uri).
+                aget_uri = getattr(conn, "aget_uri", None)
+                if aget_uri is not None:
+                    uri = await aget_uri()
+                else:
+                    uri = await sync_to_async(conn.get_uri)()
+                SecretCache.save_connection_uri(conn_id, uri)
                 await _amask_connection_secrets(conn)
                 return conn
         except AirflowSecretsBackendAccessDenied:

--- a/task-sdk/tests/task_sdk/definitions/test_connection.py
+++ b/task-sdk/tests/task_sdk/definitions/test_connection.py
@@ -234,6 +234,58 @@ class TestConnections:
         connection.extra = '{"auth": {"type": "oauth"}, "headers": {"User-Agent": "Airflow"}}'
         assert connection.extra_dejson == {"auth": {"type": "oauth"}, "headers": {"User-Agent": "Airflow"}}
 
+    @pytest.mark.asyncio
+    @mock.patch("airflow.sdk.definitions.connection.Connection.aextra_dejson")
+    async def test_aget_uri(self, mock_aextra_dejson):
+        """aget_uri must produce the same URI as get_uri and use aextra_dejson."""
+        extra = {"charset": "utf8", "timeout": "30"}
+        mock_aextra_dejson.return_value = extra
+
+        conn = Connection(
+            conn_id="test_conn",
+            conn_type="mysql",
+            host="localhost",
+            login="user",
+            password="password",
+            schema="test_schema",
+            port=3306,
+            extra='{"charset": "utf8", "timeout": "30"}',
+        )
+
+        uri = await conn.aget_uri()
+        assert uri == conn.get_uri()
+        mock_aextra_dejson.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_aextra_dejson_calls_amask_secret(self):
+        """aextra_dejson must use amask_secret (async), never the sync mask_secret."""
+        connection = Connection(
+            conn_id="test_conn",
+            conn_type="http",
+            extra='{"api_key": "secret"}',
+        )
+
+        with (
+            mock.patch("airflow.sdk.log.amask_secret") as mock_amask,
+            mock.patch("airflow.sdk.log.mask_secret") as mock_mask,
+        ):
+            result = await connection.aextra_dejson()
+
+        assert result == {"api_key": "secret"}
+        mock_amask.assert_awaited_once_with({"api_key": "secret"})
+        mock_mask.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_aextra_dejson_no_extra(self):
+        """aextra_dejson must return an empty dict without calling amask_secret when extra is None."""
+        connection = Connection(conn_id="test_conn", conn_type="http")
+
+        with mock.patch("airflow.sdk.log.amask_secret") as mock_amask:
+            result = await connection.aextra_dejson()
+
+        assert result == {}
+        mock_amask.assert_not_called()
+
 
 class TestConnectionsFromSecrets:
     def test_get_connection_secrets_backend(self, mock_supervisor_comms, tmp_path):

--- a/task-sdk/tests/task_sdk/execution_time/test_context.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_context.py
@@ -1227,6 +1227,43 @@ class TestAsyncGetConnection:
             mock_supervisor_comms.send.assert_not_called()
             mock_supervisor_comms.asend.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_async_get_connection_uses_aget_uri_not_get_uri(self, mock_supervisor_comms):
+        """_async_get_connection must call aget_uri() when caching, never the sync get_uri().
+
+        get_uri() accesses extra_dejson which calls mask_secret() -> comms.send()
+        from the event-loop thread, triggering DeadlockImminentError in Airflow 3.3.1.
+        aget_uri() uses amask_secret() -> asend() and is safe in async contexts.
+        """
+        from airflow.sdk.execution_time.cache import SecretCache
+
+        sample_connection = Connection(
+            conn_id="test_conn",
+            conn_type="postgres",
+            host="localhost",
+            port=5432,
+            extra='{"sslmode": "require"}',
+        )
+
+        class MockSecretsBackend:
+            def get_connection(self, conn_id: str) -> Connection | None:
+                return sample_connection if conn_id == "test_conn" else None
+
+        with (
+            patch(
+                "airflow.sdk.execution_time.supervisor.ensure_secrets_backend_loaded", autospec=True
+            ) as mock_load,
+            mock.patch.object(SecretCache, "save_connection_uri"),
+        ):
+            mock_load.return_value = [MockSecretsBackend()]
+
+            await _async_get_connection("test_conn")
+
+            # get_uri() would reach the sync mask_secret() -> comms.send(), which deadlocks
+            # on the event-loop thread; aget_uri() must go through amask_secret() -> comms.asend().
+            mock_supervisor_comms.send.assert_not_called()
+            mock_supervisor_comms.asend.assert_awaited()
+
 
 class TestSecretsBackend:
     """Test that connection resolution uses the backend chain correctly."""


### PR DESCRIPTION
Backport of #71890 to `v3-3-test` for the 3.3.2 release.

Fixes `DeadlockImminentError` when a connection is resolved inside an async task: `_async_get_connection` now uses the connection's async `aget_uri()` when available (the SDK's own `Connection` gains it here), falling back to `sync_to_async(get_uri)` for connection-shaped objects that lack it (e.g. `MetastoreBackend`'s `airflow.models.Connection`).

Clean cherry-pick (all 6 files auto-merged, no conflicts). Independent of the deferred #72127 async asset-store work — it only touches `_async_get_connection` and adds `aget_uri`/`aextra_dejson` to the SDK `Connection`. task-sdk + provider (ssh async hook) regression tests are included and run in this PR's CI.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)