### PR TITLE
Authorize POST /assets/events on the asset named in the body

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -27,7 +27,11 @@ from sqlalchemy.orm import joinedload, subqueryload
 
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.app import get_auth_manager
-from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity, DagDetails
+from airflow.api_fastapi.auth.managers.models.resource_details import (
+    AssetDetails,
+    DagAccessEntity,
+    DagDetails,
+)
 from airflow.api_fastapi.common.dagbag import DagBagDep, get_latest_version_of_dag
 from airflow.api_fastapi.common.db.assets import eager_load_asset_reference_teams
 from airflow.api_fastapi.common.db.common import SessionDep, paginated_select
@@ -407,6 +411,18 @@ def create_asset_event(
     asset_model = session.scalar(select(AssetModel).where(AssetModel.id == body.asset_id).limit(1))
     if not asset_model:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"Asset with ID: `{body.asset_id}` was not found")
+    # The asset is named in the body, which the route dependency cannot read, so it only checked the
+    # generic asset POST permission. Authorize on the resolved asset here so an auth manager can scope
+    # by id, name, or uri.
+    if not get_auth_manager().is_authorized_asset(
+        method="POST",
+        details=AssetDetails(id=str(asset_model.id), name=asset_model.name, uri=asset_model.uri),
+        user=user,
+    ):
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            f"User is not authorized to create events for asset with ID: `{body.asset_id}`",
+        )
     timestamp = timezone.utcnow()
 
     api_user_teams: set[str] = set()

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
@@ -2029,6 +2029,43 @@ class TestPostAssetEvents(TestAssets):
         }
         check_last_log(session, dag_id=None, event="create_asset_event", logical_date=None)
 
+    @mock.patch(
+        "airflow.api_fastapi.auth.managers.simple.simple_auth_manager.SimpleAuthManager.is_authorized_asset",
+        autospec=True,
+    )
+    def test_should_authorize_on_the_asset_named_in_the_body(
+        self, mock_is_authorized_asset, test_client, session
+    ):
+        """The asset id lives in the body, so the route must resolve it and authorize on the full asset."""
+        (asset,) = self.create_assets(num=1, session=session)
+        mock_is_authorized_asset.return_value = True
+
+        response = test_client.post("/assets/events", json={"asset_id": asset.id})
+
+        assert response.status_code == 200
+        mock_is_authorized_asset.assert_any_call(
+            mock.ANY,
+            method="POST",
+            details=AssetDetails(id=str(asset.id), name="simple1", uri="s3://bucket/key/1"),
+            user=mock.ANY,
+        )
+
+    @mock.patch(
+        "airflow.api_fastapi.auth.managers.simple.simple_auth_manager.SimpleAuthManager.is_authorized_asset",
+        autospec=True,
+    )
+    def test_should_respond_403_when_not_authorized_on_the_asset(
+        self, mock_is_authorized_asset, test_client, session
+    ):
+        (asset,) = self.create_assets(num=1, session=session)
+        # The route dependency has no asset id to check, so it passes; only the per-asset check denies.
+        mock_is_authorized_asset.side_effect = lambda self_, *, method, user, details=None: details.id is None
+
+        response = test_client.post("/assets/events", json={"asset_id": asset.id})
+
+        assert response.status_code == 403
+        assert session.scalar(select(func.count()).select_from(AssetEvent)) == 0
+
     def test_should_respond_401(self, unauthenticated_test_client):
         response = unauthenticated_test_client.post("/assets/events", json={"asset_uri": "s3://bucket/key/1"})
         assert response.status_code == 401


### PR DESCRIPTION
## Why

`POST /assets/events` is guarded by `requires_access_asset(method="POST")`, but that dependency reads the asset id from the URL path. This endpoint carries the id in the request body, so the dependency runs before the body is parsed and passes an empty `AssetDetails(id=None)` to the auth manager. The only question the auth manager can answer is whether the caller may post to any asset at all.

An auth manager that scopes assets by id, name, or uri, the granularity added in #72682, therefore cannot deny an event for an asset the caller may not touch, and the response still returns that asset's name and uri. The built-in Simple and FAB auth managers ignore `details`, so they are unaffected. `POST /assets/{asset_id}/materialize` is also unaffected because its id is in the path.

## What

- `airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py`: after `create_asset_event` resolves the `AssetModel` from the body, it calls `is_authorized_asset` with the full `AssetDetails(id, name, uri)` and raises 403 when denied. This mirrors the explicit second authorization `materialize_asset` performs on the Dag it resolves. The dependency-level check stays in place.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5.1)