### PR TITLE
UI: Filter backfills by status

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
@@ -28,6 +28,11 @@
     "schedulerPriorityHint": "Backfill Dag runs are ordered after non-backfill Dag runs in each scheduler cycle. Backfill runs may remain queued longer if other non-backfill runs are present.",
     "selectDescription": "Run this Dag for a range of dates",
     "selectLabel": "Backfill",
+    "status": "Status",
+    "statusOptions": {
+      "active": "Active",
+      "completed": "Completed"
+    },
     "title": "Run Backfill",
     "toaster": {
       "success": {

--- a/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
+++ b/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
@@ -101,6 +101,15 @@ export const useFilterConfigs = () => {
   }));
 
   const filterConfigMap = {
+    [SearchParamsKeys.ACTIVE]: {
+      icon: <MdCheckCircle />,
+      label: translate("components:backfill.status"),
+      options: [
+        { label: translate("components:backfill.statusOptions.active"), value: "true" },
+        { label: translate("components:backfill.statusOptions.completed"), value: "false" },
+      ],
+      type: FilterTypes.SELECT,
+    },
     [SearchParamsKeys.ASSET_EVENT_DATE_RANGE]: {
       endKey: SearchParamsKeys.END_DATE,
       icon: <MdDateRange />,

--- a/airflow-core/src/airflow/ui/src/constants/searchParams.ts
+++ b/airflow-core/src/airflow/ui/src/constants/searchParams.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 export enum SearchParamsKeys {
+  ACTIVE = "active",
   AFTER = "after",
   ASSET_EVENT_DATE_RANGE = "asset_event_date_range",
   BEFORE = "before",

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Backfills/Backfills.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Backfills/Backfills.test.tsx
@@ -192,6 +192,38 @@ describe("Backfills filters", () => {
     });
   });
 
+  it.each([
+    ["active", true],
+    ["completed", false],
+  ])("requests %s backfills from the status URL filter", (_status, active) => {
+    mocks.getBackfill.mockReturnValue({
+      data: undefined,
+      error: undefined,
+      isLoading: false,
+    });
+    mocks.listBackfillDagRuns.mockReturnValue({
+      data: { backfill_dag_runs: [], total_entries: 0 },
+      error: undefined,
+      isFetching: false,
+      isLoading: false,
+    });
+    mocks.listBackfills.mockReturnValue({
+      data: { backfills: [], total_entries: 0 },
+      error: undefined,
+      isFetching: false,
+      isLoading: false,
+    });
+
+    renderBackfills(`/dags/example_dag/backfills?active=${active}`);
+
+    expect(mocks.listBackfills).toHaveBeenCalledWith({
+      active,
+      dagId: "example_dag",
+      limit: 25,
+      offset: 0,
+    });
+  });
+
   it("opens a backfill's associated slots in a dialog", async () => {
     const backfills = [
       makeBackfill(),

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Backfills/Backfills.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Backfills/Backfills.tsx
@@ -37,6 +37,7 @@ import { BackfillDagRunsModal } from "./BackfillDagRunsModal";
 import { BackfillsFilters } from "./BackfillsFilters";
 
 const {
+  ACTIVE: ACTIVE_PARAM,
   COMPLETED_AT_GTE: COMPLETED_AT_GTE_PARAM,
   COMPLETED_AT_LTE: COMPLETED_AT_LTE_PARAM,
   CREATED_AT_GTE: CREATED_AT_GTE_PARAM,
@@ -163,6 +164,8 @@ export const Backfills = () => {
 
   const [searchParams] = useSearchParams();
 
+  const activeParam = searchParams.get(ACTIVE_PARAM);
+  const active = activeParam === "true" ? true : activeParam === "false" ? false : undefined;
   const fromDateGte = searchParams.get(FROM_DATE_GTE_PARAM);
   const fromDateLte = searchParams.get(FROM_DATE_LTE_PARAM);
   const toDateGte = searchParams.get(TO_DATE_GTE_PARAM);
@@ -177,6 +180,7 @@ export const Backfills = () => {
   const reprocessBehavior = isReprocessBehavior(reprocessBehaviorParam) ? reprocessBehaviorParam : undefined;
 
   const { data, error, isFetching, isLoading } = useBackfillServiceListBackfillsUi({
+    active,
     completedAtGte: completedAtGte ?? undefined,
     completedAtLte: completedAtLte ?? undefined,
     createdAtGte: createdAtGte ?? undefined,

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Backfills/BackfillsFilters.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Backfills/BackfillsFilters.tsx
@@ -25,6 +25,7 @@ import { useFiltersHandler, type FilterableSearchParamsKeys } from "src/utils";
 
 export const BackfillsFilters = () => {
   const searchParamKeys: Array<FilterableSearchParamsKeys> = [
+    SearchParamsKeys.ACTIVE,
     SearchParamsKeys.FROM_RANGE,
     SearchParamsKeys.TO_RANGE,
     SearchParamsKeys.CREATED_AT_RANGE,

--- a/airflow-core/src/airflow/ui/src/utils/useFiltersHandler.ts
+++ b/airflow-core/src/airflow/ui/src/utils/useFiltersHandler.ts
@@ -57,6 +57,7 @@ const handleDateRangeChange = (
 };
 
 export type FilterableSearchParamsKeys =
+  | SearchParamsKeys.ACTIVE
   | SearchParamsKeys.ASSET_EVENT_DATE_RANGE
   | SearchParamsKeys.BODY_SEARCH
   | SearchParamsKeys.BUNDLE_VERSION


### PR DESCRIPTION
Add an Active/Completed status filter to the DAG Backfills tab. The filter is stored in the URL and reuses the existing `active` query parameter on the backfills endpoint, so operators can isolate in-flight or historical reprocessing runs without a backend or schema change.

This implements the status portion of the broader filter request.

related: #53049

## Validation

- `pnpm test src/pages/Dag/Backfills/Backfills.test.tsx` (5 passed)
- `pnpm exec tsc --noEmit -p tsconfig.app.json`
- focused ESLint and Prettier checks for all changed UI files
- `prek run --from-ref upstream/main --stage pre-commit`
- `prek run --from-ref upstream/main --stage manual --skip compile-ui-assets-dev --skip view-skill-eval --skip run-skill-eval-codex`
- negative control: the two new status-filter cases fail when `active` is removed from the generated API query, then pass after restoration

## Visual evidence

No screenshot is attached to this draft yet. The standalone Vite client requires a running Airflow API server to render this authenticated DAG view; this draft is therefore backed by the focused component tests, TypeScript check, and production UI asset build above.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

Drafted-by: Codex (GPT-5) (no human review before posting)
