### PR TITLE
Log the HTTP response in HttpToS3Operator when log_response is set

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/http_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/http_to_s3.py
@@ -164,6 +164,8 @@ class HttpToS3Operator(BaseOperator):
     def execute(self, context: Context):
         self.log.info("Calling HTTP method")
         response = self.http_hook.run(self.endpoint, self.data, self.headers, self.extra_options)
+        if self.log_response:
+            self.log.info(response.text)
 
         self.s3_hook.load_bytes(
             response.content,

--- a/providers/amazon/tests/unit/amazon/aws/transfers/test_http_to_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/transfers/test_http_to_s3.py
@@ -18,9 +18,11 @@
 from __future__ import annotations
 
 import datetime
+import logging
 from unittest import mock
 
 import boto3
+import pytest
 from moto import mock_aws
 
 from airflow.models.dag import DAG
@@ -74,3 +76,23 @@ class TestHttpToS3Operator:
         assert len(objects_in_bucket["Contents"]) == 1
         # the object found should be consistent with dest_key specified earlier
         assert objects_in_bucket["Contents"][0]["Key"] == self.s3_key
+
+    @pytest.mark.parametrize("log_response", [True, False])
+    @mock_aws
+    def test_execute_logs_response_only_when_requested(self, requests_mock, caplog, log_response):
+        requests_mock.register_uri("GET", EXAMPLE_URL, content=self.response)
+        boto3.client("s3").create_bucket(Bucket=self.s3_bucket)
+        operator = HttpToS3Operator(
+            task_id="http_to_s3_operator",
+            http_conn_id=self.http_conn_id,
+            endpoint=self.endpoint,
+            s3_key=self.s3_key,
+            s3_bucket=self.s3_bucket,
+            log_response=log_response,
+            dag=self.dag,
+        )
+
+        with caplog.at_level(logging.INFO, logger=operator.log.name):
+            operator.execute(None)
+
+        assert (self.response.decode() in caplog.text) is log_response


### PR DESCRIPTION
`HttpToS3Operator` documents `log_response` ("Log the response (default: False)") and stores it, but `execute()` never reads it, so the response body is never logged no matter what the user sets. This logs `response.text` after the request when the flag is set, the same way `HttpOperator` does.

**Changes**

- `providers/amazon/src/airflow/providers/amazon/aws/transfers/http_to_s3.py`: log the response text when `log_response` is true
- `providers/amazon/tests/unit/amazon/aws/transfers/test_http_to_s3.py`: `test_execute_logs_response_only_when_requested`, parametrized over both values

**Testing**

- `providers/amazon`: `tests/unit/amazon/aws/transfers/test_http_to_s3.py`
- mypy on the changed module, prek hooks on the changed files

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Claude Fable 5.1) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions). I reviewed and understand all changes; the tests were run locally as listed above.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
