### PR TITLE
Fix flaky test_trigger_log in triggerer job tests

### DIFF
--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -1183,18 +1183,24 @@ def test_trigger_log(mock_monotonic, trigger, watcher_count, trigger_count, sess
     Checks that the triggerer will log watcher and trigger in separate lines.
     """
     create_trigger_in_db(session, trigger)
+    trigger_line = f"{trigger_count} triggers currently running"
+    watcher_line = f"{watcher_count} watchers currently running"
 
     trigger_runner_supervisor = TriggerRunnerSupervisor.start(job=Job(id=123456), capacity=10)
-    trigger_runner_supervisor.load_triggers()
+    try:
+        trigger_runner_supervisor.load_triggers()
 
-    for _ in range(30):
-        trigger_runner_supervisor._service_subprocess(0.1)
+        stdout = ""
+        for _ in range(300):
+            trigger_runner_supervisor._service_subprocess(0.1)
+            stdout += capsys.readouterr().out
+            if trigger_line in stdout and watcher_line in stdout:
+                break
+    finally:
+        trigger_runner_supervisor.kill(force=False)
 
-    stdout = capsys.readouterr().out
-    assert f"{trigger_count} triggers currently running" in stdout
-    assert f"{watcher_count} watchers currently running" in stdout
-
-    trigger_runner_supervisor.kill(force=False)
+    assert trigger_line in stdout
+    assert watcher_line in stdout
 
 
 def test_trigger_logger_close():


### PR DESCRIPTION
`test_trigger_log` fails intermittently on CI. The test calls `_service_subprocess(0.1)` 30 times before checking stdout. The forked runner inherits the test's `time.monotonic` patch, so its watchdog logs nonstop ahead of the status lines. The supervisor reads at most 4096 bytes of runner logs per call. If the runner starts slowly, or the supervisor is briefly busy, the 30 calls run out before the status lines are read. Sample run:

- https://github.com/apache/airflow/actions/runs/34496070008/job/102941543949
- https://github.com/apache/airflow/actions/runs/33582219324/job/100101874765
- https://github.com/apache/airflow/actions/runs/32091435702/job/95577614679
- https://github.com/apache/airflow/actions/runs/28159425286/job/83403110039
- https://github.com/apache/airflow/actions/runs/28092166063/job/83174934542

This fix changes the call 30 calls to 300 like #70941.

- `uv run --project airflow-core pytest airflow-core/tests/unit/jobs/test_triggerer_job.py`

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
