### PR TITLE
Depend on httpx2 instead of httpx in the Task SDK

### DIFF
--- a/airflow-core/docs/security/jwt_token_authentication.rst
+++ b/airflow-core/docs/security/jwt_token_authentication.rst
@@ -300,7 +300,7 @@ The token flows through the execution stack as follows:
 2. The workload JSON is passed to the worker process (via the executor-specific mechanism:
    Celery message, Kubernetes Pod spec, local subprocess arguments, etc.).
 3. The worker's ``execute_workload()`` function reads the workload JSON and extracts the token.
-4. The ``supervise_task()`` function receives the token and creates an ``httpx.Client`` instance
+4. The ``supervise_task()`` function receives the token and creates an ``httpx2.Client`` instance
    with ``BearerAuth(token)`` for all Execution API HTTP requests.
 5. The worker calls the ``/run`` endpoint with the ``workload``-scoped token to mark the task
    as running. The server responds with a fresh ``execution``-scoped token in the

--- a/airflow-core/newsfragments/72977.significant.rst
+++ b/airflow-core/newsfragments/72977.significant.rst
@@ -1,0 +1,20 @@
+The Task SDK now depends on ``httpx2`` instead of ``httpx``
+
+The Task SDK's Execution API client is now an ``httpx2.Client``. ``httpx2`` is a fork of
+``httpx`` 0.28.1 with the same public API, maintained at https://pydantic.dev/docs/httpx2/.
+
+Objects do not cross the ``httpx``/``httpx2`` boundary: the two packages define distinct
+``Client``, ``Request``, ``Response``, ``Timeout``, transport and exception classes. Code that
+interacts with the SDK client must switch to ``httpx2``:
+
+- ``except httpx.HTTPStatusError`` (or ``HTTPError``, ``RequestError``, ``ConnectError``) around
+  Execution API calls no longer catches anything. ``airflow.sdk.api.client.ServerResponseError``
+  now subclasses ``httpx2.HTTPStatusError``.
+- Custom transports passed to the client, including ``httpx.MockTransport`` in tests, must be
+  ``httpx2`` transports.
+- ``isinstance()`` checks against ``httpx`` classes fail for SDK client objects.
+
+``certifi`` is now a direct Task SDK dependency. It was previously installed as a transitive
+dependency of ``httpx``; ``httpx2`` depends on ``truststore`` instead. TLS verification behaviour
+is unchanged, because the client always builds and passes its own ``ssl.SSLContext`` — the
+``[api] client_use_public_certs``, ``ssl_ca_file`` and ``ssl_cert`` options work as before.

--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -102,6 +102,9 @@ dependencies = [
     "uvicorn>=0.37.0",
     "starlette>=1.0.1",
     "httpx>=0.25.0",
+    # Only for InProcessExecutionAPI's transports, which feed httpx2-based Task SDK clients.
+    # The rest of airflow-core is still on httpx; tracked at https://github.com/apache/airflow/issues/70522
+    "httpx2>=2.0.0",
     'importlib_metadata>=6.5;python_version<"3.12"',
     'importlib_metadata>=7.0;python_version>="3.12"',
     "itsdangerous>=2.0",

--- a/airflow-core/src/airflow/api_fastapi/execution_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/app.py
@@ -46,7 +46,7 @@ from airflow.api_fastapi.auth.tokens import (
 )
 
 if TYPE_CHECKING:
-    import httpx
+    import httpx2
 
 import structlog
 from structlog.contextvars import bind_contextvars
@@ -378,7 +378,7 @@ class InProcessExecutionAPI:
     A helper class to make it possible to run the ExecutionAPI "in-process".
 
     The sync version of this makes use of a2wsgi which runs the async loop in a separate thread. This is
-    needed so that we can use the sync httpx client
+    needed so that we can use the sync httpx2 client
     """
 
     _app: FastAPI | None = None
@@ -422,9 +422,11 @@ class InProcessExecutionAPI:
 
         return self._app
 
+    # httpx2, not httpx: the only consumers are Task SDK clients, which subclass httpx2.Client,
+    # and transports do not cross the httpx/httpx2 package boundary.
     @cached_property
-    def transport(self) -> httpx.WSGITransport:
-        import httpx
+    def transport(self) -> httpx2.WSGITransport:
+        import httpx2
         from a2wsgi import ASGIMiddleware
 
         # We choose to own the event loop + executor thread here so that we can have explicit control over
@@ -445,7 +447,7 @@ class InProcessExecutionAPI:
         # safely aclose() a context whose __aenter__ has actually run.
         asyncio.run_coroutine_threadsafe(start_lifespan(cm, self.app), loop).result()
 
-        transport = httpx.WSGITransport(app=middleware)  # type: ignore[arg-type]
+        transport = httpx2.WSGITransport(app=middleware)  # type: ignore[arg-type]
 
         # Stop the loop + thread and unwind the lifespan when the *transport* is garbage collected, not
         # this InProcessExecutionAPI instance. Callers commonly build a Client from ``.transport`` and drop
@@ -457,7 +459,7 @@ class InProcessExecutionAPI:
         return transport
 
     @cached_property
-    def atransport(self) -> httpx.ASGITransport:
-        import httpx
+    def atransport(self) -> httpx2.ASGITransport:
+        import httpx2
 
-        return httpx.ASGITransport(app=self.app)
+        return httpx2.ASGITransport(app=self.app)

--- a/airflow-core/tests/unit/api_fastapi/execution_api/test_app.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/test_app.py
@@ -22,7 +22,7 @@ import threading
 from unittest import mock
 from uuid import UUID
 
-import httpx
+import httpx2
 import pytest
 from fastapi import Request, status
 from fastapi.params import Security as SecurityParam
@@ -158,7 +158,7 @@ def test_routes_with_task_instance_id_param_enforce_ti_self(client):
 def test_in_process_execution_api_runs_without_jwt_secret():
     """The in-process API must not require ``api_auth/jwt_secret`` to be configured."""
     api = InProcessExecutionAPI()
-    with httpx.Client(transport=api.transport) as client:
+    with httpx2.Client(transport=api.transport) as client:
         response = client.get("http://localhost/health")
     assert response.status_code == 200
 

--- a/devel-common/src/tests_common/test_utils/in_process_taskrun.py
+++ b/devel-common/src/tests_common/test_utils/in_process_taskrun.py
@@ -57,25 +57,25 @@ _XCOM_PATH_PARTS = 5  # /xcoms/{dag_id}/{run_id}/{task_id}/{key}
 
 def _remembering_handler(store: dict, run_context_json: bytes) -> Callable:
     """A dry-run transport handler: valid run-context + XCom round-trip from ``store``, else no-op."""
-    import httpx
+    import httpx2
 
     from airflow.sdk.api.client import noop_handler
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(request: httpx2.Request) -> httpx2.Response:
         path = request.url.path
         if path.startswith("/task-instances/") and path.endswith("/run"):
-            return httpx.Response(200, content=run_context_json)
+            return httpx2.Response(200, content=run_context_json)
         parts = path.strip("/").split("/")
         if len(parts) == _XCOM_PATH_PARTS and parts[0] == "xcoms":
             dag_id, run_id, task_id, key = parts[1:]
             sig = (dag_id, run_id, task_id, key)
             if request.method == "POST":
                 store[sig] = json.loads(request.content)
-                return httpx.Response(201, json={"ok": True})
+                return httpx2.Response(201, json={"ok": True})
             if request.method == "GET":
                 if sig in store:
-                    return httpx.Response(200, json={"key": key, "value": store[sig]})
-                return httpx.Response(404, json={"detail": "XCom not found"})
+                    return httpx2.Response(200, json={"key": key, "value": store[sig]})
+                return httpx2.Response(404, json={"detail": "XCom not found"})
         return noop_handler(request)
 
     return handler
@@ -87,7 +87,7 @@ def build_in_memory_client(ti_context) -> Client:
     ``ti_context`` (a ``TIRunContext``) is replayed for the task-start request. Pushed XCom
     values are exposed as ``client.pushed_xcoms`` keyed by ``(dag_id, run_id, task_id, key)``.
     """
-    import httpx
+    import httpx2
 
     from airflow.sdk.api.client import Client
 
@@ -96,7 +96,7 @@ def build_in_memory_client(ti_context) -> Client:
         base_url=None,
         dry_run=True,
         token="",
-        transport=httpx.MockTransport(_remembering_handler(store, ti_context.model_dump_json().encode())),
+        transport=httpx2.MockTransport(_remembering_handler(store, ti_context.model_dump_json().encode())),
     )
     client.pushed_xcoms = store  # type: ignore[attr-defined]
     return client

--- a/shared/logging/src/airflow_shared/logging/structlog.py
+++ b/shared/logging/src/airflow_shared/logging/structlog.py
@@ -420,22 +420,16 @@ def structlog_processors(
     # structlog to ignore.
 
     import contextlib
+    import importlib
 
     import click
 
     suppress: tuple[ModuleType, ...] = (click, contextlib)
-    try:
-        import httpcore
-
-        suppress = (*suppress, httpcore)
-    except ImportError:
-        pass
-    try:
-        import httpx
-
-        suppress = (*suppress, httpx)
-    except ImportError:
-        pass
+    # airflow-core is still on httpx while the Task SDK is on httpx2, so either (or both) may
+    # be installed; tracked at https://github.com/apache/airflow/issues/70522
+    for module_name in ("httpcore", "httpcore2", "httpx", "httpx2"):
+        with contextlib.suppress(ImportError):
+            suppress = (*suppress, importlib.import_module(module_name))
 
     if json_output:
         dict_exc_formatter = structlog.tracebacks.ExceptionDictTransformer(
@@ -690,6 +684,7 @@ def configure_logging(
             "airflow": {"level": log_level.upper()},
             # These ones are too chatty even at info
             "httpx": {"level": "WARN"},
+            "httpx2": {"level": "WARN"},
             "sqlalchemy.engine": {"level": "WARN"},
             "alembic.runtime.plugins": {"level": "WARN"},
         }

--- a/task-sdk/.ast-grep/rules/no-httpx-import.yml
+++ b/task-sdk/.ast-grep/rules/no-httpx-import.yml
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,25 +14,25 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Generate Execution API OpenAPI schema. Prints JSON to stdout. Run with cwd at repo root."""
-
-from __future__ import annotations
-
-import json
-import os
-import sys
-from pathlib import Path
-
-os.environ["_AIRFLOW__AS_LIBRARY"] = "1"
-sys.path.insert(0, str(Path("airflow-core/src").resolve()))
-
-import httpx2
-
-from airflow.api_fastapi.execution_api.app import InProcessExecutionAPI
-
-app = InProcessExecutionAPI()
-version = app.app.versions.version_values[0]
-client = httpx2.Client(transport=app.transport)
-response = client.get(f"http://localhost/openapi.json?version={version}")
-response.raise_for_status()
-print(json.dumps(response.json()))
+---
+id: no-httpx-import
+language: python
+severity: error
+message: Import 'httpx2' instead of 'httpx' -- see https://github.com/apache/airflow/issues/70522
+note: >-
+  The Task SDK's Execution API client is an 'httpx2.Client'. Requests, responses,
+  transports and exceptions do not cross the 'httpx'/'httpx2' boundary, so a stray
+  'httpx' import here silently breaks mocking, retries and error handling.
+files:
+  - "**/*.py"
+rule:
+  all:
+    - kind: dotted_name
+    - regex: ^httpx($|\.)
+    - any:
+        - inside:
+            kind: import_statement
+            stopBy: end
+        - inside:
+            kind: import_from_statement
+            field: module_name

--- a/task-sdk/.ast-grep/sgconfig.yml
+++ b/task-sdk/.ast-grep/sgconfig.yml
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,25 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Generate Execution API OpenAPI schema. Prints JSON to stdout. Run with cwd at repo root."""
-
-from __future__ import annotations
-
-import json
-import os
-import sys
-from pathlib import Path
-
-os.environ["_AIRFLOW__AS_LIBRARY"] = "1"
-sys.path.insert(0, str(Path("airflow-core/src").resolve()))
-
-import httpx2
-
-from airflow.api_fastapi.execution_api.app import InProcessExecutionAPI
-
-app = InProcessExecutionAPI()
-version = app.app.versions.version_values[0]
-client = httpx2.Client(transport=app.transport)
-response = client.get(f"http://localhost/openapi.json?version={version}")
-response.raise_for_status()
-print(json.dumps(response.json()))
+---
+# NOTE: this file configures `ast-grep`, which is used for enforcing custom lint / auto-formatting
+# across a number of different languages. Currently, we use this in a pre-commit hook to avoid
+# regressions of reintroducing `httpx` in the Task SDK, which is fully migrated to `httpx2`.
+#
+# If new ast-grep rules are required, they may be added in the rules directory listed below.
+#
+# See also:
+#   https://github.com/ast-grep/ast-grep
+#   https://ast-grep.github.io/guide/introduction
+ruleDirs:
+  - rules

--- a/task-sdk/.pre-commit-config.yaml
+++ b/task-sdk/.pre-commit-config.yaml
@@ -65,3 +65,12 @@ repos:
         pass_filenames: false
         files: ^.*\.py$
         require_serial: true
+  - repo: https://github.com/boidolr/ast-grep-pre-commit
+    rev: 0.45.2
+    hooks:
+      - id: ast-grep
+        name: Check task-sdk imports httpx2 rather than httpx
+        types: [python]
+        # Pinned to the task-sdk config rather than relying on ast-grep walking up
+        # from the working directory, so a future root sgconfig.yml cannot shadow it.
+        args: ["--config", "./.ast-grep/sgconfig.yml"]

--- a/task-sdk/dev/generate_task_sdk_models.py
+++ b/task-sdk/dev/generate_task_sdk_models.py
@@ -21,7 +21,7 @@ import os
 import sys
 from pathlib import Path
 
-import httpx
+import httpx2
 from datamodel_code_generator import (
     DataModelType,
     DatetimeClassType,
@@ -81,7 +81,7 @@ def generate_file():
     app = InProcessExecutionAPI()
 
     latest_version = app.app.versions.version_values[0]
-    client = httpx.Client(transport=app.transport)
+    client = httpx2.Client(transport=app.transport)
     openapi_schema = (
         client.get(f"http://localhost/openapi.json?version={latest_version}").raise_for_status().text
     )

--- a/task-sdk/pyproject.toml
+++ b/task-sdk/pyproject.toml
@@ -53,8 +53,10 @@ dependencies = [
     "asgiref>=3.11.1; python_version >= '3.14'",
     "attrs>=24.2.0, !=25.2.0",
     "babel>=2.17.0",
+    # Direct import in airflow.sdk.api.client; used to arrive via httpx, but httpx2 uses truststore.
+    "certifi>=2024.7.4",
     "fsspec>=2023.10.0",
-    "httpx>=0.27.0",
+    "httpx2>=2.0.0",
     "jinja2>=3.1.5",
     "methodtools>=0.4.7",
     "msgspec>=0.19.0",

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 from urllib.parse import quote
 
 import certifi
-import httpx
+import httpx2
 import msgspec
 import structlog
 from opentelemetry import trace
@@ -190,22 +190,22 @@ __all__ = [
 ]
 
 
-def get_json_error(response: httpx.Response):
+def get_json_error(response: httpx2.Response):
     """Raise a ServerResponseError if we can extract error info from the error."""
     err = ServerResponseError.from_response(response)
     if err:
         raise err
 
 
-def raise_on_4xx_5xx(response: httpx.Response):
+def raise_on_4xx_5xx(response: httpx2.Response):
     return get_json_error(response) or response.raise_for_status()
 
 
 # Py 3.11+ version
-def raise_on_4xx_5xx_with_note(response: httpx.Response):
+def raise_on_4xx_5xx_with_note(response: httpx2.Response):
     try:
         return get_json_error(response) or response.raise_for_status()
-    except httpx.HTTPStatusError as e:
+    except httpx2.HTTPStatusError as e:
         if TYPE_CHECKING:
             assert hasattr(e, "add_note")
         e.add_note(
@@ -225,11 +225,11 @@ if hasattr(BaseException, "add_note"):
     raise_on_4xx_5xx = raise_on_4xx_5xx_with_note
 
 
-def add_correlation_id(request: httpx.Request):
+def add_correlation_id(request: httpx2.Request):
     request.headers["correlation-id"] = str(uuid7())
 
 
-def inject_trace_context(request: httpx.Request) -> None:
+def inject_trace_context(request: httpx2.Request) -> None:
     _trace_propagator.inject(request.headers)
 
 
@@ -1108,11 +1108,11 @@ class CallbackOperations:
         self.client.patch(f"callbacks/{callback_id}/run")
 
 
-class BearerAuth(httpx.Auth):
+class BearerAuth(httpx2.Auth):
     def __init__(self, token: str):
         self.token: str = token
 
-    def auth_flow(self, request: httpx.Request):
+    def auth_flow(self, request: httpx2.Request):
         if self.token:
             request.headers["Authorization"] = "Bearer " + self.token
         yield request
@@ -1120,13 +1120,13 @@ class BearerAuth(httpx.Auth):
 
 # This exists as an aid for debugging or local running via the `dry_run` argument to Client. It doesn't make
 # sense for returning connections etc.
-def noop_handler(request: httpx.Request) -> httpx.Response:
+def noop_handler(request: httpx2.Request) -> httpx2.Response:
     path = request.url.path
     log.debug("Dry-run request", method=request.method, path=path)
 
     if path.startswith("/task-instances/") and path.endswith("/run"):
         # Return a fake context
-        return httpx.Response(
+        return httpx2.Response(
             200,
             json={
                 "dag_run": {
@@ -1142,7 +1142,7 @@ def noop_handler(request: httpx.Request) -> httpx.Response:
                 "should_retry": False,
             },
         )
-    return httpx.Response(200, json={"text": "Hello, world!"})
+    return httpx2.Response(200, json={"text": "Hello, world!"})
 
 
 # Note: Given defaults make attempts after 1, 3, 7, 15 and fails after 31seconds
@@ -1159,13 +1159,13 @@ API_CLIENT_USE_PUBLIC_CERTS = conf.getboolean("api", "client_use_public_certs", 
 
 def _should_retry_api_request(exception: BaseException) -> bool:
     """Determine if an API request should be retried based on the exception type."""
-    if isinstance(exception, httpx.HTTPStatusError):
+    if isinstance(exception, httpx2.HTTPStatusError):
         return exception.response.status_code >= 500
 
-    return isinstance(exception, httpx.RequestError)
+    return isinstance(exception, httpx2.RequestError)
 
 
-class Client(httpx.Client):
+class Client(httpx2.Client):
     @lru_cache()
     @staticmethod
     def _get_ssl_context_cached(ca_file: str | None = None, ca_path: str | None = None) -> ssl.SSLContext:
@@ -1193,7 +1193,7 @@ class Client(httpx.Client):
         if dry_run:
             # If dry run is requested, install a no op handler so that simple tasks can "heartbeat" using a
             # real client, but just don't make any HTTP requests
-            kwargs.setdefault("transport", httpx.MockTransport(noop_handler))
+            kwargs.setdefault("transport", httpx2.MockTransport(noop_handler))
             kwargs.setdefault("base_url", "dry-run://server")
         else:
             kwargs["base_url"] = base_url
@@ -1223,7 +1223,7 @@ class Client(httpx.Client):
             **kwargs,
         )
 
-    def _update_auth(self, response: httpx.Response):
+    def _update_auth(self, response: httpx2.Response):
         if new_token := response.headers.get("Refreshed-API-Token"):
             log.debug("Execution API issued us a refreshed Task token")
             self.auth = BearerAuth(new_token)
@@ -1236,7 +1236,7 @@ class Client(httpx.Client):
         reraise=True,
     )
     def request(self, *args, **kwargs):
-        """Implement a convenience for httpx.Client.request with a retry layer."""
+        """Implement a convenience for httpx2.Client.request with a retry layer."""
         # Set content type as convenience if not already set
         if kwargs.get("content", None) is not None and "content-type" not in (
             kwargs.get("headers", {}) or {}
@@ -1336,18 +1336,19 @@ class _ErrorBody(BaseModel):
         return repr(self.detail)
 
 
-class ServerResponseError(httpx.HTTPStatusError):
-    def __init__(self, message: str, *, request: httpx.Request, response: httpx.Response):
+class ServerResponseError(httpx2.HTTPStatusError):
+    def __init__(self, message: str, *, request: httpx2.Request, response: httpx2.Response):
         super().__init__(message, request=request, response=response)
 
     detail: list[RemoteValidationError] | str | dict[str, Any] | None
 
     def __reduce__(self) -> tuple[Any, ...]:
-        # Needed because https://github.com/encode/httpx/pull/3108 isn't merged yet.
+        # Needed because https://github.com/encode/httpx/pull/3108 never landed, and httpx2
+        # forked from httpx 0.28.1 without it.
         return Exception.__new__, (type(self),) + self.args, self.__dict__
 
     @classmethod
-    def from_response(cls, response: httpx.Response) -> ServerResponseError | None:
+    def from_response(cls, response: httpx2.Response) -> ServerResponseError | None:
         if response.is_success:
             return None
         # 4xx or 5xx error?
@@ -1373,7 +1374,7 @@ class ServerResponseError(httpx.HTTPStatusError):
             try:
                 detail = msgspec.json.decode(response.content)
             except Exception:
-                # Fallback to a normal httpx error
+                # Fallback to a normal httpx2 error
                 return None
             msg = "Server returned error"
 

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -43,7 +43,7 @@ from urllib.parse import urlparse
 from uuid import UUID
 
 import attrs
-import httpx
+import httpx2
 import msgspec
 import psutil
 import structlog
@@ -983,8 +983,8 @@ class WatchedSubprocess:
                     request_id=request.id,
                 )
             except Exception as e:
-                # Generic exception handling so a transient network error (httpx.ConnectError /
-                # httpx.TimeoutException) or any other exception
+                # Generic exception handling so a transient network error (httpx2.ConnectError /
+                # httpx2.TimeoutException) or any other exception
                 # doesn't crash this generator and crash the IPC communication between supervisor and task.
                 log.exception(
                     "Unhandled exception while handling task request",
@@ -1330,7 +1330,7 @@ def _ensure_client(
         yield client
         return
 
-    limits = httpx.Limits(max_keepalive_connections=1, max_connections=10)
+    limits = httpx2.Limits(max_keepalive_connections=1, max_connections=10)
     new_client = Client(base_url=server or "", limits=limits, dry_run=dry_run, token=token)
     log.debug("Connecting to execution API server", server=server)
     try:

--- a/task-sdk/tests/task_sdk/__init__.py
+++ b/task-sdk/tests/task_sdk/__init__.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-import httpx
+import httpx2
 
 from airflow.sdk.api.client import Client
 from airflow.sdk.execution_time.comms import BundleInfo
@@ -24,7 +24,7 @@ from airflow.sdk.execution_time.comms import BundleInfo
 FAKE_BUNDLE = BundleInfo(name="anything", version="any")
 
 
-def make_client(transport: httpx.MockTransport) -> Client:
+def make_client(transport: httpx2.MockTransport) -> Client:
     """Get a client with a custom transport."""
     return Client(base_url="test://server", token="", transport=transport)
 
@@ -34,12 +34,12 @@ def make_client_w_dry_run() -> Client:
     return Client(base_url=None, dry_run=True, token="")
 
 
-def make_client_w_responses(responses: list[httpx.Response]) -> Client:
+def make_client_w_responses(responses: list[httpx2.Response]) -> Client:
     """Get a client with custom responses."""
 
-    def handle_request(request: httpx.Request) -> httpx.Response:
+    def handle_request(request: httpx2.Request) -> httpx2.Response:
         return responses.pop(0)
 
     return Client(
-        base_url=None, dry_run=True, token="", mounts={"'http://": httpx.MockTransport(handle_request)}
+        base_url=None, dry_run=True, token="", mounts={"'http://": httpx2.MockTransport(handle_request)}
     )

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING
 from unittest import mock
 
 import certifi
-import httpx
+import httpx2
 import pytest
 import time_machine
 import uuid6
@@ -99,53 +99,53 @@ class TestClient:
 
     @mock.patch("airflow.sdk.api.client.API_SSL_CERT_PATH", "/capath/does/not/exist/")
     def test_add_capath(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(status_code=200)
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
+            return httpx2.Response(status_code=200)
 
         with pytest.raises(FileNotFoundError) as err:
-            make_client(httpx.MockTransport(handle_request))
+            make_client(httpx2.MockTransport(handle_request))
 
         assert isinstance(err.value, FileNotFoundError)
 
     @mock.patch("airflow.sdk.api.client.API_SSL_CA_FILE_PATH", "/capath/does/not/exist/")
     def test_ssl_with_cafile(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(status_code=200)
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
+            return httpx2.Response(status_code=200)
 
         with pytest.raises(FileNotFoundError) as err:
-            make_client(httpx.MockTransport(handle_request))
+            make_client(httpx2.MockTransport(handle_request))
 
         assert isinstance(err.value, FileNotFoundError)
 
     @mock.patch("ssl.create_default_context")
     @mock.patch("airflow.sdk.api.client.API_CLIENT_USE_PUBLIC_CERTS", True)
     def test_use_public_certs(self, mock_default_context):
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(status_code=200)
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
+            return httpx2.Response(status_code=200)
 
-        make_client(httpx.MockTransport(handle_request))
+        make_client(httpx2.MockTransport(handle_request))
         mock_default_context.return_value.load_verify_locations.assert_called_with(certifi.where())
 
     @mock.patch("airflow.sdk.api.client.API_TIMEOUT", 60.0)
     def test_timeout_configuration(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(status_code=200)
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
+            return httpx2.Response(status_code=200)
 
-        client = make_client(httpx.MockTransport(handle_request))
-        assert client.timeout == httpx.Timeout(60.0)
+        client = make_client(httpx2.MockTransport(handle_request))
+        assert client.timeout == httpx2.Timeout(60.0)
 
     def test_timeout_can_be_overridden(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(status_code=200)
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
+            return httpx2.Response(status_code=200)
 
         client = Client(
-            base_url="test://server", token="", transport=httpx.MockTransport(handle_request), timeout=120.0
+            base_url="test://server", token="", transport=httpx2.MockTransport(handle_request), timeout=120.0
         )
-        assert client.timeout == httpx.Timeout(120.0)
+        assert client.timeout == httpx2.Timeout(120.0)
 
     def test_error_parsing(self):
         responses = [
-            httpx.Response(422, json={"detail": [{"loc": ["#0"], "msg": "err", "type": "required"}]})
+            httpx2.Response(422, json={"detail": [{"loc": ["#0"], "msg": "err", "type": "required"}]})
         ]
         client = make_client_w_responses(responses)
 
@@ -159,15 +159,15 @@ class TestClient:
         ]
 
     def test_error_parsing_plain_text(self):
-        responses = [httpx.Response(422, content=b"Internal Server Error")]
+        responses = [httpx2.Response(422, content=b"Internal Server Error")]
         client = make_client_w_responses(responses)
 
-        with pytest.raises(httpx.HTTPStatusError) as err:
+        with pytest.raises(httpx2.HTTPStatusError) as err:
             client.get("http://error")
         assert not isinstance(err.value, ServerResponseError)
 
     def test_error_parsing_other_json(self):
-        responses = [httpx.Response(404, json={"detail": "Not found"})]
+        responses = [httpx2.Response(404, json={"detail": "Not found"})]
         client = make_client_w_responses(responses)
 
         with pytest.raises(ServerResponseError) as err:
@@ -176,7 +176,7 @@ class TestClient:
         assert err.value.detail is None
 
     def test_server_response_error_pickling(self):
-        responses = [httpx.Response(404, json={"detail": {"message": "Invalid input"}})]
+        responses = [httpx2.Response(404, json={"detail": {"message": "Invalid input"}})]
         client = make_client_w_responses(responses)
 
         with pytest.raises(ServerResponseError) as exc_info:
@@ -201,7 +201,7 @@ class TestClient:
     @pytest.mark.skipif(sys.version_info < (3, 11), reason="Exception notes (PEP 678) require Python 3.11")
     def test_server_error_detail_added_as_note(self):
         """Notes survive uncaught propagation, handled sites still log detail directly."""
-        responses = [httpx.Response(404, json={"detail": {"message": "Invalid input"}})]
+        responses = [httpx2.Response(404, json={"detail": {"message": "Invalid input"}})]
         client = make_client_w_responses(responses)
 
         with pytest.raises(ServerResponseError) as exc_info:
@@ -216,24 +216,24 @@ class TestClient:
 
     def test_retry_handling_unrecoverable_error(self):
         with time_machine.travel("2023-01-01T00:00:00Z", tick=False):
-            responses: list[httpx.Response] = [
-                *[httpx.Response(500, text="Internal Server Error")] * 6,
-                httpx.Response(200, json={"detail": "Recovered from error - but will fail before"}),
-                httpx.Response(400, json={"detail": "Should not get here"}),
+            responses: list[httpx2.Response] = [
+                *[httpx2.Response(500, text="Internal Server Error")] * 6,
+                httpx2.Response(200, json={"detail": "Recovered from error - but will fail before"}),
+                httpx2.Response(400, json={"detail": "Should not get here"}),
             ]
             client = make_client_w_responses(responses)
 
-            with pytest.raises(httpx.HTTPStatusError) as err:
+            with pytest.raises(httpx2.HTTPStatusError) as err:
                 client.get("http://error")
             assert not isinstance(err.value, ServerResponseError)
             assert len(responses) == 3
 
     def test_retry_handling_recovered(self):
         with time_machine.travel("2023-01-01T00:00:00Z", tick=False):
-            responses: list[httpx.Response] = [
-                *[httpx.Response(500, text="Internal Server Error")] * 2,
-                httpx.Response(200, json={"detail": "Recovered from error"}),
-                httpx.Response(400, json={"detail": "Should not get here"}),
+            responses: list[httpx2.Response] = [
+                *[httpx2.Response(500, text="Internal Server Error")] * 2,
+                httpx2.Response(200, json={"detail": "Recovered from error"}),
+                httpx2.Response(400, json={"detail": "Should not get here"}),
             ]
             client = make_client_w_responses(responses)
 
@@ -243,9 +243,9 @@ class TestClient:
 
     def test_retry_handling_non_retry_error(self):
         with time_machine.travel("2023-01-01T00:00:00Z", tick=False):
-            responses: list[httpx.Response] = [
-                httpx.Response(422, json={"detail": "Somehow this is a bad request"}),
-                httpx.Response(400, json={"detail": "Should not get here"}),
+            responses: list[httpx2.Response] = [
+                httpx2.Response(422, json={"detail": "Somehow this is a bad request"}),
+                httpx2.Response(400, json={"detail": "Should not get here"}),
             ]
             client = make_client_w_responses(responses)
 
@@ -256,9 +256,9 @@ class TestClient:
 
     def test_retry_handling_ok(self):
         with time_machine.travel("2023-01-01T00:00:00Z", tick=False):
-            responses: list[httpx.Response] = [
-                httpx.Response(200, json={"detail": "Recovered from error"}),
-                httpx.Response(400, json={"detail": "Should not get here"}),
+            responses: list[httpx2.Response] = [
+                httpx2.Response(200, json={"detail": "Recovered from error"}),
+                httpx2.Response(400, json={"detail": "Should not get here"}),
             ]
             client = make_client_w_responses(responses)
 
@@ -267,10 +267,10 @@ class TestClient:
             assert len(responses) == 1
 
     def test_token_renewal(self):
-        responses: list[httpx.Response] = [
-            httpx.Response(200, json={"ok": "1"}),
-            httpx.Response(404, json={"var": "not_found"}, headers={"Refreshed-API-Token": "abc"}),
-            httpx.Response(200, json={"ok": "3"}),
+        responses: list[httpx2.Response] = [
+            httpx2.Response(200, json={"ok": "1"}),
+            httpx2.Response(404, json={"var": "not_found"}, headers={"Refreshed-API-Token": "abc"}),
+            httpx2.Response(200, json={"ok": "3"}),
         ]
         client = make_client_w_responses(responses)
         response = client.get("/")
@@ -299,35 +299,35 @@ class TestClient:
     )
     def test_server_response_error_invalid_status_codes(self, status_code, description):
         """Test that ServerResponseError.from_response returns None for invalid status codes."""
-        response = httpx.Response(status_code, json={"detail": f"Test {description}"})
+        response = httpx2.Response(status_code, json={"detail": f"Test {description}"})
         assert ServerResponseError.from_response(response) is None
 
     @mock.patch("airflow.sdk.api.client.API_CLIENT_SSL_CERT", "/etc/airflow/certs/client.crt")
     @mock.patch("airflow.sdk.api.client.API_CLIENT_SSL_KEY", "/etc/airflow/certs/client.key")
     def test_sets_cert_tuple(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(status_code=200)
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
+            return httpx2.Response(status_code=200)
 
         captured: dict[str, object] = {}
-        real_init = httpx.Client.__init__
+        real_init = httpx2.Client.__init__
 
         def spy_init(self, *args, **kwargs):
             captured["cert"] = kwargs.get("cert")
             return real_init(self, *args, **kwargs)
 
-        with mock.patch.object(httpx.Client, "__init__", spy_init):
-            make_client(httpx.MockTransport(handle_request))
+        with mock.patch.object(httpx2.Client, "__init__", spy_init):
+            make_client(httpx2.MockTransport(handle_request))
 
         assert captured["cert"] == ("/etc/airflow/certs/client.crt", "/etc/airflow/certs/client.key")
 
     @mock.patch("airflow.sdk.api.client.API_CLIENT_SSL_CERT", "/etc/airflow/certs/client.crt")
     @mock.patch("airflow.sdk.api.client.API_CLIENT_SSL_KEY", None)
     def test_requires_both_cert_and_key(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(status_code=200)
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
+            return httpx2.Response(status_code=200)
 
         with pytest.raises(ValueError, match="Both client_ssl_cert and client_ssl_key must be set"):
-            make_client(httpx.MockTransport(handle_request))
+            make_client(httpx2.MockTransport(handle_request))
 
 
 class TestTaskInstanceOperations:
@@ -351,23 +351,23 @@ class TestTaskInstanceOperations:
             # ...including a validation that retry really works
             call_count = 0
 
-            def handle_request(request: httpx.Request) -> httpx.Response:
+            def handle_request(request: httpx2.Request) -> httpx2.Response:
                 nonlocal call_count
                 call_count += 1
                 if call_count < 3:
-                    return httpx.Response(status_code=500, json={"detail": "Internal Server Error"})
+                    return httpx2.Response(status_code=500, json={"detail": "Internal Server Error"})
                 if request.url.path == f"/task-instances/{ti_id}/run":
                     actual_body = json.loads(request.read())
                     assert actual_body["pid"] == 100
                     assert actual_body["start_date"] == start_date
                     assert actual_body["state"] == "running"
-                    return httpx.Response(
+                    return httpx2.Response(
                         status_code=200,
                         json=ti_context.model_dump(mode="json"),
                     )
-                return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+                return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-            client = make_client(transport=httpx.MockTransport(handle_request))
+            client = make_client(transport=httpx2.MockTransport(handle_request))
             resp = client.task_instances.start(ti_id, 100, start_date)
             assert resp == ti_context
             assert call_count == 3
@@ -376,9 +376,9 @@ class TestTaskInstanceOperations:
         """Test that start() raises TaskAlreadyRunningError when TI is already running."""
         ti_id = uuid6.uuid7()
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == f"/task-instances/{ti_id}/run":
-                return httpx.Response(
+                return httpx2.Response(
                     409,
                     json={
                         "detail": {
@@ -388,9 +388,9 @@ class TestTaskInstanceOperations:
                         }
                     },
                 )
-            return httpx.Response(status_code=204)
+            return httpx2.Response(status_code=204)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
 
         with pytest.raises(TaskAlreadyRunningError, match="already running"):
             client.task_instances.start(ti_id, 100, datetime(2024, 10, 31, tzinfo=timezone.utc))
@@ -400,9 +400,9 @@ class TestTaskInstanceOperations:
         """Test that start() raises ServerResponseError for non-running invalid states."""
         ti_id = uuid6.uuid7()
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == f"/task-instances/{ti_id}/run":
-                return httpx.Response(
+                return httpx2.Response(
                     409,
                     json={
                         "detail": {
@@ -412,9 +412,9 @@ class TestTaskInstanceOperations:
                         }
                     },
                 )
-            return httpx.Response(status_code=204)
+            return httpx2.Response(status_code=204)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
 
         with pytest.raises(ServerResponseError):
             client.task_instances.start(ti_id, 100, datetime(2024, 10, 31, tzinfo=timezone.utc))
@@ -426,18 +426,18 @@ class TestTaskInstanceOperations:
         # Simulate a successful response from the server that finishes (moved to terminal state) a task
         ti_id = uuid6.uuid7()
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == f"/task-instances/{ti_id}/state":
                 actual_body = json.loads(request.read())
                 assert actual_body["end_date"] == "2024-10-31T12:00:00Z"
                 assert actual_body["state"] == state
                 assert actual_body["rendered_map_index"] == "test"
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=204,
                 )
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+            return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         client.task_instances.finish(
             ti_id, state=state, when="2024-10-31T12:00:00Z", rendered_map_index="test"
         )
@@ -446,16 +446,16 @@ class TestTaskInstanceOperations:
         # Simulate a successful response from the server that sends a heartbeat for a ti
         ti_id = uuid6.uuid7()
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == f"/task-instances/{ti_id}/heartbeat":
                 actual_body = json.loads(request.read())
                 assert actual_body["pid"] == 100
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=204,
                 )
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+            return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         client.task_instances.heartbeat(ti_id, 100)
 
     @pytest.mark.parametrize("queues_enabled", [False, True])
@@ -478,7 +478,7 @@ class TestTaskInstanceOperations:
             queue=task_queue if queues_enabled else None,
         )
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == f"/task-instances/{ti_id}/state":
                 actual_body = json.loads(request.read())
                 assert actual_body["state"] == "deferred"
@@ -491,30 +491,30 @@ class TestTaskInstanceOperations:
                     assert actual_body["queue"] == task_queue
                 else:
                     assert actual_body.get("queue") is None
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=204,
                 )
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+            return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         client.task_instances.defer(ti_id, msg)
 
     def test_task_instance_reschedule(self):
         # Simulate a successful response from the server that reschedules a task
         ti_id = uuid6.uuid7()
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == f"/task-instances/{ti_id}/state":
                 actual_body = json.loads(request.read())
                 assert actual_body["state"] == "up_for_reschedule"
                 assert actual_body["reschedule_date"] == "2024-10-31T12:00:00Z"
                 assert actual_body["end_date"] == "2024-10-31T12:00:00Z"
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=204,
                 )
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+            return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         msg = RescheduleTask(
             reschedule_date=timezone.parse("2024-10-31T12:00:00Z"),
             end_date=timezone.parse("2024-10-31T12:00:00Z"),
@@ -524,18 +524,18 @@ class TestTaskInstanceOperations:
     def test_task_instance_up_for_retry(self):
         ti_id = uuid6.uuid7()
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == f"/task-instances/{ti_id}/state":
                 actual_body = json.loads(request.read())
                 assert actual_body["state"] == "up_for_retry"
                 assert actual_body["end_date"] == "2024-10-31T12:00:00Z"
                 assert actual_body["rendered_map_index"] == "test"
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=204,
                 )
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+            return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         client.task_instances.retry(
             ti_id, end_date=timezone.parse("2024-10-31T12:00:00Z"), rendered_map_index="test"
         )
@@ -558,15 +558,15 @@ class TestTaskInstanceOperations:
     def test_taskinstance_set_rtif_success(self, rendered_fields):
         TI_ID = uuid6.uuid7()
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == f"/task-instances/{TI_ID}/rtif":
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=201,
                     json={"message": "Rendered task instance fields successfully set"},
                 )
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+            return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.task_instances.set_rtif(id=TI_ID, body=rendered_fields)
 
         assert result == OKResponse(ok=True)
@@ -575,16 +575,16 @@ class TestTaskInstanceOperations:
         TI_ID = uuid6.uuid7()
         rendered_map_index = "Label: task_1"
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == f"/task-instances/{TI_ID}/rendered-map-index":
                 actual_body = json.loads(request.read())
                 assert request.method == "PATCH"
                 # Body should be the string directly, not wrapped in JSON
                 assert actual_body == rendered_map_index
-                return httpx.Response(status_code=204)
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+                return httpx2.Response(status_code=204)
+            return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.task_instances.set_rendered_map_index(id=TI_ID, rendered_map_index=rendered_map_index)
 
         assert result == OKResponse(ok=True)
@@ -592,12 +592,12 @@ class TestTaskInstanceOperations:
     def test_get_count_basic(self):
         """Test basic get_count functionality with just dag_id."""
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             assert request.url.path == "/task-instances/count"
             assert request.url.params.get("dag_id") == "test_dag"
-            return httpx.Response(200, json=5)
+            return httpx2.Response(200, json=5)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.task_instances.get_count(dag_id="test_dag")
         assert result.count == 5
 
@@ -609,7 +609,7 @@ class TestTaskInstanceOperations:
         task_ids = ["task1", "task2"]
         states = ["success", "failed"]
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             assert request.url.path == "/task-instances/count"
             assert request.method == "GET"
             params = request.url.params
@@ -620,9 +620,9 @@ class TestTaskInstanceOperations:
             assert params.get_list("run_ids") == []
             assert params.get_list("states") == states
             assert params["map_index"] == "0"
-            return httpx.Response(200, json=10)
+            return httpx2.Response(200, json=10)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.task_instances.get_count(
             dag_id="test_dag",
             map_index=0,
@@ -636,15 +636,15 @@ class TestTaskInstanceOperations:
     def test_get_task_states_basic(self):
         """Test basic get_task_states functionality with just dag_id."""
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             assert request.url.path == "/task-instances/states"
             assert request.url.params.get("dag_id") == "test_dag"
             assert request.url.params.get("task_group_id") == "group1"
-            return httpx.Response(
+            return httpx2.Response(
                 200, json={"task_states": {"run_id": {"group1.task1": "success", "group1.task2": "failed"}}}
             )
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.task_instances.get_task_states(dag_id="test_dag", task_group_id="group1")
         assert result.task_states == {"run_id": {"group1.task1": "success", "group1.task2": "failed"}}
 
@@ -654,7 +654,7 @@ class TestTaskInstanceOperations:
         logical_dates_str = ["2024-01-01T00:00:00+00:00", "2024-01-02T00:00:00+00:00"]
         logical_dates = [timezone.parse(d) for d in logical_dates_str]
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             assert request.url.path == "/task-instances/states"
             assert request.method == "GET"
             params = request.url.params
@@ -664,11 +664,11 @@ class TestTaskInstanceOperations:
             assert params.get_list("task_ids") == []
             assert params.get_list("run_ids") == []
             assert params.get("map_index") == "0"
-            return httpx.Response(
+            return httpx2.Response(
                 200, json={"task_states": {"run_id": {"group1.task1": "success", "group1.task2": "failed"}}}
             )
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.task_instances.get_task_states(
             dag_id="test_dag",
             map_index=0,
@@ -681,14 +681,14 @@ class TestTaskInstanceOperations:
         """Test basic get_previous functionality."""
         logical_date = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == "/task-instances/previous/test_dag/test_task":
-                assert request.url.params == httpx.QueryParams(
+                assert request.url.params == httpx2.QueryParams(
                     logical_date=logical_date.isoformat(),
                     map_index="-1",
                 )
                 # Return complete TI data
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=200,
                     json={
                         "task_id": "test_task",
@@ -703,9 +703,9 @@ class TestTaskInstanceOperations:
                         "duration": 300.0,
                     },
                 )
-            return httpx.Response(status_code=422)
+            return httpx2.Response(status_code=422)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.task_instances.get_previous(
             dag_id="test_dag", task_id="test_task", logical_date=logical_date
         )
@@ -720,14 +720,14 @@ class TestTaskInstanceOperations:
         """Test get_previous functionality with state filtering."""
         logical_date = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == "/task-instances/previous/test_dag/test_task":
-                assert request.url.params == httpx.QueryParams(
+                assert request.url.params == httpx2.QueryParams(
                     logical_date=logical_date.isoformat(),
                     map_index="-1",
                     state="success",
                 )
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=200,
                     json={
                         "task_id": "test_task",
@@ -742,9 +742,9 @@ class TestTaskInstanceOperations:
                         "duration": 300.0,
                     },
                 )
-            return httpx.Response(status_code=422)
+            return httpx2.Response(status_code=422)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.task_instances.get_previous(
             dag_id="test_dag", task_id="test_task", logical_date=logical_date, state="success"
         )
@@ -754,12 +754,12 @@ class TestTaskInstanceOperations:
     def test_get_previous_with_map_index_filter(self):
         """Test get_previous functionality with map_index filtering."""
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == "/task-instances/previous/test_dag/test_task":
-                assert request.url.params == httpx.QueryParams(
+                assert request.url.params == httpx2.QueryParams(
                     map_index="0",
                 )
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=200,
                     json={
                         "task_id": "test_task",
@@ -774,9 +774,9 @@ class TestTaskInstanceOperations:
                         "duration": 300.0,
                     },
                 )
-            return httpx.Response(status_code=422)
+            return httpx2.Response(status_code=422)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.task_instances.get_previous(dag_id="test_dag", task_id="test_task", map_index=0)
 
         assert result.task_instance.map_index == 0
@@ -784,13 +784,13 @@ class TestTaskInstanceOperations:
     def test_get_previous_not_found(self):
         """Test get_previous when no previous TI exists returns None."""
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == "/task-instances/previous/test_dag/test_task":
                 # Return None (null) when no previous TI found
-                return httpx.Response(status_code=200, content="null")
-            return httpx.Response(status_code=422)
+                return httpx2.Response(status_code=200, content="null")
+            return httpx2.Response(status_code=422)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.task_instances.get_previous(dag_id="test_dag", task_id="test_task")
 
         assert isinstance(result, PreviousTIResult)
@@ -810,19 +810,19 @@ class TestVariableOperations:
             # ...including a validation that retry really works
             call_count = 0
 
-            def handle_request(request: httpx.Request) -> httpx.Response:
+            def handle_request(request: httpx2.Request) -> httpx2.Response:
                 nonlocal call_count
                 call_count += 1
                 if call_count < 2:
-                    return httpx.Response(status_code=500, json={"detail": "Internal Server Error"})
+                    return httpx2.Response(status_code=500, json={"detail": "Internal Server Error"})
                 if request.url.path == "/variables/test_key":
-                    return httpx.Response(
+                    return httpx2.Response(
                         status_code=200,
                         json={"key": "test_key", "value": "test_value"},
                     )
-                return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+                return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-            client = make_client(transport=httpx.MockTransport(handle_request))
+            client = make_client(transport=httpx2.MockTransport(handle_request))
             result = client.variables.get(key="test_key")
 
             assert isinstance(result, VariableResponse)
@@ -832,9 +832,9 @@ class TestVariableOperations:
 
     def test_variable_not_found(self, cap_structlog):
         # Simulate a 404 response from the server
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == "/variables/non_existent_var":
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=404,
                     json={
                         "detail": {
@@ -843,9 +843,9 @@ class TestVariableOperations:
                         }
                     },
                 )
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+            return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
 
         with cap_structlog.at_level("debug"):
             resp = client.variables.get(key="non_existent_var")
@@ -859,9 +859,9 @@ class TestVariableOperations:
     def test_variable_get_500_error(self):
         with time_machine.travel("2023-01-01T00:00:00Z", tick=False):
             # Simulate a response from the server returning a 500 error
-            def handle_request(request: httpx.Request) -> httpx.Response:
+            def handle_request(request: httpx2.Request) -> httpx2.Response:
                 if request.url.path == "/variables/test_key":
-                    return httpx.Response(
+                    return httpx2.Response(
                         status_code=500,
                         headers=[("content-Type", "application/json")],
                         json={
@@ -869,9 +869,9 @@ class TestVariableOperations:
                             "message": "Internal Server Error",
                         },
                     )
-                return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+                return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-            client = make_client(transport=httpx.MockTransport(handle_request))
+            client = make_client(transport=httpx2.MockTransport(handle_request))
             with pytest.raises(ServerResponseError):
                 client.variables.get(
                     key="test_key",
@@ -885,10 +885,10 @@ class TestVariableOperations:
         to a less-restrictive backend on an explicit deny.
         """
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(status_code=status_code, json={"detail": "Forbidden"})
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
+            return httpx2.Response(status_code=status_code, json={"detail": "Forbidden"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         resp = client.variables.get(key="denied_var")
         assert isinstance(resp, ErrorResponse)
         assert resp.error == ErrorType.PERMISSION_DENIED
@@ -896,30 +896,30 @@ class TestVariableOperations:
 
     def test_variable_set_success(self):
         # Simulate a successful response from the server when putting a variable
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == "/variables/test_key":
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=201,
                     json={"message": "Variable successfully set"},
                 )
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+            return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
 
         result = client.variables.set(key="test_key", value="test_value", description="test_description")
         assert result == OKResponse(ok=True)
 
     def test_variable_delete_success(self):
         # Simulate a successful response from the server when deleting a variable
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.method == "DELETE" and request.url.path == "/variables/test_key":
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=200,
                     json={"count": 1},
                 )
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+            return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
 
         result = client.variables.delete(key="test_key")
         assert result == OKResponse(ok=True)
@@ -948,19 +948,19 @@ class TestXCOMOperations:
             # ...including a validation that retry really works
             call_count = 0
 
-            def handle_request(request: httpx.Request) -> httpx.Response:
+            def handle_request(request: httpx2.Request) -> httpx2.Response:
                 nonlocal call_count
                 call_count += 1
                 if call_count < 3:
-                    return httpx.Response(status_code=500, json={"detail": "Internal Server Error"})
+                    return httpx2.Response(status_code=500, json={"detail": "Internal Server Error"})
                 if request.url.path == "/xcoms/dag_id/run_id/task_id/key":
-                    return httpx.Response(
+                    return httpx2.Response(
                         status_code=201,
                         json={"key": "test_key", "value": value},
                     )
-                return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+                return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-            client = make_client(transport=httpx.MockTransport(handle_request))
+            client = make_client(transport=httpx2.MockTransport(handle_request))
             result = client.xcoms.get(
                 dag_id="dag_id",
                 run_id="run_id",
@@ -974,18 +974,18 @@ class TestXCOMOperations:
 
     def test_xcom_get_success_with_map_index(self):
         # Simulate a successful response from the server when getting an xcom with map_index passed
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if (
                 request.url.path == "/xcoms/dag_id/run_id/task_id/key"
                 and request.url.params.get("map_index") == "2"
             ):
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=201,
                     json={"key": "test_key", "value": "test_value"},
                 )
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+            return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.xcoms.get(
             dag_id="dag_id",
             run_id="run_id",
@@ -999,17 +999,17 @@ class TestXCOMOperations:
 
     def test_xcom_get_success_with_include_prior_dates(self):
         # Simulate a successful response from the server when getting an xcom with include_prior_dates passed
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == "/xcoms/dag_id/run_id/task_id/key" and request.url.params.get(
                 "include_prior_dates"
             ):
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=201,
                     json={"key": "test_key", "value": "test_value"},
                 )
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+            return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.xcoms.get(
             dag_id="dag_id",
             run_id="run_id",
@@ -1024,9 +1024,9 @@ class TestXCOMOperations:
     def test_xcom_get_500_error(self):
         with time_machine.travel("2023-01-01T00:00:00Z", tick=False):
             # Simulate a successful response from the server returning a 500 error
-            def handle_request(request: httpx.Request) -> httpx.Response:
+            def handle_request(request: httpx2.Request) -> httpx2.Response:
                 if request.url.path == "/xcoms/dag_id/run_id/task_id/key":
-                    return httpx.Response(
+                    return httpx2.Response(
                         status_code=500,
                         headers=[("content-Type", "application/json")],
                         json={
@@ -1034,9 +1034,9 @@ class TestXCOMOperations:
                             "message": "XCom value is not a valid JSON",
                         },
                     )
-                return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+                return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-            client = make_client(transport=httpx.MockTransport(handle_request))
+            client = make_client(transport=httpx2.MockTransport(handle_request))
             with pytest.raises(ServerResponseError):
                 client.xcoms.get(
                     dag_id="dag_id",
@@ -1056,16 +1056,16 @@ class TestXCOMOperations:
     )
     def test_xcom_set_success(self, values):
         # Simulate a successful response from the server when setting an xcom
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == "/xcoms/dag_id/run_id/task_id/key":
                 assert json.loads(request.read()) == values
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=201,
                     json={"message": "XCom successfully set"},
                 )
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+            return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.xcoms.set(
             dag_id="dag_id",
             run_id="run_id",
@@ -1077,19 +1077,19 @@ class TestXCOMOperations:
 
     def test_xcom_set_with_map_index(self):
         # Simulate a successful response from the server when setting an xcom with map_index passed
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if (
                 request.url.path == "/xcoms/dag_id/run_id/task_id/key"
                 and request.url.params.get("map_index") == "2"
             ):
                 assert json.loads(request.read()) == "value1"
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=201,
                     json={"message": "XCom successfully set"},
                 )
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+            return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.xcoms.set(
             dag_id="dag_id",
             run_id="run_id",
@@ -1102,20 +1102,20 @@ class TestXCOMOperations:
 
     def test_xcom_set_with_mapped_length(self):
         # Simulate a successful response from the server when setting an xcom with mapped_length
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if (
                 request.url.path == "/xcoms/dag_id/run_id/task_id/key"
                 and request.url.params.get("map_index") == "2"
                 and request.url.params.get("mapped_length") == "3"
             ):
                 assert json.loads(request.read()) == "value1"
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=201,
                     json={"message": "XCom successfully set"},
                 )
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+            return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.xcoms.set(
             dag_id="dag_id",
             run_id="run_id",
@@ -1137,9 +1137,9 @@ class TestConnectionOperations:
 
     def test_connection_get_success(self):
         # Simulate a successful response from the server with a connection
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == "/connections/test_conn":
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=200,
                     json={
                         "conn_id": "test_conn",
@@ -1152,9 +1152,9 @@ class TestConnectionOperations:
                         "extra": None,
                     },
                 )
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+            return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.connections.get(conn_id="test_conn")
 
         assert isinstance(result, ConnectionResponse)
@@ -1163,18 +1163,18 @@ class TestConnectionOperations:
 
     def test_connection_get_404_not_found(self):
         # Simulate a successful response from the server with a connection
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == "/connections/test_conn":
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=404,
                     json={
                         "reason": "not_found",
                         "message": "Connection with ID test_conn not found",
                     },
                 )
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+            return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.connections.get(conn_id="test_conn")
 
         assert isinstance(result, ErrorResponse)
@@ -1184,10 +1184,10 @@ class TestConnectionOperations:
     def test_connection_get_authz_returns_permission_denied(self, status_code):
         """401/403 from the API server is reported as PERMISSION_DENIED, not raised."""
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(status_code=status_code, json={"detail": "Forbidden"})
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
+            return httpx2.Response(status_code=status_code, json={"detail": "Forbidden"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.connections.get(conn_id="denied_conn")
         assert isinstance(result, ErrorResponse)
         assert result.error == ErrorType.PERMISSION_DENIED
@@ -1226,7 +1226,7 @@ class TestAssetEventOperations:
         ],
     )
     def test_by_name_get_success(self, request_params, created_dagruns, expected_created_dagruns):
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             params = request.url.params
             if request.url.path == "/asset-events/by-asset":
                 assert params.get("name") == request_params.get("name")
@@ -1234,9 +1234,9 @@ class TestAssetEventOperations:
             elif request.url.path == "/asset-events/by-asset-alias":
                 assert params.get("name") == request_params.get("alias_name")
             else:
-                return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+                return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-            return httpx.Response(
+            return httpx2.Response(
                 status_code=200,
                 json={
                     "asset_events": [
@@ -1254,7 +1254,7 @@ class TestAssetEventOperations:
                 },
             )
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.asset_events.get(**request_params)
 
         assert isinstance(result, AssetEventsResponse)
@@ -1266,11 +1266,11 @@ class TestAssetEventOperations:
             assert result.asset_events[0].created_dagruns[0].start_date is None
 
     def test_partition_key_exact_match_param_passed(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             params = request.url.params
             assert params.get("partition_key") == "2024-01-01"
             assert "partition_key_regexp_pattern" not in params
-            return httpx.Response(
+            return httpx2.Response(
                 status_code=200,
                 json={
                     "asset_events": [
@@ -1289,42 +1289,42 @@ class TestAssetEventOperations:
                 },
             )
 
-        client = make_client(httpx.MockTransport(handle_request))
+        client = make_client(httpx2.MockTransport(handle_request))
         result = client.asset_events.get(name="this_asset", partition_key="2024-01-01")
 
         assert isinstance(result, AssetEventsResponse)
         assert len(result.asset_events) == 1
 
     def test_partition_key_regexp_pattern_param_passed(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             params = request.url.params
             assert params.get("partition_key_regexp_pattern") == "^2024-01-"
             assert "partition_key" not in params
-            return httpx.Response(
+            return httpx2.Response(
                 status_code=200,
                 json={"asset_events": []},
             )
 
-        client = make_client(httpx.MockTransport(handle_request))
+        client = make_client(httpx2.MockTransport(handle_request))
         result = client.asset_events.get(name="this_asset", partition_key_regexp_pattern="^2024-01-")
 
         assert isinstance(result, AssetEventsResponse)
         assert len(result.asset_events) == 0
 
     def test_partition_key_regexp_pattern_with_other_params(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             params = request.url.params
             assert params.get("partition_key_regexp_pattern") == r"^us\|2024-.*"
             assert "partition_key" not in params
             assert params.get("after") == "2023-06-01T00:00:00+00:00"
             assert params.get("limit") == "5"
             assert params.get("ascending") == "false"
-            return httpx.Response(
+            return httpx2.Response(
                 status_code=200,
                 json={"asset_events": []},
             )
 
-        client = make_client(httpx.MockTransport(handle_request))
+        client = make_client(httpx2.MockTransport(handle_request))
         result = client.asset_events.get(
             name="this_asset",
             partition_key_regexp_pattern=r"^us\|2024-.*",
@@ -1337,29 +1337,29 @@ class TestAssetEventOperations:
         assert len(result.asset_events) == 0
 
     def test_partition_key_with_alias(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             assert request.url.path == "/asset-events/by-asset-alias"
             params = request.url.params
             assert params.get("name") == "my_alias"
             assert params.get("partition_key") == "us-east|2024-01-01"
             assert "partition_key_regexp_pattern" not in params
-            return httpx.Response(
+            return httpx2.Response(
                 status_code=200,
                 json={"asset_events": []},
             )
 
-        client = make_client(httpx.MockTransport(handle_request))
+        client = make_client(httpx2.MockTransport(handle_request))
         result = client.asset_events.get(alias_name="my_alias", partition_key="us-east|2024-01-01")
 
         assert isinstance(result, AssetEventsResponse)
         assert len(result.asset_events) == 0
 
     def test_extra_dict_param_passed(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             params = request.url.params
             extra_pairs = [v for k, v in params.multi_items() if k == "extra"]
             assert sorted(extra_pairs) == sorted(["region=us", "env=prod"])
-            return httpx.Response(
+            return httpx2.Response(
                 status_code=200,
                 json={
                     "asset_events": [
@@ -1373,18 +1373,18 @@ class TestAssetEventOperations:
                 },
             )
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.asset_events.get(name="a", uri="s3://b", extra={"region": "us", "env": "prod"})
         assert isinstance(result, AssetEventsResponse)
         assert len(result.asset_events) == 1
 
     def test_extra_dict_with_alias(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             params = request.url.params
             assert request.url.path == "/asset-events/by-asset-alias"
             extra_pairs = [v for k, v in params.multi_items() if k == "extra"]
             assert extra_pairs == ["env=prod"]
-            return httpx.Response(
+            return httpx2.Response(
                 status_code=200,
                 json={
                     "asset_events": [
@@ -1398,21 +1398,21 @@ class TestAssetEventOperations:
                 },
             )
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.asset_events.get(alias_name="my_alias", extra={"env": "prod"})
         assert isinstance(result, AssetEventsResponse)
         assert len(result.asset_events) == 1
 
     def test_extra_none_not_sent(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             params = request.url.params
             assert "extra" not in params
-            return httpx.Response(
+            return httpx2.Response(
                 status_code=200,
                 json={"asset_events": []},
             )
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.asset_events.get(name="a", uri="s3://b")
         assert isinstance(result, AssetEventsResponse)
 
@@ -1426,9 +1426,9 @@ class TestAssetOperations:
         ],
     )
     def test_by_name_get_success(self, request_params):
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path in ("/assets/by-name", "/assets/by-uri"):
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=200,
                     json={
                         "name": "this_asset",
@@ -1437,9 +1437,9 @@ class TestAssetOperations:
                         "extra": {"foo": "bar"},
                     },
                 )
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+            return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.assets.get(**request_params)
 
         assert isinstance(result, AssetResponse)
@@ -1454,9 +1454,9 @@ class TestAssetOperations:
         ],
     )
     def test_by_name_get_404_not_found(self, request_params):
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path in ("/assets/by-name", "/assets/by-uri"):
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=404,
                     json={
                         "detail": {
@@ -1465,19 +1465,19 @@ class TestAssetOperations:
                         }
                     },
                 )
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+            return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.assets.get(**request_params)
 
         assert isinstance(result, ErrorResponse)
         assert result.error == ErrorType.ASSET_NOT_FOUND
 
     def test_get_by_alias_returns_list(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             assert request.url.path == "/assets/by-alias"
             assert request.url.params["alias_name"] == "my_alias"
-            return httpx.Response(
+            return httpx2.Response(
                 status_code=200,
                 json=[
                     {"name": "asset_a", "uri": "s3://bucket/a", "group": "asset", "extra": {}},
@@ -1485,7 +1485,7 @@ class TestAssetOperations:
                 ],
             )
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.assets.get_by_alias("my_alias")
 
         assert isinstance(result, AssetsByAliasResult)
@@ -1496,10 +1496,10 @@ class TestAssetOperations:
         assert result.assets[1].name == "asset_b"
 
     def test_get_by_alias_returns_empty_for_unknown_alias(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(status_code=200, json=[])
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
+            return httpx2.Response(status_code=200, json=[])
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.assets.get_by_alias("unknown_alias")
 
         assert result.assets == []
@@ -1508,7 +1508,7 @@ class TestAssetOperations:
 class TestDagRunOperations:
     def test_trigger(self):
         # Simulate a successful response from the server when triggering a dag run
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == "/dag-runs/test_trigger/test_run_id":
                 actual_body = json.loads(request.read())
                 assert actual_body["logical_date"] == "2025-01-01T00:00:00Z"
@@ -1516,10 +1516,10 @@ class TestDagRunOperations:
 
                 # Since the value for `reset_dag_run` is default, it should not be present in the request body
                 assert "reset_dag_run" not in actual_body
-                return httpx.Response(status_code=204)
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+                return httpx2.Response(status_code=204)
+            return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.dag_runs.trigger(
             dag_id="test_trigger",
             run_id="test_run_id",
@@ -1532,9 +1532,9 @@ class TestDagRunOperations:
     def test_trigger_conflict(self):
         """Test that if the dag run already exists, the client returns an error when default reset_dag_run=False"""
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == "/dag-runs/test_trigger_conflict/test_run_id":
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=409,
                     json={
                         "detail": {
@@ -1543,9 +1543,9 @@ class TestDagRunOperations:
                         }
                     },
                 )
-            return httpx.Response(status_code=422)
+            return httpx2.Response(status_code=422)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.dag_runs.trigger(dag_id="test_trigger_conflict", run_id="test_run_id")
 
         assert result == ErrorResponse(error=ErrorType.DAGRUN_ALREADY_EXISTS)
@@ -1553,9 +1553,9 @@ class TestDagRunOperations:
     def test_trigger_conflict_reset_dag_run(self):
         """Test that if dag run already exists and reset_dag_run=True, the client clears the dag run"""
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == "/dag-runs/test_trigger_conflict_reset/test_run_id":
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=409,
                     json={
                         "detail": {
@@ -1565,10 +1565,10 @@ class TestDagRunOperations:
                     },
                 )
             if request.url.path == "/dag-runs/test_trigger_conflict_reset/test_run_id/clear":
-                return httpx.Response(status_code=204)
-            return httpx.Response(status_code=422)
+                return httpx2.Response(status_code=204)
+            return httpx2.Response(status_code=422)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.dag_runs.trigger(
             dag_id="test_trigger_conflict_reset",
             run_id="test_run_id",
@@ -1580,12 +1580,12 @@ class TestDagRunOperations:
     def test_clear(self):
         """Test that the client can clear a dag run"""
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == "/dag-runs/test_clear/test_run_id/clear":
-                return httpx.Response(status_code=204)
-            return httpx.Response(status_code=422)
+                return httpx2.Response(status_code=204)
+            return httpx2.Response(status_code=422)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.dag_runs.clear(dag_id="test_clear", run_id="test_run_id")
 
         assert result == OKResponse(ok=True)
@@ -1593,39 +1593,39 @@ class TestDagRunOperations:
     def test_get_state(self):
         """Test that the client can get the state of a dag run"""
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == "/dag-runs/test_state/test_run_id/state":
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=200,
                     json={"state": "running"},
                 )
-            return httpx.Response(status_code=422)
+            return httpx2.Response(status_code=422)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.dag_runs.get_state(dag_id="test_state", run_id="test_run_id")
 
         assert result == DagRunStateResponse(state=DagRunState.RUNNING)
 
     def test_get_count_basic(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == "/dag-runs/count":
                 assert request.url.params["dag_id"] == "test_dag"
-                return httpx.Response(status_code=200, json=1)
-            return httpx.Response(status_code=422)
+                return httpx2.Response(status_code=200, json=1)
+            return httpx2.Response(status_code=422)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.dag_runs.get_count(dag_id="test_dag")
         assert result.count == 1
 
     def test_get_count_with_states(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == "/dag-runs/count":
                 assert request.url.params["dag_id"] == "test_dag"
                 assert request.url.params.get_list("states") == ["success", "failed"]
-                return httpx.Response(status_code=200, json=2)
-            return httpx.Response(status_code=422)
+                return httpx2.Response(status_code=200, json=2)
+            return httpx2.Response(status_code=422)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.dag_runs.get_count(dag_id="test_dag", states=["success", "failed"])
         assert result.count == 2
 
@@ -1633,28 +1633,28 @@ class TestDagRunOperations:
         logical_dates = [timezone.datetime(2025, 1, 1), timezone.datetime(2025, 1, 2)]
         logical_dates_str = [d.isoformat() for d in logical_dates]
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == "/dag-runs/count":
                 assert request.url.params["dag_id"] == "test_dag"
                 assert request.url.params.get_list("logical_dates") == logical_dates_str
-                return httpx.Response(status_code=200, json=2)
-            return httpx.Response(status_code=422)
+                return httpx2.Response(status_code=200, json=2)
+            return httpx2.Response(status_code=422)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.dag_runs.get_count(
             dag_id="test_dag", logical_dates=[timezone.datetime(2025, 1, 1), timezone.datetime(2025, 1, 2)]
         )
         assert result.count == 2
 
     def test_get_count_with_run_ids(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == "/dag-runs/count":
                 assert request.url.params["dag_id"] == "test_dag"
                 assert request.url.params.get_list("run_ids") == ["run1", "run2"]
-                return httpx.Response(status_code=200, json=2)
-            return httpx.Response(status_code=422)
+                return httpx2.Response(status_code=200, json=2)
+            return httpx2.Response(status_code=422)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.dag_runs.get_count(dag_id="test_dag", run_ids=["run1", "run2"])
         assert result.count == 2
 
@@ -1662,14 +1662,14 @@ class TestDagRunOperations:
         """Test basic get_previous functionality with dag_id and logical_date."""
         logical_date = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == "/dag-runs/previous":
-                assert request.url.params == httpx.QueryParams(
+                assert request.url.params == httpx2.QueryParams(
                     dag_id="test_dag",
                     logical_date=logical_date.isoformat(),
                 )
                 # Return complete DagRun data
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=200,
                     json={
                         "dag_id": "test_dag",
@@ -1686,9 +1686,9 @@ class TestDagRunOperations:
                         "partition_key": None,
                     },
                 )
-            return httpx.Response(status_code=422)
+            return httpx2.Response(status_code=422)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.dag_runs.get_previous(dag_id="test_dag", logical_date=logical_date)
 
         assert isinstance(result, PreviousDagRunResult)
@@ -1700,15 +1700,15 @@ class TestDagRunOperations:
         """Test get_previous functionality with state filtering."""
         logical_date = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == "/dag-runs/previous":
-                assert request.url.params == httpx.QueryParams(
+                assert request.url.params == httpx2.QueryParams(
                     dag_id="test_dag",
                     logical_date=logical_date.isoformat(),
                     state="success",
                 )
                 # Return complete DagRun data
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=200,
                     json={
                         "dag_id": "test_dag",
@@ -1725,9 +1725,9 @@ class TestDagRunOperations:
                         "partition_key": None,
                     },
                 )
-            return httpx.Response(status_code=422)
+            return httpx2.Response(status_code=422)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.dag_runs.get_previous(dag_id="test_dag", logical_date=logical_date, state="success")
 
         assert isinstance(result, PreviousDagRunResult)
@@ -1739,17 +1739,17 @@ class TestDagRunOperations:
         """Test get_previous when no previous Dag run exists returns None."""
         logical_date = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == "/dag-runs/previous":
-                assert request.url.params == httpx.QueryParams(
+                assert request.url.params == httpx2.QueryParams(
                     dag_id="test_dag",
                     logical_date=logical_date.isoformat(),
                 )
                 # Return None (null) when no previous Dag run found
-                return httpx.Response(status_code=200, content="null")
-            return httpx.Response(status_code=422)
+                return httpx2.Response(status_code=200, content="null")
+            return httpx2.Response(status_code=422)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.dag_runs.get_previous(dag_id="test_dag", logical_date=logical_date)
 
         assert isinstance(result, PreviousDagRunResult)
@@ -1761,17 +1761,17 @@ class TestTaskRescheduleOperations:
         """Test that the client can get the start date of a task reschedule"""
         ti_id = uuid6.uuid7()
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == f"/task-reschedules/{ti_id}/start_date":
                 assert request.url.params.get("try_number") == "1"
 
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=200,
                     json="2024-01-01T00:00:00Z",
                 )
-            return httpx.Response(status_code=422)
+            return httpx2.Response(status_code=422)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.task_instances.get_reschedule_start_date(id=ti_id, try_number=1)
 
         assert isinstance(result, TaskRescheduleStartDate)
@@ -1782,9 +1782,9 @@ class TestHITLOperations:
     def test_add_response(self) -> None:
         ti_id = uuid7()
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path in (f"/hitlDetails/{ti_id}"):
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=201,
                     json={
                         "ti_id": str(ti_id),
@@ -1796,9 +1796,9 @@ class TestHITLOperations:
                         "multiple": False,
                     },
                 )
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+            return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.hitl.add_response(
             ti_id=ti_id,
             options=["Approval", "Reject"],
@@ -1822,9 +1822,9 @@ class TestHITLOperations:
         time_machine.move_to(datetime(2025, 7, 3, 0, 0, 0))
         ti_id = uuid7()
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path in (f"/hitlDetails/{ti_id}"):
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=200,
                     json={
                         "chosen_options": ["Approval"],
@@ -1834,9 +1834,9 @@ class TestHITLOperations:
                         "responded_at": "2025-07-03T00:00:00Z",
                     },
                 )
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+            return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.hitl.update_response(
             ti_id=ti_id,
             chosen_options=["Approve"],
@@ -1853,9 +1853,9 @@ class TestHITLOperations:
         time_machine.move_to(datetime(2025, 7, 3, 0, 0, 0))
         ti_id = uuid7()
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path in (f"/hitlDetails/{ti_id}"):
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=200,
                     json={
                         "chosen_options": ["Approval"],
@@ -1865,9 +1865,9 @@ class TestHITLOperations:
                         "responded_at": "2025-07-03T00:00:00Z",
                     },
                 )
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+            return httpx2.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.hitl.get_detail_response(ti_id=ti_id)
         assert isinstance(result, HITLDetailResponse)
         assert result.response_received is True
@@ -1914,9 +1914,9 @@ class TestDagsOperations:
     def test_get(self):
         """Test that the client can get a dag."""
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == "/dags/test_dag":
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=200,
                     json={
                         "dag_id": "test_dag",
@@ -1929,9 +1929,9 @@ class TestDagsOperations:
                         "next_dagrun": "2026-04-13T00:00:00Z",
                     },
                 )
-            return httpx.Response(status_code=200)
+            return httpx2.Response(status_code=200)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.dags.get(dag_id="test_dag")
 
         assert result == DagResponse(
@@ -1950,14 +1950,14 @@ class TestDagsOperations:
         requests_seen = []
         crafted_dag_id = "x/../../variables/secret_key"
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             requests_seen.append(request)
             if request.url.path == "/variables/secret_key":
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=200,
                     json={"key": "secret_key", "value": "super-secret-value"},
                 )
-            return httpx.Response(
+            return httpx2.Response(
                 status_code=404,
                 json={
                     "detail": {
@@ -1967,7 +1967,7 @@ class TestDagsOperations:
                 },
             )
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
 
         with pytest.raises(ServerResponseError) as exc_info:
             client.dags.get(dag_id=crafted_dag_id)
@@ -1979,9 +1979,9 @@ class TestDagsOperations:
     def test_get_not_found(self):
         """Test that getting a missing dag raises a server response error."""
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == "/dags/missing_dag":
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=404,
                     json={
                         "detail": {
@@ -1990,9 +1990,9 @@ class TestDagsOperations:
                         }
                     },
                 )
-            return httpx.Response(status_code=200)
+            return httpx2.Response(status_code=200)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
 
         with pytest.raises(ServerResponseError) as exc_info:
             client.dags.get(dag_id="missing_dag")
@@ -2006,9 +2006,9 @@ class TestDagsOperations:
     def test_get_server_error(self):
         """Test that a server error while getting a dag."""
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == "/dags/test_dag":
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=500,
                     headers=[("content-Type", "application/json")],
                     json={
@@ -2016,9 +2016,9 @@ class TestDagsOperations:
                         "message": "Internal Server Error",
                     },
                 )
-            return httpx.Response(status_code=200)
+            return httpx2.Response(status_code=200)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
 
         with pytest.raises(ServerResponseError):
             client.dags.get(dag_id="test_dag")
@@ -2028,12 +2028,12 @@ class TestTaskStateOperations:
     TI_ID = uuid7()
 
     def test_get_success(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == f"/store/ti/{self.TI_ID}/job_id":
-                return httpx.Response(status_code=200, json={"value": "spark_app_001"})
-            return httpx.Response(status_code=400)
+                return httpx2.Response(status_code=200, json={"value": "spark_app_001"})
+            return httpx2.Response(status_code=400)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.task_state_store.get(ti_id=self.TI_ID, key="job_id")
 
         assert isinstance(result, TaskStateStoreResponse)
@@ -2042,24 +2042,24 @@ class TestTaskStateOperations:
     def test_get_url_encodes_key_with_slash(self):
         requests_seen = []
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             requests_seen.append(request)
-            return httpx.Response(status_code=200, json={"value": "spark_app_001"})
+            return httpx2.Response(status_code=200, json={"value": "spark_app_001"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         client.task_state_store.get(ti_id=self.TI_ID, key="spark/job_id")
 
         assert b"%2F" in requests_seen[0].url.raw_path
         assert requests_seen[0].url.raw_path == f"/store/ti/{self.TI_ID}/spark%2Fjob_id".encode()
 
     def test_get_returns_error_response_on_404(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
+            return httpx2.Response(
                 status_code=404,
                 json={"detail": {"reason": "not_found", "message": "Task state key 'job_id' not found"}},
             )
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.task_state_store.get(ti_id=self.TI_ID, key="job_id")
         assert isinstance(result, ErrorResponse)
         assert result.error == ErrorType.TASK_STORE_NOT_FOUND
@@ -2067,13 +2067,13 @@ class TestTaskStateOperations:
     def test_set_success(self):
         expires = datetime(2026, 6, 13, 12, 0, 0, tzinfo=dt_timezone.utc)
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             assert request.method == "PUT"
             assert request.url.path == f"/store/ti/{self.TI_ID}/job_id"
             assert b'"value":"spark_app_001"' in request.content
-            return httpx.Response(status_code=204)
+            return httpx2.Response(status_code=204)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.task_state_store.set(
             ti_id=self.TI_ID, key="job_id", value="spark_app_001", expires_at=expires
         )
@@ -2082,11 +2082,11 @@ class TestTaskStateOperations:
     def test_set_url_encodes_key_with_slash(self):
         requests_seen = []
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             requests_seen.append(request)
-            return httpx.Response(status_code=204)
+            return httpx2.Response(status_code=204)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         client.task_state_store.set(
             ti_id=self.TI_ID, key="spark/job_id", value="spark_app_001", expires_at=None
         )
@@ -2098,13 +2098,13 @@ class TestTaskStateOperations:
         """expires_at is forwarded as an ISO datetime string in the request body."""
         expires = datetime(2026, 5, 21, 12, 0, 0, tzinfo=dt_timezone.utc)
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             body = json.loads(request.content)
             assert body["value"] == "spark_app_001"
             assert body["expires_at"] == "2026-05-21T12:00:00Z"
-            return httpx.Response(status_code=204)
+            return httpx2.Response(status_code=204)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.task_state_store.set(
             ti_id=self.TI_ID, key="job_id", value="spark_app_001", expires_at=expires
         )
@@ -2113,12 +2113,12 @@ class TestTaskStateOperations:
     def test_set_with_never_expire_sends_null_expires_at(self):
         """NEVER_EXPIRE sends expires_at=null — stored as NULL in DB, GC skips it."""
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             body = json.loads(request.content)
             assert body.get("expires_at") is None
-            return httpx.Response(status_code=204)
+            return httpx2.Response(status_code=204)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.task_state_store.set(
             ti_id=self.TI_ID,
             key="job_id",
@@ -2128,156 +2128,156 @@ class TestTaskStateOperations:
         assert result == OKResponse(ok=True)
 
     def test_delete_success(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             assert request.method == "DELETE"
             assert request.url.path == f"/store/ti/{self.TI_ID}/job_id"
-            return httpx.Response(status_code=204)
+            return httpx2.Response(status_code=204)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.task_state_store.delete(ti_id=self.TI_ID, key="job_id")
         assert result == OKResponse(ok=True)
 
     def test_delete_url_encodes_key_with_slash(self):
         requests_seen = []
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             requests_seen.append(request)
-            return httpx.Response(status_code=204)
+            return httpx2.Response(status_code=204)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         client.task_state_store.delete(ti_id=self.TI_ID, key="spark/job_id")
 
         assert b"%2F" in requests_seen[0].url.raw_path
         assert requests_seen[0].url.raw_path == f"/store/ti/{self.TI_ID}/spark%2Fjob_id".encode()
 
     def test_clear_sends_delete_request(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             assert request.method == "DELETE"
             assert request.url.path == f"/store/ti/{self.TI_ID}"
-            return httpx.Response(status_code=204)
+            return httpx2.Response(status_code=204)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.task_state_store.clear(ti_id=self.TI_ID)
         assert result == OKResponse(ok=True)
 
 
 class TestAssetStateOperations:
     def test_get_by_name_success(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if (
                 request.url.path == "/store/asset/by-name/value"
                 and request.url.params["name"] == "test_asset"
                 and request.url.params["key"] == "watermark"
             ):
-                return httpx.Response(status_code=200, json={"value": "2026-04-30T00:00:00Z"})
-            return httpx.Response(status_code=400)
+                return httpx2.Response(status_code=200, json={"value": "2026-04-30T00:00:00Z"})
+            return httpx2.Response(status_code=400)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.asset_state_store.get(key="watermark", name="test_asset")
 
         assert isinstance(result, AssetStateStoreResponse)
         assert result.value == "2026-04-30T00:00:00Z"
 
     def test_get_by_uri_success(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if (
                 request.url.path == "/store/asset/by-uri/value"
                 and request.url.params["uri"] == "s3://bucket/key"
                 and request.url.params["key"] == "watermark"
             ):
-                return httpx.Response(status_code=200, json={"value": "2026-04-30T00:00:00Z"})
-            return httpx.Response(status_code=400)
+                return httpx2.Response(status_code=200, json={"value": "2026-04-30T00:00:00Z"})
+            return httpx2.Response(status_code=400)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.asset_state_store.get(key="watermark", uri="s3://bucket/key")
 
         assert isinstance(result, AssetStateStoreResponse)
         assert result.value == "2026-04-30T00:00:00Z"
 
     def test_get_returns_error_response_on_404(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
+            return httpx2.Response(
                 status_code=404,
                 json={"detail": {"reason": "not_found", "message": "Asset state key 'watermark' not found"}},
             )
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.asset_state_store.get(key="watermark", name="test_asset")
         assert isinstance(result, ErrorResponse)
         assert result.error == ErrorType.ASSET_STORE_NOT_FOUND
 
     def test_set_by_name_success(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             assert request.method == "PUT"
             assert request.url.path == "/store/asset/by-name/value"
             assert request.url.params["name"] == "test_asset"
             assert request.url.params["key"] == "watermark"
             assert b'"value":"2026-04-30T00:00:00Z"' in request.content
-            return httpx.Response(status_code=204)
+            return httpx2.Response(status_code=204)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.asset_state_store.set(
             key="watermark", value="2026-04-30T00:00:00Z", name="test_asset"
         )
         assert result == OKResponse(ok=True)
 
     def test_set_by_uri_success(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             assert request.method == "PUT"
             assert request.url.path == "/store/asset/by-uri/value"
             assert request.url.params["uri"] == "s3://bucket/key"
             assert request.url.params["key"] == "watermark"
-            return httpx.Response(status_code=204)
+            return httpx2.Response(status_code=204)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.asset_state_store.set(
             key="watermark", value="2026-04-30T00:00:00Z", uri="s3://bucket/key"
         )
         assert result == OKResponse(ok=True)
 
     def test_delete_by_name_success(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             assert request.method == "DELETE"
             assert request.url.path == "/store/asset/by-name/value"
             assert request.url.params["name"] == "test_asset"
             assert request.url.params["key"] == "watermark"
-            return httpx.Response(status_code=204)
+            return httpx2.Response(status_code=204)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.asset_state_store.delete(key="watermark", name="test_asset")
         assert result == OKResponse(ok=True)
 
     def test_delete_by_uri_success(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             assert request.method == "DELETE"
             assert request.url.path == "/store/asset/by-uri/value"
             assert request.url.params["uri"] == "s3://bucket/key"
             assert request.url.params["key"] == "watermark"
-            return httpx.Response(status_code=204)
+            return httpx2.Response(status_code=204)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.asset_state_store.delete(key="watermark", uri="s3://bucket/key")
         assert result == OKResponse(ok=True)
 
     def test_clear_by_name_success(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             assert request.method == "DELETE"
             assert request.url.path == "/store/asset/by-name/clear"
             assert request.url.params["name"] == "test_asset"
-            return httpx.Response(status_code=204)
+            return httpx2.Response(status_code=204)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.asset_state_store.clear(name="test_asset")
         assert result == OKResponse(ok=True)
 
     def test_clear_by_uri_success(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             assert request.method == "DELETE"
             assert request.url.path == "/store/asset/by-uri/clear"
             assert request.url.params["uri"] == "s3://bucket/key"
-            return httpx.Response(status_code=204)
+            return httpx2.Response(status_code=204)
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         result = client.asset_state_store.clear(uri="s3://bucket/key")
         assert result == OKResponse(ok=True)
 
@@ -2286,15 +2286,15 @@ class TestCallbackOperations:
     def test_run_exchanges_token(self):
         callback_id = uuid7()
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             assert request.method == "PATCH"
             assert request.url.path == f"/callbacks/{callback_id}/run"
-            return httpx.Response(
+            return httpx2.Response(
                 status_code=204,
                 headers={"Refreshed-API-Token": "execution-token"},
             )
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         client.callbacks.run(callback_id)
 
         assert client.auth is not None
@@ -2303,13 +2303,13 @@ class TestCallbackOperations:
     def test_run_raises_on_conflict(self):
         callback_id = uuid7()
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
+            return httpx2.Response(
                 status_code=409,
                 json={"detail": {"reason": "invalid_state", "previous_state": "running"}},
             )
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
+        client = make_client(transport=httpx2.MockTransport(handle_request))
         with pytest.raises(ServerResponseError) as err:
             client.callbacks.run(callback_id)
         assert err.value.response.status_code == 409

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -39,7 +39,7 @@ from typing import TYPE_CHECKING, Any
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
-import httpx
+import httpx2
 import msgspec
 import psutil
 import pytest
@@ -457,9 +457,9 @@ class TestWatchedSubprocess:
         main_pid = os.getpid()
         ti_id = "4d828a62-a417-4936-a7a6-2b3fabacecab"
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == f"/task-instances/{ti_id}/heartbeat":
-                return httpx.Response(
+                return httpx2.Response(
                     status_code=409,
                     json={
                         "detail": {
@@ -470,8 +470,8 @@ class TestWatchedSubprocess:
                     },
                 )
             if request.url.path == f"/task-instances/{ti_id}/run":
-                return httpx.Response(200, json=make_ti_context_dict())
-            return httpx.Response(status_code=204)
+                return httpx2.Response(200, json=make_ti_context_dict())
+            return httpx2.Response(status_code=204)
 
         def subprocess_main():
             # Ensure we follow the "protocol" and get the startup message before we do anything
@@ -516,7 +516,7 @@ class TestWatchedSubprocess:
                 dag_version_id=uuid7(),
                 queue="default",
             ),
-            client=make_client(transport=httpx.MockTransport(handle_request)),
+            client=make_client(transport=httpx2.MockTransport(handle_request)),
             target=subprocess_main,
         )
 
@@ -873,14 +873,14 @@ class TestWatchedSubprocess:
         # Track the number of requests to simulate mixed responses
         request_count = {"count": 0}
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == f"/task-instances/{ti_id}/heartbeat":
                 request_count["count"] += 1
                 if request_count["count"] == 1:
                     # First request succeeds
-                    return httpx.Response(status_code=204)
+                    return httpx2.Response(status_code=204)
                 # Second request returns a conflict status code
-                return httpx.Response(
+                return httpx2.Response(
                     409,
                     json={
                         "reason": "not_running",
@@ -889,11 +889,11 @@ class TestWatchedSubprocess:
                     },
                 )
             if request.url.path == f"/task-instances/{ti_id}/run":
-                return httpx.Response(200, json=make_ti_context_dict())
+                return httpx2.Response(200, json=make_ti_context_dict())
             if request.url.path == f"/task-instances/{ti_id}/state":
                 pytest.fail("Should not have sent a state update request")
             # Return a 204 for all other requests
-            return httpx.Response(status_code=204)
+            return httpx2.Response(status_code=204)
 
         proc = ActivitySubprocess.start(
             dag_rel_path=os.devnull,
@@ -906,7 +906,7 @@ class TestWatchedSubprocess:
                 dag_version_id=uuid7(),
                 queue="default",
             ),
-            client=make_client(transport=httpx.MockTransport(handle_request)),
+            client=make_client(transport=httpx2.MockTransport(handle_request)),
             target=subprocess_main,
             bundle_info=FAKE_BUNDLE,
         )
@@ -959,9 +959,9 @@ class TestWatchedSubprocess:
         when the API returns 409 with previous_state='running'."""
         ti_id = uuid7()
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
+        def handle_request(request: httpx2.Request) -> httpx2.Response:
             if request.url.path == f"/task-instances/{ti_id}/run":
-                return httpx.Response(
+                return httpx2.Response(
                     409,
                     json={
                         "detail": {
@@ -971,7 +971,7 @@ class TestWatchedSubprocess:
                         }
                     },
                 )
-            return httpx.Response(status_code=204)
+            return httpx2.Response(status_code=204)
 
         def subprocess_main():
             # Ensure we follow the "protocol" and get the startup message before we do anything
@@ -990,7 +990,7 @@ class TestWatchedSubprocess:
                     dag_version_id=uuid7(),
                     queue="default",
                 ),
-                client=make_client(transport=httpx.MockTransport(handle_request)),
+                client=make_client(transport=httpx2.MockTransport(handle_request)),
                 target=subprocess_main,
             )
 
@@ -3449,8 +3449,8 @@ class TestHandleRequest:
 
         error = ServerResponseError(
             message="API Server Error",
-            request=httpx.Request("GET", "http://test"),
-            response=httpx.Response(500, json={"detail": "Internal Server Error"}),
+            request=httpx2.Request("GET", "http://test"),
+            response=httpx2.Response(500, json={"detail": "Internal Server Error"}),
         )
 
         mock_client_method = mocker.Mock(side_effect=error)
@@ -3510,8 +3510,8 @@ class TestHandleRequest:
 
         error = ServerResponseError(
             message="boom",
-            request=httpx.Request("PUT", "http://test"),
-            response=httpx.Response(status_code, json={"detail": "boom"}),
+            request=httpx2.Request("PUT", "http://test"),
+            response=httpx2.Response(status_code, json={"detail": "boom"}),
         )
         watched_subprocess.client.task_instances.set_rtif = mocker.Mock(side_effect=error)
 
@@ -3537,7 +3537,7 @@ class TestHandleRequest:
     def test_handle_requests_network_exception_does_not_crash_loop(self, watched_subprocess, mocker):
         """A transient network error must not crash the IPC generator.
 
-        Without the catch-all in handle_requests, an httpx.ConnectError would
+        Without the catch-all in handle_requests, an httpx2.ConnectError would
         propagate, the generator would terminate, the task subprocess would
         get EOFError on every subsequent send, and the worker would be stuck.
         Verify that the error is reported back to the task as an
@@ -3547,7 +3547,7 @@ class TestHandleRequest:
         watched_subprocess, read_socket = watched_subprocess
 
         # First request raises a network exception, second succeeds.
-        first_call = httpx.ConnectError("connection refused")
+        first_call = httpx2.ConnectError("connection refused")
         watched_subprocess.client.task_instances.succeed = mocker.Mock(side_effect=[first_call, None])
 
         generator = watched_subprocess.handle_requests(log=mocker.Mock())
@@ -3625,10 +3625,10 @@ class TestHandleRequest:
         setattr(
             watched_subprocess.client.task_instances,
             api_method,
-            mocker.Mock(side_effect=httpx.ConnectError("connection refused")),
+            mocker.Mock(side_effect=httpx2.ConnectError("connection refused")),
         )
 
-        with pytest.raises(httpx.ConnectError):
+        with pytest.raises(httpx2.ConnectError):
             watched_subprocess._handle_request(msg, mocker.Mock(), req_id=1)
 
         assert watched_subprocess._terminal_state is None
@@ -3839,17 +3839,17 @@ class TestInProcessClient:
     def test_no_retries(self):
         called = 0
 
-        def noop_handler(request: httpx.Request) -> httpx.Response:
+        def noop_handler(request: httpx2.Request) -> httpx2.Response:
             nonlocal called
             called += 1
-            return httpx.Response(500)
+            return httpx2.Response(500)
 
-        transport = httpx.MockTransport(noop_handler)
+        transport = httpx2.MockTransport(noop_handler)
         client = InProcessTestSupervisor._Client(
             base_url="http://local.invalid", token="", transport=transport
         )
 
-        with pytest.raises(httpx.HTTPStatusError):
+        with pytest.raises(httpx2.HTTPStatusError):
             client.get("/goo")
 
         assert called == 1
@@ -3874,8 +3874,8 @@ def test_remote_logging_conn(remote_logging, remote_conn, expected_env, monkeypa
     monkeypatch.delitem(sys.modules, "airflow.config_templates.airflow_local_settings", raising=False)
     monkeypatch.delitem(sys.modules, "airflow.sdk.log", raising=False)
 
-    def handle_request(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
+    def handle_request(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(
             status_code=200,
             json={
                 # Minimal enough to pass validation, we don't care what fields are in here for the tests
@@ -3911,7 +3911,7 @@ def test_remote_logging_conn(remote_logging, remote_conn, expected_env, monkeypa
             }
         ):
             env = os.environ.copy()
-            client = make_client(transport=httpx.MockTransport(handle_request))
+            client = make_client(transport=httpx2.MockTransport(handle_request))
 
             with _remote_logging_conn(client):
                 new_keys = os.environ.keys() - env.keys()
@@ -3994,11 +3994,11 @@ def test_logs_uploaded_even_when_state_update_fails(mocker):
     mocker.patch.object(
         ActivitySubprocess,
         "update_task_state_if_needed",
-        side_effect=httpx.ConnectError("connection refused"),
+        side_effect=httpx2.ConnectError("connection refused"),
     )
     upload_logs = mocker.patch.object(ActivitySubprocess, "_upload_logs")
 
-    with pytest.raises(httpx.ConnectError):
+    with pytest.raises(httpx2.ConnectError):
         proc.wait()
 
     upload_logs.assert_called_once_with()
@@ -4019,8 +4019,8 @@ def test_remote_logging_conn_sets_process_context(monkeypatch, mocker):
     conn_id = "s3_conn_logs"
     conn_uri = "aws:///?region_name=us-east-1"
 
-    def handle_request(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
+    def handle_request(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(
             status_code=200,
             json={
                 "conn_id": conn_id,
@@ -4046,7 +4046,7 @@ def test_remote_logging_conn_sets_process_context(monkeypatch, mocker):
                 ("logging", "remote_log_conn_id"): conn_id,
             }
         ):
-            client = make_client(transport=httpx.MockTransport(handle_request))
+            client = make_client(transport=httpx2.MockTransport(handle_request))
 
             assert os.getenv("_AIRFLOW_PROCESS_CONTEXT") is None
 
@@ -4211,12 +4211,12 @@ def test_remote_logging_conn_caches_connection_not_client(monkeypatch):
         }
     ):
 
-        def noop_request(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200)
+        def noop_request(request: httpx2.Request) -> httpx2.Response:
+            return httpx2.Response(200)
 
         clients = []
         for _ in range(3):
-            client = make_client(transport=httpx.MockTransport(noop_request))
+            client = make_client(transport=httpx2.MockTransport(noop_request))
             clients.append(weakref.ref(client))
             with _remote_logging_conn(client):
                 pass

--- a/uv.lock
+++ b/uv.lock
@@ -29,146 +29,146 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P4D"
 
 [options.exclude-newer-package]
-apache-airflow-providers-informatica = false
-apache-airflow-providers-clickhousedb = false
-apache-airflow-providers-amazon = false
-apache-airflow-providers-elasticsearch = false
-apache-airflow-providers-microsoft-winrm = false
-apache-airflow-docker-tests = false
-apache-airflow-providers = false
-apache-airflow-providers-fab = false
-apache-airflow-providers-openlineage = false
-apache-airflow-providers-sftp = false
-apache-airflow-e2e-tests = false
-apache-airflow-shared-logging = false
-apache-airflow-providers-common-dataquality = false
-apache-airflow-providers-apache-drill = false
-apache-airflow-providers-pgvector = false
-apache-airflow-providers-imap = false
-apache-airflow-providers-qdrant = false
-apache-airflow-providers-edge3 = false
-apache-airflow-providers-neo4j = false
-apache-airflow-providers-discord = false
-apache-airflow-providers-opensearch = false
-apache-airflow-providers-samba = false
-apache-airflow-providers-arangodb = false
-apache-airflow-providers-apache-spark = false
-apache-airflow-providers-ftp = false
-apache-airflow-providers-jenkins = false
-apache-airflow-shared-listeners = false
-apache-airflow-shared-providers-discovery = false
-apache-airflow-providers-telegram = false
-apache-airflow-providers-celery = false
-apache-airflow-providers-docker = false
-apache-airflow-providers-sendgrid = false
-apache-airflow-providers-common-ai = false
 apache-airflow = false
-apache-airflow-shared-observability = false
-apache-airflow-dev = false
-apache-airflow-providers-dbt-cloud = false
-apache-airflow-providers-openfaas = false
-apache-airflow-devel-common = false
-apache-airflow-providers-apache-cassandra = false
-apache-airflow-providers-asana = false
-apache-airflow-providers-oracle = false
-apache-airflow-providers-mysql = false
-apache-airflow-providers-alibaba = false
-apache-airflow-providers-microsoft-mssql = false
-apache-airflow-providers-teradata = false
-apache-airflow-providers-jdbc = false
-apache-airflow-helm-chart = false
-apache-airflow-providers-anthropic = false
-apache-airflow-providers-common-io = false
-apache-airflow-providers-cohere = false
-apache-airflow-providers-pinecone = false
-apache-airflow-providers-segment = false
-apache-airflow-providers-redis = false
-apache-airflow-shared-dagnode = false
-apache-airflow-providers-apache-pinot = false
-apache-airflow-providers-weaviate = false
-google-cloud-aiplatform = "2026-08-13T00:00:00Z"
-apache-airflow-providers-akeyless = false
-apache-airflow-providers-salesforce = false
-apache-airflow-providers-ssh = false
-apache-airflow-providers-papermill = false
-apache-airflow-providers-google = false
-pydantic-ai-skills = "2026-07-16T00:00:00Z"
-apache-airflow-providers-apache-beam = false
-apache-airflow-providers-microsoft-psrp = false
-apache-airflow-providers-vertica = false
-apache-airflow-providers-apache-hdfs = false
-apache-airflow-shared-template-rendering = false
-apache-airflow-mypy = false
-apache-airflow-providers-http = false
-apache-airflow-providers-slack = false
-apache-airflow-providers-vespa = false
-apache-airflow-providers-databricks = false
-apache-airflow-shared-state = false
-apache-airflow-docker-stack = false
-apache-airflow-providers-sqlite = false
-apache-airflow-providers-ibm-mq = false
-apache-airflow-shared-module-loading = false
-apache-airflow-providers-yandex = false
-apache-airflow-shared-serialization = false
-apache-airflow-scripts = false
-apache-airflow-providers-exasol = false
-apache-airflow-providers-mongo = false
-apache-airflow-providers-apache-arrow = false
-apache-airflow-providers-apprise = false
-apache-airflow-providers-apache-impala = false
+apache-airflow-breeze = false
+apache-airflow-core = false
 apache-airflow-ctl = false
-apache-airflow-providers-github = false
-apache-airflow-providers-snowflake = false
-apache-airflow-providers-zendesk = false
-apache-airflow-providers-presto = false
-apache-airflow-providers-airbyte = false
-apache-airflow-providers-apache-hive = false
+apache-airflow-ctl-tests = false
+apache-airflow-dev = false
+apache-airflow-devel-common = false
+apache-airflow-docker-stack = false
+apache-airflow-docker-tests = false
+apache-airflow-e2e-tests = false
+apache-airflow-helm-chart = false
 apache-airflow-kubernetes-tests = false
-apache-airflow-providers-grpc = false
+apache-airflow-mypy = false
+apache-airflow-providers = false
+apache-airflow-providers-airbyte = false
+apache-airflow-providers-akeyless = false
+apache-airflow-providers-alibaba = false
+apache-airflow-providers-amazon = false
+apache-airflow-providers-anthropic = false
+apache-airflow-providers-apache-arrow = false
+apache-airflow-providers-apache-beam = false
+apache-airflow-providers-apache-cassandra = false
+apache-airflow-providers-apache-drill = false
 apache-airflow-providers-apache-druid = false
 apache-airflow-providers-apache-flink = false
-apache-airflow-providers-cncf-kubernetes = false
-apache-airflow-providers-apache-pig = false
-apache-airflow-providers-apache-tinkerpop = false
-apache-airflow-shared-timezones = false
+apache-airflow-providers-apache-hdfs = false
+apache-airflow-providers-apache-hive = false
 apache-airflow-providers-apache-iceberg = false
-apache-airflow-breeze = false
-apache-airflow-providers-opsgenie = false
-apache-airflow-providers-apache-livy = false
-apache-airflow-core = false
-apache-airflow-providers-hashicorp = false
-apache-airflow-providers-pagerduty = false
-apache-airflow-providers-datadog = false
+apache-airflow-providers-apache-impala = false
 apache-airflow-providers-apache-kafka = false
-apache-airflow-providers-influxdb = false
-apache-airflow-providers-keycloak = false
-apache-airflow-providers-trino = false
-apache-airflow-providers-common-messaging = false
-apache-airflow-providers-standard = false
-apache-airflow-providers-singularity = false
+apache-airflow-providers-apache-kylin = false
+apache-airflow-providers-apache-livy = false
+apache-airflow-providers-apache-pig = false
+apache-airflow-providers-apache-pinot = false
+apache-airflow-providers-apache-spark = false
+apache-airflow-providers-apache-tinkerpop = false
+apache-airflow-providers-apprise = false
+apache-airflow-providers-arangodb = false
+apache-airflow-providers-asana = false
+apache-airflow-providers-atlassian-jira = false
+apache-airflow-providers-celery = false
+apache-airflow-providers-clickhousedb = false
+apache-airflow-providers-cloudant = false
+apache-airflow-providers-cncf-kubernetes = false
+apache-airflow-providers-cohere = false
+apache-airflow-providers-common-ai = false
 apache-airflow-providers-common-compat = false
-apache-airflow-ctl-tests = false
-apache-airflow-providers-tableau = false
-apache-airflow-providers-ibm-db2 = false
+apache-airflow-providers-common-dataquality = false
+apache-airflow-providers-common-io = false
+apache-airflow-providers-common-messaging = false
 apache-airflow-providers-common-sql = false
-apache-airflow-shared-configuration = false
+apache-airflow-providers-databricks = false
+apache-airflow-providers-datadog = false
+apache-airflow-providers-dbt-cloud = false
+apache-airflow-providers-dingding = false
+apache-airflow-providers-discord = false
+apache-airflow-providers-docker = false
+apache-airflow-providers-edge3 = false
+apache-airflow-providers-elasticsearch = false
+apache-airflow-providers-exasol = false
+apache-airflow-providers-fab = false
 apache-airflow-providers-facebook = false
-apache-airflow-providers-ydb = false
+apache-airflow-providers-ftp = false
+apache-airflow-providers-git = false
+apache-airflow-providers-github = false
+apache-airflow-providers-google = false
+apache-airflow-providers-grpc = false
+apache-airflow-providers-hashicorp = false
+apache-airflow-providers-http = false
+apache-airflow-providers-ibm-db2 = false
+apache-airflow-providers-ibm-mq = false
+apache-airflow-providers-imap = false
+apache-airflow-providers-influxdb = false
+apache-airflow-providers-informatica = false
+apache-airflow-providers-jdbc = false
+apache-airflow-providers-jenkins = false
+apache-airflow-providers-keycloak = false
 apache-airflow-providers-microsoft-azure = false
+apache-airflow-providers-microsoft-mssql = false
+apache-airflow-providers-microsoft-psrp = false
+apache-airflow-providers-microsoft-winrm = false
+apache-airflow-providers-mongo = false
+apache-airflow-providers-mysql = false
+apache-airflow-providers-neo4j = false
+apache-airflow-providers-odbc = false
+apache-airflow-providers-openai = false
+apache-airflow-providers-openfaas = false
+apache-airflow-providers-openlineage = false
+apache-airflow-providers-opensearch = false
+apache-airflow-providers-opsgenie = false
+apache-airflow-providers-oracle = false
+apache-airflow-providers-pagerduty = false
+apache-airflow-providers-papermill = false
+apache-airflow-providers-pgvector = false
+apache-airflow-providers-pinecone = false
+apache-airflow-providers-postgres = false
+apache-airflow-providers-presto = false
+apache-airflow-providers-qdrant = false
+apache-airflow-providers-redis = false
+apache-airflow-providers-salesforce = false
+apache-airflow-providers-samba = false
+apache-airflow-providers-segment = false
+apache-airflow-providers-sendgrid = false
+apache-airflow-providers-sftp = false
+apache-airflow-providers-singularity = false
+apache-airflow-providers-slack = false
+apache-airflow-providers-smtp = false
+apache-airflow-providers-snowflake = false
+apache-airflow-providers-sqlite = false
+apache-airflow-providers-ssh = false
+apache-airflow-providers-standard = false
+apache-airflow-providers-tableau = false
+apache-airflow-providers-telegram = false
+apache-airflow-providers-teradata = false
+apache-airflow-providers-trino = false
+apache-airflow-providers-vertica = false
+apache-airflow-providers-vespa = false
+apache-airflow-providers-weaviate = false
+apache-airflow-providers-yandex = false
+apache-airflow-providers-ydb = false
+apache-airflow-providers-zendesk = false
+apache-airflow-scripts = false
+apache-airflow-shared-configuration = false
+apache-airflow-shared-dagnode = false
+apache-airflow-shared-listeners = false
+apache-airflow-shared-logging = false
+apache-airflow-shared-module-loading = false
+apache-airflow-shared-observability = false
 apache-airflow-shared-plugins-manager = false
+apache-airflow-shared-providers-discovery = false
 apache-airflow-shared-secrets-backend = false
 apache-airflow-shared-secrets-masker = false
-apache-airflow-providers-git = false
+apache-airflow-shared-serialization = false
+apache-airflow-shared-state = false
+apache-airflow-shared-template-rendering = false
+apache-airflow-shared-timezones = false
 apache-airflow-task-sdk = false
-apache-airflow-providers-atlassian-jira = false
-apache-airflow-providers-odbc = false
-apache-airflow-providers-postgres = false
-apache-airflow-providers-openai = false
 apache-airflow-task-sdk-integration-tests = false
-apache-airflow-providers-smtp = false
-apache-airflow-providers-dingding = false
-apache-airflow-providers-cloudant = false
-apache-airflow-providers-apache-kylin = false
+google-cloud-aiplatform = "2026-08-13T00:00:00Z"
+pydantic-ai-skills = "2026-07-16T00:00:00Z"
 
 [manifest]
 members = [
@@ -518,7 +518,7 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "caio", version = "0.9.25", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "caio", version = "0.9.25", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
 wheels = [
@@ -550,7 +550,7 @@ resolution-markers = [
     "(python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "caio", version = "0.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "caio", version = "0.12.2", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/14/31/edb06aabd8f8f0b56d659f30800795f40b93cba96be946ce179f6931e3a5/aiofile-3.12.3.tar.gz", hash = "sha256:caa6aa746b5e47e2165f7abd741b6415e49cf4d44fddc0f61844612cc3924d41", size = 21600, upload-time = "2026-08-04T22:59:27.171Z" }
 wheels = [
@@ -717,7 +717,7 @@ name = "aiohttp-cors"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp", marker = "python_full_version < '3.15'" },
+    { name = "aiohttp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/d89e846a5444b3d5eb8985a6ddb0daef3774928e1bfbce8e84ec97b0ffa7/aiohttp_cors-0.8.1.tar.gz", hash = "sha256:ccacf9cb84b64939ea15f859a146af1f662a6b1d68175754a07315e305fb1403", size = 38626, upload-time = "2025-03-31T14:16:20.048Z" }
 wheels = [
@@ -1998,6 +1998,7 @@ dependencies = [
     { name = "dill" },
     { name = "fastapi", extra = ["standard-no-fastapi-cloud-cli"] },
     { name = "httpx" },
+    { name = "httpx2" },
     { name = "importlib-metadata" },
     { name = "isoduration" },
     { name = "itsdangerous" },
@@ -2135,6 +2136,7 @@ requires-dist = [
     { name = "greenlet", marker = "python_full_version < '3.14' and extra == 'async'", specifier = ">=3.1.0" },
     { name = "gunicorn", marker = "extra == 'gunicorn'", specifier = ">=23.0.0,!=25.1.0" },
     { name = "httpx", specifier = ">=0.25.0" },
+    { name = "httpx2", specifier = ">=2.0.0" },
     { name = "importlib-metadata", marker = "python_full_version < '3.12'", specifier = ">=6.5" },
     { name = "importlib-metadata", marker = "python_full_version >= '3.12'", specifier = ">=7.0" },
     { name = "isoduration", specifier = ">=20.11.0" },
@@ -9240,10 +9242,11 @@ dependencies = [
     { name = "asgiref" },
     { name = "attrs" },
     { name = "babel" },
+    { name = "certifi" },
     { name = "colorlog" },
     { name = "fsspec" },
     { name = "greenback" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
     { name = "isoduration" },
     { name = "jinja2" },
@@ -9317,12 +9320,13 @@ requires-dist = [
     { name = "asgiref", marker = "python_full_version >= '3.14'", specifier = ">=3.11.1" },
     { name = "attrs", specifier = ">=24.2.0,!=25.2.0" },
     { name = "babel", specifier = ">=2.17.0" },
+    { name = "certifi", specifier = ">=2024.7.4" },
     { name = "colorlog", specifier = ">=6.8.2" },
     { name = "datadog", marker = "extra == 'all'", specifier = ">=0.50.0" },
     { name = "datadog", marker = "extra == 'datadog'", specifier = ">=0.50.0" },
     { name = "fsspec", specifier = ">=2023.10.0" },
     { name = "greenback", specifier = ">=1.2.1" },
-    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "httpx2", specifier = ">=2.0.0" },
     { name = "importlib-metadata", marker = "python_full_version < '3.12'", specifier = ">=6.5" },
     { name = "isoduration", specifier = ">=20.11.0" },
     { name = "jinja2", specifier = ">=3.1.5" },
@@ -10936,8 +10940,8 @@ name = "cassandra-driver"
 version = "3.30.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "deprecated", marker = "python_full_version < '3.14'" },
-    { name = "geomet", marker = "python_full_version < '3.14'" },
+    { name = "deprecated" },
+    { name = "geomet" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bb/ed/4e16210e194660f107929ee494f1cf18557252655067d9b39029c241be2d/cassandra_driver-3.30.1.tar.gz", hash = "sha256:0c6a3e1428f7c6a9aa6c944b9c47a37cd2cdbeb5b5a82d42c33afdd56f14e398", size = 289233, upload-time = "2026-07-06T20:14:31.37Z" }
 wheels = [
@@ -11603,7 +11607,7 @@ name = "colorful"
 version = "0.5.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.15' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/82/31/109ef4bedeb32b4202e02ddb133162457adc4eb890a9ed9c05c9dd126ed0/colorful-0.5.8.tar.gz", hash = "sha256:bb16502b198be2f1c42ba3c52c703d5f651d826076817185f0294c1a549a7445", size = 209361, upload-time = "2025-10-29T11:53:21.663Z" }
 wheels = [
@@ -13168,7 +13172,7 @@ name = "geomet"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "python_full_version < '3.14'" },
+    { name = "click" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2a/8c/dde022aa6747b114f6b14a7392871275dea8867e2bd26cddb80cc6d66620/geomet-1.1.0.tar.gz", hash = "sha256:51e92231a0ef6aaa63ac20c443377ba78a303fd2ecd179dc3567de79f3c11605", size = 28732, upload-time = "2023-11-14T15:43:36.764Z" }
 wheels = [
@@ -13351,10 +13355,10 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "fasteners", marker = "python_full_version < '3.13'" },
-    { name = "httplib2", marker = "python_full_version < '3.13'" },
-    { name = "oauth2client", marker = "python_full_version < '3.13'" },
-    { name = "six", marker = "python_full_version < '3.13'" },
+    { name = "fasteners" },
+    { name = "httplib2" },
+    { name = "oauth2client" },
+    { name = "six" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/da/aefc4cf4c168b5d875344cd9dddc77e3a2d11986b630251af5ce47dd2843/google-apitools-0.5.31.tar.gz", hash = "sha256:4af0dd6dd4582810690251f0b57a97c1873dadfda54c5bc195844c8907624170", size = 173463, upload-time = "2020-05-14T17:25:19.126Z" }
 
@@ -13375,10 +13379,10 @@ resolution-markers = [
     "(python_full_version == '3.13.*' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "fasteners", marker = "python_full_version >= '3.13'" },
-    { name = "httplib2", marker = "python_full_version >= '3.13'" },
-    { name = "oauth2client", marker = "python_full_version >= '3.13'" },
-    { name = "six", marker = "python_full_version >= '3.13'" },
+    { name = "fasteners" },
+    { name = "httplib2" },
+    { name = "oauth2client" },
+    { name = "six" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/e4/15fbddfffa968e10c602a30b7ca4703f3e41d2dbdef011e98eee85575133/google-apitools-0.5.35.tar.gz", hash = "sha256:911bc3698686c74187414c610ae30bd6e3c0a7404178fc6479ead6c420d2dd94", size = 531707, upload-time = "2025-09-24T20:22:51.11Z" }
 wheels = [
@@ -14691,7 +14695,7 @@ name = "gssapi"
 version = "1.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "decorator", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
+    { name = "decorator" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6b/fb/9492eb37b5786369b7e96fff2cf4040713acb33b96124813e058cbbd4356/gssapi-1.12.0.tar.gz", hash = "sha256:0b48f17296f869db89221c3bde463fdff35152a4cb99ae4aaa42b0b64333fc6c", size = 95321, upload-time = "2026-08-26T03:00:50.067Z" }
 wheels = [
@@ -14871,8 +14875,8 @@ name = "httpcore2"
 version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "h11", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
-    { name = "truststore", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
+    { name = "h11" },
+    { name = "truststore" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
 wheels = [
@@ -15519,17 +15523,17 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -15561,17 +15565,17 @@ resolution-markers = [
     "(python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "psutil", marker = "python_full_version >= '3.11' and sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "psutil", marker = "sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/32/99451b1283ec5d92ad77073f12e1c667dc10775384d8f15c2914207149dd/ipython-9.17.1.tar.gz", hash = "sha256:8919be8c27f20a6f4423145028063f6637b42a03ce57665bb12015ee1f073529", size = 4539289, upload-time = "2026-09-01T08:29:32.6Z" }
 wheels = [
@@ -15583,7 +15587,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -16582,18 +16586,18 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "aiohttp", marker = "python_full_version < '3.14'" },
-    { name = "click", marker = "python_full_version < '3.14'" },
-    { name = "fastuuid", marker = "python_full_version < '3.14'" },
-    { name = "httpx", marker = "python_full_version < '3.14'" },
-    { name = "importlib-metadata", marker = "python_full_version < '3.14'" },
-    { name = "jinja2", marker = "python_full_version < '3.14'" },
-    { name = "jsonschema", marker = "python_full_version < '3.14'" },
-    { name = "openai", marker = "python_full_version < '3.14'" },
-    { name = "pydantic", marker = "python_full_version < '3.14'" },
-    { name = "python-dotenv", marker = "python_full_version < '3.14'" },
-    { name = "tiktoken", marker = "python_full_version < '3.14'" },
-    { name = "tokenizers", marker = "python_full_version < '3.14'" },
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "fastuuid" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0d/59/364fa090acef716effd88e6432d3442982b1f965b2d291f1528db0e6aabb/litellm-1.85.7.tar.gz", hash = "sha256:461cc5d5a6c7d5086b67f06f1d5a00c40d6fb0240099764cb040dc4a28452938", size = 15363830, upload-time = "2026-06-24T04:54:55.115Z" }
 wheels = [
@@ -16613,19 +16617,19 @@ resolution-markers = [
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "aiohttp", marker = "python_full_version >= '3.14'" },
-    { name = "click", marker = "python_full_version >= '3.14'" },
-    { name = "fastuuid", marker = "python_full_version >= '3.14'" },
-    { name = "httpx", marker = "python_full_version >= '3.14'" },
-    { name = "importlib-metadata", marker = "python_full_version >= '3.14'" },
-    { name = "jinja2", marker = "python_full_version >= '3.14'" },
-    { name = "jsonschema", marker = "python_full_version >= '3.14'" },
-    { name = "openai", marker = "python_full_version >= '3.14'" },
-    { name = "pydantic", marker = "python_full_version >= '3.14'" },
-    { name = "pydantic-settings", marker = "python_full_version >= '3.14'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.14'" },
-    { name = "tiktoken", marker = "python_full_version >= '3.14'" },
-    { name = "tokenizers", marker = "python_full_version >= '3.14'" },
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "fastuuid" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/79/fe/d03be8a6be6914fabacef29457a2b3d02128c52c448cc6f3019b8e63488b/litellm-1.96.2.tar.gz", hash = "sha256:80d477ae092b05ce023b5084542cb3cb75999b52b1dd2e4d834fb348effc9399", size = 17682558, upload-time = "2026-08-11T21:12:24.117Z" }
 wheels = [
@@ -18651,9 +18655,9 @@ name = "opencensus"
 version = "0.11.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core", marker = "python_full_version < '3.15'" },
-    { name = "opencensus-context", marker = "python_full_version < '3.15'" },
-    { name = "six", marker = "python_full_version < '3.15'" },
+    { name = "google-api-core" },
+    { name = "opencensus-context" },
+    { name = "six" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/15/a7/a46dcffa1b63084f9f17fe3c8cb20724c4c8f91009fd0b2cfdb27d5d2b35/opencensus-0.11.4.tar.gz", hash = "sha256:cbef87d8b8773064ab60e5c2a1ced58bbaa38a6d052c41aec224958ce544eff2", size = 64966, upload-time = "2024-01-03T18:04:07.085Z" }
 wheels = [
@@ -19160,10 +19164,10 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "pytz", marker = "python_full_version < '3.11'" },
-    { name = "tzdata", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -19218,9 +19222,9 @@ wheels = [
 
 [package.optional-dependencies]
 sql-other = [
-    { name = "adbc-driver-postgresql", marker = "python_full_version < '3.11'" },
-    { name = "adbc-driver-sqlite", marker = "python_full_version < '3.11'" },
-    { name = "sqlalchemy", marker = "python_full_version < '3.11'" },
+    { name = "adbc-driver-postgresql" },
+    { name = "adbc-driver-sqlite" },
+    { name = "sqlalchemy" },
 ]
 
 [[package]]
@@ -19248,9 +19252,9 @@ resolution-markers = [
     "(python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
-    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/be/4f/5f3422a2afec5ffc46308b79e53291365a93748b498ac2e58bead0197916/pandas-3.0.5.tar.gz", hash = "sha256:dca3734d6ab7c906e6730f0788b0a1dbb9f2467731f9711f77995c8e9d62d712", size = 4658219, upload-time = "2026-07-22T22:19:28.819Z" }
 wheels = [
@@ -19299,9 +19303,9 @@ wheels = [
 
 [package.optional-dependencies]
 sql-other = [
-    { name = "adbc-driver-postgresql", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "adbc-driver-sqlite", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "sqlalchemy", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "adbc-driver-postgresql" },
+    { name = "adbc-driver-sqlite" },
+    { name = "sqlalchemy" },
 ]
 
 [[package]]
@@ -21873,9 +21877,9 @@ name = "python3-saml"
 version = "1.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "isodate", marker = "python_full_version < '3.13'" },
-    { name = "lxml", marker = "python_full_version < '3.13'" },
-    { name = "xmlsec", marker = "python_full_version < '3.13'" },
+    { name = "isodate" },
+    { name = "lxml" },
+    { name = "xmlsec" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5d/98/6e0268c3a9893af3d4c5cf670183e0314cd6b5cb034a612d6a7cc5060df8/python3-saml-1.16.0.tar.gz", hash = "sha256:97c9669aecabc283c6e5fb4eb264f446b6e006f5267d01c9734f9d8bffdac133", size = 83468, upload-time = "2023-10-09T10:37:43.128Z" }
 wheels = [
@@ -22194,14 +22198,14 @@ name = "ray"
 version = "2.58.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "python_full_version < '3.15'" },
-    { name = "filelock", marker = "python_full_version < '3.15'" },
-    { name = "jsonschema", marker = "python_full_version < '3.15'" },
-    { name = "msgpack", marker = "python_full_version < '3.15'" },
-    { name = "packaging", marker = "python_full_version < '3.15'" },
-    { name = "protobuf", marker = "python_full_version < '3.15'" },
-    { name = "pyyaml", marker = "python_full_version < '3.15'" },
-    { name = "requests", marker = "python_full_version < '3.15'" },
+    { name = "click" },
+    { name = "filelock" },
+    { name = "jsonschema" },
+    { name = "msgpack" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "pyyaml" },
+    { name = "requests" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2f/41/760f9a076085d043d9fbb8f840436e1d21e47682c976d3620efbf02a3b9e/ray-2.58.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:a2235a5a17e865be053e8aff6d9e9e36d1edb45ad8162f57f7cdfd0202a5a397", size = 67217855, upload-time = "2026-08-23T04:45:46.075Z" },
@@ -22228,20 +22232,20 @@ wheels = [
 
 [package.optional-dependencies]
 default = [
-    { name = "aiohttp", marker = "python_full_version < '3.15'" },
-    { name = "aiohttp-cors", marker = "python_full_version < '3.15'" },
-    { name = "colorful", marker = "python_full_version < '3.15'" },
-    { name = "grpcio", marker = "python_full_version < '3.15'" },
-    { name = "opencensus", marker = "python_full_version < '3.15'" },
-    { name = "opentelemetry-exporter-prometheus", marker = "python_full_version < '3.15'" },
-    { name = "opentelemetry-proto", marker = "python_full_version < '3.15'" },
-    { name = "opentelemetry-sdk", marker = "python_full_version < '3.15'" },
-    { name = "prometheus-client", marker = "python_full_version < '3.15'" },
-    { name = "py-spy", marker = "python_full_version < '3.15'" },
-    { name = "pydantic", marker = "python_full_version < '3.15'" },
-    { name = "requests", marker = "python_full_version < '3.15'" },
-    { name = "smart-open", marker = "python_full_version < '3.15'" },
-    { name = "virtualenv", marker = "python_full_version < '3.15'" },
+    { name = "aiohttp" },
+    { name = "aiohttp-cors" },
+    { name = "colorful" },
+    { name = "grpcio" },
+    { name = "opencensus" },
+    { name = "opentelemetry-exporter-prometheus" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "prometheus-client" },
+    { name = "py-spy" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "smart-open" },
+    { name = "virtualenv" },
 ]
 
 [[package]]
@@ -23039,10 +23043,10 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
+    { name = "joblib" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/37/59/44985a2bdc95c74e34fef3d10cb5d93ce13b0e2a7baefffe1b53853b502d/scikit_learn-1.5.2.tar.gz", hash = "sha256:b4237ed7b3fdd0a4882792e68ef2545d5baa50aca3bb45aa7df468138ad8f94d", size = 7001680, upload-time = "2024-09-11T15:50:10.957Z" }
 wheels = [
@@ -23093,12 +23097,12 @@ resolution-markers = [
     "(python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version >= '3.11'" },
-    { name = "narwhals", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "joblib" },
+    { name = "narwhals" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "scipy", version = "1.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
 wheels = [
@@ -23143,7 +23147,7 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -23205,7 +23209,7 @@ resolution-markers = [
     "(python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -23292,7 +23296,7 @@ resolution-markers = [
     "(python_full_version == '3.12.*' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7e/74/66de6258867beb2ef08f35f9f2ac017a52cacd5081714d239ff1a442d458/scipy-1.18.1.tar.gz", hash = "sha256:52c4b7422442aba924d03ad4019852b08a92e64ea187b933135687bfe2747307", size = 30781235, upload-time = "2026-08-21T23:28:50.599Z" }
 wheels = [
@@ -23398,8 +23402,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (platform_machine != 'arm64' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "jeepney", marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (platform_machine != 'arm64' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -23598,7 +23602,7 @@ name = "smart-open"
 version = "8.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wrapt", marker = "python_full_version < '3.15'" },
+    { name = "wrapt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/53/9c513747547fd595d5c143259129ea8b9c3ea2f6b7bb9dcea2b1966ded3c/smart_open-8.0.1.tar.gz", hash = "sha256:18b1c4496003c6902be17c15f032b5c319f307c89c6ae9e6b028b508bed8b2cf", size = 61882, upload-time = "2026-07-15T13:56:10.492Z" }
 wheels = [
@@ -23712,15 +23716,15 @@ name = "snowflake-snowpark-python"
 version = "1.54.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cloudpickle", marker = "python_full_version < '3.14'" },
-    { name = "protobuf", marker = "python_full_version < '3.14'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.14'" },
-    { name = "pyyaml", marker = "python_full_version < '3.14'" },
-    { name = "setuptools", marker = "python_full_version < '3.14'" },
-    { name = "snowflake-connector-python", marker = "python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
-    { name = "tzlocal", marker = "python_full_version < '3.14'" },
-    { name = "wheel", marker = "python_full_version < '3.14'" },
+    { name = "cloudpickle" },
+    { name = "protobuf" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "setuptools" },
+    { name = "snowflake-connector-python" },
+    { name = "typing-extensions" },
+    { name = "tzlocal" },
+    { name = "wheel" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/05/3f/e883292df8a23ade5eaf04a98cbebef75291de537c7e484b726849cb4e3b/snowflake_snowpark_python-1.54.0.tar.gz", hash = "sha256:5ae52602dc528bf822a3ee8e1c8a679484afcb44dd12463211b0238148e0cf7b", size = 1791687, upload-time = "2026-07-29T22:36:54.86Z" }
 wheels = [
@@ -23767,23 +23771,23 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version < '3.11'" },
-    { name = "babel", marker = "python_full_version < '3.11'" },
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "imagesize", marker = "python_full_version < '3.11'" },
-    { name = "jinja2", marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "requests", marker = "python_full_version < '3.11'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+    { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -23801,23 +23805,23 @@ resolution-markers = [
     "(python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version == '3.11.*'" },
-    { name = "babel", marker = "python_full_version == '3.11.*'" },
-    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "imagesize", marker = "python_full_version == '3.11.*'" },
-    { name = "jinja2", marker = "python_full_version == '3.11.*'" },
-    { name = "packaging", marker = "python_full_version == '3.11.*'" },
-    { name = "pygments", marker = "python_full_version == '3.11.*'" },
-    { name = "requests", marker = "python_full_version == '3.11.*'" },
-    { name = "roman-numerals", marker = "python_full_version == '3.11.*'" },
-    { name = "snowballstemmer", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.11.*'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -23845,23 +23849,23 @@ resolution-markers = [
     "(python_full_version == '3.12.*' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.12'" },
-    { name = "babel", marker = "python_full_version >= '3.12'" },
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "imagesize", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [
@@ -23927,12 +23931,12 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "starlette", marker = "python_full_version < '3.11'" },
-    { name = "uvicorn", marker = "python_full_version < '3.11'" },
-    { name = "watchfiles", marker = "python_full_version < '3.11'" },
-    { name = "websockets", marker = "python_full_version < '3.11'" },
+    { name = "colorama" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "starlette" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a5/2c/155e1de2c1ba96a72e5dba152c509a8b41e047ee5c2def9e9f0d812f8be7/sphinx_autobuild-2024.10.3.tar.gz", hash = "sha256:248150f8f333e825107b6d4b86113ab28fa51750e5f9ae63b59dc339be951fb1", size = 14023, upload-time = "2024-10-02T23:15:30.172Z" }
 wheels = [
@@ -23964,13 +23968,13 @@ resolution-markers = [
     "(python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11'" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "colorama" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "starlette", marker = "python_full_version >= '3.11'" },
-    { name = "uvicorn", marker = "python_full_version >= '3.11'" },
-    { name = "watchfiles", marker = "python_full_version >= '3.11'" },
-    { name = "websockets", marker = "python_full_version >= '3.11'" },
+    { name = "starlette" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e0/3c/a59a3a453d4133777f7ed2e83c80b7dc817d43c74b74298ca0af869662ad/sphinx_autobuild-2025.8.25.tar.gz", hash = "sha256:9cf5aab32853c8c31af572e4fecdc09c997e2b8be5a07daf2a389e270e85b213", size = 15200, upload-time = "2025-08-25T18:44:55.436Z" }
 wheels = [
@@ -24000,7 +24004,7 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2b/69/b34e0cb5336f09c6866d53b4a19d76c227cdec1bbc7ac4de63ca7d58c9c7/sphinx_design-0.6.1.tar.gz", hash = "sha256:b44eea3719386d04d765c1a8257caca2b3e6f8421d7b3a5e742c0fd45f84e632", size = 2193689, upload-time = "2024-08-02T13:48:44.277Z" }
 wheels = [
@@ -24032,7 +24036,7 @@ resolution-markers = [
     "(python_full_version == '3.11.*' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 dependencies = [
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/7b/804f311da4663a4aecc6cf7abd83443f3d4ded970826d0c958edc77d4527/sphinx_design-0.7.0.tar.gz", hash = "sha256:d2a3f5b19c24b916adb52f97c5f00efab4009ca337812001109084a740ec9b7a", size = 2203582, upload-time = "2026-01-19T13:12:53.297Z" }
@@ -26073,7 +26077,7 @@ name = "xmlsec"
 version = "1.3.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lxml", marker = "python_full_version < '3.13'" },
+    { name = "lxml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/14/538b75379e6ab8f688f14d8663e2ab138d9c778bac4999d155b5f33c71c1/xmlsec-1.3.17.tar.gz", hash = "sha256:f3fac9ae679f66585925cc00c5f6839ae36c1d03157619571dee18acc05b9c01", size = 115637, upload-time = "2025-11-11T16:20:46.019Z" }
 wheels = [


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->
## What?
* Modifies `apache-airflow-task-sdk`'s dependency on `httpx` &rarr; `httpx2`. The Execution API `Client` is now an `httpx2.Client`.
* Adds `certifi` as an explicit `task-sdk` dependency — `client.py` imports it directly and it used to arrive via `httpx`, but `httpx2` depends on `truststore` instead. TLS behaviour is unchanged: the client always passes its own `ssl.SSLContext`.
* Moves `InProcessExecutionAPI.transport` / `.atransport` in `airflow-core` to `httpx2`, plus the call sites that build or drive them. Objects don't cross the `httpx`/`httpx2` boundary, and the only consumers of those transports are Task SDK clients. The rest of `airflow-core` stays on `httpx`.
* Teaches `shared/logging` to suppress and mute both stacks, since `airflow-core` and the Task SDK are now on different ones.
* Adds an [`ast-grep`](https://github.com/ast-grep/ast-grep) pre-commit check to prevent re-introducing `httpx` in the Task SDK, mirroring the providers one.

## Why?
* related: #70522
* follows: #72111

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

* Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
* Scope of AI use:
    * I pointed Claude Code at the `task-sdk` `httpx` usage and it did the import replacements and dependency updates.
    * It traced the cross-package boundary (in-process Execution API transports, `devel-common` test helpers, prek scripts) and migrated those call sites.
    * It wrote the `ast-grep` rule and verified it fires.
    * I reviewed the diff and wrote the PR description.
