### PR TITLE
Fix flaky Iceberg snapshot trigger test on slow CI runners

### DIFF
--- a/providers/apache/iceberg/tests/unit/apache/iceberg/triggers/test_iceberg.py
+++ b/providers/apache/iceberg/tests/unit/apache/iceberg/triggers/test_iceberg.py
@@ -43,7 +43,7 @@ def _table_at(snapshot_id: int | None, branch: str = "main") -> MagicMock:
     return table
 
 
-async def _collect(trigger: IcebergTableSnapshotTrigger, count: int, timeout: float = 1.0) -> list[dict]:
+async def _collect(trigger: IcebergTableSnapshotTrigger, count: int, timeout: float = 10.0) -> list[dict]:
     """Pull up to ``count`` payloads off the trigger, giving up after ``timeout``."""
     payloads: list[dict] = []
     generator: AsyncGenerator = trigger.run()  # type: ignore[assignment]
@@ -137,9 +137,7 @@ async def test_emits_once_per_new_snapshot():
     """Each commit produces exactly one event carrying the snapshot it replaced."""
     with patch(LOAD_TABLE, side_effect=[_table_at(111), _table_at(222), _table_at(222), _table_at(333)]):
         trigger = IcebergTableSnapshotTrigger(table="db.tbl", poll_interval=0.01, last_seen_snapshot_id=111)
-        # Gathering 2 events takes 4 polling rounds, each with a real asyncio.to_thread call;
-        # the default 1s budget is too tight under CI thread-pool scheduling latency.
-        payloads = await _collect(trigger, 2, timeout=3.0)
+        payloads = await _collect(trigger, 2)
 
     assert [(p["previous_snapshot_id"], p["snapshot_id"]) for p in payloads] == [(111, 222), (222, 333)]
 
@@ -194,9 +192,7 @@ async def test_persists_the_watermark_on_each_event():
     trigger.asset_state_store = store
 
     with patch(LOAD_TABLE, side_effect=[_table_at(111), _table_at(222), _table_at(222)]):
-        # Gathering 2 events runs several real asyncio.to_thread calls (head lookup + store
-        # get/set); the default 1s budget is too tight under CI thread-pool scheduling latency.
-        payloads = await _collect(trigger, 2, timeout=3.0)
+        payloads = await _collect(trigger, 2)
 
     assert [p["snapshot_id"] for p in payloads] == [111, 222]
     assert [c.args for c in store.set.call_args_list] == [("snapshot_id", 111), ("snapshot_id", 222)]


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->


Related to https://github.com/apache/airflow/actions/runs/34575132708/job/103193684464

Example failure:
```
_______________________________________________________________________ test_runs_without_a_watermark_when_several_assets_watch_it _______________________________________________________________________
providers/apache/iceberg/tests/unit/apache/iceberg/triggers/test_iceberg.py:217: in test_runs_without_a_watermark_when_several_assets_watch_it
    assert [p["snapshot_id"] for p in payloads] == [111]
E   assert equals failed
E     []      [111]
```

The compat 2.11.1 ARM job failed with an empty payload list even though the log shows the multi-asset warning was emitted, so the trigger had reached the polling loop and was cut off by the collector's wall clock rather than by any
behaviour change.

Every polling round goes through real asyncio.to_thread calls, so the budget has to absorb thread-pool scheduling latency instead of reflecting how long the work takes. Raising it at the helper covers the whole family of tests rather than the one that happened to flake, which is what #71825 did for two of its siblings.

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
