### PR TITLE
Restore missing serialized Dags without a full reparse

### DIFF
--- a/airflow-core/docs/howto/usage-cli.rst
+++ b/airflow-core/docs/howto/usage-cli.rst
@@ -358,16 +358,20 @@ file in a bundle:
     airflow dags reserialize --only-missing --bundle-name dags-folder
 
 This option selects recorded source files for active Dags that have no serialized
-version. It parses each selected file once and commits that file independently, so
-restored Dags become available before the command finishes. Existing serialized
-rows and versions are preserved. A selected file can define several Dags, which
-all follow the normal synchronization path.
+version and initializes only bundles that contain those files. It parses each
+selected file once. The first file containing Dags is committed immediately;
+remaining files are committed in batches of up to 32 files within each bundle.
+This makes initial recovery available quickly while reducing database round trips
+for larger recoveries. Existing serialized rows and versions are preserved. A
+selected file can define several Dags, which all follow the normal synchronization
+path.
 
 The option does not discover unregistered Dags or reconstruct missing historical
 versions. Use ``dags reserialize`` without this option to refresh existing
 definitions. Files that are unavailable or fail to parse produce an error exit
-after the remaining files are processed; successfully restored files remain
-committed. Normal Dag processing remains responsible for detecting removals.
+after the remaining files are processed; successfully committed batches remain
+available. A database failure can roll back the current batch, but not earlier
+batches. Normal Dag processing remains responsible for detecting removals.
 
 .. note::
 

--- a/airflow-core/docs/howto/usage-cli.rst
+++ b/airflow-core/docs/howto/usage-cli.rst
@@ -364,10 +364,10 @@ rows and versions are preserved. A selected file can define several Dags, which
 all follow the normal synchronization path.
 
 The option does not discover unregistered Dags or reconstruct missing historical
-versions. Use normal reserialization to refresh existing definitions. Unavailable
-or unparsable files produce an error exit after the remaining files are processed;
-successfully restored files remain committed. Normal Dag processing remains
-responsible for detecting removals.
+versions. Use ``dags reserialize`` without this option to refresh existing
+definitions. Files that are unavailable or fail to parse produce an error exit
+after the remaining files are processed; successfully restored files remain
+committed. Normal Dag processing remains responsible for detecting removals.
 
 .. note::
 

--- a/airflow-core/docs/howto/usage-cli.rst
+++ b/airflow-core/docs/howto/usage-cli.rst
@@ -349,6 +349,26 @@ The ``dags reserialize`` command parses the Dag files visible to it and updates 
 serialized representation in the metadata database. It is a maintenance command, useful
 for example to refresh serialized Dags after upgrading or downgrading Airflow.
 
+Use ``--only-missing`` to restore missing serialized metadata without parsing every
+file in a bundle:
+
+.. code-block:: bash
+
+    airflow dags reserialize --only-missing
+    airflow dags reserialize --only-missing --bundle-name dags-folder
+
+This option selects recorded source files for active Dags that have no serialized
+version. It parses each selected file once and commits that file independently, so
+restored Dags become available before the command finishes. Existing serialized
+rows and versions are preserved. A selected file can define several Dags, which
+all follow the normal synchronization path.
+
+The option does not discover unregistered Dags or reconstruct missing historical
+versions. Use normal reserialization to refresh existing definitions. Unavailable
+or unparsable files produce an error exit after the remaining files are processed;
+successfully restored files remain committed. Normal Dag processing remains
+responsible for detecting removals.
+
 .. note::
 
     ``airflow dags reserialize`` serializes the Dag files visible to the process

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -1445,6 +1445,11 @@ DAGS_COMMANDS = (
         func=lazy_load_command("airflow.cli.commands.dag_command.dag_reserialize"),
         args=(
             ARG_BUNDLE_NAME,
+            Arg(
+                ("--only-missing",),
+                action="store_true",
+                help="Parse only files of active Dags without serialized metadata.",
+            ),
             ARG_VERBOSE,
         ),
     ),

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -28,6 +28,8 @@ import operator
 import re
 import subprocess
 import sys
+from contextlib import nullcontext
+from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 from sqlalchemy import func, select
@@ -55,6 +57,7 @@ from airflow.utils.cli import (
     validate_dag_bundle_arg,
 )
 from airflow.utils.dot_renderer import render_dag, render_dag_dependencies
+from airflow.utils.file import correct_maybe_zipped
 from airflow.utils.helpers import ask_yesno, chunks
 from airflow.utils.platform import getuser
 from airflow.utils.providers_configuration_loader import providers_configuration_loaded
@@ -63,6 +66,7 @@ from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.types import DagRunType
 
 if TYPE_CHECKING:
+    from argparse import Namespace
     from collections.abc import Iterable, Iterator
 
     from graphviz.dot import Dot
@@ -871,7 +875,7 @@ def dag_test(args, dag: DAG | None = None, *, session: Session = NEW_SESSION) ->
 @cli_utils.action_cli
 @providers_configuration_loaded
 @provide_session
-def dag_reserialize(args, *, session: Session = NEW_SESSION) -> None:
+def dag_reserialize(args: Namespace, *, session: Session = NEW_SESSION) -> None:
     """Serialize a DAG instance."""
     manager = DagBundlesManager()
     manager.sync_bundles_to_db(session=session)
@@ -884,12 +888,47 @@ def dag_reserialize(args, *, session: Session = NEW_SESSION) -> None:
     else:
         bundles_to_reserialize = {b.name for b in all_bundles}
 
+    failed_files = 0
     for bundle in all_bundles:
         if bundle.name not in bundles_to_reserialize:
             continue
         bundle.initialize()
-        dag_bag = BundleDagBag(bundle.path, bundle_path=bundle.path, bundle_name=bundle.name)
+        paths: set[Path] = {bundle.path}
+        if args.only_missing:
+            with create_session(scoped=False) as query_session:
+                paths = {
+                    Path(correct_maybe_zipped(bundle.path / fileloc))
+                    for fileloc in query_session.scalars(
+                        select(DagModel.relative_fileloc)
+                        .where(
+                            DagModel.bundle_name == bundle.name,
+                            DagModel.is_stale.is_(False),
+                            DagModel.relative_fileloc.is_not(None),
+                            ~DagModel.dag_id.in_(select(SerializedDagModel.dag_id)),
+                        )
+                        .distinct()
+                    )
+                    if fileloc is not None
+                }
+            log.info(
+                "Found %s Dag files with missing serialized metadata in bundle %s", len(paths), bundle.name
+            )
         version, version_data = unpack_bundle_version(bundle.get_current_version(), bundle)
-        sync_bag_to_db(
-            dag_bag, bundle.name, bundle_version=version, version_data=version_data, session=session
-        )
+        for path in sorted(paths):
+            if args.only_missing and not path.is_file():
+                log.error("Dag file is unavailable: %s", path)
+                failed_files += 1
+                continue
+            dag_bag = BundleDagBag(dag_folder=path, bundle_path=bundle.path, bundle_name=bundle.name)
+            with create_session(scoped=False) if args.only_missing else nullcontext(session) as sync_session:
+                sync_bag_to_db(
+                    dagbag=dag_bag,
+                    bundle_name=bundle.name,
+                    bundle_version=version,
+                    version_data=version_data,
+                    session=sync_session,
+                )
+            if args.only_missing and dag_bag.import_errors:
+                failed_files += 1
+    if failed_files:
+        raise SystemExit(f"Failed to reserialize {failed_files} Dag file(s); see the errors above.")

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -28,7 +28,9 @@ import operator
 import re
 import subprocess
 import sys
+from collections import defaultdict
 from contextlib import nullcontext
+from itertools import islice
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -39,6 +41,7 @@ from airflow.api.client import get_current_api_client
 from airflow.api_fastapi.core_api.datamodels.dags import DAGResponse
 from airflow.cli.simple_table import AirflowConsole
 from airflow.cli.utils import deprecated_for_airflowctl, fetch_dag_run_from_run_id_or_logical_date_string
+from airflow.configuration import conf
 from airflow.dag_processing.bundles.base import unpack_bundle_version
 from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.dag_processing.dagbag import BundleDagBag, DagBag, sync_bag_to_db
@@ -73,6 +76,7 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from airflow import DAG
+    from airflow.dag_processing.bundles.base import BaseDagBundle
     from airflow.serialization.definitions.dag import SerializedDAG
     from airflow.timetables.base import DagRunInfo
 
@@ -82,6 +86,7 @@ log = logging.getLogger(__name__)
 
 # Chunk size for bulk delete.
 _RUN_CHUNK_SIZE = 500
+_RESERIALIZE_BATCH_SIZE: int = 32
 
 
 @deprecated_for_airflowctl("airflowctl dags trigger")
@@ -881,45 +886,71 @@ def dag_reserialize(args: Namespace, *, session: Session = NEW_SESSION) -> None:
     manager.sync_bundles_to_db(session=session)
     session.commit()
 
-    all_bundles = list(manager.get_all_dag_bundles())
     if args.bundle_name:
         validate_dag_bundle_arg(args.bundle_name)
         bundles_to_reserialize = set(args.bundle_name)
     else:
-        bundles_to_reserialize = {b.name for b in all_bundles}
+        bundles_to_reserialize = set(manager.get_all_bundle_names())
 
+    missing_files: defaultdict[str, set[str]] = defaultdict(set)
+    bundles: Iterable[BaseDagBundle]
+    if args.only_missing:
+        with create_session(scoped=False) as query_session:
+            for bundle_name, fileloc in query_session.execute(
+                select(DagModel.bundle_name, DagModel.relative_fileloc)
+                .where(
+                    DagModel.bundle_name.in_(bundles_to_reserialize),
+                    DagModel.is_stale.is_(False),
+                    DagModel.relative_fileloc.is_not(None),
+                    ~select(SerializedDagModel.dag_id)
+                    .where(SerializedDagModel.dag_id == DagModel.dag_id)
+                    .exists(),
+                )
+                .distinct()
+            ):
+                if fileloc is not None:
+                    missing_files[bundle_name].add(fileloc)
+        if not missing_files:
+            log.info("No active Dags have missing serialized metadata in the selected bundles")
+        bundles = (manager.get_bundle(name=name) for name in sorted(missing_files))
+    else:
+        bundles = list(manager.get_all_dag_bundles())
+
+    safe_mode: bool = conf.getboolean("core", "dag_discovery_safe_mode")
     failed_files = 0
-    for bundle in all_bundles:
+    for bundle in bundles:
         if bundle.name not in bundles_to_reserialize:
             continue
         bundle.initialize()
         paths: set[Path] = {bundle.path}
         if args.only_missing:
-            with create_session(scoped=False) as query_session:
-                paths = {
-                    Path(correct_maybe_zipped(bundle.path / fileloc))
-                    for fileloc in query_session.scalars(
-                        select(DagModel.relative_fileloc)
-                        .where(
-                            DagModel.bundle_name == bundle.name,
-                            DagModel.is_stale.is_(False),
-                            DagModel.relative_fileloc.is_not(None),
-                            ~DagModel.dag_id.in_(select(SerializedDagModel.dag_id)),
-                        )
-                        .distinct()
-                    )
-                    if fileloc is not None
-                }
+            paths = {
+                Path(correct_maybe_zipped(bundle.path / fileloc)) for fileloc in missing_files[bundle.name]
+            }
             log.info(
                 "Found %s Dag files with missing serialized metadata in bundle %s", len(paths), bundle.name
             )
         version, version_data = unpack_bundle_version(bundle.get_current_version(), bundle)
-        for path in sorted(paths):
-            if args.only_missing and not path.is_file():
-                log.error("Dag file is unavailable: %s", path)
-                failed_files += 1
+        remaining_paths = iter(sorted(paths))
+        batch_size = 1
+        while batch := list(islice(remaining_paths, batch_size)):
+            dag_bag = BundleDagBag(
+                dag_folder=bundle.path,
+                bundle_path=bundle.path,
+                bundle_name=bundle.name,
+                collect_dags=False,
+            )
+            for path in batch:
+                if args.only_missing and not path.is_file():
+                    log.error("Dag file is unavailable: %s", path)
+                    failed_files += 1
+                    continue
+                error_count = len(dag_bag.import_errors)
+                dag_bag.collect_dags(dag_folder=path, safe_mode=safe_mode)
+                if args.only_missing and len(dag_bag.import_errors) > error_count:
+                    failed_files += 1
+            if args.only_missing and not dag_bag.file_last_changed and not dag_bag.import_errors:
                 continue
-            dag_bag = BundleDagBag(dag_folder=path, bundle_path=bundle.path, bundle_name=bundle.name)
             with create_session(scoped=False) if args.only_missing else nullcontext(session) as sync_session:
                 sync_bag_to_db(
                     dagbag=dag_bag,
@@ -928,7 +959,7 @@ def dag_reserialize(args: Namespace, *, session: Session = NEW_SESSION) -> None:
                     version_data=version_data,
                     session=sync_session,
                 )
-            if args.only_missing and dag_bag.import_errors:
-                failed_files += 1
+            if args.only_missing and dag_bag.dags:
+                batch_size = _RESERIALIZE_BATCH_SIZE
     if failed_files:
         raise SystemExit(f"Failed to reserialize {failed_files} Dag file(s); see the errors above.")

--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -755,8 +755,9 @@ class SerializedDagModel(Base):
             )
 
             if getattr(result, "rowcount", 0) == 0:
-                # No rows updated - serialized DAG doesn't exist
-                return False
+                new_serialized_dag.dag_version = dag_version
+                session.add(new_serialized_dag)
+                session.flush()
 
             if deadline_uuid_mapping:
                 updated_serialized_dag = session.scalar(

--- a/airflow-core/tests/unit/cli/commands/test_dag_reserialize.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_reserialize.py
@@ -1,0 +1,273 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from sqlalchemy import delete, select, update
+
+from airflow import settings
+from airflow.cli import cli_parser
+from airflow.cli.commands.dag_command import dag_reserialize
+from airflow.models import DagModel
+from airflow.models.dag_version import DagVersion
+from airflow.models.serialized_dag import SerializedDagModel
+from airflow.utils.session import create_session
+
+from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.db import clear_db_dags
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+    from contextlib import AbstractContextManager
+
+pytestmark = pytest.mark.db_test
+
+
+@pytest.fixture
+def bundle_files(
+    tmp_path: Path,
+    request: pytest.FixtureRequest,
+    configure_dag_bundles: Callable[[dict[str, Path]], AbstractContextManager[None]],
+) -> Iterator[dict[str, Path]]:
+    clear_db_dags()
+    sources = {
+        "first/repair.py": ["repair_a", "repair_b", "shared"],
+        "first/healthy.py": ["healthy"],
+        "second/other.py": ["other"],
+        "second/stale.py": ["stale"],
+    }
+    sources.update(
+        {f"first/healthy_{index}.py": [f"extra_{index}"] for index in range(getattr(request, "param", 0))}
+    )
+    for filename, dag_ids in sources.items():
+        path = tmp_path / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            "from airflow.sdk import DAG\n"
+            "from airflow.providers.standard.operators.empty import EmptyOperator\n"
+            f"with open({str(tmp_path / 'parsed.txt')!r}, 'a') as stream:\n"
+            "    stream.write(__file__ + '\\n')\n"
+            f"for dag_id in {dag_ids!r}:\n"
+            "    with DAG(dag_id=dag_id, schedule=None) as dag:\n"
+            "        EmptyOperator(task_id='task')\n"
+        )
+    bundles = {"first": tmp_path / "first", "second": tmp_path / "second"}
+    with conf_vars({("core", "load_examples"): "False"}), configure_dag_bundles(bundles):
+        dag_reserialize(cli_parser.get_parser().parse_args(["dags", "reserialize"]))
+        (tmp_path / "parsed.txt").unlink()
+        yield bundles
+    clear_db_dags()
+
+
+def test_reserialize_restores_missing_row_with_existing_version(bundle_files: dict[str, Path]) -> None:
+    with create_session() as session:
+        version_id = session.scalar(select(DagVersion.id).where(DagVersion.dag_id == "repair_a"))
+        session.execute(delete(SerializedDagModel).where(SerializedDagModel.dag_id == "repair_a"))
+
+    dag_reserialize(cli_parser.get_parser().parse_args(["dags", "reserialize"]))
+
+    with create_session() as session:
+        assert (
+            session.scalar(
+                select(SerializedDagModel.dag_version_id).where(SerializedDagModel.dag_id == "repair_a")
+            )
+            == version_id
+        )
+
+
+@pytest.mark.parametrize("bundle_names", [[], ["first"], ["first", "second"]])
+def test_only_missing_scopes_bundles_and_preserves_rows(
+    bundle_files: dict[str, Path], bundle_names: list[str]
+) -> None:
+    with create_session() as session:
+        session.execute(
+            delete(SerializedDagModel).where(
+                SerializedDagModel.dag_id.in_(["repair_a", "repair_b", "other", "stale"])
+            )
+        )
+        session.execute(update(DagModel).where(DagModel.dag_id == "stale").values(is_stale=True))
+        retained_rows = set(
+            session.execute(
+                select(SerializedDagModel.id, SerializedDagModel.dag_hash, SerializedDagModel.dag_version_id)
+            )
+        )
+    args = ["dags", "reserialize", "--only-missing"]
+    for name in bundle_names:
+        args.extend(["--bundle-name", name])
+    dag_reserialize(cli_parser.get_parser().parse_args(args))
+
+    expected_ids = {"repair_a", "repair_b", "shared", "healthy"}
+    expected_files = [str(bundle_files["first"] / "repair.py")]
+    if not bundle_names or "second" in bundle_names:
+        expected_ids.add("other")
+        expected_files.append(str(bundle_files["second"] / "other.py"))
+    with create_session() as session:
+        assert set(session.scalars(select(SerializedDagModel.dag_id))) == expected_ids
+        assert retained_rows <= set(
+            session.execute(
+                select(SerializedDagModel.id, SerializedDagModel.dag_hash, SerializedDagModel.dag_version_id)
+            )
+        )
+    trace = bundle_files["first"].parent / "parsed.txt"
+    assert sorted(trace.read_text().splitlines()) == sorted(expected_files)
+    trace.unlink()
+    dag_reserialize(cli_parser.get_parser().parse_args(args))
+    assert not trace.exists()
+
+
+@pytest.mark.parametrize("source_state", ["missing", "import_error"])
+def test_only_missing_preserves_progress_when_a_file_is_unreadable(
+    bundle_files: dict[str, Path], source_state: str
+) -> None:
+    with create_session() as session:
+        session.execute(
+            delete(SerializedDagModel).where(SerializedDagModel.dag_id.in_(["repair_a", "other"]))
+        )
+    source = bundle_files["first"] / "repair.py"
+    if source_state == "missing":
+        source.unlink()
+    else:
+        source.write_text("from airflow.sdk import DAG\nraise RuntimeError('unavailable dependency')\n")
+    with pytest.raises(SystemExit, match="Failed to reserialize 1 Dag file"):
+        dag_reserialize(cli_parser.get_parser().parse_args(["dags", "reserialize", "--only-missing"]))
+    with create_session() as session:
+        assert set(session.scalars(select(SerializedDagModel.dag_id))) == {
+            "repair_b",
+            "shared",
+            "healthy",
+            "other",
+            "stale",
+        }
+
+
+def test_only_missing_uses_current_bundle_path(
+    bundle_files: dict[str, Path],
+    configure_dag_bundles: Callable[[dict[str, Path]], AbstractContextManager[None]],
+) -> None:
+    with create_session() as session:
+        session.execute(delete(SerializedDagModel).where(SerializedDagModel.dag_id == "repair_a"))
+    relocated = bundle_files["first"].with_name("relocated")
+    bundle_files["first"].rename(relocated)
+
+    with configure_dag_bundles({**bundle_files, "first": relocated}):
+        dag_reserialize(cli_parser.get_parser().parse_args(["dags", "reserialize", "--only-missing"]))
+
+    with create_session() as session:
+        assert "repair_a" in set(session.scalars(select(SerializedDagModel.dag_id)))
+        assert session.scalar(select(DagModel.fileloc).where(DagModel.dag_id == "repair_a")) == str(
+            relocated / "repair.py"
+        )
+
+
+@pytest.mark.parametrize("bundle_kind", ["file", "zip"])
+def test_only_missing_supports_file_bundles(
+    bundle_files: dict[str, Path],
+    bundle_kind: str,
+    test_zip_path: str,
+    configure_dag_bundles: Callable[[dict[str, Path]], AbstractContextManager[None]],
+) -> None:
+    source = Path(test_zip_path) if bundle_kind == "zip" else bundle_files["first"] / "repair.py"
+    with configure_dag_bundles({"selected": source}):
+        dag_reserialize(
+            cli_parser.get_parser().parse_args(["dags", "reserialize", "--bundle-name", "selected"])
+        )
+        with create_session() as session:
+            selected_ids = set(
+                session.scalars(select(DagModel.dag_id).where(DagModel.bundle_name == "selected"))
+            )
+            assert selected_ids
+            session.execute(delete(SerializedDagModel).where(SerializedDagModel.dag_id.in_(selected_ids)))
+
+        dag_reserialize(
+            cli_parser.get_parser().parse_args(
+                ["dags", "reserialize", "--only-missing", "--bundle-name", "selected"]
+            )
+        )
+
+        with create_session() as session:
+            assert selected_ids <= set(session.scalars(select(SerializedDagModel.dag_id)))
+
+
+@pytest.mark.parametrize("bundle_files", [0, 64], indirect=True, ids=["small", "many-files"])
+@pytest.mark.parametrize("only_missing", [False, True], ids=["full", "only-missing"])
+def test_reserialize_native_cli(bundle_files: dict[str, Path], only_missing: bool) -> None:
+    with create_session() as session:
+        expected_ids = set(session.scalars(select(SerializedDagModel.dag_id)))
+        session.execute(
+            delete(SerializedDagModel).where(SerializedDagModel.dag_id.in_(["repair_a", "repair_b"]))
+        )
+        retained_rows = set(
+            session.execute(
+                select(SerializedDagModel.id, SerializedDagModel.dag_hash, SerializedDagModel.dag_version_id)
+            )
+        )
+    command = [sys.executable, "-m", "airflow", "dags", "reserialize"]
+    if only_missing:
+        command.append("--only-missing")
+    assert settings.SQL_ALCHEMY_CONN is not None
+    result = subprocess.run(
+        args=command,
+        env={
+            **os.environ,
+            "AIRFLOW__DATABASE__SQL_ALCHEMY_CONN": settings.SQL_ALCHEMY_CONN,
+            "AIRFLOW__CORE__LOAD_EXAMPLES": "False",
+            "AIRFLOW__DAG_PROCESSOR__DAG_BUNDLE_CONFIG_LIST": json.dumps(
+                [
+                    {
+                        "name": name,
+                        "classpath": "airflow.dag_processing.bundles.local.LocalDagBundle",
+                        "kwargs": {"path": str(path)},
+                    }
+                    for name, path in bundle_files.items()
+                ]
+            ),
+        },
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    print(result.stdout, end="")
+    print(result.stderr, end="")
+    parsed_files = len((bundle_files["first"].parent / "parsed.txt").read_text().splitlines())
+    with create_session() as session:
+        dag_ids = set(session.scalars(select(SerializedDagModel.dag_id)))
+        assert retained_rows <= set(
+            session.execute(
+                select(SerializedDagModel.id, SerializedDagModel.dag_hash, SerializedDagModel.dag_version_id)
+            )
+        )
+    print(
+        json.dumps(
+            {
+                "mode": "only-missing" if only_missing else "full",
+                "parsed_files": parsed_files,
+                "serialized_dags": len(dag_ids),
+                "retained_rows_unchanged": True,
+            }
+        )
+    )
+    assert dag_ids == expected_ids
+    assert parsed_files == (
+        1 if only_missing else sum(len(list(path.glob("*.py"))) for path in bundle_files.values())
+    )

--- a/airflow-core/tests/unit/cli/commands/test_dag_reserialize.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_reserialize.py
@@ -20,15 +20,19 @@ import json
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
-from sqlalchemy import delete, select, update
+from sqlalchemy import delete, event, func, select, update
+from sqlalchemy.orm import Session
 
 from airflow import settings
 from airflow.cli import cli_parser
+from airflow.cli.commands import dag_command
 from airflow.cli.commands.dag_command import dag_reserialize
+from airflow.dag_processing.bundles.local import LocalDagBundle
 from airflow.models import DagModel
 from airflow.models.dag_version import DagVersion
 from airflow.models.serialized_dag import SerializedDagModel
@@ -40,6 +44,8 @@ from tests_common.test_utils.db import clear_db_dags
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
     from contextlib import AbstractContextManager
+
+    from pytest_mock import MockerFixture
 
 pytestmark = pytest.mark.db_test
 
@@ -178,6 +184,94 @@ def test_only_missing_uses_current_bundle_path(
         assert session.scalar(select(DagModel.fileloc).where(DagModel.dag_id == "repair_a")) == str(
             relocated / "repair.py"
         )
+
+
+@pytest.mark.parametrize("has_missing", [False, True])
+def test_only_missing_initializes_needed_bundles(
+    bundle_files: dict[str, Path], mocker: MockerFixture, has_missing: bool
+) -> None:
+    if has_missing:
+        with create_session() as session:
+            session.execute(delete(SerializedDagModel).where(SerializedDagModel.dag_id == "repair_a"))
+    initialize = mocker.spy(LocalDagBundle, "initialize")
+
+    dag_reserialize(cli_parser.get_parser().parse_args(["dags", "reserialize", "--only-missing"]))
+
+    assert [call.args[0].name for call in initialize.call_args_list] == (["first"] if has_missing else [])
+
+
+@pytest.mark.parametrize("bundle_files", [64], indirect=True)
+def test_only_missing_batches_after_first_file(bundle_files: dict[str, Path], mocker: MockerFixture) -> None:
+    missing_ids = {f"extra_{index}" for index in range(64)}
+    with create_session() as session:
+        session.execute(delete(SerializedDagModel).where(SerializedDagModel.dag_id.in_(missing_ids)))
+    sync = mocker.spy(dag_command, "sync_bag_to_db")
+
+    dag_reserialize(cli_parser.get_parser().parse_args(["dags", "reserialize", "--only-missing"]))
+
+    assert sync.call_count == 3
+    assert len(sync.call_args_list[0].kwargs["dagbag"].file_last_changed) == 1
+    assert max(len(call.kwargs["dagbag"].file_last_changed) for call in sync.call_args_list) == 32
+    with create_session() as session:
+        assert missing_ids <= set(session.scalars(select(SerializedDagModel.dag_id)))
+
+
+@pytest.mark.parametrize("bundle_files", [64], indirect=True)
+def test_only_missing_exposes_committed_progress(bundle_files: dict[str, Path]) -> None:
+    missing_ids = {f"extra_{index}" for index in range(64)}
+    with create_session() as session:
+        session.execute(delete(SerializedDagModel).where(SerializedDagModel.dag_id.in_(missing_ids)))
+    engine = settings.engine
+    assert engine is not None
+    milestones: list[tuple[int, float]] = []
+    args = cli_parser.get_parser().parse_args(["dags", "reserialize", "--only-missing"])
+    started = time.monotonic()
+
+    def record_commit(_session: Session) -> None:
+        with engine.connect() as connection:
+            count: int = connection.execute(
+                select(func.count())
+                .select_from(SerializedDagModel)
+                .where(SerializedDagModel.dag_id.in_(missing_ids))
+            ).scalar_one()
+        if count and (not milestones or milestones[-1][0] != count):
+            milestones.append((count, time.monotonic() - started))
+
+    event.listen(target=Session, identifier="after_commit", fn=record_commit)
+    try:
+        dag_reserialize(args)
+    finally:
+        event.remove(target=Session, identifier="after_commit", fn=record_commit)
+
+    print(
+        json.dumps(
+            {
+                "recovery_commits": len(milestones),
+                "first_committed_dags": milestones[0][0] if milestones else 0,
+                "first_visible_seconds": round(milestones[0][1], 3) if milestones else None,
+                "recovery_seconds": round(time.monotonic() - started, 3),
+            }
+        )
+    )
+    assert [count for count, _ in milestones] == [1, 33, 64]
+
+
+@pytest.mark.parametrize("bundle_files", [4], indirect=True)
+def test_only_missing_reports_an_import_error_in_a_batch(bundle_files: dict[str, Path]) -> None:
+    missing_ids = {f"extra_{index}" for index in range(4)}
+    with create_session() as session:
+        session.execute(delete(SerializedDagModel).where(SerializedDagModel.dag_id.in_(missing_ids)))
+    (bundle_files["first"] / "healthy_1.py").write_text(
+        "from airflow.sdk import DAG\nraise RuntimeError('unavailable dependency')\n"
+    )
+
+    with pytest.raises(SystemExit, match="Failed to reserialize 1 Dag file"):
+        dag_reserialize(cli_parser.get_parser().parse_args(["dags", "reserialize", "--only-missing"]))
+
+    with create_session() as session:
+        restored_ids = set(session.scalars(select(SerializedDagModel.dag_id)))
+    assert missing_ids - {"extra_1"} <= restored_ids
+    assert "extra_1" not in restored_ids
 
 
 @pytest.mark.parametrize("bundle_kind", ["file", "zip"])

--- a/airflow-core/tests/unit/models/test_serialized_dag.py
+++ b/airflow-core/tests/unit/models/test_serialized_dag.py
@@ -880,12 +880,18 @@ class TestSerializedDagModel:
         # Hashes should be identical
         assert hash_1 == hash_2, "Hashes should be identical when dicts are sorted consistently"
 
-    def test_dynamic_dag_update_preserves_null_check(self, dag_maker, session):
-        """
-        Test that dynamic DAG update gracefully handles case where SerializedDagModel doesn't exist.
-        This preserves the null-check fix from PR #56422 and tests the direct UPDATE path.
-        """
-        with dag_maker(dag_id="test_missing_serdag", serialized=True, session=session) as dag:
+    @pytest.mark.parametrize("with_deadline", [False, True])
+    def test_dynamic_dag_update_restores_missing_serialization(self, dag_maker, session, with_deadline):
+        deadline = (
+            DeadlineAlert(
+                reference=DeadlineReference.DAGRUN_QUEUED_AT,
+                interval=timedelta(minutes=5),
+                callback=AsyncCallback(empty_callback_for_deadline),
+            )
+            if with_deadline
+            else None
+        )
+        with dag_maker(dag_id="test_missing_serdag", deadline=deadline, session=session) as dag:
             EmptyOperator(task_id="task1")
 
         # Write the DAG first
@@ -911,7 +917,6 @@ class TestSerializedDagModel:
         # Verify no SerializedDagModel exists
         assert SDM.get("test_missing_serdag", session=session) is None
 
-        # Try to update - should return False gracefully (not crash)
         result = SDM.write_dag(
             dag=lazy_dag,
             bundle_name="test_bundle",
@@ -920,7 +925,15 @@ class TestSerializedDagModel:
             session=session,
         )
 
-        assert result is False  # Should return False when SerializedDagModel is missing
+        assert result is True
+        restored = SDM.get("test_missing_serdag", session=session)
+        assert restored is not None
+        assert restored.dag_version_id == dag_version.id
+        if with_deadline:
+            assert len(restored.deadline_alerts) == 1
+            DagSerialization.validate_schema(restored.data)
+        else:
+            assert restored.dag_hash == SDM.hash(lazy_dag.data)
 
     def test_dynamic_dag_update_success(self, dag_maker, session):
         """


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

On upstream Airflow 3, metadata repair can leave an active Dag registered but without a serialized definition, even when its source file is still available. [This public report](https://github.com/apache/airflow/issues/56306) describes missing metadata and unsuccessful attempts to recover by reserializing.

In our past incident recovery, we needed to get missing definitions back quickly while preserving usable metadata. Reparsing unrelated healthy files delayed that work. This PR addresses that recovery need in AF3 without changing Dag cleanup.

## Recovery behavior

`airflow dags reserialize --only-missing` selects the recorded files for active Dags without serialized metadata. It queries the selected bundles together, initializes only bundles with work, and parses each selected file once. `--bundle-name` limits the scope.

The first file containing Dags is committed immediately. Later writes use batches of up to 32 files per bundle to reduce repeated queries and commits. Existing serialized definitions are not cleared; normal Dag processing still owns removals.

The shared writer also recreates a missing serialized row when its unused Dag version survives. Previously, that path returned without restoring the row. The fix applies to normal Dag processing as well as the CLI.

This repairs current definitions for active, registered Dags with usable source locations. Stale or unregistered Dags still need normal discovery. It does not repair source or schema failures or reconstruct historical versions.

## Benchmark

The same test recovered 64 generated one-task Dags against real SQLite, with three alternating samples of the [per-file revision](https://github.com/apache/airflow/commit/38cba6be05168f807130916fbedf8ff7b0cdb698) and the [optimized revision](https://github.com/apache/airflow/commit/ed2c9d0857e95b603f984375e387df99bccc578b). These are recovery-handler timings, not production or end-to-end CLI latency.

| Revision | Recovery commits | First definition visible, median | Recovery complete, median |
|---|---:|---:|---:|
| Per-file | 64 | 0.267 s | 1.913 s |
| Optimized | 3 | 0.345 s | 0.768 s |

Both made one definition visible on the first recovery commit. First-visible ranges overlapped; this sample does not show an improvement in first-availability latency.

A separate native-CLI case restores two missing definitions among 70 generated Dags by parsing one file instead of 68, while preserving the existing serialized rows.

<details><summary>Benchmark setup, commands, and raw samples</summary>

The fixture first parses and stores the Dags normally, then removes the selected serialized definitions. The timing includes its read-after-commit visibility checks and excludes process startup, argument parsing, and database initialization. First-visible ranges were 0.226 to 0.446 seconds before and 0.240 to 0.425 seconds after.

The baseline checkout is `38cba6be05168f807130916fbedf8ff7b0cdb698`; the optimized checkout is `ed2c9d0857e95b603f984375e387df99bccc578b`. Copy this PR's `airflow-core/tests/unit/cli/commands/test_dag_reserialize.py` into the baseline checkout so both run the same observer. Runtime source stays at the pinned revisions.

Run this command from each checkout. The three sample pairs used before/after, after/before, then before/after order:

```bash
breeze --answer yes run bash -c '
  export AIRFLOW_HOME="$(mktemp -d)"
  export AIRFLOW_CONFIG="$AIRFLOW_HOME/airflow.cfg"
  export AIRFLOW__DATABASE__SQL_ALCHEMY_CONN="sqlite:///$AIRFLOW_HOME/airflow.db"
  export AIRFLOW__CORE__LOAD_EXAMPLES=False
  export AIRFLOW__DAG_PROCESSOR__DAG_BUNDLE_CONFIG_LIST="[]"
  airflow db migrate &&
  pytest airflow-core/tests/unit/cli/commands/test_dag_reserialize.py::test_only_missing_exposes_committed_progress \
    --without-db-init -q -s --tb=line
'
```

The baseline restores all 64 definitions but fails the new `[1, 33, 64]` progress assertion because it commits once per file. The optimized revision passes. These are the recorded samples, with revision and sample labels added by the benchmark driver:

```json
{"recovery_commits":64,"first_committed_dags":1,"first_visible_seconds":0.446,"recovery_seconds":2.917,"variant":"before","sample":1}
{"recovery_commits":3,"first_committed_dags":1,"first_visible_seconds":0.24,"recovery_seconds":0.717,"variant":"after","sample":1}
{"recovery_commits":3,"first_committed_dags":1,"first_visible_seconds":0.425,"recovery_seconds":1.721,"variant":"after","sample":2}
{"recovery_commits":64,"first_committed_dags":1,"first_visible_seconds":0.226,"recovery_seconds":1.631,"variant":"before","sample":2}
{"recovery_commits":64,"first_committed_dags":1,"first_visible_seconds":0.267,"recovery_seconds":1.913,"variant":"before","sample":3}
{"recovery_commits":3,"first_committed_dags":1,"first_visible_seconds":0.345,"recovery_seconds":0.768,"variant":"after","sample":3}
```

The native-CLI file-selection case produced:

```text
{"mode": "full", "parsed_files": 68, "serialized_dags": 70, "retained_rows_unchanged": true}
{"mode": "only-missing", "parsed_files": 1, "serialized_dags": 70, "retained_rows_unchanged": true}
```

</details>

Coverage also includes bundle filtering, relocated paths, ZIP and single-file bundles, import failures within a batch, compressed metadata, and the surviving-version recovery case. A database failure can interrupt the current batch; previously committed recovery remains available.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes: GitHub Copilot CLI (GPT-6 Astra).

Generated-by: GitHub Copilot CLI (GPT-6 Astra) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
