### PR TITLE
Log the HTTP response in HttpToGCSOperator when log_response is set

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/transfers/http_to_gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/http_to_gcs.py
@@ -176,6 +176,8 @@ class HttpToGCSOperator(BaseOperator):
         response = self.http_hook.run(
             endpoint=self.endpoint, data=self.data, headers=self.headers, extra_options=self.extra_options
         )
+        if self.log_response:
+            self.log.info(response.text)
 
         self.log.info("Uploading to GCS")
         self.gcs_hook.upload(

--- a/providers/google/tests/unit/google/cloud/transfers/test_http_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_http_to_gcs.py
@@ -17,7 +17,10 @@
 # under the License.
 from __future__ import annotations
 
+import logging
 from unittest import mock
+
+import pytest
 
 from airflow.providers.google.cloud.transfers.http_to_gcs import HttpToGCSOperator
 
@@ -125,3 +128,23 @@ class TestHttpToGCSOperator:
 
         expected_uris = f"gs://{TEST_BUCKET}/{DESTINATION_PATH_FILE}"
         assert result == [expected_uris]
+
+    @pytest.mark.parametrize("log_response", [True, False])
+    @mock.patch("airflow.providers.google.cloud.transfers.http_to_gcs.GCSHook")
+    @mock.patch("airflow.providers.google.cloud.transfers.http_to_gcs.HttpHook")
+    def test_execute_logs_response_only_when_requested(self, http_hook, gcs_hook, caplog, log_response):
+        http_hook.return_value.run.return_value.text = "response body"
+        task = HttpToGCSOperator(
+            task_id=TASK_ID,
+            http_conn_id=HTTP_CONN_ID,
+            endpoint=ENDPOINT,
+            object_name=DESTINATION_PATH_FILE,
+            bucket_name=TEST_BUCKET,
+            gcp_conn_id=GCP_CONN_ID,
+            log_response=log_response,
+        )
+
+        with caplog.at_level(logging.INFO, logger=task.log.name):
+            task.execute(None)
+
+        assert ("response body" in caplog.text) is log_response


### PR DESCRIPTION
`HttpToGCSOperator` documents `log_response` ("Log the response (default: False)") and stores it, but `execute()` never reads it, so the response body is never logged no matter what the user sets. This logs `response.text` after the request when the flag is set, the same way `HttpOperator` does.

**Changes**

- `providers/google/src/airflow/providers/google/cloud/transfers/http_to_gcs.py`: log the response text when `log_response` is true
- `providers/google/tests/unit/google/cloud/transfers/test_http_to_gcs.py`: `test_execute_logs_response_only_when_requested`, parametrized over both values

**Testing**

- `providers/google`: `tests/unit/google/cloud/transfers/test_http_to_gcs.py`
- mypy on the changed module, prek hooks on the changed files

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Claude Fable 5.1) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions). I reviewed and understand all changes; the tests were run locally as listed above.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
