### PR TITLE
[v3-3-test] Explicitly state 'durable execution' in airflow docs (#71863)

### DIFF
--- a/airflow-core/docs/core-concepts/resumable-tasks.rst
+++ b/airflow-core/docs/core-concepts/resumable-tasks.rst
@@ -32,8 +32,27 @@ entire polling duration, and if the worker process is restarted or the host is p
 retries from scratch, losing all the progress made. Depending on the operator, that means the external
 job is submitted again, creating a duplicate run in context of the external system.
 
-Airflow recommends three approaches for handling long-running external work. Understanding the trade-offs
-between them helps you choose the right one for your situation.
+.. _concepts-durable-execution:
+
+Durable execution
+-----------------
+
+Surviving that failure mode is what **durable execution** means: a task outlives the loss of the
+process running it and can continue / re-attach from where it stopped, rather than repeating work
+already done or submitting a duplicate job to an external system.
+
+The :doc:`task state store <task-state-store>` is the mechanism Airflow provides to achieve it. It
+is the only per-task-instance storage that outlives a worker crash and is still readable by the
+next attempt, which is what lets a retry recover a checkpoint or an external job identifier written
+by the attempt before it. Durable execution is the outcome; the task state store is how you get it.
+
+Operator documentation across the provider ecosystem uses the same term for the operator-level
+feature built on this mechanism, normally exposed as a ``durable`` parameter. Spark, Kubernetes,
+Databricks, Snowflake, BigQuery, Redshift and Glue operators each have a "Durable execution"
+section describing what they persist and how they reconnect on retry.
+
+Airflow recommends three approaches for achieving this with long-running external work.
+Understanding the trade-offs between them helps you choose the right one for your situation.
 
 .. _concepts-resumable-tasks-deferrable:
 

--- a/airflow-core/docs/core-concepts/task-state-store.rst
+++ b/airflow-core/docs/core-concepts/task-state-store.rst
@@ -30,6 +30,9 @@ Task State Store
 
 Task store is a persistent key/value store scoped to a single task instance (``dag_id`` + ``run_id`` + ``task_id`` + ``map_index``). It survives worker crashes and task retries within the same Dag run, making it suitable for storing external job IDs, intra-task checkpoints, and progress metadata.
 
+Because it outlives a worker crash and stays readable by the next attempt, the task state store is the mechanism behind :ref:`durable execution <concepts-durable-execution>`, where a task continues
+from where it stopped instead of repeating work or submitting a duplicate external job. Provider operators that advertise a ``durable`` parameter are built on the API described here.
+
 Data persisted via task state store is accessed through the task context via ``context["task_state_store"]`` and exposes four methods: ``get``, ``set``, ``delete``, and ``clear``.
 
 


### PR DESCRIPTION
Backport of #71863 to `v3-3-test` for the 3.3.2 release.

Documents "durable execution" in the core docs (the resumable-tasks and task-state-store concept pages), closing a gap where the core docs lacked this content. #71863 is already milestoned Airflow 3.3.2.

**Adaptation for v3-3:** the original also documented async `task_state_store` counterparts (`aget`/`aset`/`adelete`/`aclear`). On `v3-3-test` the `TaskStateStoreAccessor` exposes only the synchronous `get`/`set`/`delete`/`clear` (async accessors exist here only on the asset state store, not the task state store), so this backport keeps the sync-only method list to stay accurate. The durable-execution content is otherwise backported as-is.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)