### PR TITLE
Fix airflow edge list-workers always showing null concurrency

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/cli/edge_command.py
+++ b/providers/edge3/src/airflow/providers/edge3/cli/edge_command.py
@@ -266,28 +266,14 @@ def list_edge_workers(args) -> None:
         queues=args.queues.split(",") if args.queues else None,
     )
     # Format and print worker info on the screen
-    fields = [
-        "worker_name",
-        "state",
-        "queues",
-        "jobs_active",
-        "concurrency",
-        "free_concurrency",
-        "maintenance_comment",
-    ]
+    fields = ["worker_name", "state", "queues", "jobs_active", "maintenance_comment"]
 
     all_hosts = []
     for host in all_hosts_iter:
-        host_data = {
-            f: getattr(host, f, None) for f in fields if f not in ("concurrency", "free_concurrency")
-        }
-        try:
-            sysinfo = json.loads(host.sysinfo or "{}")
-            host_data["concurrency"] = sysinfo.get("concurrency")
-            host_data["free_concurrency"] = sysinfo.get("free_concurrency")
-        except (json.JSONDecodeError, TypeError):
-            host_data["concurrency"] = None
-            host_data["free_concurrency"] = None
+        host_data = {f: getattr(host, f, None) for f in fields}
+        sysinfo = host.sysinfo if isinstance(host.sysinfo, dict) else {}
+        host_data["concurrency"] = sysinfo.get("concurrency")
+        host_data["free_concurrency"] = sysinfo.get("free_concurrency")
         all_hosts.append(host_data)
 
     AirflowConsole().print_as(data=all_hosts, output=args.output)

--- a/providers/edge3/tests/unit/edge3/cli/test_worker.py
+++ b/providers/edge3/tests/unit/edge3/cli/test_worker.py
@@ -1088,6 +1088,7 @@ class TestEdgeWorker:
 
     @pytest.mark.db_test
     def test_list_edge_workers(self, mock_edgeworker: EdgeWorkerModel):
+        mock_edgeworker.sysinfo = {"concurrency": 8, "free_concurrency": 3}
         args = self.parser.parse_args(["edge", "list-workers", "--output", "json"])
         with contextlib.redirect_stdout(StringIO()) as temp_stdout:
             with (
@@ -1113,6 +1114,9 @@ class TestEdgeWorker:
         ]:
             assert key in edge_workers[0]
         assert any("test_edge_worker" in h["worker_name"] for h in edge_workers)
+        # print_as stringifies scalars for json output
+        assert edge_workers[0]["concurrency"] == "8"
+        assert edge_workers[0]["free_concurrency"] == "3"
 
     @pytest.mark.db_test
     def test_list_edge_workers_passes_name_pattern(self, mock_edgeworker: EdgeWorkerModel):


### PR DESCRIPTION
## Why

`airflow edge list-workers` reports `concurrency` and `free_concurrency` as `null` for every worker, regardless of what the worker last heartbeated.

The listing was written when `edge_worker.sysinfo` was a VARCHAR holding JSON text, so it ran `json.loads` on the value. Since #65472 (edge3 3.5.0) the column is a JSON type and SQLAlchemy already returns a `dict`. `json.loads(dict)` raises `TypeError`, the surrounding `except (json.JSONDecodeError, TypeError)` swallowed it, and both fields fell through to `None`. No error was ever shown, and the existing test only asserted the keys were present, so the regression went unnoticed.

## What

- `providers/edge3/src/airflow/providers/edge3/cli/edge_command.py`: read `host.sysinfo` as the dict it already is. A non-dict value (`None` before the first heartbeat, or a stale row) still yields `null` rather than aborting the command, matching the previous degrade-to-null behaviour. The `fields` list no longer carries the two names that were only there to be filtered out again; output columns and their order are unchanged.
- `providers/edge3/tests/unit/edge3/cli/test_worker.py`: `test_list_edge_workers` now sets a `sysinfo` dict on the mocked worker and asserts the reported values, so it fails on the old code.

Not touched: `EdgeWorkerModel.concurrency` is the operator-requested override written by `set-concurrency`, not the value the worker actually runs with, so the CLI keeps reading the worker-reported `sysinfo` value like the UI does.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5.1)

Generated-by: Claude Code (Fable 5.1) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
