### PR TITLE
Fix lock_rows never acquiring a database row lock

### DIFF
--- a/airflow-core/src/airflow/utils/sqlalchemy.py
+++ b/airflow-core/src/airflow/utils/sqlalchemy.py
@@ -580,7 +580,7 @@ def lock_rows(query: Select, session: Session) -> Generator[None, None, None]:
 
     :meta private:
     """
-    locked_rows = with_row_locks(query, session)
+    locked_rows = session.execute(with_row_locks(query, session)).all()
     yield
     del locked_rows
 

--- a/airflow-core/tests/unit/utils/test_sqlalchemy.py
+++ b/airflow-core/tests/unit/utils/test_sqlalchemy.py
@@ -38,6 +38,7 @@ from airflow.utils.sqlalchemy import (
     apply_regex_query_timeout,
     ensure_pod_is_valid_after_unpickling,
     get_dialect_name,
+    lock_rows,
     prohibit_commit,
     with_row_locks,
 )
@@ -179,6 +180,19 @@ class TestSqlAlchemyUtils:
         else:
             assert returned_value == query
             query.with_for_update.assert_not_called()
+
+    def test_lock_rows_executes_locking_query(self):
+        query = mock.Mock()
+        session = mock.Mock()
+        locked_query = mock.Mock()
+
+        with mock.patch("airflow.utils.sqlalchemy.with_row_locks", return_value=locked_query) as mock_wrl:
+            with lock_rows(query, session):
+                pass
+
+        mock_wrl.assert_called_once_with(query, session)
+        session.execute.assert_called_once_with(locked_query)
+        session.execute.return_value.all.assert_called_once()
 
     def test_prohibit_commit(self):
         with prohibit_commit(self.session) as guard:


### PR DESCRIPTION
lock_rows() built a locked query via with_row_locks() but never executed it against the database, so the SELECT ... FOR UPDATE was never sent and no row lock was actually taken. This left its only caller, set_task_group_state's bulk clear/mark-state action, without the concurrency protection it was written to rely on: a user clearing or marking a task group could race with the scheduler concurrently processing the same Dag run, with no database-level serialization between the two despite the code appearing to guard against it.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (Claude Sonnet 5)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
