### PR TITLE
Edge: Return 400 instead of 500 on invalid worker version

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/worker_api/routes/worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/worker_api/routes/worker.py
@@ -21,7 +21,7 @@ from datetime import datetime
 from typing import Annotated
 
 from fastapi import Body, Depends, HTTPException, Path, status
-from packaging.version import Version
+from packaging.version import InvalidVersion, Version
 from sqlalchemy import select
 
 from airflow import __version__ as airflow_version
@@ -55,7 +55,13 @@ worker_router = AirflowRouter(
 
 def _version(version_str: str) -> tuple[int, int, int]:
     """Convert a version string into a tuple of integers for comparison."""
-    version = Version(version_str)
+    try:
+        version = Version(version_str)
+    except InvalidVersion as e:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            f"Invalid version string '{version_str}': {e}",
+        ) from e
     return version.major, version.minor, version.micro
 
 

--- a/providers/edge3/src/airflow/providers/edge3/worker_api/routes/worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/worker_api/routes/worker.py
@@ -75,8 +75,10 @@ def _assert_version(sysinfo: dict[str, str | int | float | datetime]) -> bool:
             minimum_acceptable_core_version_for_workers = conf.get(
                 "edge", "minimum_acceptable_core_version_for_workers", fallback=None
             )
-            if not minimum_acceptable_core_version_for_workers or _version(airflow_on_worker) < _version(
-                minimum_acceptable_core_version_for_workers
+            if (
+                not minimum_acceptable_core_version_for_workers
+                or _version(airflow_on_worker)
+                < Version(minimum_acceptable_core_version_for_workers).release[:3]
             ):
                 raise HTTPException(
                     status.HTTP_400_BAD_REQUEST,
@@ -95,8 +97,10 @@ def _assert_version(sysinfo: dict[str, str | int | float | datetime]) -> bool:
             minimum_acceptable_edge_version_for_workers = conf.get(
                 "edge", "minimum_acceptable_edge_version_for_workers", fallback=None
             )
-            if not minimum_acceptable_edge_version_for_workers or _version(provider_on_worker) < _version(
-                minimum_acceptable_edge_version_for_workers
+            if (
+                not minimum_acceptable_edge_version_for_workers
+                or _version(provider_on_worker)
+                < Version(minimum_acceptable_edge_version_for_workers).release[:3]
             ):
                 raise HTTPException(
                     status.HTTP_400_BAD_REQUEST,

--- a/providers/edge3/tests/unit/edge3/worker_api/routes/test_worker.py
+++ b/providers/edge3/tests/unit/edge3/worker_api/routes/test_worker.py
@@ -23,11 +23,13 @@ from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
 from sqlalchemy import delete, select
 
 from airflow import __version__ as airflow_version
-from airflow.providers.common.compat.sdk import Stats, timezone
+from airflow.api_fastapi.auth.tokens import JWTGenerator
+from airflow.providers.common.compat.sdk import Stats, conf, timezone
 from airflow.providers.edge3 import __version__ as edge_provider_version
 from airflow.providers.edge3.cli.worker import EdgeWorker
 from airflow.providers.edge3.models.edge_worker import (
@@ -35,6 +37,7 @@ from airflow.providers.edge3.models.edge_worker import (
     EdgeWorkerState,
     set_worker_concurrency,
 )
+from airflow.providers.edge3.worker_api.auth import jwt_validator
 from airflow.providers.edge3.worker_api.datamodels import WorkerQueueUpdateBody, WorkerStateBody
 from airflow.providers.edge3.worker_api.routes.worker import (
     _assert_version,
@@ -42,6 +45,7 @@ from airflow.providers.edge3.worker_api.routes.worker import (
     register,
     set_state,
     update_queues,
+    worker_router,
 )
 
 from tests_common.test_utils.config import conf_vars
@@ -78,10 +82,43 @@ class TestWorkerApiRoutes:
         assert _version("1.2.3rc1") == (1, 2, 3)
         assert _version("1.2.3.dev0") == (1, 2, 3)
 
-    def test_version_invalid_raises_http_400(self):
-        with pytest.raises(HTTPException) as exc_info:
-            _version("invalid-version-string")
-        assert exc_info.value.status_code == 400
+    @conf_vars({("api_auth", "jwt_secret"): "edge-version-test-secret"})
+    @pytest.mark.parametrize(
+        ("field", "minimum_key"),
+        [
+            ("airflow_version", "minimum_acceptable_core_version_for_workers"),
+            ("edge_provider_version", "minimum_acceptable_edge_version_for_workers"),
+        ],
+    )
+    @pytest.mark.parametrize("method", ["POST", "PATCH"])
+    @pytest.mark.parametrize("invalid_source", ["worker", "server"])
+    def test_invalid_version_http_status(self, session: Session, field, minimum_key, method, invalid_source):
+        session.commit()
+        app = FastAPI()
+        app.include_router(worker_router, prefix="/edge_worker/v1")
+        path = "/edge_worker/v1/worker/version_test"
+        token = JWTGenerator(
+            secret_key=conf.get("api_auth", "jwt_secret"), valid_for=60, audience="api"
+        ).generate(extras={"method": "worker/version_test"})
+        body = {
+            "state": EdgeWorkerState.STARTING,
+            "jobs_active": 0,
+            "queues": ["default"],
+            "sysinfo": dict(self.MOCK_SYSINFO),
+        }
+        jwt_validator.cache_clear()
+        try:
+            with TestClient(app, raise_server_exceptions=False, headers={"Authorization": token}) as client:
+                if method == "PATCH":
+                    assert client.post(path, json=body).status_code == 200
+                body["sysinfo"][field] = "invalid-version" if invalid_source == "worker" else "0.0.0"
+                minimum = "0.0.0" if invalid_source == "worker" else "invalid-version"
+                with conf_vars({("edge", minimum_key): minimum}):
+                    response = client.request(method=method, url=path, json=body)
+        finally:
+            jwt_validator.cache_clear()
+
+        assert response.status_code == (400 if invalid_source == "worker" else 500)
 
     def test_assert_version(self):
         from airflow import __version__ as airflow_version
@@ -113,12 +150,6 @@ class TestWorkerApiRoutes:
         with conf_vars({("edge", "minimum_acceptable_core_version_for_workers"): "3.1.0"}):
             with pytest.raises(HTTPException):
                 _assert_version({"airflow_version": "3.0.0", "edge_provider_version": edge_provider_version})
-
-            with pytest.raises(HTTPException) as exc_info:
-                _assert_version(
-                    {"airflow_version": "invalid-version", "edge_provider_version": edge_provider_version}
-                )
-            assert exc_info.value.status_code == 400
 
             _assert_version({"airflow_version": "3.1.0", "edge_provider_version": edge_provider_version})
             _assert_version({"airflow_version": "3.2.0rc3", "edge_provider_version": edge_provider_version})

--- a/providers/edge3/tests/unit/edge3/worker_api/routes/test_worker.py
+++ b/providers/edge3/tests/unit/edge3/worker_api/routes/test_worker.py
@@ -78,6 +78,11 @@ class TestWorkerApiRoutes:
         assert _version("1.2.3rc1") == (1, 2, 3)
         assert _version("1.2.3.dev0") == (1, 2, 3)
 
+    def test_version_invalid_raises_http_400(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _version("invalid-version-string")
+        assert exc_info.value.status_code == 400
+
     def test_assert_version(self):
         from airflow import __version__ as airflow_version
         from airflow.providers.edge3 import __version__ as edge_provider_version
@@ -108,6 +113,12 @@ class TestWorkerApiRoutes:
         with conf_vars({("edge", "minimum_acceptable_core_version_for_workers"): "3.1.0"}):
             with pytest.raises(HTTPException):
                 _assert_version({"airflow_version": "3.0.0", "edge_provider_version": edge_provider_version})
+
+            with pytest.raises(HTTPException) as exc_info:
+                _assert_version(
+                    {"airflow_version": "invalid-version", "edge_provider_version": edge_provider_version}
+                )
+            assert exc_info.value.status_code == 400
 
             _assert_version({"airflow_version": "3.1.0", "edge_provider_version": edge_provider_version})
             _assert_version({"airflow_version": "3.2.0rc3", "edge_provider_version": edge_provider_version})


### PR DESCRIPTION
When minimum acceptable worker versions were configured, an edge worker submitting an unparseable version string caused packaging version parsing to raise an unhandled InvalidVersion exception. This escaped to the application handler and returned an HTTP 500 error for invalid client input.

This change catches InvalidVersion in _version and raises an HTTP 400 Bad Request error matching the route error specification.

# Testing Done

Reproduction before fix:
```bash
uv run --project providers/edge3 pytest -k test_version_invalid_raises_http_400
```

Pre-fix output:
```text
FAILED test_worker.py test_version_invalid_raises_http_400 - packaging.version.InvalidVersion: Invalid version: 'invalid-version-string'
```

Verification after fix:
```bash
uv run --project providers/edge3 pytest providers/edge3/tests/unit/edge3/worker_api/routes/test_worker.py -k "test_version or test_assert_version"
```

Post-fix output:
```text
================= 3 passed, 37 deselected, 1 warning in 9.72s ==================
```

<details>
<summary>Raw logs</summary>

```text
test_worker.py test_version PASSED [  2%]
test_worker.py test_version_invalid_raises_http_400 PASSED [  5%]
test_worker.py test_assert_version PASSED [  7%]
```

</details>
