### PR TITLE
Honor download_num_attempts and upload_num_attempts in GCSTimeSpanFileTransformOperator

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/gcs.py
@@ -22,8 +22,9 @@ from __future__ import annotations
 import datetime
 import subprocess
 import sys
+import time
 import warnings
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
@@ -996,7 +997,11 @@ class GCSTimeSpanFileTransformOperator(GoogleCloudBaseOperator):
                     )
                 destination_file.parent.mkdir(parents=True, exist_ok=True)
 
-                blob.download_to_filename(filename=str(destination_file))
+                self._run_with_attempts(
+                    lambda: blob.download_to_filename(filename=str(destination_file)),
+                    num_attempts=self.download_num_attempts,
+                    description=f"Download of gs://{self.source_bucket}/{blob_name}",
+                )
 
                 return blob_name
 
@@ -1071,8 +1076,10 @@ class GCSTimeSpanFileTransformOperator(GoogleCloudBaseOperator):
 
                 blob = bucket.blob(blob_name=upload_file_name, chunk_size=self.chunk_size)
 
-                blob.upload_from_filename(
-                    filename=str(upload_file),
+                self._run_with_attempts(
+                    lambda: blob.upload_from_filename(filename=str(upload_file)),
+                    num_attempts=self.upload_num_attempts,
+                    description=f"Upload of {upload_file_name} to gs://{self.destination_bucket}",
                 )
 
                 return upload_file_name
@@ -1100,6 +1107,28 @@ class GCSTimeSpanFileTransformOperator(GoogleCloudBaseOperator):
                         self.log.warning("Upload failed for %s: %s", upload_file, e)
 
             return files_uploaded
+
+    def _run_with_attempts(
+        self, operation: Callable[[], object], *, num_attempts: int, description: str
+    ) -> None:
+        """
+        Run ``operation`` up to ``num_attempts`` times, retrying on ``GoogleCloudError``.
+
+        This mirrors the retry loop of :meth:`GCSHook.download` and :meth:`GCSHook.upload`, which the
+        operator relied on before it started transferring blobs through the storage client directly.
+        """
+        for attempt in range(1, max(num_attempts, 1) + 1):
+            try:
+                operation()
+                return
+            except GoogleCloudError as e:
+                if attempt >= num_attempts:
+                    raise
+                self.log.warning(
+                    "%s failed on attempt %s of %s: %s. Retrying.", description, attempt, num_attempts, e
+                )
+                # Wait with exponential backoff scheme before retrying.
+                time.sleep(2**attempt)
 
     def get_openlineage_facets_on_complete(self, task_instance):
         """Implement on_complete as execute() resolves object prefixes."""

--- a/providers/google/tests/unit/google/cloud/operators/test_gcs.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_gcs.py
@@ -458,6 +458,16 @@ class TestGCSTimeSpanFileTransformOperator:
         mock_blob = mock_bucket.blob.return_value
         return mock_client, mock_bucket, mock_blob
 
+    @staticmethod
+    def _setup_transform_process(mock_subprocess):
+        mock_proc = mock.MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout.readline = lambda: b""
+        mock_proc.wait.return_value = None
+        mock_subprocess.Popen.return_value.__enter__.return_value = mock_proc
+        mock_subprocess.PIPE = "pipe"
+        mock_subprocess.STDOUT = "stdout"
+
     @mock.patch("airflow.providers.google.cloud.operators.gcs.TemporaryDirectory")
     @mock.patch("airflow.providers.google.cloud.operators.gcs.subprocess")
     @mock.patch("airflow.providers.google.cloud.operators.gcs.GCSHook")
@@ -1087,6 +1097,131 @@ class TestGCSTimeSpanFileTransformOperator:
         with pytest.raises(ValueError, match="escapes the temp directory"):
             op.execute(context=context)
         mock_blob.download_to_filename.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("num_attempts", "outcomes", "succeeds", "expected_sleeps"),
+        [
+            (1, [GoogleCloudError("fail")], False, []),
+            (2, [GoogleCloudError("fail"), GoogleCloudError("fail")], False, [2]),
+            (3, [GoogleCloudError("fail"), None], True, [2]),
+        ],
+    )
+    @mock.patch("airflow.providers.google.cloud.operators.gcs.time.sleep")
+    @mock.patch("airflow.providers.google.cloud.operators.gcs.TemporaryDirectory")
+    @mock.patch("airflow.providers.google.cloud.operators.gcs.subprocess")
+    @mock.patch("airflow.providers.google.cloud.operators.gcs.GCSHook")
+    def test_download_honors_download_num_attempts(
+        self,
+        mock_hook,
+        mock_subprocess,
+        mock_tempdir,
+        mock_sleep,
+        num_attempts,
+        outcomes,
+        succeeds,
+        expected_sleeps,
+    ):
+        timespan_start = datetime(2015, 2, 1, tzinfo=timezone.utc)
+        context = {
+            "logical_date": timespan_start,
+            "data_interval_start": timespan_start,
+            "data_interval_end": timespan_start + timedelta(hours=1),
+            "ti": mock.Mock(),
+            "task": mock.MagicMock(),
+        }
+        mock_tempdir.return_value.__enter__.side_effect = ["source", "destination"]
+        mock_hook.return_value.list_by_timespan.return_value = ["file1"]
+        _, _, mock_blob = self._setup_gcs_client_chain(mock_hook)
+        mock_blob.download_to_filename.side_effect = outcomes
+        self._setup_transform_process(mock_subprocess)
+
+        op = GCSTimeSpanFileTransformOperator(
+            task_id=TASK_ID,
+            source_bucket="bucket",
+            source_prefix="prefix",
+            source_gcp_conn_id="",
+            destination_bucket="dest",
+            destination_prefix="dest",
+            destination_gcp_conn_id="",
+            transform_script="script.py",
+            download_num_attempts=num_attempts,
+        )
+
+        with (
+            mock.patch.object(Path, "glob") as path_glob,
+            mock.patch.object(Path, "is_file", return_value=True),
+        ):
+            path_glob.return_value.__iter__.return_value = []
+            if succeeds:
+                op.execute(context=context)
+            else:
+                with pytest.raises(GoogleCloudError):
+                    op.execute(context=context)
+
+        assert mock_blob.download_to_filename.call_count == len(outcomes)
+        assert [call.args[0] for call in mock_sleep.call_args_list] == expected_sleeps
+
+    @pytest.mark.parametrize(
+        ("num_attempts", "outcomes", "succeeds", "expected_sleeps"),
+        [
+            (1, [GoogleCloudError("fail")], False, []),
+            (2, [GoogleCloudError("fail"), None], True, [2]),
+        ],
+    )
+    @mock.patch("airflow.providers.google.cloud.operators.gcs.time.sleep")
+    @mock.patch("airflow.providers.google.cloud.operators.gcs.TemporaryDirectory")
+    @mock.patch("airflow.providers.google.cloud.operators.gcs.subprocess")
+    @mock.patch("airflow.providers.google.cloud.operators.gcs.GCSHook")
+    def test_upload_honors_upload_num_attempts(
+        self,
+        mock_hook,
+        mock_subprocess,
+        mock_tempdir,
+        mock_sleep,
+        num_attempts,
+        outcomes,
+        succeeds,
+        expected_sleeps,
+    ):
+        timespan_start = datetime(2015, 2, 1, tzinfo=timezone.utc)
+        context = {
+            "logical_date": timespan_start,
+            "data_interval_start": timespan_start,
+            "data_interval_end": timespan_start + timedelta(hours=1),
+            "ti": mock.Mock(),
+            "task": mock.MagicMock(),
+        }
+        mock_tempdir.return_value.__enter__.side_effect = ["source", "destination"]
+        mock_hook.return_value.list_by_timespan.return_value = []
+        _, _, mock_blob = self._setup_gcs_client_chain(mock_hook)
+        mock_blob.upload_from_filename.side_effect = outcomes
+        self._setup_transform_process(mock_subprocess)
+
+        op = GCSTimeSpanFileTransformOperator(
+            task_id=TASK_ID,
+            source_bucket="bucket",
+            source_prefix="prefix",
+            source_gcp_conn_id="",
+            destination_bucket="dest",
+            destination_prefix="dest",
+            destination_gcp_conn_id="",
+            transform_script="script.py",
+            upload_num_attempts=num_attempts,
+        )
+
+        with (
+            mock.patch.object(Path, "glob") as path_glob,
+            mock.patch.object(Path, "is_file", return_value=True),
+        ):
+            path_glob.return_value.__iter__.return_value = [Path("destination/file1")]
+            if succeeds:
+                assert op.execute(context=context) == ["dest/file1"]
+            else:
+                with pytest.raises(GoogleCloudError):
+                    op.execute(context=context)
+
+        assert mock_blob.upload_from_filename.call_count == len(outcomes)
+        assert [call.args[0] for call in mock_sleep.call_args_list] == expected_sleeps
 
 
 class TestGCSDeleteBucketOperator:


### PR DESCRIPTION
`GCSTimeSpanFileTransformOperator` accepts `download_num_attempts` and `upload_num_attempts` ("Number of attempts to try to download/upload a single file"), but since #62196 moved the transfers from `GCSHook.download()` / `GCSHook.upload()` to direct `blob.download_to_filename()` / `blob.upload_from_filename()` calls, both values are stored and never read. Every blob gets exactly one attempt regardless of the setting, so a transient `GoogleCloudError` either fails the task or, with `*_continue_on_fail`, silently drops that file.

This restores the retry behaviour the operator had through the hook: a small `_run_with_attempts` helper retries `GoogleCloudError` up to the configured number of attempts with the hook's exponential back-off (`2**attempt` seconds), and both worker functions go through it. The default of one attempt keeps today's behaviour, and the `*_continue_on_fail` handling around the futures is unchanged.

**Changes**

- `providers/google/src/airflow/providers/google/cloud/operators/gcs.py`: `_run_with_attempts` helper; `_download` and `_upload` honor `download_num_attempts` and `upload_num_attempts`
- `providers/google/tests/unit/google/cloud/operators/test_gcs.py`: `test_download_honors_download_num_attempts` and `test_upload_honors_upload_num_attempts` (retry, give-up and single-attempt cases; `time.sleep` is patched and its calls asserted), plus a shared `_setup_transform_process` helper

**Testing**

- `providers/google`: `tests/unit/google/cloud/operators/test_gcs.py` (`TestGCSTimeSpanFileTransformOperator`, 28 tests)
- mypy on the changed module, prek hooks on the changed files

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Claude Fable 5.1) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions). I reviewed and understand all changes; the tests were run locally as listed above.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
