### PR TITLE
Add unit tests for the Cloud Functions links

### DIFF
--- a/airflow-core/tests/unit/always/test_project_structure.py
+++ b/airflow-core/tests/unit/always/test_project_structure.py
@@ -128,7 +128,6 @@ class TestProjectStructure:
             "providers/google/tests/unit/google/cloud/links/test_bigquery_dts.py",
             "providers/google/tests/unit/google/cloud/links/test_bigtable.py",
             "providers/google/tests/unit/google/cloud/links/test_cloud_build.py",
-            "providers/google/tests/unit/google/cloud/links/test_cloud_functions.py",
             "providers/google/tests/unit/google/cloud/links/test_cloud_memorystore.py",
             "providers/google/tests/unit/google/cloud/links/test_cloud_sql.py",
             "providers/google/tests/unit/google/cloud/links/test_cloud_tasks.py",

--- a/providers/google/tests/unit/google/cloud/links/test_cloud_functions.py
+++ b/providers/google/tests/unit/google/cloud/links/test_cloud_functions.py
@@ -1,0 +1,106 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for Cloud Functions links."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from airflow.providers.google.cloud.links.cloud_functions import (
+    CLOUD_FUNCTIONS_DETAILS_LINK,
+    CLOUD_FUNCTIONS_LIST_LINK,
+    CloudFunctionsDetailsLink,
+    CloudFunctionsListLink,
+)
+
+TEST_FUNCTION_NAME = "test-function-name"
+TEST_LOCATION = "test-location"
+TEST_PROJECT_ID = "test-project-id"
+
+
+class TestCloudFunctionsDetailsLink:
+    def test_class_attributes(self):
+        assert CloudFunctionsDetailsLink.key == "cloud_functions_details"
+        assert CloudFunctionsDetailsLink.name == "Cloud Functions Details"
+        assert CloudFunctionsDetailsLink.format_str == CLOUD_FUNCTIONS_DETAILS_LINK
+
+    def test_persist(self):
+        mock_context = mock.MagicMock()
+        mock_context["ti"] = mock.MagicMock()
+        mock_context["task"] = mock.MagicMock(spec=[])
+
+        CloudFunctionsDetailsLink.persist(
+            context=mock_context,
+            function_name=TEST_FUNCTION_NAME,
+            location=TEST_LOCATION,
+            project_id=TEST_PROJECT_ID,
+        )
+
+        mock_context["ti"].xcom_push.assert_called_once_with(
+            key="cloud_functions_details",
+            value={
+                "function_name": TEST_FUNCTION_NAME,
+                "location": TEST_LOCATION,
+                "project_id": TEST_PROJECT_ID,
+            },
+        )
+
+    def test_format_link(self):
+        link = CloudFunctionsDetailsLink()
+
+        result = link._format_link(
+            function_name=TEST_FUNCTION_NAME, location=TEST_LOCATION, project_id=TEST_PROJECT_ID
+        )
+
+        # ``CLOUD_FUNCTIONS_DETAILS_LINK`` already embeds ``BASE_LINK``, so ``_format_link``
+        # returns the formatted string instead of prefixing it a second time.
+        assert result == CLOUD_FUNCTIONS_DETAILS_LINK.format(
+            function_name=TEST_FUNCTION_NAME, location=TEST_LOCATION, project_id=TEST_PROJECT_ID
+        )
+
+
+class TestCloudFunctionsListLink:
+    def test_class_attributes(self):
+        assert CloudFunctionsListLink.key == "cloud_functions_list"
+        assert CloudFunctionsListLink.name == "Cloud Functions List"
+        assert CloudFunctionsListLink.format_str == CLOUD_FUNCTIONS_LIST_LINK
+
+    def test_persist(self):
+        mock_context = mock.MagicMock()
+        mock_context["ti"] = mock.MagicMock()
+        mock_context["task"] = mock.MagicMock(spec=[])
+
+        CloudFunctionsListLink.persist(
+            context=mock_context,
+            project_id=TEST_PROJECT_ID,
+        )
+
+        mock_context["ti"].xcom_push.assert_called_once_with(
+            key="cloud_functions_list",
+            value={"project_id": TEST_PROJECT_ID},
+        )
+
+    def test_format_link(self):
+        link = CloudFunctionsListLink()
+
+        result = link._format_link(project_id=TEST_PROJECT_ID)
+
+        # ``CLOUD_FUNCTIONS_LIST_LINK`` already embeds ``BASE_LINK``, so ``_format_link``
+        # returns the formatted string instead of prefixing it a second time.
+        assert result == CLOUD_FUNCTIONS_LIST_LINK.format(project_id=TEST_PROJECT_ID)


### PR DESCRIPTION
`providers/google/tests/unit/google/cloud/links/test_cloud_functions.py` was listed in `OVERLOOKED_TESTS`, so `CloudFunctionsDetailsLink` and `CloudFunctionsListLink` had no coverage.

Adds the checks the sibling link tests use, for each class:

- `test_class_attributes` — `key`, `name`, `format_str`
- `test_persist` — the XCom payload pushed by `BaseGoogleLink.persist`
- `test_format_link` — the `_format_link` output

This module builds its link constants on top of `BASE_LINK`, so the formatted URL is already absolute and `_format_link` returns it instead of prefixing the console base a second time. The `_format_link` assertions pin that.

Same shape as `test_bigquery.py` (added in #68066) in the same directory, and the `OVERLOOKED_TESTS` entry is removed in this PR.

related: #35442

### Was generative AI tooling used to co-author this PR?

- [x] Yes

`Generated-by: Claude Code`

The test bodies were written by an AI assistant following the existing `test_bigquery.py` pattern in the same directory. I verified them myself:

- `pytest providers/google/tests/unit/google/cloud/links/test_cloud_functions.py` — 6 passed
- `pytest airflow-core/tests/unit/always/test_project_structure.py` — 10 passed, 1 xfailed
- `ruff check` / `ruff format --check` on the test file — clean
- `prek run --files providers/google/tests/unit/google/cloud/links/test_cloud_functions.py airflow-core/tests/unit/always/test_project_structure.py` — 43 passed, 212 skipped, 0 failed
