### PR TITLE
Scope upstream asset events of a Dag run to readable assets and Dags

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -26,7 +26,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import StreamingResponse
 from pydantic import ValidationError
 from sqlalchemy import select
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import joinedload, subqueryload
 
 from airflow.api_fastapi.app import get_auth_manager
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity, DagDetails
@@ -100,6 +100,8 @@ from airflow.api_fastapi.core_api.datamodels.task_instances import (
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
 from airflow.api_fastapi.core_api.security import (
     GetUserDep,
+    ReadableAssetEventsByAssetFilterDep,
+    ReadableAssetEventsFilterDep,
     ReadableDagRunsFilterDep,
     requires_access_asset,
     requires_access_dag,
@@ -120,7 +122,7 @@ from airflow.api_fastapi.core_api.services.public.dag_run import (
 from airflow.api_fastapi.logging.decorators import action_logging
 from airflow.exceptions import DagVersionNotFound, ParamValidationError
 from airflow.models import DagModel, DagRun
-from airflow.models.asset import AssetEvent
+from airflow.models.asset import AssetEvent, association_table as dagrun_asset_event_table
 from airflow.models.dag_version import DagVersion
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
@@ -280,26 +282,34 @@ def bulk_dag_runs(
     ],
 )
 def get_upstream_asset_events(
-    dag_id: str, dag_run_id: str, session: SessionDep
+    dag_id: str,
+    dag_run_id: str,
+    readable_asset_events_filter: ReadableAssetEventsFilterDep,
+    readable_asset_events_by_asset_filter: ReadableAssetEventsByAssetFilterDep,
+    session: SessionDep,
 ) -> AssetEventCollectionResponse:
     """If dag run is asset-triggered, return the asset events that triggered it."""
-    dag_run: DagRun | None = session.scalar(
-        select(DagRun)
-        .where(
+    dag_run_pk = session.scalar(
+        select(DagRun.id).where(
             DagRun.dag_id == dag_id,
             DagRun.run_id == dag_run_id,
         )
-        .options(
-            joinedload(DagRun.consumed_asset_events).joinedload(AssetEvent.asset),
-            joinedload(DagRun.consumed_asset_events).subqueryload(AssetEvent.created_dagruns),
-        )
     )
-    if dag_run is None:
+    if dag_run_pk is None:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND,
             f"The DagRun with dag_id: `{dag_id}` and run_id: `{dag_run_id}` was not found",
         )
-    events = dag_run.consumed_asset_events
+    # Reading the consuming run must not expose events of assets or source Dags the caller may not read.
+    events_select = apply_filters_to_select(
+        statement=select(AssetEvent)
+        .join(dagrun_asset_event_table, dagrun_asset_event_table.c.event_id == AssetEvent.id)
+        .where(dagrun_asset_event_table.c.dag_run_id == dag_run_pk)
+        .options(joinedload(AssetEvent.asset), subqueryload(AssetEvent.created_dagruns))
+        .order_by(AssetEvent.id),
+        filters=[readable_asset_events_filter, readable_asset_events_by_asset_filter],
+    )
+    events = session.scalars(events_select).unique().all()
     return AssetEventCollectionResponse(
         asset_events=serialize_asset_events(events, session=session),
         total_entries=len(events),

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -1964,7 +1964,7 @@ class TestGetDagRunAssetTriggerEvents:
         session.commit()
         assert event.timestamp
 
-        with assert_queries_count(4):
+        with assert_queries_count(7):
             response = test_client.get(
                 "/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID/upstreamAssetEvents",
             )
@@ -2046,7 +2046,7 @@ class TestGetDagRunAssetTriggerEvents:
         session.commit()
 
         # Constant regardless of the number of consumed events (parametrized 1 vs 5).
-        with assert_queries_count(4):
+        with assert_queries_count(7):
             response = test_client.get("/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID/upstreamAssetEvents")
 
         assert response.status_code == 200
@@ -2059,6 +2059,90 @@ class TestGetDagRunAssetTriggerEvents:
         newest_event_id = max(event.id for event in events)
         assert triggering_by_event[newest_event_id] is True
         assert all(value is False for eid, value in triggering_by_event.items() if eid != newest_event_id)
+
+    def _create_consuming_run_with_events(self, dag_maker, session):
+        """
+        Create a run consuming three events: one per source Dag, one with no source Dag.
+
+        Returns the asset ids keyed by index and the event ids keyed by scenario.
+        """
+        asset_ids = {}
+        for index in (1, 2):
+            asset = AssetModel(name=f"ds{index}", uri=f"file:///da{index}", group="asset")
+            session.add(asset)
+            session.flush()
+            asset_ids[index] = asset.id
+        events = {
+            "dag_a": AssetEvent(asset_id=asset_ids[1], source_dag_id="source_dag_a", timestamp=START_DATE1),
+            "dag_b": AssetEvent(asset_id=asset_ids[2], source_dag_id="source_dag_b", timestamp=START_DATE1),
+            "dagless": AssetEvent(asset_id=asset_ids[1], timestamp=START_DATE1),
+        }
+        session.add_all(events.values())
+        session.flush()
+        with dag_maker(
+            dag_id="TEST_DAG_ID", start_date=START_DATE1, schedule=timedelta(days=1), session=session
+        ):
+            pass
+        dag_run = dag_maker.create_dagrun(run_id="TEST_DAG_RUN_ID", run_type=DagRunType.ASSET_TRIGGERED)
+        dag_run.consumed_asset_events.extend(events.values())
+        session.commit()
+        return asset_ids, {key: event.id for key, event in events.items()}
+
+    @pytest.mark.parametrize(
+        ("readable_dags", "expected_events"),
+        [
+            pytest.param(["source_dag_a"], ["dag_a", "dagless"], id="one-readable-source-dag-plus-dagless"),
+            pytest.param(
+                ["source_dag_a", "source_dag_b"],
+                ["dag_a", "dag_b", "dagless"],
+                id="both-source-dags-readable",
+            ),
+            pytest.param([], ["dagless"], id="no-readable-source-dags-still-sees-dagless"),
+        ],
+    )
+    @mock.patch(
+        "airflow.api_fastapi.auth.managers.base_auth_manager.BaseAuthManager.get_authorized_dag_ids",
+        autospec=True,
+    )
+    def test_returns_only_events_from_source_dags_the_caller_may_read(
+        self, mock_get_authorized_dag_ids, test_client, dag_maker, session, readable_dags, expected_events
+    ):
+        """Reading the consuming run must not expose events produced by Dags the caller cannot read."""
+        mock_get_authorized_dag_ids.return_value = set(readable_dags)
+        _, event_ids = self._create_consuming_run_with_events(dag_maker, session)
+        expected_ids = [event_ids[key] for key in expected_events]
+
+        response = test_client.get("/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID/upstreamAssetEvents")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert [event["id"] for event in body["asset_events"]] == expected_ids
+        # The count must be scoped too, so the existence of hidden events does not leak.
+        assert body["total_entries"] == len(expected_ids)
+
+    @mock.patch(
+        "airflow.api_fastapi.auth.managers.base_auth_manager.BaseAuthManager.get_authorized_dag_ids",
+        autospec=True,
+    )
+    @mock.patch(
+        "airflow.api_fastapi.auth.managers.base_auth_manager.BaseAuthManager.get_authorized_assets",
+        autospec=True,
+    )
+    def test_returns_only_events_of_assets_the_caller_may_read(
+        self, mock_get_authorized_assets, mock_get_authorized_dag_ids, test_client, dag_maker, session
+    ):
+        """An event of an asset the caller cannot read is hidden even when its source Dag is readable."""
+        asset_ids, event_ids = self._create_consuming_run_with_events(dag_maker, session)
+        mock_get_authorized_dag_ids.return_value = {"source_dag_a", "source_dag_b"}
+        mock_get_authorized_assets.return_value = {asset_ids[2]}
+
+        response = test_client.get("/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID/upstreamAssetEvents")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert [event["id"] for event in body["asset_events"]] == [event_ids["dag_b"]]
+        assert {event["uri"] for event in body["asset_events"]} == {"file:///da2"}
+        assert body["total_entries"] == 1
 
     def test_should_respond_401(self, unauthenticated_test_client):
         response = unauthenticated_test_client.get(


### PR DESCRIPTION
## Why

`GET /dags/{dag_id}/dagRuns/{dag_run_id}/upstreamAssetEvents` only checked that the caller may read the consuming Dag run and that they hold a coarse, class-level asset read permission. It then returned every asset event the run consumed, straight from the `DagRun.consumed_asset_events` relationship, without scoping the events themselves.

For auth managers that authorize assets and Dags individually, this exposed events of assets the caller may not read, and events produced by source Dags the caller may not read. Each event carries the asset's `name`, `uri`, `group` and `extra`, plus `source_dag_id`, `source_task_id` and `source_run_id`. The same events are already hidden from `GET /assets/events` by `ReadableAssetEventsFilterDep` and `ReadableAssetEventsByAssetFilterDep`, so reading the consuming run was a way around that filtering.

## What

- `airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py`: `get_upstream_asset_events` now looks up the run's primary key (still 404 when missing), then selects the consumed events through the `dagrun_asset_event` association table and applies the same per-source-Dag and per-asset readability filters as `GET /assets/events`. `total_entries` is the filtered count, so hidden events do not leak through the total either.
---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Fable 5.1)