### PR TITLE
Edge: Return 404 for missing task logs and emit failed job metrics

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/worker_api/routes/jobs.py
+++ b/providers/edge3/src/airflow/providers/edge3/worker_api/routes/jobs.py
@@ -142,7 +142,7 @@ def state(
     """Update the state of a job running on the edge worker."""
     # execute query to catch the queue and check if state toggles to success or failed
     # otherwise possible that Executor resets orphaned jobs and stats are exported 2 times
-    if state in [TaskInstanceState.SUCCESS, state == TaskInstanceState.FAILED]:
+    if state in [TaskInstanceState.SUCCESS, TaskInstanceState.FAILED]:
         query = select(EdgeJobModel).where(
             EdgeJobModel.dag_id == dag_id,
             EdgeJobModel.task_id == task_id,

--- a/providers/edge3/src/airflow/providers/edge3/worker_api/routes/logs.py
+++ b/providers/edge3/src/airflow/providers/edge3/worker_api/routes/logs.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 
 from functools import cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated
+from typing import Annotated
 
-from fastapi import Body, Depends, status
+from fastapi import Body, Depends, HTTPException, status
 
 from airflow.api_fastapi.common.db.common import SessionDep  # noqa: TC001
 from airflow.api_fastapi.common.router import AirflowRouter
@@ -48,9 +48,11 @@ def _logfile_path(task: TaskInstanceKey, *, session=NEW_SESSION) -> str:
         map_index=task.map_index,
         session=session,
     )
-    if TYPE_CHECKING:
-        assert ti
-        assert isinstance(ti, TaskInstance)
+    if not ti:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            f"TaskInstance not found for dag_id={task.dag_id}, task_id={task.task_id}, run_id={task.run_id}, map_index={task.map_index}",
+        )
     return FileTaskHandler(".")._render_filename(ti, task.try_number)
 
 
@@ -61,6 +63,7 @@ def _logfile_path(task: TaskInstanceKey, *, session=NEW_SESSION) -> str:
         [
             status.HTTP_400_BAD_REQUEST,
             status.HTTP_403_FORBIDDEN,
+            status.HTTP_404_NOT_FOUND,
         ]
     ),
 )

--- a/providers/edge3/src/airflow/providers/edge3/worker_api/v2-edge-generated.yaml
+++ b/providers/edge3/src/airflow/providers/edge3/worker_api/v2-edge-generated.yaml
@@ -245,6 +245,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPExceptionResponse'
           description: Forbidden
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Not Found
         '422':
           description: Validation Error
           content:

--- a/providers/edge3/tests/unit/edge3/worker_api/routes/test_jobs.py
+++ b/providers/edge3/tests/unit/edge3/worker_api/routes/test_jobs.py
@@ -141,6 +141,45 @@ class TestJobsApiRoutes:
             assert db_job.state == TaskInstanceState.SUCCESS
 
     @patch(f"{Stats.__module__}.Stats.incr")
+    def test_state_failed(self, mock_stats_incr, session: Session):
+        with create_session() as session:
+            job = EdgeJobModel(
+                dag_id=DAG_ID,
+                task_id=TASK_ID,
+                run_id=RUN_ID,
+                try_number=1,
+                map_index=-1,
+                state=TaskInstanceState.RUNNING,
+                queue=QUEUE,
+                concurrency_slots=1,
+                command="execute",
+                team_name="team_a",
+            )
+            session.add(job)
+            session.commit()
+
+            state(
+                dag_id=DAG_ID,
+                task_id=TASK_ID,
+                run_id=RUN_ID,
+                try_number=1,
+                map_index=-1,
+                state=TaskInstanceState.FAILED,
+                session=session,
+            )
+
+            mock_stats_incr.assert_called_with(
+                "edge_worker.ti.finish",
+                tags={
+                    "dag_id": DAG_ID,
+                    "queue": QUEUE,
+                    "state": str(TaskInstanceState.FAILED),
+                    "task_id": TASK_ID,
+                    "team_name": "team_a",
+                },
+            )
+
+    @patch(f"{Stats.__module__}.Stats.incr")
     def test_state_finish_metric_omits_team_name_for_global_job(self, mock_stats_incr, session: Session):
         with create_session() as session:
             job = EdgeJobModel(

--- a/providers/edge3/tests/unit/edge3/worker_api/routes/test_logs.py
+++ b/providers/edge3/tests/unit/edge3/worker_api/routes/test_logs.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
+from fastapi import HTTPException
 from sqlalchemy import delete, select
 
 from airflow.providers.common.compat.sdk import timezone
@@ -56,6 +57,11 @@ class TestLogsApiRoutes:
         assert p
         assert str(Path(f"dag_id={DAG_ID}") / f"run_id={RUN_ID}" / f"task_id={TASK_ID}" / "attempt=1") in p
         assert "-1" not in Path(p).parts
+
+    def test_logfile_path_missing_ti_returns_404(self, session: Session):
+        with pytest.raises(HTTPException) as exc_info:
+            logfile_path(dag_id=DAG_ID, task_id="nonexistent_task", run_id=RUN_ID, try_number=1, map_index=-1)
+        assert exc_info.value.status_code == 404
 
     def test_push_logs(self, session: Session):
         log_data = PushLogsBody(

--- a/providers/edge3/tests/unit/edge3/worker_api/routes/test_logs.py
+++ b/providers/edge3/tests/unit/edge3/worker_api/routes/test_logs.py
@@ -21,15 +21,20 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 from sqlalchemy import delete, select
 
-from airflow.providers.common.compat.sdk import timezone
+from airflow.api_fastapi.auth.tokens import JWTGenerator
+from airflow.providers.common.compat.sdk import conf, timezone
 from airflow.providers.edge3.models.edge_logs import EdgeLogsModel
+from airflow.providers.edge3.worker_api.auth import jwt_validator
 from airflow.providers.edge3.worker_api.datamodels import PushLogsBody
-from airflow.providers.edge3.worker_api.routes.logs import logfile_path, push_logs
+from airflow.providers.edge3.worker_api.routes.logs import logfile_path, logs_router, push_logs
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.utils.session import create_session
+
+from tests_common.test_utils.config import conf_vars
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -58,10 +63,28 @@ class TestLogsApiRoutes:
         assert str(Path(f"dag_id={DAG_ID}") / f"run_id={RUN_ID}" / f"task_id={TASK_ID}" / "attempt=1") in p
         assert "-1" not in Path(p).parts
 
-    def test_logfile_path_missing_ti_returns_404(self, session: Session):
-        with pytest.raises(HTTPException) as exc_info:
-            logfile_path(dag_id=DAG_ID, task_id="nonexistent_task", run_id=RUN_ID, try_number=1, map_index=-1)
-        assert exc_info.value.status_code == 404
+    @conf_vars({("api_auth", "jwt_secret"): "edge-log-test-secret"})
+    def test_logfile_path_missing_ti_returns_404(self):
+        app = FastAPI()
+        app.include_router(logs_router, prefix="/edge_worker/v1")
+        method = f"logs/logfile_path/{DAG_ID}/nonexistent_task/{RUN_ID}/1/-1"
+        token = JWTGenerator(
+            secret_key=conf.get("api_auth", "jwt_secret"), valid_for=60, audience="api"
+        ).generate(extras={"method": method})
+        jwt_validator.cache_clear()
+        try:
+            with TestClient(app, raise_server_exceptions=False) as client:
+                response = client.get(f"/edge_worker/v1/{method}", headers={"Authorization": token})
+        finally:
+            jwt_validator.cache_clear()
+
+        assert response.status_code == 404
+        assert response.json() == {
+            "detail": (
+                f"TaskInstance not found for dag_id={DAG_ID}, task_id=nonexistent_task, "
+                f"run_id={RUN_ID}, map_index=-1"
+            )
+        }
 
     def test_push_logs(self, session: Session):
         log_data = PushLogsBody(


### PR DESCRIPTION
Querying logs for a nonexistent task instance returned an internal server error instead of a missing resource response, while failed edge jobs omitted finish metrics entirely.

In the worker API, requesting logs for a missing task instance dereferenced None in the file task handler, raising an AttributeError and returning HTTP 500. Separately, the job state endpoint checked an invalid comparison list that prevented the failed state from matching, so finish metrics were never emitted on job failure.

This change returns a 404 Not Found error when the task instance cannot be found and corrects the state list so finish metrics emit for both successful and failed tasks.

# Testing Done

Reproduction before fix:
```bash
uv run --project providers/edge3 pytest -k "test_logfile_path_missing_ti or test_state_failed"
```

Pre-fix output:
```text
FAILED test_logs.py test_logfile_path_missing_ti_returns_404 - AttributeError: 'NoneType' object has no attribute 'get_dagrun'
FAILED test_jobs.py test_state_failed - AssertionError: expected call not found
```

Verification after fix:
```bash
uv run --project providers/edge3 pytest providers/edge3/tests/unit/edge3/worker_api/routes/test_logs.py providers/edge3/tests/unit/edge3/worker_api/routes/test_jobs.py -k "test_logfile_path or test_state_failed"
```

Post-fix output:
```text
================== 3 passed, 9 deselected, 1 warning in 4.03s ==================
```

<details>
<summary>Raw logs</summary>

```text
test_logs.py test_logfile_path PASSED [ 33%]
test_logs.py test_logfile_path_missing_ti_returns_404 PASSED [ 66%]
test_jobs.py test_state_failed PASSED [100%]
```

</details>
