### PR TITLE
Fix airflow variables import exiting 0 even when imports fail

### DIFF
--- a/airflow-core/src/airflow/cli/commands/variable_command.py
+++ b/airflow-core/src/airflow/cli/commands/variable_command.py
@@ -152,7 +152,7 @@ def variables_import(args, *, session: Session = NEW_SESSION):
     if action_on_existing != "overwrite":
         existing_keys = set(session.scalars(select(Variable.key).where(Variable.key.in_(var_json))))
     if action_on_existing == "fail" and existing_keys:
-        raise SystemExit(f"Failed. These keys: {sorted(existing_keys)} already exists.")
+        raise SystemExit(f"Failed. These keys: {sorted(existing_keys)} already exist.")
     for k, v in var_json.items():
         if action_on_existing == "skip" and k in existing_keys:
             skipped.add(k)
@@ -169,12 +169,12 @@ def variables_import(args, *, session: Session = NEW_SESSION):
         else:
             suc_count += 1
     print(f"{suc_count} of {len(var_json)} variables successfully updated.")
-    if fail_count:
-        print(f"{fail_count} variable(s) failed to be updated.")
     if skipped:
         print(
-            f"The variables with these keys: {list(sorted(skipped))} were skipped because they already exists"
+            f"The variables with these keys: {list(sorted(skipped))} were skipped because they already exist"
         )
+    if fail_count:
+        raise SystemExit(f"{fail_count} variable(s) failed to be updated.")
 
 
 @providers_configuration_loaded

--- a/airflow-core/tests/unit/cli/commands/test_variable_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_variable_command.py
@@ -21,6 +21,7 @@ import json
 import os
 from contextlib import redirect_stdout
 from io import StringIO
+from unittest import mock
 
 import pytest
 import yaml
@@ -356,6 +357,22 @@ class TestCliVariables:
                     self.parser.parse_args(["variables", "import", file_path]), session=session
                 )
 
+    def test_variables_import_exits_with_error_on_failed_key(self, tmp_path):
+        """variables_import must exit non-zero when any key fails to be set, not just print a message."""
+        path = tmp_path / "variables.json"
+        path.write_text(json.dumps({"good_key": "good_value", "bad_key": "bad_value"}))
+
+        def fake_set(key, value, description=None, serialize_json=False):
+            if key == "bad_key":
+                raise ValueError("boom")
+
+        with mock.patch.object(Variable, "set", autospec=True, side_effect=fake_set):
+            with pytest.raises(SystemExit, match=r"1 variable\(s\) failed to be updated\."):
+                with create_session() as session:
+                    variable_command.variables_import(
+                        self.parser.parse_args(["variables", "import", os.fspath(path)]), session=session
+                    )
+
     def test_variables_export(self):
         """Test variables_export command"""
         variable_command.variables_export(self.parser.parse_args(["variables", "export", os.devnull]))
@@ -591,7 +608,7 @@ class TestCliVariables:
 
         # Test fail action - should fail when key1 already exists
         Variable.set("key1", "original_value")
-        with pytest.raises(SystemExit, match="already exists"):
+        with pytest.raises(SystemExit, match="already exist"):
             with create_session() as session:
                 variable_command.variables_import(
                     self.parser.parse_args(


### PR DESCRIPTION
`airflow variables import` counted and printed per-key failures (e.g. a key exceeding the 250-char limit enforced by Postgres/MySQL, unlike SQLite) but never caused the command to exit non-zero. A caller chaining `airflow variables import vars.json && next_step` would proceed as if the import had fully succeeded.

This mirrors the existing behavior of the sibling `pools import` command, which already does `raise SystemExit(...)` when any pool fails to import.

Also fixes a small grammar issue ("already exists" -> "already exist") in the two messages that describe multiple keys.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)