### PR TITLE
Add unit tests for the Cloud Datastore links

### DIFF
--- a/airflow-core/tests/unit/always/test_project_structure.py
+++ b/airflow-core/tests/unit/always/test_project_structure.py
@@ -140,7 +140,6 @@ class TestProjectStructure:
             "providers/google/tests/unit/google/cloud/links/test_datafusion.py",
             "providers/google/tests/unit/google/cloud/links/test_dataprep.py",
             "providers/google/tests/unit/google/cloud/links/test_dataproc.py",
-            "providers/google/tests/unit/google/cloud/links/test_datastore.py",
             "providers/google/tests/unit/google/cloud/links/test_kubernetes_engine.py",
             "providers/google/tests/unit/google/cloud/links/test_pubsub.py",
             "providers/google/tests/unit/google/cloud/links/test_spanner.py",

--- a/providers/google/tests/unit/google/cloud/links/test_datastore.py
+++ b/providers/google/tests/unit/google/cloud/links/test_datastore.py
@@ -1,0 +1,86 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for Cloud Datastore links."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from airflow.providers.google.cloud.links.base import BASE_LINK
+from airflow.providers.google.cloud.links.datastore import (
+    DATASTORE_ENTITIES_LINK,
+    DATASTORE_IMPORT_EXPORT_LINK,
+    CloudDatastoreEntitiesLink,
+    CloudDatastoreImportExportLink,
+)
+
+TEST_PROJECT_ID = "test-project"
+
+
+class TestCloudDatastoreImportExportLink:
+    def test_class_attributes(self):
+        assert CloudDatastoreImportExportLink.key == "import_export_conf"
+        assert CloudDatastoreImportExportLink.name == "Import/Export Page"
+        assert CloudDatastoreImportExportLink.format_str == DATASTORE_IMPORT_EXPORT_LINK
+
+    def test_persist(self):
+        mock_context = mock.MagicMock()
+        mock_context["ti"] = mock.MagicMock()
+        mock_context["task"] = mock.MagicMock(spec=[])
+
+        CloudDatastoreImportExportLink.persist(
+            context=mock_context,
+            project_id=TEST_PROJECT_ID,
+        )
+
+        mock_context["ti"].xcom_push.assert_called_once_with(
+            key="import_export_conf",
+            value={"project_id": TEST_PROJECT_ID},
+        )
+
+    def test_format_link(self):
+        link = CloudDatastoreImportExportLink()
+        result = link._format_link(project_id=TEST_PROJECT_ID)
+        assert result == BASE_LINK + DATASTORE_IMPORT_EXPORT_LINK.format(project_id=TEST_PROJECT_ID)
+
+
+class TestCloudDatastoreEntitiesLink:
+    def test_class_attributes(self):
+        assert CloudDatastoreEntitiesLink.key == "entities_conf"
+        assert CloudDatastoreEntitiesLink.name == "Entities"
+        assert CloudDatastoreEntitiesLink.format_str == DATASTORE_ENTITIES_LINK
+
+    def test_persist(self):
+        mock_context = mock.MagicMock()
+        mock_context["ti"] = mock.MagicMock()
+        mock_context["task"] = mock.MagicMock(spec=[])
+
+        CloudDatastoreEntitiesLink.persist(
+            context=mock_context,
+            project_id=TEST_PROJECT_ID,
+        )
+
+        mock_context["ti"].xcom_push.assert_called_once_with(
+            key="entities_conf",
+            value={"project_id": TEST_PROJECT_ID},
+        )
+
+    def test_format_link(self):
+        link = CloudDatastoreEntitiesLink()
+        result = link._format_link(project_id=TEST_PROJECT_ID)
+        assert result == BASE_LINK + DATASTORE_ENTITIES_LINK.format(project_id=TEST_PROJECT_ID)


### PR DESCRIPTION
`providers/google/tests/unit/google/cloud/links/test_datastore.py` was listed in `OVERLOOKED_TESTS`, so `CloudDatastoreImportExportLink` and `CloudDatastoreEntitiesLink` had no coverage.

Adds class-attribute, `persist` and `_format_link` checks for both, following the shape of `test_bigquery.py` in the same directory.

One thing I deliberately left out: `DATASTORE_EXPORT_ENTITIES_LINK` is defined in the module but no link class references it, so there is nothing to assert about it here. Flagging it in case that is an oversight worth a separate look.

The `OVERLOOKED_TESTS` entry is removed in this PR.

Third in the series after #72949 (`bigquery_dts`) and #72955 (`dataprep`).

related: #35442

### Was generative AI tooling used to co-author this PR?

- [x] Yes

`Generated-by: Claude Code`

The test bodies were written by an AI assistant following the existing `test_bigquery.py` pattern in the same directory. I verified them myself:

- `pytest providers/google/tests/unit/google/cloud/links/test_datastore.py` — 6 passed
- `pytest airflow-core/tests/unit/always/test_project_structure.py` — 10 passed, 1 pre-existing xfail
- `prek run --files <both files>` — 43 passed, 212 skipped, 0 failed
