### PR TITLE
Convert team references to names when upgrading past the team_id removal

### DIFF
--- a/airflow-core/newsfragments/72980.bugfix.rst
+++ b/airflow-core/newsfragments/72980.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the 3.1 to 3.2 upgrade destroying team bindings when it runs after a downgrade to 3.1

--- a/airflow-core/src/airflow/migrations/versions/0096_3_2_0_remove_team_id.py
+++ b/airflow-core/src/airflow/migrations/versions/0096_3_2_0_remove_team_id.py
@@ -36,6 +36,27 @@ depends_on = None
 airflow_version = "3.2.0"
 
 
+def _convert_team_ids_to_names(
+    conn,
+    tables: tuple[str, ...] = ("connection", "variable", "slot_pool", "dag_bundle_team"),
+    team_table: str = "team",
+) -> None:
+    """
+    Rewrite team references from team ids to team names, one team at a time.
+
+    Runs while both the id and the name still exist on the team table. The Python loop
+    keeps the comparison a plain string equality on every backend, matching how the
+    downgrade converts in the opposite direction.
+    """
+    teams = conn.execute(sa.text(f"SELECT id, name FROM {team_table}")).fetchall()
+    for team in teams:
+        for table in tables:
+            conn.execute(
+                sa.text(f"UPDATE {table} SET team_name = :name WHERE team_name = :old_id"),
+                {"name": team.name, "old_id": str(team.id)},
+            )
+
+
 def upgrade():
     # Drop team id references
     for table in ("connection", "variable", "slot_pool"):
@@ -63,6 +84,12 @@ def upgrade():
             type_=sa.String(50),
             nullable=False,
         )
+
+    # Convert the UUID values the renamed columns still hold into team names, while
+    # team.id — the only mapping — still exists. Without this the foreign keys created
+    # below fail validation on any populated deployment, mirroring the name-to-UUID
+    # conversion the downgrade performs in the opposite direction.
+    _convert_team_ids_to_names(op.get_bind())
 
     # Team table
     with op.batch_alter_table("team") as batch_op:

--- a/airflow-core/tests/unit/migrations/test_0096_remove_team_id_migration.py
+++ b/airflow-core/tests/unit/migrations/test_0096_remove_team_id_migration.py
@@ -1,0 +1,90 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Regression test for migration 0096 (b12d4f98a91e).
+
+The upgrade renames ``team_id`` columns to ``team_name`` while the values are still team
+UUIDs, then drops ``team.id`` and creates foreign keys onto ``team.name``. Without a value
+conversion first, FK validation fails on populated deployments (or silently orphans the
+references on SQLite). The conversion helper is exercised here against scratch tables.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+
+from airflow import settings
+
+from tests_common.test_utils.paths import AIRFLOW_CORE_SOURCES_PATH
+
+pytestmark = pytest.mark.db_test
+
+_MIGRATION_PATH = Path(AIRFLOW_CORE_SOURCES_PATH) / "airflow/migrations/versions/0096_3_2_0_remove_team_id.py"
+_spec = importlib.util.spec_from_file_location("migration_0096", _MIGRATION_PATH)
+_migration = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+_spec.loader.exec_module(_migration)  # type: ignore[union-attr]
+
+_TEAM_TABLE = "_test_team_conv"
+_REF_TABLE = "_test_team_conv_ref"
+
+
+class TestMigration0096TeamIdConversion:
+    """The upgrade must turn team UUID references into names before dropping the mapping."""
+
+    @pytest.fixture
+    def scratch_tables(self):
+        with settings.engine.begin() as conn:
+            for table in (_REF_TABLE, _TEAM_TABLE):
+                conn.execute(sa.text(f"DROP TABLE IF EXISTS {table}"))
+            conn.execute(
+                sa.text(f"CREATE TABLE {_TEAM_TABLE} (id VARCHAR(36) PRIMARY KEY, name VARCHAR(50))")
+            )
+            conn.execute(sa.text(f"CREATE TABLE {_REF_TABLE} (id INT PRIMARY KEY, team_name VARCHAR(50))"))
+        yield
+        with settings.engine.begin() as conn:
+            for table in (_REF_TABLE, _TEAM_TABLE):
+                conn.execute(sa.text(f"DROP TABLE IF EXISTS {table}"))
+
+    @pytest.mark.usefixtures("scratch_tables")
+    def test_uuid_references_become_names_and_others_are_untouched(self):
+        team_id = "355e7498-3dca-4432-9d90-33f1dbc5af3d"
+        with settings.engine.begin() as conn:
+            conn.execute(
+                sa.text(f"INSERT INTO {_TEAM_TABLE} (id, name) VALUES (:i, :n)"),
+                {"i": team_id, "n": "team-a"},
+            )
+            rows = [
+                (1, team_id),  # must become the team name
+                (2, None),  # unbound row must stay NULL
+                (3, "other-uuid-not-a-team"),  # unknown value must stay as it is
+            ]
+            for row_id, value in rows:
+                conn.execute(
+                    sa.text(f"INSERT INTO {_REF_TABLE} (id, team_name) VALUES (:i, :v)"),
+                    {"i": row_id, "v": value},
+                )
+
+            _migration._convert_team_ids_to_names(conn, tables=(_REF_TABLE,), team_table=_TEAM_TABLE)
+
+            result = dict(conn.execute(sa.text(f"SELECT id, team_name FROM {_REF_TABLE}")).fetchall())
+
+        assert result == {1: "team-a", 2: None, 3: "other-uuid-not-a-team"}


### PR DESCRIPTION
The 3.1 to 3.2 upgrade destroys team bindings on any deployment that has team rows. The reachable path is the supported cycle: `airflow db downgrade` to 3.1, whose conversion turns team names into freshly generated UUIDs, followed by `airflow db migrate`. The upgrade then fails foreign key validation on Postgres, leaves MySQL half-committed with the id-to-name mapping already dropped, and on SQLite silently orphans every team reference:

```
psycopg.errors.ForeignKeyViolation: insert or update on table "connection" violates
foreign key constraint "connection_team_name_fkey"
DETAIL:  Key (team_name)=(59a79660-...) is not present in table "team".
```

### Root cause

`upgrade()` renames `team_id` columns to `team_name` while the values are still UUIDs, drops `team.id`, which is the only mapping between the two, and then creates validated foreign keys onto `team.name`. Its own `downgrade()` performs the value conversion in the opposite direction; the upgrade never did.

### Fix

Convert the references while the mapping still exists, one team at a time, mirroring the downgrade's own Python loop so the comparison stays a plain string equality on every backend. The fix has to live in this migration rather than a follow-up one: it must run between the rename and the `team.id` drop, and no later migration can recover the dropped mapping. Verified with the real CLI round-trip on Postgres, MySQL and SQLite; the upgrade now succeeds and the seeded binding survives:

```
GATE downgrade to 3.1 exit code: 0
GATE re-upgrade exit code: 0
GATE after round-trip: connection.team_name = 'gate-team', teams = ['gate-team']
GATE binding preserved
```

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5.1)

Generated-by: Claude Code (Fable 5.1) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
