### PR TITLE
Add missing unit tests for the common-messaging provider base class

### DIFF
--- a/airflow-core/tests/unit/always/test_project_structure.py
+++ b/airflow-core/tests/unit/always/test_project_structure.py
@@ -97,7 +97,6 @@ class TestProjectStructure:
             "providers/common/compat/tests/unit/common/compat/standard/test_operators.py",
             "providers/common/compat/tests/unit/common/compat/standard/test_triggers.py",
             "providers/common/compat/tests/unit/common/compat/standard/test_utils.py",
-            "providers/common/messaging/tests/unit/common/messaging/providers/test_base_provider.py",
             "providers/common/messaging/tests/unit/common/messaging/providers/test_sqs.py",
             "providers/edge3/tests/unit/edge3/cli/test_example_extended_sysinfo.py",
             "providers/edge3/tests/unit/edge3/models/test_edge_job.py",

--- a/providers/common/messaging/tests/unit/common/messaging/providers/__init__.py
+++ b/providers/common/messaging/tests/unit/common/messaging/providers/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/common/messaging/tests/unit/common/messaging/providers/test_base_provider.py
+++ b/providers/common/messaging/tests/unit/common/messaging/providers/test_base_provider.py
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow.providers.common.messaging.providers.base_provider import BaseMessageQueueProvider
+
+
+class KafkaLikeProvider(BaseMessageQueueProvider):
+    """Minimal complete provider used to exercise the base-class contract."""
+
+    scheme = "kafka"
+
+    def queue_matches(self, queue: str) -> bool:
+        return queue.startswith("kafka://")
+
+    def trigger_class(self):
+        raise NotImplementedError
+
+    def trigger_kwargs(self, queue: str, **kwargs) -> dict:
+        return {}
+
+
+class TestSchemeMatches:
+    @pytest.mark.parametrize(
+        ("scheme", "expected"),
+        [
+            ("kafka", True),
+            ("sqs", False),
+            ("kafka://", False),
+            ("", False),
+            (None, False),
+        ],
+    )
+    def test_subclass_matches_only_its_own_scheme(self, scheme, expected):
+        assert KafkaLikeProvider().scheme_matches(scheme) is expected
+
+    def test_base_class_scheme_defaults_to_none_and_matches_nothing(self):
+        assert BaseMessageQueueProvider.scheme is None
+        assert KafkaLikeProvider.scheme_matches(BaseMessageQueueProvider(), "kafka") is False
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    [
+        "queue_matches",
+        "trigger_class",
+        "trigger_kwargs",
+    ],
+)
+def test_provider_contract_methods_are_marked_abstract(method_name):
+    assert getattr(BaseMessageQueueProvider, method_name).__isabstractmethod__ is True
+
+
+def test_scheme_matches_is_part_of_the_concrete_surface():
+    assert getattr(BaseMessageQueueProvider.scheme_matches, "__isabstractmethod__", False) is False


### PR DESCRIPTION
Adds the missing test module for `airflow.providers.common.messaging.providers.base_provider` and removes its entry from `OVERLOOKED_TESTS` in `test_project_structure.py`, per the checklist in the meta issue.

The tests cover the concrete surface of `BaseMessageQueueProvider`: `scheme_matches` across matching / non-matching / empty / None schemes, the base-class `scheme = None` default matching nothing, and markers asserting which contract methods are declared abstract (and that `scheme_matches` is not).

While writing these I noticed the declared abstract contract is out of sync with the in-tree providers (three of them implement only `trigger_class`, which currently goes unenforced because the base class does not inherit `abc.ABC`) — that needs a maintainer decision on direction, so it is filed separately rather than "fixed" here; the tests deliberately avoid enshrining the unenforced behavior.

10 tests, all passing locally via `uv run --project providers/common/messaging pytest ...`; the `test_providers_modules_should_have_tests` guard passes with the entry removed.

related: #35442

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)