### PR TITLE
Validate Connection port is within valid range (0-65535)

### DIFF
--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -28,7 +28,7 @@ from typing import Any
 from urllib.parse import parse_qsl, quote, unquote, urlencode, urlsplit
 
 from sqlalchemy import ForeignKey, Integer, String, Text, select
-from sqlalchemy.orm import Mapped, mapped_column, reconstructor
+from sqlalchemy.orm import Mapped, mapped_column, reconstructor, validates
 
 from airflow._shared.module_loading import import_string
 from airflow._shared.secrets_backend.base import call_secrets_backend_method
@@ -147,6 +147,12 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
     schema: Mapped[str | None] = mapped_column(String(500), nullable=True)
     login: Mapped[str | None] = mapped_column(Text(), nullable=True)
     port: Mapped[int | None] = mapped_column(Integer(), nullable=True)
+
+    @validates("port")
+    def _validate_port(self, key, port):
+        if port is not None and not (0 <= port <= 65535):
+            raise ValueError(f"Invalid port number: {port}. Port must be between 0 and 65535.")
+        return port
     team_name: Mapped[str | None] = mapped_column(
         String(50),
         ForeignKey("team.name", ondelete="SET NULL"),

--- a/airflow-core/tests/unit/models/test_connection.py
+++ b/airflow-core/tests/unit/models/test_connection.py
@@ -621,3 +621,26 @@ class TestConnection:
             "test_conn2": None,
         }
         clear_db_connections()
+
+    def test_port_rejects_out_of_range_high_value(self):
+        with pytest.raises(ValueError, match="Invalid port number"):
+            Connection(conn_id="test_conn", conn_type="http", port=999999)
+
+    def test_port_rejects_negative_value(self):
+        with pytest.raises(ValueError, match="Invalid port number"):
+            Connection(conn_id="test_conn", conn_type="http", port=-5)
+
+    def test_port_accepts_valid_value(self):
+        connection = Connection(conn_id="test_conn", conn_type="http", port=5432)
+        assert connection.port == 5432
+
+    def test_port_accepts_none(self):
+        connection = Connection(conn_id="test_conn", conn_type="http", port=None)
+        assert connection.port is None
+
+    def test_port_accepts_boundary_values(self):
+        connection_min = Connection(conn_id="test_conn_min", conn_type="http", port=0)
+        assert connection_min.port == 0
+
+        connection_max = Connection(conn_id="test_conn_max", conn_type="http", port=65535)
+        assert connection_max.port == 65535


### PR DESCRIPTION
Closes #68382

`Connection.port` had no validation at all, so you could set it to something like `999999` or `-5` and it would just silently save. Neither of those can ever be a real port, so this adds a check that raises a clear error instead of quietly storing garbage.

Valid ports are 0-65535. Added a `@validates` hook on the port column that enforces that range, and still lets `port=None` through since not every connection needs one.

Added tests for the obvious cases: too high, negative, a normal valid port, `None`, and the two boundary values (0 and 65535). Ran the full model test suite locally and nothing else broke.