### PR TITLE
Avoid a full asset table scan per request in simple auth manager

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
@@ -33,6 +33,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from sqlalchemy import select
 from termcolor import colored
 
 from airflow.api_fastapi.app import AUTH_MANAGER_FASTAPI_APP_PREFIX
@@ -41,8 +42,11 @@ from airflow.api_fastapi.auth.managers.models.resource_details import AccessView
 from airflow.api_fastapi.auth.managers.simple.user import SimpleAuthManagerUser
 from airflow.api_fastapi.common.types import MenuItem
 from airflow.configuration import AIRFLOW_HOME, conf
+from airflow.models.asset import AssetModel
+from airflow.utils.session import NEW_SESSION, provide_session
 
 if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
     from starlette.middleware import _MiddlewareFactory
 
     from airflow.api_fastapi.auth.managers.base_auth_manager import ResourceMethod
@@ -308,6 +312,29 @@ class SimpleAuthManager(BaseAuthManager[SimpleAuthManagerUser]):
             allow_role=SimpleAuthManagerRole.OP,
             user=user,
         )
+
+    @provide_session
+    def get_authorized_assets(
+        self,
+        *,
+        user: SimpleAuthManagerUser,
+        method: ResourceMethod = "GET",
+        session: Session = NEW_SESSION,
+    ) -> set[int]:
+        """
+        Get the ids of the assets the user has access to.
+
+        Simple auth manager authorizes assets at the role level: ``is_authorized_asset`` ignores the
+        asset details, so one check decides the whole listing. The default per-asset loop would
+        re-evaluate that same decision once per row.
+
+        :param user: the user
+        :param method: the method to filter on
+        :param session: the session
+        """
+        if not self.is_authorized_asset(method=method, user=user):
+            return set()
+        return set(session.execute(select(AssetModel.id)).scalars().all())
 
     def is_authorized_pool(
         self,

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/simple/test_simple_auth_manager.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/simple/test_simple_auth_manager.py
@@ -35,8 +35,10 @@ from airflow.api_fastapi.auth.managers.models.resource_details import (
 from airflow.api_fastapi.auth.managers.simple.simple_auth_manager import SimpleAuthManager
 from airflow.api_fastapi.auth.managers.simple.user import SimpleAuthManagerUser
 from airflow.api_fastapi.common.types import MenuItem
+from airflow.models.asset import AssetActive, AssetModel
 
 from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.db import clear_db_assets
 
 
 class TestSimpleAuthManager:
@@ -523,3 +525,36 @@ class TestSimpleAuthManager:
             password = SimpleAuthManager._generate_password()
             assert len(password) == 16
             assert set(password).issubset(alphabet)
+
+    @pytest.mark.db_test
+    @pytest.mark.parametrize(
+        ("role", "expect_authorized"),
+        [
+            ("ADMIN", True),
+            (None, False),
+        ],
+    )
+    def test_get_authorized_assets_checks_authorization_once(
+        self, auth_manager, session, role, expect_authorized
+    ):
+        """With three assets in the table, a call count of one rather than three is what separates
+        the role-level override from the inherited per-asset loop."""
+        clear_db_assets()
+        assets = [AssetModel(name=f"asset{i}", uri=f"s3://bucket/asset{i}", group="asset") for i in range(3)]
+        session.add_all(assets)
+        session.add_all(AssetActive.for_asset(asset) for asset in assets)
+        session.commit()
+        expected_ids = {asset.id for asset in assets} if expect_authorized else set()
+
+        user = SimpleAuthManagerUser(username="test", role=role)
+        with mock.patch.object(
+            auth_manager,
+            "is_authorized_asset",
+            wraps=auth_manager.is_authorized_asset,
+        ) as mock_is_authorized_asset:
+            result = auth_manager.get_authorized_assets(user=user, session=session)
+
+        assert result == expected_ids
+        mock_is_authorized_asset.assert_called_once_with(method="GET", user=user)
+
+        clear_db_assets()


### PR DESCRIPTION
Scoping asset API responses to what a user may read (#72682) gave BaseAuthManager a default that loads the id, name and uri of every asset and then asks is_authorized_asset about each row. Simple auth manager grants asset access by role alone and never inspects the asset it is asked about, so that loop re-derives a single constant answer once per row, and listing one page of assets costs time proportional to the size of the asset table rather than to the page.

The auth managers whose is_authorized_asset makes a remote call were given batched overrides at the time; simple auth manager, which is the default, was left on the generic path.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
