### PR TITLE
Fix airflow teams list --output json printing prose when no teams exist

### DIFF
--- a/airflow-core/src/airflow/cli/commands/team_command.py
+++ b/airflow-core/src/airflow/cli/commands/team_command.py
@@ -44,8 +44,6 @@ from airflow.utils.session import NEW_SESSION, provide_session
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
-NO_TEAMS_LIST_MSG = "No teams found."
-
 
 def _show_teams(teams, output):
     """Display teams in the specified output format."""
@@ -206,10 +204,7 @@ def team_delete(args, *, session=NEW_SESSION):
 def team_list(args, *, session=NEW_SESSION):
     """List all teams."""
     teams = session.scalars(select(Team).order_by(Team.name)).all()
-    if not teams:
-        print(NO_TEAMS_LIST_MSG)
-    else:
-        _show_teams(teams=teams, output=args.output)
+    _show_teams(teams=teams, output=args.output)
 
 
 @cli_utils.action_cli

--- a/airflow-core/tests/unit/cli/commands/test_team_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_team_command.py
@@ -149,16 +149,20 @@ class TestCliTeams:
         with pytest.raises(SystemExit, match="Team with name 'duplicate-team' already exists"):
             team_command.team_create(self.parser.parse_args(["teams", "create", "duplicate-team"]))
 
-    def test_team_list_empty(self, stdout_capture):
-        """Test listing teams when none exist."""
+    @pytest.mark.parametrize(
+        ("output", "expected"),
+        [
+            ("json", "[]"),
+            ("yaml", "[]"),
+            ("table", "No data found"),
+            ("plain", "No data found"),
+        ],
+    )
+    def test_team_list_empty(self, stdout_capture, output, expected):
         with stdout_capture as stdout:
-            team_command.team_list(self.parser.parse_args(["teams", "list"]))
+            team_command.team_list(self.parser.parse_args(["teams", "list", "--output", output]))
 
-        # Should not error, just show empty result
-        output = stdout.getvalue()
-        # The exact output format depends on the AirflowConsole implementation
-        # but it should not contain any team names
-        assert team_command.NO_TEAMS_LIST_MSG in output
+        assert stdout.getvalue().strip() == expected
 
     def test_team_list_with_teams(self, stdout_capture):
         """Test listing teams when teams exist."""


### PR DESCRIPTION
`airflow teams list --output json` (and `--output yaml`) now prints `[]` on an empty metadata DB instead of the prose line `No teams found.`, so the output can be piped into `jq` and other JSON consumers like every other `list` command.

## Why

`team_list` short-circuited with a hard-coded `print("No teams found.")` when the `team` table was empty, before the result ever reached `AirflowConsole().print_as`. The `--output` flag was therefore ignored on that path: a machine-readable format emitted a prose line, and `airflow teams list --output json | jq length` failed with `parse error: Invalid numeric literal at line 1, column 3`.

Every other `list` command (`pools list`, `variables list`, `connections list`, `dags list-import-errors`, ...) hands the possibly-empty sequence straight to `print_as`, which already renders the empty case per format: `[]` for json/yaml and `No data found` for table/plain. That convention is documented in `airflow-core/docs/howto/usage-cli.rst` in the `dags list-import-errors` example. `teams list` was the only list command with its own guard in front of the renderer.

## What

- Drop the empty-list guard in `team_list` so the empty sequence flows through `print_as` like the sibling commands.
- Remove `NO_TEAMS_LIST_MSG`, which had no other reader.
- Replace the single-format `test_team_list_empty` with a parametrized case that pins the empty output for all four formats.

Output on an empty database, before vs. after:

| format | before | after |
|---|---|---|
| json | `No teams found.` | `[]` |
| yaml | `No teams found.` | `[]` |
| table (default) | `No teams found.` | `No data found` |
| plain | `No teams found.` | `No data found` |

**Note for reviewers on the table/plain rows.** The json/yaml rows are the bug. The table/plain rows are a side effect of removing the guard: the human-readable wording moves from `No teams found.` (shipped in 3.2.0) to the `No data found` that `print_as` and every other list command already emit. A script that greps stdout for the old wording would stop matching. I kept the plain removal because it makes `teams list` consistent with the documented convention and deletes code rather than adding a format-specific branch. If you would rather keep the old wording for the human formats, the alternative is to guard only when `args.output` is `table` or `plain` and let json/yaml through. Happy to switch, and to add a newsfragment if you consider the wording change user-facing.

**Same defect elsewhere, deliberately not in this PR.** `airflow plugins --output json` has the identical shape: `dump_plugins` prints `No plugins loaded` and returns before `print_as`, and `test_plugins_command.py` pins that prose while invoking `--output=json`. Left for a follow-up so this diff stays one command.

## How to test

Run the changed test file:

    uv run --project airflow-core pytest airflow-core/tests/unit/cli/commands/test_team_command.py -q

With the fix, all 40 tests in the file pass. Reverting the change in `team_command.py` and re-running the whole file makes the four `test_team_list_empty` cases fail.

Manual check on an empty metadata DB (each line was run, output shown after `#`):

- `airflow teams list --output json | jq length` # `0`
- `airflow teams list --output yaml` # `[]`
- `airflow teams list` # `No data found`
- `airflow teams create team-a && airflow teams list --output json | jq .` # `[{"name": "team-a"}]`

Static checks: `prek run --files` on the two changed files and the `mypy-airflow-core` hook both pass.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5.1)

Generated-by: Claude Code (Fable 5.1) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
