### PR TITLE
Stop airflow db downgrade corrupting deadline alerts it cannot convert

### DIFF
--- a/airflow-core/newsfragments/72979.bugfix.rst
+++ b/airflow-core/newsfragments/72979.bugfix.rst
@@ -1,0 +1,1 @@
+Stop ``airflow db downgrade`` from Airflow 3.3 corrupting deadline alerts whose interval is not a timedelta; it now refuses up front and names the affected alerts

--- a/airflow-core/src/airflow/migrations/versions/0117_3_3_0_change_deadline_interval_to_json.py
+++ b/airflow-core/src/airflow/migrations/versions/0117_3_3_0_change_deadline_interval_to_json.py
@@ -27,6 +27,8 @@ Create Date: 2026-05-28 17:36:56.837243
 
 from __future__ import annotations
 
+import json
+
 import sqlalchemy as sa
 from alembic import context, op
 
@@ -151,6 +153,33 @@ def upgrade():
             """)
 
 
+def _find_non_timedelta_intervals(conn, table_name: str = "deadline_alert") -> list[tuple]:
+    """
+    Return ``(id, classname)`` for rows whose interval cannot become a float again.
+
+    The pre-upgrade column is FLOAT NOT NULL, so only plain numbers and serialized
+    ``datetime.timedelta`` values can be converted back. Other serialized intervals, such as
+    ``VariableInterval``, have no float representation; converting them would either violate
+    the NOT NULL constraint (Postgres), corrupt the value before a failing retype (MySQL), or
+    silently become ``0.0`` (SQLite). The table holds one row per deadline alert definition,
+    so reading it entirely is cheap and works identically on every backend.
+    """
+    interval_col = conn.dialect.identifier_preparer.quote("interval")
+    offenders = []
+    for row_id, raw in conn.execute(sa.text(f"SELECT id, {interval_col} FROM {table_name}")):
+        value = raw.decode() if isinstance(raw, (bytes, bytearray)) else raw
+        if isinstance(value, str):
+            try:
+                value = json.loads(value)
+            except (TypeError, ValueError):
+                continue
+        if isinstance(value, dict):
+            classname = value.get("__classname__")
+            if classname and classname != "datetime.timedelta":
+                offenders.append((row_id, classname))
+    return offenders
+
+
 def downgrade():
     """Revert deadline interval back to float."""
     conn = op.get_bind()
@@ -223,9 +252,23 @@ def downgrade():
 
             Step 2: SQLite does not support ALTER COLUMN TYPE.
             Recreate the table with interval as REAL and copy data.
+
+            Both variants require that no row holds a serialized interval other than
+            datetime.timedelta (for example VariableInterval); delete those deadline
+            alerts or change their interval to a timedelta first.
             """
         )
         return
+
+    offenders = _find_non_timedelta_intervals(conn)
+    if offenders:
+        details = ", ".join(f"id={row_id} ({classname})" for row_id, classname in offenders)
+        raise RuntimeError(
+            f"Cannot downgrade: {len(offenders)} deadline alert(s) use a serialized interval "
+            f"with no float representation: {details}. The previous schema stores intervals as "
+            "float seconds. Delete these deadline alerts or change their interval to a "
+            "timedelta, then re-run the downgrade."
+        )
 
     if dialect == "postgresql":
         op.execute("""
@@ -243,10 +286,8 @@ def downgrade():
     elif dialect == "mysql":
         op.execute(_mysql_downgrade_interval_value_sql())
 
-    # Serialized VariableInterval objects do not contain a numeric "__data__" field
-    # and therefore cannot be converted back to a float representation.
-    # During downgrade, only timedelta-style serialized values are converted.
-    # Other serialized interval types (e.g. VariableInterval) will cast as null.
+    # Only plain numbers and serialized timedelta values reach this point; the guard above
+    # rejects any other serialized interval type before data is touched.
     else:
         # Detect availability of SQLite JSON functions (JSON1 extension).
         json_functions_available = False

--- a/airflow-core/tests/unit/migrations/test_0117_deadline_interval_json_migration.py
+++ b/airflow-core/tests/unit/migrations/test_0117_deadline_interval_json_migration.py
@@ -57,6 +57,60 @@ _TABLE = "_test_deadline_interval_dg"
 _WRAPPED_TIMEDELTA = '{"__classname__": "datetime.timedelta", "__version__": 2, "__data__": 300.0}'
 
 
+_GUARD_TABLE = "_test_deadline_interval_guard"
+_WRAPPED_VARIABLE_INTERVAL = (
+    '{"__classname__": "airflow.sdk.definitions.deadline.VariableInterval",'
+    ' "__version__": 0, "__data__": {"key": "deadline_secs"}}'
+)
+
+
+class TestMigration0117DowngradeGuard:
+    """The downgrade must refuse rows that cannot become a float again, and only those."""
+
+    @pytest.fixture
+    def guard_table(self):
+        preparer = settings.engine.dialect.identifier_preparer
+        interval_col = preparer.quote("interval")
+        with settings.engine.begin() as conn:
+            conn.execute(sa.text(f"DROP TABLE IF EXISTS {_GUARD_TABLE}"))
+            conn.execute(
+                sa.text(f"CREATE TABLE {_GUARD_TABLE} (id INT PRIMARY KEY, {interval_col} TEXT NOT NULL)")
+            )
+        yield interval_col
+        with settings.engine.begin() as conn:
+            conn.execute(sa.text(f"DROP TABLE IF EXISTS {_GUARD_TABLE}"))
+
+    def test_guard_flags_only_intervals_without_float_form(self, guard_table):
+        interval_col = guard_table
+        rows = [
+            (1, _WRAPPED_TIMEDELTA),
+            (2, "60.0"),
+            (3, _WRAPPED_VARIABLE_INTERVAL),
+        ]
+        with settings.engine.begin() as conn:
+            for row_id, value in rows:
+                conn.execute(
+                    sa.text(f"INSERT INTO {_GUARD_TABLE} (id, {interval_col}) VALUES (:i, :v)"),
+                    {"i": row_id, "v": value},
+                )
+            offenders = _migration._find_non_timedelta_intervals(conn, table_name=_GUARD_TABLE)
+
+        assert [(row_id, classname) for row_id, classname in offenders] == [
+            (3, "airflow.sdk.definitions.deadline.VariableInterval")
+        ]
+
+    def test_guard_accepts_clean_table(self, guard_table):
+        interval_col = guard_table
+        with settings.engine.begin() as conn:
+            conn.execute(
+                sa.text(f"INSERT INTO {_GUARD_TABLE} (id, {interval_col}) VALUES (1, :v)"),
+                {"v": _WRAPPED_TIMEDELTA},
+            )
+            offenders = _migration._find_non_timedelta_intervals(conn, table_name=_GUARD_TABLE)
+
+        assert offenders == []
+
+
 class TestMigration0117Downgrade:
     @pytest.mark.backend("mysql")
     def test_mysql_downgrade_interval_value_update_does_not_reject_on_json_column(self):


### PR DESCRIPTION
`airflow db downgrade` from 3.3 destroys deadline alerts whose interval is not a plain timedelta. With a `VariableInterval` row present, Postgres aborts mid-migration, MySQL corrupts the value and then fails the column retype after the implicit commit has persisted the corruption, and SQLite silently converts the interval to `0.0`, a deadline that fires immediately after the downgrade.

Verified by seeding one serialized `VariableInterval` (the exact shape Dag parsing stores) and running the real `airflow db downgrade`:

```
sqlalchemy.exc.IntegrityError: (psycopg.errors.NotNullViolation) null value in column
"interval" of relation "deadline_alert" violates not-null constraint
```

### Root cause

The previous schema stores intervals as FLOAT NOT NULL, so only numbers and serialized `datetime.timedelta` values can be converted back. The conversion CASE maps everything else to NULL, and the in-file comment claiming such values "will cast as null" cannot be true against a NOT NULL column.

### Fix

A pre-flight check reads the table (one row per alert definition, so this is cheap and dialect-free) and refuses the downgrade with the affected alert ids before any value is modified on any backend, in particular before MySQL's implicitly committing UPDATE. Deployments without such intervals are unaffected; the clean path still converts a serialized 5-minute timedelta to `300.0`. Re-run of the same seed after the fix:

```
RuntimeError: Cannot downgrade: 1 deadline alert(s) use a serialized interval with no float
representation: id=... (airflow.sdk.definitions.deadline.VariableInterval). The previous schema
stores intervals as float seconds. Delete these deadline alerts or change their interval to a
timedelta, then re-run the downgrade.
```

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5.1)

Generated-by: Claude Code (Fable 5.1) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
