### PR TITLE
Wait for the EKS cluster to be stable before deleting Fargate profiles

### DIFF
--- a/providers/amazon/tests/system/amazon/aws/example_eks_with_fargate_in_one_step.py
+++ b/providers/amazon/tests/system/amazon/aws/example_eks_with_fargate_in_one_step.py
@@ -123,6 +123,15 @@ with DAG(
         target_state=FargateProfileStates.ACTIVE,
     )
 
+    # The cluster can still report an update in progress after the fargate profile turns ACTIVE, and EKS
+    # rejects the DeleteFargateProfile call below with ResourceInUseException while that update runs.
+    await_cluster_stable = EksClusterStateSensor(
+        task_id="await_cluster_stable",
+        trigger_rule=TriggerRule.ALL_DONE,
+        cluster_name=cluster_name,
+        target_state=ClusterStates.ACTIVE,
+    )
+
     # An Amazon EKS cluster can not be deleted with attached resources such as nodegroups or Fargate profiles.
     # Setting the `force` to `True` will delete any attached resources before deleting the cluster.
     delete_cluster_and_fargate_profile = EksDeleteClusterOperator(
@@ -150,6 +159,7 @@ with DAG(
         # TEST TEARDOWN
         describe_pod,
         await_fargate_profile_stable,
+        await_cluster_stable,
         delete_cluster_and_fargate_profile,
         await_delete_cluster,
     )

--- a/providers/amazon/tests/system/amazon/aws/example_eks_with_fargate_profile.py
+++ b/providers/amazon/tests/system/amazon/aws/example_eks_with_fargate_profile.py
@@ -139,6 +139,15 @@ with DAG(
         target_state=FargateProfileStates.ACTIVE,
     )
 
+    # The cluster can still report an update in progress after the fargate profile turns ACTIVE, and EKS
+    # rejects DeleteFargateProfile with ResourceInUseException while that update runs.
+    await_cluster_stable_before_profile_delete = EksClusterStateSensor(
+        task_id="await_cluster_stable_before_profile_delete",
+        trigger_rule=TriggerRule.ALL_DONE,
+        cluster_name=cluster_name,
+        target_state=ClusterStates.ACTIVE,
+    )
+
     # [START howto_operator_eks_delete_fargate_profile]
     delete_fargate_profile = EksDeleteFargateProfileOperator(
         task_id="delete_eks_fargate_profile",
@@ -190,6 +199,7 @@ with DAG(
         # TEARDOWN
         describe_pod,
         await_fargate_profile_stable,
+        await_cluster_stable_before_profile_delete,
         delete_fargate_profile,  # part of the test AND teardown
         await_delete_fargate_profile,
         await_cluster_stable,


### PR DESCRIPTION
The EKS Fargate system tests deleted the Fargate profile as soon as the profile itself reported ACTIVE, but the cluster can still have an update in progress at that point. EKS then rejects DeleteFargateProfile with ResourceInUseException, and the operator's bounded retry window is not always long enough to ride it out, so the teardown fails and leaks the cluster.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
