### PR TITLE
Add unit tests for the Spanner links

### DIFF
--- a/airflow-core/tests/unit/always/test_project_structure.py
+++ b/airflow-core/tests/unit/always/test_project_structure.py
@@ -142,7 +142,6 @@ class TestProjectStructure:
             "providers/google/tests/unit/google/cloud/links/test_datastore.py",
             "providers/google/tests/unit/google/cloud/links/test_kubernetes_engine.py",
             "providers/google/tests/unit/google/cloud/links/test_pubsub.py",
-            "providers/google/tests/unit/google/cloud/links/test_spanner.py",
             "providers/google/tests/unit/google/cloud/links/test_stackdriver.py",
             "providers/google/tests/unit/google/cloud/links/test_workflows.py",
             "providers/google/tests/unit/google/cloud/links/test_translate.py",

--- a/providers/google/tests/unit/google/cloud/links/test_spanner.py
+++ b/providers/google/tests/unit/google/cloud/links/test_spanner.py
@@ -1,0 +1,106 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for Spanner links."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from airflow.providers.google.cloud.links.base import BASE_LINK
+from airflow.providers.google.cloud.links.spanner import (
+    SPANNER_DATABASE_LINK,
+    SPANNER_INSTANCE_LINK,
+    SpannerDatabaseLink,
+    SpannerInstanceLink,
+)
+
+TEST_DATABASE_ID = "test-database-id"
+TEST_INSTANCE_ID = "test-instance-id"
+TEST_PROJECT_ID = "test-project-id"
+
+
+class TestSpannerInstanceLink:
+    def test_class_attributes(self):
+        assert SpannerInstanceLink.key == "spanner_instance"
+        assert SpannerInstanceLink.name == "Spanner Instance"
+        assert SpannerInstanceLink.format_str == SPANNER_INSTANCE_LINK
+
+    def test_persist(self):
+        mock_context = mock.MagicMock()
+        mock_context["ti"] = mock.MagicMock()
+        mock_context["task"] = mock.MagicMock(spec=[])
+
+        SpannerInstanceLink.persist(
+            context=mock_context,
+            instance_id=TEST_INSTANCE_ID,
+            project_id=TEST_PROJECT_ID,
+        )
+
+        mock_context["ti"].xcom_push.assert_called_once_with(
+            key="spanner_instance",
+            value={"instance_id": TEST_INSTANCE_ID, "project_id": TEST_PROJECT_ID},
+        )
+
+    def test_format_link(self):
+        link = SpannerInstanceLink()
+
+        result = link._format_link(instance_id=TEST_INSTANCE_ID, project_id=TEST_PROJECT_ID)
+
+        assert result == BASE_LINK + SPANNER_INSTANCE_LINK.format(
+            instance_id=TEST_INSTANCE_ID, project_id=TEST_PROJECT_ID
+        )
+
+
+class TestSpannerDatabaseLink:
+    def test_class_attributes(self):
+        assert SpannerDatabaseLink.key == "spanner_database"
+        assert SpannerDatabaseLink.name == "Spanner Database"
+        assert SpannerDatabaseLink.format_str == SPANNER_DATABASE_LINK
+
+    def test_persist(self):
+        mock_context = mock.MagicMock()
+        mock_context["ti"] = mock.MagicMock()
+        mock_context["task"] = mock.MagicMock(spec=[])
+
+        SpannerDatabaseLink.persist(
+            context=mock_context,
+            database_id=TEST_DATABASE_ID,
+            instance_id=TEST_INSTANCE_ID,
+            project_id=TEST_PROJECT_ID,
+        )
+
+        mock_context["ti"].xcom_push.assert_called_once_with(
+            key="spanner_database",
+            value={
+                "database_id": TEST_DATABASE_ID,
+                "instance_id": TEST_INSTANCE_ID,
+                "project_id": TEST_PROJECT_ID,
+            },
+        )
+
+    def test_format_link(self):
+        link = SpannerDatabaseLink()
+
+        result = link._format_link(
+            database_id=TEST_DATABASE_ID, instance_id=TEST_INSTANCE_ID, project_id=TEST_PROJECT_ID
+        )
+
+        assert result == BASE_LINK + SPANNER_DATABASE_LINK.format(
+            database_id=TEST_DATABASE_ID, instance_id=TEST_INSTANCE_ID, project_id=TEST_PROJECT_ID
+        )


### PR DESCRIPTION
`providers/google/tests/unit/google/cloud/links/test_spanner.py` was listed in `OVERLOOKED_TESTS`, so `SpannerInstanceLink` and `SpannerDatabaseLink` had no coverage.

Adds the checks the sibling link tests use, for each class:

- `test_class_attributes` — `key`, `name`, `format_str`
- `test_persist` — the XCom payload pushed by `BaseGoogleLink.persist`
- `test_format_link` — the `_format_link` output

Same shape as `test_bigquery.py` (added in #68066) in the same directory, and the `OVERLOOKED_TESTS` entry is removed in this PR.

related: #35442

### Was generative AI tooling used to co-author this PR?

- [x] Yes

`Generated-by: Claude Code`

The test bodies were written by an AI assistant following the existing `test_bigquery.py` pattern in the same directory. I verified them myself:

- `pytest providers/google/tests/unit/google/cloud/links/test_spanner.py` — 6 passed
- `pytest airflow-core/tests/unit/always/test_project_structure.py` — 10 passed, 1 xfailed
- `ruff check` / `ruff format --check` on the test file — clean
- `prek run --files providers/google/tests/unit/google/cloud/links/test_spanner.py airflow-core/tests/unit/always/test_project_structure.py` — 43 passed, 212 skipped, 0 failed
