### PR TITLE
Show audit log link when task logs are unavailable

### DIFF
--- a/airflow-core/newsfragments/72901.feature.rst
+++ b/airflow-core/newsfragments/72901.feature.rst
@@ -1,0 +1,1 @@
+Show a link to the task instance Audit Log when task logs are unavailable.

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
@@ -93,6 +93,8 @@
     "debug": "DEBUG",
     "error": "ERROR",
     "info": "INFO",
+    "noLogsHelp": "Check the <AuditLogLink>Audit Log</AuditLogLink> for details.",
+    "noLogsTitle": "No task logs are available.",
     "noTryNumber": "No try number",
     "search": {
       "matchCount": "{{current}} of {{total}}",

--- a/airflow-core/src/airflow/ui/src/mocks/handlers/log.ts
+++ b/airflow-core/src/airflow/ui/src/mocks/handlers/log.ts
@@ -62,6 +62,38 @@ const ti = {
 };
 
 export const handlers: Array<HttpHandler> = [
+  http.get("/api/v2/dags/log_grouping/dagRuns/manual__2025-02-18T12:19/taskInstances/empty_logs/-1", () =>
+    HttpResponse.json({
+      ...ti,
+      dag_run_id: "manual__2025-02-18T12:19",
+      state: "failed",
+      task_display_name: "empty_logs",
+      task_id: "empty_logs",
+    }),
+  ),
+  http.get("/api/v2/dags/log_grouping/dagRuns/manual__2025-02-18T12:19/taskInstances/empty_logs/logs/1", () =>
+    HttpResponse.json({ content: [], continuation_token: null }),
+  ),
+  http.get("/api/v2/dags/log_grouping/dagRuns/manual__2025-02-18T12:19/taskInstances/no_logs/-1", () =>
+    HttpResponse.json({
+      ...ti,
+      dag_run_id: "manual__2025-02-18T12:19",
+      state: "failed",
+      task_display_name: "no_logs",
+      task_id: "no_logs",
+      try_number: 0,
+    }),
+  ),
+  http.get("/api/v2/dags/log_grouping/dagRuns/manual__2025-02-18T12:19/taskInstances/no_logs/logs/0", () =>
+    HttpResponse.json({
+      content: [
+        { event: "::group::Log message source details", timestamp: null },
+        { event: "::endgroup::", timestamp: null },
+        { event: "No logs available for this task.", timestamp: "2025-02-18T12:19:56.467235Z" },
+      ],
+      continuation_token: null,
+    }),
+  ),
   http.get("/api/v2/dags/log_grouping/dagRuns/manual__2025-02-18T12:19/taskInstances/generate/-1", () =>
     HttpResponse.json({ ...ti, dag_run_id: "manual__2025-02-18T12:19" }),
   ),

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
@@ -17,14 +17,18 @@
  * under the License.
  */
 import "@testing-library/jest-dom";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeAll, describe, expect, it } from "vitest";
 
+import i18n from "src/i18n/config";
 import { AppWrapper } from "src/utils/AppWrapper";
+
+import dagLocale from "../../../../public/i18n/locales/en/dag.json";
 
 const ITEM_HEIGHT = 20;
 
 beforeAll(() => {
+  i18n.addResourceBundle("en", "dag", dagLocale, true, true);
   Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
     value: ITEM_HEIGHT,
   });
@@ -49,6 +53,38 @@ const waitForLogs = async () => {
 
   fireEvent.scroll(screen.getByTestId("virtualized-list"), { target: { scrollTop: ITEM_HEIGHT * 2 } });
 };
+
+describe("Missing task logs", () => {
+  it.each(["empty_logs", "no_logs"])(
+    "links to the task instance audit log when %s are returned",
+    async (taskId) => {
+      render(
+        <AppWrapper initialEntries={[`/dags/log_grouping/runs/manual__2025-02-18T12:19/tasks/${taskId}`]} />,
+      );
+
+      const noLogsAlert = await screen.findByTestId("no-task-logs");
+      const auditLogLink = within(noLogsAlert).getByRole("link", { name: "Audit Log" });
+
+      expect(noLogsAlert).toHaveTextContent(
+        /No task logs are available\.\s*Check the Audit Log for details\./u,
+      );
+      expect(auditLogLink).toHaveAttribute(
+        "href",
+        `/dags/log_grouping/runs/manual__2025-02-18T12:19/tasks/${taskId}/events`,
+      );
+    },
+  );
+
+  it("does not show audit log guidance when task logs are available", async () => {
+    render(
+      <AppWrapper initialEntries={["/dags/log_grouping/runs/manual__2025-02-18T12:19/tasks/generate"]} />,
+    );
+
+    await waitForLogs();
+
+    expect(screen.queryByTestId("no-task-logs")).not.toBeInTheDocument();
+  });
+});
 
 describe("Task log source", () => {
   it("Toggles logger and location on click", async () => {

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
@@ -19,13 +19,13 @@
 import { useState } from "react";
 
 import { Box, Heading } from "@chakra-ui/react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { useParams, useSearchParams } from "react-router-dom";
 import { useLocalStorage } from "usehooks-ts";
 
 import { useTaskInstanceServiceGetMappedTaskInstance } from "openapi/queries";
 
-import { Modal } from "src/system-components";
+import { Alert, Modal, RouterLink } from "src/system-components";
 
 import { LOG_SHOW_SOURCE_KEY, LOG_SHOW_TIMESTAMP_KEY, LOG_WRAP_KEY } from "src/constants/localStorage";
 import { SearchParamsKeys } from "src/constants/searchParams";
@@ -33,6 +33,7 @@ import { SHORTCUTS } from "src/context/keyboardShortcuts";
 import { useShortcut } from "src/hooks/useShortcut";
 import { useConfig } from "src/queries/useConfig";
 import { useLogs } from "src/queries/useLogs";
+import { getTaskInstanceLink } from "src/utils/links";
 
 import { ExternalLogLink } from "./ExternalLogLink";
 import { TaskLogContent, type TaskLogContentProps } from "./TaskLogContent";
@@ -234,6 +235,24 @@ export const Logs = () => {
     wrap,
   };
 
+  const noLogsAlert =
+    taskInstance !== undefined &&
+    fetchedData !== undefined &&
+    !isLoadingLogs &&
+    error === null &&
+    logError === null &&
+    (tryNumber === 0 || parsedData.parsedLogs?.length === 0) ? (
+      <Alert data-testid="no-task-logs" status="info" title={translate("logs.noLogsTitle")}>
+        <Trans
+          components={{
+            AuditLogLink: <RouterLink to={getTaskInstanceLink(taskInstance, "events")} />,
+          }}
+          i18nKey="logs.noLogsHelp"
+          ns="dag"
+        />
+      </Alert>
+    ) : undefined;
+
   return (
     <Box display="flex" flexDirection="column" h="100%" p={2}>
       <TaskLogHeader {...logHeaderProps} />
@@ -248,6 +267,7 @@ export const Logs = () => {
           />
         )
       ) : undefined}
+      {noLogsAlert}
       <TaskLogContent {...logContentProps} />
       <Modal
         bodyProps={{ display: "flex", flexDirection: "column" }}
@@ -267,6 +287,7 @@ export const Logs = () => {
         scrollBehavior="inside"
         size="full"
       >
+        {noLogsAlert}
         <TaskLogContent {...logContentProps} />
       </Modal>
     </Box>


### PR DESCRIPTION
closes: #43510

Task logs can be absent when a task times out in queued state, becomes a zombie, or never starts. The log pane now shows an informational alert in those cases with a direct link to the task instance Audit Log, while preserving any state-specific log message returned by the API.

The regression coverage includes an empty log response, a zero-attempt task with the current synthetic no-log response, and a task with normal logs.

### Validation

- `pnpm exec vitest run src/pages/TaskInstance/Logs/Logs.test.tsx` (17 passed)
- `pnpm lint`
- `pnpm build`
- `prek run --files <changed files>`

### Screenshots

Rendered with the existing Airflow UI components against the reproduced no-log state:

![Before and after views of the task log pane](https://raw.githubusercontent.com/emecii/airflow/pr-assets/pr-assets/72901-before-after.jpg)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---
Drafted-by: Codex (GPT-5) (no human review before posting)