### PR TITLE
Add unit tests for the Workflows links

### DIFF
--- a/airflow-core/tests/unit/always/test_project_structure.py
+++ b/airflow-core/tests/unit/always/test_project_structure.py
@@ -144,7 +144,6 @@ class TestProjectStructure:
             "providers/google/tests/unit/google/cloud/links/test_pubsub.py",
             "providers/google/tests/unit/google/cloud/links/test_spanner.py",
             "providers/google/tests/unit/google/cloud/links/test_stackdriver.py",
-            "providers/google/tests/unit/google/cloud/links/test_workflows.py",
             "providers/google/tests/unit/google/cloud/links/test_translate.py",
             "providers/google/tests/unit/google/cloud/operators/vertex_ai/test_auto_ml.py",
             "providers/google/tests/unit/google/cloud/operators/vertex_ai/test_batch_prediction_job.py",

--- a/providers/google/tests/unit/google/cloud/links/test_workflows.py
+++ b/providers/google/tests/unit/google/cloud/links/test_workflows.py
@@ -1,0 +1,153 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for Workflows links."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from airflow.providers.google.cloud.links.base import BASE_LINK
+from airflow.providers.google.cloud.links.workflows import (
+    EXECUTION_LINK,
+    WORKFLOW_LINK,
+    WORKFLOWS_LINK,
+    WorkflowsExecutionLink,
+    WorkflowsListOfWorkflowsLink,
+    WorkflowsWorkflowDetailsLink,
+)
+
+TEST_EXECUTION_ID = "test-execution-id"
+TEST_LOCATION_ID = "test-location-id"
+TEST_PROJECT_ID = "test-project-id"
+TEST_WORKFLOW_ID = "test-workflow-id"
+
+
+class TestWorkflowsWorkflowDetailsLink:
+    def test_class_attributes(self):
+        assert WorkflowsWorkflowDetailsLink.key == "workflow_details"
+        assert WorkflowsWorkflowDetailsLink.name == "Workflow details"
+        assert WorkflowsWorkflowDetailsLink.format_str == WORKFLOW_LINK
+
+    def test_persist(self):
+        mock_context = mock.MagicMock()
+        mock_context["ti"] = mock.MagicMock()
+        mock_context["task"] = mock.MagicMock(spec=[])
+
+        WorkflowsWorkflowDetailsLink.persist(
+            context=mock_context,
+            location_id=TEST_LOCATION_ID,
+            project_id=TEST_PROJECT_ID,
+            workflow_id=TEST_WORKFLOW_ID,
+        )
+
+        mock_context["ti"].xcom_push.assert_called_once_with(
+            key="workflow_details",
+            value={
+                "location_id": TEST_LOCATION_ID,
+                "project_id": TEST_PROJECT_ID,
+                "workflow_id": TEST_WORKFLOW_ID,
+            },
+        )
+
+    def test_format_link(self):
+        link = WorkflowsWorkflowDetailsLink()
+
+        result = link._format_link(
+            location_id=TEST_LOCATION_ID, project_id=TEST_PROJECT_ID, workflow_id=TEST_WORKFLOW_ID
+        )
+
+        assert result == BASE_LINK + WORKFLOW_LINK.format(
+            location_id=TEST_LOCATION_ID, project_id=TEST_PROJECT_ID, workflow_id=TEST_WORKFLOW_ID
+        )
+
+
+class TestWorkflowsListOfWorkflowsLink:
+    def test_class_attributes(self):
+        assert WorkflowsListOfWorkflowsLink.key == "list_of_workflows"
+        assert WorkflowsListOfWorkflowsLink.name == "List of workflows"
+        assert WorkflowsListOfWorkflowsLink.format_str == WORKFLOWS_LINK
+
+    def test_persist(self):
+        mock_context = mock.MagicMock()
+        mock_context["ti"] = mock.MagicMock()
+        mock_context["task"] = mock.MagicMock(spec=[])
+
+        WorkflowsListOfWorkflowsLink.persist(
+            context=mock_context,
+            project_id=TEST_PROJECT_ID,
+        )
+
+        mock_context["ti"].xcom_push.assert_called_once_with(
+            key="list_of_workflows",
+            value={"project_id": TEST_PROJECT_ID},
+        )
+
+    def test_format_link(self):
+        link = WorkflowsListOfWorkflowsLink()
+
+        result = link._format_link(project_id=TEST_PROJECT_ID)
+
+        assert result == BASE_LINK + WORKFLOWS_LINK.format(project_id=TEST_PROJECT_ID)
+
+
+class TestWorkflowsExecutionLink:
+    def test_class_attributes(self):
+        assert WorkflowsExecutionLink.key == "workflow_execution"
+        assert WorkflowsExecutionLink.name == "Workflow Execution"
+        assert WorkflowsExecutionLink.format_str == EXECUTION_LINK
+
+    def test_persist(self):
+        mock_context = mock.MagicMock()
+        mock_context["ti"] = mock.MagicMock()
+        mock_context["task"] = mock.MagicMock(spec=[])
+
+        WorkflowsExecutionLink.persist(
+            context=mock_context,
+            execution_id=TEST_EXECUTION_ID,
+            location_id=TEST_LOCATION_ID,
+            project_id=TEST_PROJECT_ID,
+            workflow_id=TEST_WORKFLOW_ID,
+        )
+
+        mock_context["ti"].xcom_push.assert_called_once_with(
+            key="workflow_execution",
+            value={
+                "execution_id": TEST_EXECUTION_ID,
+                "location_id": TEST_LOCATION_ID,
+                "project_id": TEST_PROJECT_ID,
+                "workflow_id": TEST_WORKFLOW_ID,
+            },
+        )
+
+    def test_format_link(self):
+        link = WorkflowsExecutionLink()
+
+        result = link._format_link(
+            execution_id=TEST_EXECUTION_ID,
+            location_id=TEST_LOCATION_ID,
+            project_id=TEST_PROJECT_ID,
+            workflow_id=TEST_WORKFLOW_ID,
+        )
+
+        assert result == BASE_LINK + EXECUTION_LINK.format(
+            execution_id=TEST_EXECUTION_ID,
+            location_id=TEST_LOCATION_ID,
+            project_id=TEST_PROJECT_ID,
+            workflow_id=TEST_WORKFLOW_ID,
+        )


### PR DESCRIPTION
`providers/google/tests/unit/google/cloud/links/test_workflows.py` was listed in `OVERLOOKED_TESTS`, so `WorkflowsWorkflowDetailsLink`, `WorkflowsListOfWorkflowsLink` and `WorkflowsExecutionLink` had no coverage.

Adds the checks the sibling link tests use, for each class:

- `test_class_attributes` — `key`, `name`, `format_str`
- `test_persist` — the XCom payload pushed by `BaseGoogleLink.persist`
- `test_format_link` — the `_format_link` output

Same shape as `test_bigquery.py` (added in #68066) in the same directory, and the `OVERLOOKED_TESTS` entry is removed in this PR.

related: #35442

### Was generative AI tooling used to co-author this PR?

- [x] Yes

`Generated-by: Claude Code`

The test bodies were written by an AI assistant following the existing `test_bigquery.py` pattern in the same directory. I verified them myself:

- `pytest providers/google/tests/unit/google/cloud/links/test_workflows.py` — 9 passed
- `pytest airflow-core/tests/unit/always/test_project_structure.py` — 10 passed, 1 xfailed
- `ruff check` / `ruff format --check` on the test file — clean
- `prek run --files providers/google/tests/unit/google/cloud/links/test_workflows.py airflow-core/tests/unit/always/test_project_structure.py` — 43 passed, 212 skipped, 0 failed
