### PR TITLE
Add unit tests for the Cloud SQL links

### DIFF
--- a/airflow-core/tests/unit/always/test_project_structure.py
+++ b/airflow-core/tests/unit/always/test_project_structure.py
@@ -130,7 +130,6 @@ class TestProjectStructure:
             "providers/google/tests/unit/google/cloud/links/test_cloud_build.py",
             "providers/google/tests/unit/google/cloud/links/test_cloud_functions.py",
             "providers/google/tests/unit/google/cloud/links/test_cloud_memorystore.py",
-            "providers/google/tests/unit/google/cloud/links/test_cloud_sql.py",
             "providers/google/tests/unit/google/cloud/links/test_cloud_tasks.py",
             "providers/google/tests/unit/google/cloud/links/test_compute.py",
             "providers/google/tests/unit/google/cloud/links/test_data_loss_prevention.py",

--- a/providers/google/tests/unit/google/cloud/links/test_cloud_sql.py
+++ b/providers/google/tests/unit/google/cloud/links/test_cloud_sql.py
@@ -1,0 +1,98 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for Cloud SQL links."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from airflow.providers.google.cloud.links.base import BASE_LINK
+from airflow.providers.google.cloud.links.cloud_sql import (
+    CLOUD_SQL_INSTANCE_DATABASE_LINK,
+    CLOUD_SQL_INSTANCE_LINK,
+    CloudSQLInstanceDatabaseLink,
+    CloudSQLInstanceLink,
+)
+
+TEST_INSTANCE = "test-instance"
+TEST_PROJECT_ID = "test-project-id"
+
+
+class TestCloudSQLInstanceLink:
+    def test_class_attributes(self):
+        assert CloudSQLInstanceLink.key == "cloud_sql_instance"
+        assert CloudSQLInstanceLink.name == "Cloud SQL Instance"
+        assert CloudSQLInstanceLink.format_str == CLOUD_SQL_INSTANCE_LINK
+
+    def test_persist(self):
+        mock_context = mock.MagicMock()
+        mock_context["ti"] = mock.MagicMock()
+        mock_context["task"] = mock.MagicMock(spec=[])
+
+        CloudSQLInstanceLink.persist(
+            context=mock_context,
+            instance=TEST_INSTANCE,
+            project_id=TEST_PROJECT_ID,
+        )
+
+        mock_context["ti"].xcom_push.assert_called_once_with(
+            key="cloud_sql_instance",
+            value={"instance": TEST_INSTANCE, "project_id": TEST_PROJECT_ID},
+        )
+
+    def test_format_link(self):
+        link = CloudSQLInstanceLink()
+
+        result = link._format_link(instance=TEST_INSTANCE, project_id=TEST_PROJECT_ID)
+
+        assert result == BASE_LINK + CLOUD_SQL_INSTANCE_LINK.format(
+            instance=TEST_INSTANCE, project_id=TEST_PROJECT_ID
+        )
+
+
+class TestCloudSQLInstanceDatabaseLink:
+    def test_class_attributes(self):
+        assert CloudSQLInstanceDatabaseLink.key == "cloud_sql_instance_database"
+        assert CloudSQLInstanceDatabaseLink.name == "Cloud SQL Instance Database"
+        assert CloudSQLInstanceDatabaseLink.format_str == CLOUD_SQL_INSTANCE_DATABASE_LINK
+
+    def test_persist(self):
+        mock_context = mock.MagicMock()
+        mock_context["ti"] = mock.MagicMock()
+        mock_context["task"] = mock.MagicMock(spec=[])
+
+        CloudSQLInstanceDatabaseLink.persist(
+            context=mock_context,
+            instance=TEST_INSTANCE,
+            project_id=TEST_PROJECT_ID,
+        )
+
+        mock_context["ti"].xcom_push.assert_called_once_with(
+            key="cloud_sql_instance_database",
+            value={"instance": TEST_INSTANCE, "project_id": TEST_PROJECT_ID},
+        )
+
+    def test_format_link(self):
+        link = CloudSQLInstanceDatabaseLink()
+
+        result = link._format_link(instance=TEST_INSTANCE, project_id=TEST_PROJECT_ID)
+
+        assert result == BASE_LINK + CLOUD_SQL_INSTANCE_DATABASE_LINK.format(
+            instance=TEST_INSTANCE, project_id=TEST_PROJECT_ID
+        )


### PR DESCRIPTION
`providers/google/tests/unit/google/cloud/links/test_cloud_sql.py` was listed in `OVERLOOKED_TESTS`, so `CloudSQLInstanceLink` and `CloudSQLInstanceDatabaseLink` had no coverage.

Adds the checks the sibling link tests use, for each class:

- `test_class_attributes` — `key`, `name`, `format_str`
- `test_persist` — the XCom payload pushed by `BaseGoogleLink.persist`
- `test_format_link` — the `_format_link` output

Same shape as `test_bigquery.py` (added in #68066) in the same directory, and the `OVERLOOKED_TESTS` entry is removed in this PR.

related: #35442

### Was generative AI tooling used to co-author this PR?

- [x] Yes

`Generated-by: Claude Code`

The test bodies were written by an AI assistant following the existing `test_bigquery.py` pattern in the same directory. I verified them myself:

- `pytest providers/google/tests/unit/google/cloud/links/test_cloud_sql.py` — 6 passed
- `pytest airflow-core/tests/unit/always/test_project_structure.py` — 10 passed, 1 xfailed
- `ruff check` / `ruff format --check` on the test file — clean
- `prek run --files providers/google/tests/unit/google/cloud/links/test_cloud_sql.py airflow-core/tests/unit/always/test_project_structure.py` — 43 passed, 212 skipped, 0 failed
