### PR TITLE
Add unit tests for the Stackdriver links

### DIFF
--- a/airflow-core/tests/unit/always/test_project_structure.py
+++ b/airflow-core/tests/unit/always/test_project_structure.py
@@ -143,7 +143,6 @@ class TestProjectStructure:
             "providers/google/tests/unit/google/cloud/links/test_kubernetes_engine.py",
             "providers/google/tests/unit/google/cloud/links/test_pubsub.py",
             "providers/google/tests/unit/google/cloud/links/test_spanner.py",
-            "providers/google/tests/unit/google/cloud/links/test_stackdriver.py",
             "providers/google/tests/unit/google/cloud/links/test_workflows.py",
             "providers/google/tests/unit/google/cloud/links/test_translate.py",
             "providers/google/tests/unit/google/cloud/operators/vertex_ai/test_auto_ml.py",

--- a/providers/google/tests/unit/google/cloud/links/test_stackdriver.py
+++ b/providers/google/tests/unit/google/cloud/links/test_stackdriver.py
@@ -1,0 +1,91 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for Stackdriver links."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from airflow.providers.google.cloud.links.base import BASE_LINK
+from airflow.providers.google.cloud.links.stackdriver import (
+    STACKDRIVER_NOTIFICATIONS_LINK,
+    STACKDRIVER_POLICIES_LINK,
+    StackdriverNotificationsLink,
+    StackdriverPoliciesLink,
+)
+
+TEST_PROJECT_ID = "test-project-id"
+
+
+class TestStackdriverNotificationsLink:
+    def test_class_attributes(self):
+        assert StackdriverNotificationsLink.key == "stackdriver_notifications"
+        assert StackdriverNotificationsLink.name == "Cloud Monitoring Notifications"
+        assert StackdriverNotificationsLink.format_str == STACKDRIVER_NOTIFICATIONS_LINK
+
+    def test_persist(self):
+        mock_context = mock.MagicMock()
+        mock_context["ti"] = mock.MagicMock()
+        mock_context["task"] = mock.MagicMock(spec=[])
+
+        StackdriverNotificationsLink.persist(
+            context=mock_context,
+            project_id=TEST_PROJECT_ID,
+        )
+
+        mock_context["ti"].xcom_push.assert_called_once_with(
+            key="stackdriver_notifications",
+            value={"project_id": TEST_PROJECT_ID},
+        )
+
+    def test_format_link(self):
+        link = StackdriverNotificationsLink()
+
+        result = link._format_link(project_id=TEST_PROJECT_ID)
+
+        assert result == BASE_LINK + STACKDRIVER_NOTIFICATIONS_LINK.format(project_id=TEST_PROJECT_ID)
+
+
+class TestStackdriverPoliciesLink:
+    def test_class_attributes(self):
+        assert StackdriverPoliciesLink.key == "stackdriver_policies"
+        assert StackdriverPoliciesLink.name == "Cloud Monitoring Policies"
+        assert StackdriverPoliciesLink.format_str == STACKDRIVER_POLICIES_LINK
+
+    def test_persist(self):
+        mock_context = mock.MagicMock()
+        mock_context["ti"] = mock.MagicMock()
+        mock_context["task"] = mock.MagicMock(spec=[])
+
+        StackdriverPoliciesLink.persist(
+            context=mock_context,
+            project_id=TEST_PROJECT_ID,
+        )
+
+        mock_context["ti"].xcom_push.assert_called_once_with(
+            key="stackdriver_policies",
+            value={"project_id": TEST_PROJECT_ID},
+        )
+
+    def test_format_link(self):
+        link = StackdriverPoliciesLink()
+
+        result = link._format_link(project_id=TEST_PROJECT_ID)
+
+        assert result == BASE_LINK + STACKDRIVER_POLICIES_LINK.format(project_id=TEST_PROJECT_ID)


### PR DESCRIPTION
`providers/google/tests/unit/google/cloud/links/test_stackdriver.py` was listed in `OVERLOOKED_TESTS`, so `StackdriverNotificationsLink` and `StackdriverPoliciesLink` had no coverage.

Adds the checks the sibling link tests use, for each class:

- `test_class_attributes` — `key`, `name`, `format_str`
- `test_persist` — the XCom payload pushed by `BaseGoogleLink.persist`
- `test_format_link` — the `_format_link` output

Same shape as `test_bigquery.py` (added in #68066) in the same directory, and the `OVERLOOKED_TESTS` entry is removed in this PR.

related: #35442

### Was generative AI tooling used to co-author this PR?

- [x] Yes

`Generated-by: Claude Code`

The test bodies were written by an AI assistant following the existing `test_bigquery.py` pattern in the same directory. I verified them myself:

- `pytest providers/google/tests/unit/google/cloud/links/test_stackdriver.py` — 6 passed
- `pytest airflow-core/tests/unit/always/test_project_structure.py` — 10 passed, 1 xfailed
- `ruff check` / `ruff format --check` on the test file — clean
- `prek run --files providers/google/tests/unit/google/cloud/links/test_stackdriver.py airflow-core/tests/unit/always/test_project_structure.py` — 43 passed, 212 skipped, 0 failed
