### PR TITLE
Pass IdP extra request parameters through to the Google token supplier

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/utils/credentials_provider.py
+++ b/providers/google/src/airflow/providers/google/cloud/utils/credentials_provider.py
@@ -399,7 +399,10 @@ class _CredentialProvider(LoggingMixin):
 
         info = _get_info_from_credential_configuration_file(self.credential_config_file)
         info["subject_token_supplier"] = ClientCredentialsGrantFlowTokenSupplier(
-            oidc_issuer_url=self.idp_issuer_url, client_id=self.client_id, client_secret=self.client_secret
+            oidc_issuer_url=self.idp_issuer_url,
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            **(self.idp_extra_params_dict or {}),
         )
 
         scopes = list(self.scopes) if self.scopes else None

--- a/providers/google/src/airflow/providers/google/common/hooks/base_google.py
+++ b/providers/google/src/airflow/providers/google/common/hooks/base_google.py
@@ -360,7 +360,11 @@ class GoogleBaseHook(BaseHook):
         idp_issuer_url: str | None = self._get_field("idp_issuer_url", None)
         client_id: str | None = self._get_field("client_id", None)
         client_secret: str | None = self._get_field("client_secret", None)
-        idp_extra_params: str | None = self._get_field("idp_extra_params", None)
+        # The connection form saves this field as ``idp_extra_parameters``; ``idp_extra_params`` is
+        # still accepted for extras that were written by hand against the previous field name.
+        idp_extra_params: str | None = self._get_field("idp_extra_parameters", None) or self._get_field(
+            "idp_extra_params", None
+        )
 
         idp_extra_params_dict: dict[str, str] | None = None
         if idp_extra_params:

--- a/providers/google/tests/unit/google/cloud/utils/test_credentials_provider.py
+++ b/providers/google/tests/unit/google/cloud/utils/test_credentials_provider.py
@@ -480,6 +480,45 @@ class TestGetGcpCredentialsAndProjectId:
                 in caplog.messages
             )
 
+    @pytest.mark.parametrize(
+        "extra_params",
+        [
+            pytest.param(None, id="no-extra-params"),
+            pytest.param({"audience": TEST_AUDIENCE, "scope": "openid"}, id="extra-params"),
+        ],
+    )
+    @mock.patch("google.auth.load_credentials_from_dict", return_value=("CREDENTIALS", "PROJECT_ID"))
+    @mock.patch(
+        "airflow.providers.google.cloud.utils.credentials_provider.ClientCredentialsGrantFlowTokenSupplier"
+    )
+    def test_get_credentials_using_identity_provider_passes_extra_params_to_token_supplier(
+        self, mock_token_supplier, mock_load_credentials_from_dict, extra_params
+    ):
+        result = get_credentials_and_project_id(
+            credential_config_file=CREDENTIAL_CONFIG_STRING_FILE,
+            idp_issuer_url=IDP_LINK,
+            client_id=CLIENT_ID,
+            client_secret=CLIENT_SECRET,
+            idp_extra_params_dict=extra_params,
+        )
+
+        mock_token_supplier.assert_called_once_with(
+            oidc_issuer_url=IDP_LINK,
+            client_id=CLIENT_ID,
+            client_secret=CLIENT_SECRET,
+            **(extra_params or {}),
+        )
+        mock_load_credentials_from_dict.assert_called_once_with(
+            info={
+                "audience": TEST_AUDIENCE,
+                "subject_token_type": TOKEN_TYPE,
+                "service_account_impersonation_url": ACCOUNT_IMPERSONATION,
+                "subject_token_supplier": mock_token_supplier.return_value,
+            },
+            scopes=ANY,
+        )
+        assert result == ("CREDENTIALS", "PROJECT_ID")
+
     def test_get_credentials_using_idp_no_credential_config(self):
         with pytest.raises(
             AirflowException,

--- a/providers/google/tests/unit/google/common/hooks/test_base_google.py
+++ b/providers/google/tests/unit/google/common/hooks/test_base_google.py
@@ -421,6 +421,37 @@ class TestGoogleBaseHook:
         )
         assert result == ("CREDENTIALS", "PROJECT_ID")
 
+    @pytest.mark.parametrize("field_name", ["idp_extra_parameters", "idp_extra_params"])
+    @mock.patch(MODULE_NAME + ".get_credentials_and_project_id", return_value=("CREDENTIALS", "PROJECT_ID"))
+    def test_get_credentials_and_project_id_passes_idp_extra_params(
+        self, mock_get_creds_and_proj_id, field_name
+    ):
+        self.instance.extras = {
+            "idp_issuer_url": "https://idp.example.com/oauth2/token",
+            "client_id": "CLIENT_ID",
+            "client_secret": "CLIENT_SECRET",
+            field_name: json.dumps({"audience": "api://airflow", "scope": "openid"}),
+        }
+
+        result = self.instance.get_credentials_and_project_id()
+
+        assert result == ("CREDENTIALS", "PROJECT_ID")
+        assert mock_get_creds_and_proj_id.call_args.kwargs["idp_extra_params_dict"] == {
+            "audience": "api://airflow",
+            "scope": "openid",
+        }
+
+    @mock.patch(MODULE_NAME + ".get_credentials_and_project_id", return_value=("CREDENTIALS", "PROJECT_ID"))
+    def test_get_credentials_and_project_id_rejects_invalid_idp_extra_params(
+        self, mock_get_creds_and_proj_id
+    ):
+        self.instance.extras = {"idp_extra_parameters": "{not json"}
+
+        with pytest.raises(AirflowException, match="Invalid JSON"):
+            self.instance.get_credentials_and_project_id()
+
+        mock_get_creds_and_proj_id.assert_not_called()
+
     @mock.patch("requests.post")
     @mock.patch(MODULE_NAME + ".get_credentials_and_project_id")
     def test_connection_success(self, mock_get_creds_and_proj_id, requests_post):


### PR DESCRIPTION
Extra request parameters for the external Identity Provider flow (OAuth2 Client Credentials Grant) never reach the IdP, for two independent reasons:

- the connection form saves the field as `idp_extra_parameters`, but `GoogleBaseHook` reads `idp_extra_params`, so a value entered in the UI is never parsed
- even when parsed, `_CredentialProvider` stores `idp_extra_params_dict` and never passes it on, although `ClientCredentialsGrantFlowTokenSupplier` already accepts `**extra_params_kwargs` and sends them in the token request payload

This reads the field under the name the form saves (keeping `idp_extra_params` as a fallback for extras written by hand) and forwards the parsed dict to the token supplier.

**Changes**

- `providers/google/src/airflow/providers/google/common/hooks/base_google.py`: read `idp_extra_parameters`, fall back to `idp_extra_params`
- `providers/google/src/airflow/providers/google/cloud/utils/credentials_provider.py`: pass `idp_extra_params_dict` to `ClientCredentialsGrantFlowTokenSupplier`
- tests: `test_get_credentials_using_identity_provider_passes_extra_params_to_token_supplier` (credentials provider, with and without extras) and `test_get_credentials_and_project_id_passes_idp_extra_params` / `test_get_credentials_and_project_id_rejects_invalid_idp_extra_params` (hook, both field names and the invalid-JSON path)

**Testing**

- `providers/google`: `tests/unit/google/cloud/utils/test_credentials_provider.py` and `tests/unit/google/common/hooks/test_base_google.py` (140 tests)
- mypy on the changed modules, prek hooks on the changed files

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Claude Fable 5.1) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions). I reviewed and understand all changes; the tests were run locally as listed above.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
