### PR TITLE
Parse only the tested Dag and its trigger targets in DAG.test()

### DIFF
--- a/airflow-core/tests/unit/models/test_dag.py
+++ b/airflow-core/tests/unit/models/test_dag.py
@@ -360,6 +360,81 @@ class TestDag:
         assert "testing" in instantiated
         assert "unrelated" not in instantiated
 
+    @conf_vars({("core", "load_examples"): "false"})
+    def test_dag_test_parses_only_needed_files_once_targets_are_known(self, test_dags_bundle, session):
+        """
+        Regression test for #72513.
+
+        Once the trigger target is known to the metadata DB, ``DAG.test()`` must parse
+        only the files that define the tested DAG and its trigger targets, instead of
+        re-walking the whole bundle and re-syncing every sibling DAG on each call.
+        """
+        parent_id = "test_dag_test_trigger_parent"
+        unrelated_id = "test_example_bash_operator"
+
+        dagbag = DagBag(dag_folder=os.fspath(TEST_DAGS_FOLDER))
+        parent = dagbag.dags.get(parent_id)
+        assert parent is not None
+
+        # First call: the parent and its target are unknown, so the bundle is walked
+        # and every sibling DAG in it is synced.
+        assert parent.test().state == DagRunState.SUCCESS
+        session.expire_all()
+        unrelated_parsed_at = session.scalar(
+            select(DagModel.last_parsed_time).where(DagModel.dag_id == unrelated_id)
+        )
+        assert unrelated_parsed_at is not None
+
+        parsed: list[str] = []
+        real_collect_dags = BundleDagBag.collect_dags
+
+        def _spy(self, dag_folder=None, *args, **kwargs):
+            parsed.append(os.fspath(dag_folder or self.dag_folder))
+            return real_collect_dags(self, dag_folder, *args, **kwargs)
+
+        with mock.patch.object(BundleDagBag, "collect_dags", _spy):
+            dr = parent.test()
+
+        assert dr.state == DagRunState.SUCCESS
+        # Second call: only the file defining the parent (and its target) is parsed.
+        assert [Path(f).resolve() for f in parsed] == [
+            (TEST_DAGS_FOLDER / "test_dag_test_with_trigger.py").resolve()
+        ]
+        session.expire_all()
+        assert (
+            session.scalar(select(DagModel.last_parsed_time).where(DagModel.dag_id == unrelated_id))
+            == unrelated_parsed_at
+        )
+
+    @conf_vars({("core", "load_examples"): "false"})
+    def test_dag_test_walks_bundle_when_trigger_target_is_templated(self, test_dags_bundle, session):
+        """
+        A trigger target that is only known at runtime cannot be located, so ``DAG.test()``
+        keeps walking the whole bundle rather than risking a missing sibling.
+        """
+        parent_id = "test_dag_test_trigger_parent"
+
+        dagbag = DagBag(dag_folder=os.fspath(TEST_DAGS_FOLDER))
+        parent = dagbag.dags.get(parent_id)
+        assert parent is not None
+        assert parent.test().state == DagRunState.SUCCESS
+
+        # A templated target cannot be resolved before runtime; the task is marked success below
+        # because only the sync behaviour is of interest here.
+        parent.task_dict["trigger_target"].trigger_dag_id = "{{ params.target }}"
+
+        parsed: list[str] = []
+        real_collect_dags = BundleDagBag.collect_dags
+
+        def _spy(self, dag_folder=None, *args, **kwargs):
+            parsed.append(os.fspath(dag_folder or self.dag_folder))
+            return real_collect_dags(self, dag_folder, *args, **kwargs)
+
+        with mock.patch.object(BundleDagBag, "collect_dags", _spy):
+            parent.test(mark_success_pattern="trigger_target")
+
+        assert [Path(f).resolve() for f in parsed] == [TEST_DAGS_FOLDER.resolve()]
+
     def teardown_method(self) -> None:
         clear_db_runs()
         clear_db_dags()

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -31,6 +31,7 @@ from collections import abc, defaultdict, deque
 from collections.abc import Callable, Collection, Iterable, MutableSet
 from datetime import datetime, timedelta
 from inspect import signature
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, TypeGuard, Union, cast, overload
 from urllib.parse import urlsplit
 from uuid import UUID
@@ -1317,12 +1318,17 @@ class DAG:
             manager.sync_bundles_to_db(session=session)
             session.commit()
 
-            # Re-sync the bundle that owns ``self`` so sibling DAGs (e.g. targets of
+            # Re-sync ``self`` and the Dags it triggers so sibling DAGs (e.g. targets of
             # TriggerDagRunOperator) are written to the metadata DB on every call,
             # not just the first one (apache/airflow#64884). When we can identify
-            # ``self``'s bundle from a prior sync we walk only that bundle; otherwise
-            # we walk every configured bundle until we find it. ``sync_bag_to_db``
-            # is idempotent at the per-DAG hash level.
+            # ``self``'s bundle from a prior sync we look only at that bundle; otherwise
+            # we walk every configured bundle until we find it.
+            #
+            # Within a bundle, only the files that define ``self`` and its trigger targets
+            # are parsed when those files are known (apache/airflow#72513). The whole
+            # bundle is walked when they are not: ``self`` lives outside the bundle, a
+            # target has never been parsed so its file is unknown, or a target is only
+            # resolvable at runtime. ``sync_bag_to_db`` is idempotent at the per-DAG hash level.
             #
             # Note: we deliberately do NOT use ``_airflow_parsing_context_manager``
             # here. Setting ``_AIRFLOW_PARSING_CONTEXT_DAG_ID`` to ``self.dag_id``
@@ -1350,7 +1356,14 @@ class DAG:
                     dag_folder=bundle.path,
                     bundle_path=bundle.path,
                     bundle_name=bundle.name,
+                    collect_dags=False,
                 )
+                files_to_parse = _dag_test_files_to_sync(self, bundle, session=session)
+                if files_to_parse is not None:
+                    for file_path in files_to_parse:
+                        dagbag.collect_dags(dag_folder=file_path)
+                if files_to_parse is None or self.dag_id not in dagbag.dags:
+                    dagbag.collect_dags()
                 sync_bag_to_db(dagbag, bundle.name, bundle.version)
                 if DagVersion.get_version(self.dag_id):
                     break
@@ -1486,6 +1499,73 @@ class DAG:
             if use_executor:
                 executor.end()
         return dr
+
+
+def _static_trigger_targets(dag: DAG) -> set[str] | None:
+    """
+    Return the dag ids that ``dag`` triggers through ``trigger_dag_id`` values known before runtime.
+
+    Any operator with a ``trigger_dag_id`` template field counts, so this does not depend on the
+    standard provider being importable. Returns ``None`` when at least one target cannot be
+    determined statically (a templated value, an XComArg, or a mapped operator expanding over it),
+    which tells the caller to fall back to syncing the whole bundle.
+    """
+    from airflow.sdk.definitions.mappedoperator import MappedOperator
+
+    targets: set[str] = set()
+    for task in dag.tasks:
+        if "trigger_dag_id" not in task.template_fields:
+            continue
+        if isinstance(task, MappedOperator):
+            value = task.partial_kwargs.get("trigger_dag_id")
+        else:
+            value = getattr(task, "trigger_dag_id", None)
+        if not isinstance(value, str) or "{{" in value:
+            return None
+        targets.add(value)
+    targets.discard(dag.dag_id)
+    return targets
+
+
+def _dag_test_files_to_sync(dag: DAG, bundle, *, session) -> list[Path] | None:
+    """
+    Return the files ``DAG.test()`` has to parse in ``bundle`` for ``dag``.
+
+    That is the file defining ``dag`` plus the files of the Dags it triggers. Returns ``None`` when
+    the whole bundle has to be walked instead: ``dag`` is not defined inside the bundle, a trigger
+    target is not resolvable statically, or a target has never been parsed, so the metadata DB does
+    not know which file defines it (apache/airflow#64884).
+    """
+    from airflow.models.dag import DagModel
+
+    bundle_path = Path(bundle.path).resolve()
+    own_file = Path(dag.fileloc).resolve()
+    if not own_file.is_relative_to(bundle_path):
+        return None
+
+    targets = _static_trigger_targets(dag)
+    if targets is None:
+        return None
+
+    files = {own_file}
+    for target_id in sorted(targets):
+        target_model = DagModel.get_current(target_id, session=session)
+        if target_model is None:
+            return None
+        if target_model.bundle_name != bundle.name:
+            # Defined in another bundle; it is already known, and this bundle cannot refresh it.
+            continue
+        if target_model.relative_fileloc:
+            target_file = bundle_path / target_model.relative_fileloc
+        elif target_model.fileloc:
+            target_file = Path(target_model.fileloc)
+        else:
+            return None
+        target_file = target_file.resolve()
+        if not target_file.is_relative_to(bundle_path) or not target_file.is_file():
+            return None
+        files.add(target_file)
+    return sorted(files)
 
 
 def _run_task(


### PR DESCRIPTION
`DAG.test()` re-walks the whole bundle that owns the tested Dag on every call: #66205 added that so Dags triggered through `TriggerDagRunOperator` exist in the metadata DB even when the parent was serialized earlier (#64884). The cost is that debugging one Dag parses and re-syncs every Dag file in the bundle each time, which is what #72513 reports.

This keeps the guarantee from #66205 but narrows the work in the common case. Within the owning bundle, `DAG.test()` now parses only the file that defines the tested Dag plus the files of the Dags it triggers, when those files are known. It still walks the whole bundle when they are not:

- the tested Dag is not defined inside the bundle
- a trigger target is not resolvable before runtime (a templated `trigger_dag_id`, an XComArg, or a mapped operator expanding over it)
- a target has never been parsed, so the metadata DB does not know which file defines it (the #64884 case)

Trigger targets are found through the `trigger_dag_id` template field rather than the operator class, so the Task SDK does not import the standard provider. The bundle-selection logic (owning bundle first, all bundles as fallback) and the "no parsing context" rule from #66205 are unchanged.

**Changes**

- `task-sdk/src/airflow/sdk/definitions/dag.py`: build the `BundleDagBag` without collecting, parse the selected files with `collect_dags(dag_folder=<file>)`, fall back to the full walk when the selection is not possible or does not yield the tested Dag; two module-level helpers, `_static_trigger_targets` and `_dag_test_files_to_sync`
- `airflow-core/tests/unit/models/test_dag.py`: `test_dag_test_parses_only_needed_files_once_targets_are_known` (second call parses one file and leaves an unrelated sibling untouched; fails on main) and `test_dag_test_walks_bundle_when_trigger_target_is_templated`

**Testing**

- `airflow-core`: `tests/unit/models/test_dag.py` (all 211 tests)
- `task-sdk`: `tests/task_sdk/definitions/test_dag.py`
- mypy on the changed module, prek hooks on the changed files

closes: #72513

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Claude Fable 5.1) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions). I reviewed and understand all changes; the tests were run locally as listed above.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
