### PR TITLE
Allow a custom Kubernetes client factory for KubernetesExecutor

### DIFF
--- a/providers/cncf/kubernetes/provider.yaml
+++ b/providers/cncf/kubernetes/provider.yaml
@@ -438,14 +438,12 @@ config:
       client_factory:
         description: |
           Import path of a zero-argument callable returning the ``kubernetes.client.CoreV1Api``
-          the executor should use, for deployments that mint their own credentials. Only the
-          KubernetesExecutor consults this setting; other users of the Kubernetes client, such as
-          operators, are unaffected. When set it replaces the executor's default client
-          construction entirely, so ``in_cluster``, ``cluster_context``, ``config_file``,
-          ``verify_ssl``, ``ssl_ca_cert``, ``enable_tcp_keepalive`` and
-          ``api_client_retry_configuration`` no longer apply to the executor. It is resolved in
-          every process that needs a client, including the pod watcher subprocess, so it must be
-          importable wherever the scheduler runs.
+          the executor should use, for deployments that mint their own credentials. When set it
+          replaces the default client construction entirely, so ``in_cluster``, ``cluster_context``,
+          ``config_file``, ``verify_ssl``, ``ssl_ca_cert``, ``enable_tcp_keepalive`` and
+          ``api_client_retry_configuration`` no longer apply. It is resolved in every process that
+          needs a client, including the pod watcher subprocess, so it must be importable wherever
+          the scheduler runs.
         version_added: 10.23.0
         type: string
         example: "my_company.kubernetes.build_client"

--- a/providers/cncf/kubernetes/provider.yaml
+++ b/providers/cncf/kubernetes/provider.yaml
@@ -438,12 +438,14 @@ config:
       client_factory:
         description: |
           Import path of a zero-argument callable returning the ``kubernetes.client.CoreV1Api``
-          the executor should use, for deployments that mint their own credentials. When set it
-          replaces the default client construction entirely, so ``in_cluster``, ``cluster_context``,
-          ``config_file``, ``verify_ssl``, ``ssl_ca_cert``, ``enable_tcp_keepalive`` and
-          ``api_client_retry_configuration`` no longer apply. It is resolved in every process that
-          needs a client, including the pod watcher subprocess, so it must be importable wherever
-          the scheduler runs.
+          the executor should use, for deployments that mint their own credentials. Only the
+          KubernetesExecutor consults this setting; other users of the Kubernetes client, such as
+          operators, are unaffected. When set it replaces the executor's default client
+          construction entirely, so ``in_cluster``, ``cluster_context``, ``config_file``,
+          ``verify_ssl``, ``ssl_ca_cert``, ``enable_tcp_keepalive`` and
+          ``api_client_retry_configuration`` no longer apply to the executor. It is resolved in
+          every process that needs a client, including the pod watcher subprocess, so it must be
+          importable wherever the scheduler runs.
         version_added: 10.23.0
         type: string
         example: "my_company.kubernetes.build_client"

--- a/providers/cncf/kubernetes/provider.yaml
+++ b/providers/cncf/kubernetes/provider.yaml
@@ -435,6 +435,19 @@ config:
         type: string
         example: ~
         default: ~
+      client_factory:
+        description: |
+          Import path of a zero-argument callable returning the ``kubernetes.client.CoreV1Api``
+          the executor should use, for deployments that mint their own credentials. When set it
+          replaces the default client construction entirely, so ``in_cluster``, ``cluster_context``,
+          ``config_file``, ``verify_ssl``, ``ssl_ca_cert``, ``enable_tcp_keepalive`` and
+          ``api_client_retry_configuration`` no longer apply. It is resolved in every process that
+          needs a client, including the pod watcher subprocess, so it must be importable wherever
+          the scheduler runs.
+        version_added: 10.23.0
+        type: string
+        example: "my_company.kubernetes.build_client"
+        default: ~
       kube_client_request_args:
         description: |
           Keyword parameters to pass while calling a kubernetes client core_v1_api methods

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -253,7 +253,7 @@ class KubernetesExecutor(BaseExecutor):
         )
         from airflow.providers.cncf.kubernetes.kube_client import get_kube_client
 
-        self.kube_client = get_kube_client()
+        self.kube_client = get_kube_client(use_client_factory=True)
         self.kube_scheduler = AirflowKubernetesScheduler(
             kube_config=self.kube_config,
             result_queue=self.result_queue,
@@ -883,7 +883,7 @@ class KubernetesExecutor(BaseExecutor):
             from airflow.providers.cncf.kubernetes.kube_client import get_kube_client
             from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
 
-            client = get_kube_client()
+            client = get_kube_client(use_client_factory=True)
 
             hostname_desc = f" {ti.hostname}" if ti.hostname else ""
             messages.append(f"Attempting to fetch logs from pod{hostname_desc} through kube API")

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py
@@ -93,7 +93,7 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
         if TYPE_CHECKING:
             assert self.scheduler_job_id
 
-        kube_client: client.CoreV1Api = get_kube_client()
+        kube_client: client.CoreV1Api = get_kube_client(use_client_factory=True)
         while True:
             try:
                 self.resource_version = self._run(

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/get_provider_info.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/get_provider_info.py
@@ -273,7 +273,7 @@ def get_provider_info():
                         "default": None,
                     },
                     "client_factory": {
-                        "description": "Import path of a zero-argument callable returning the ``kubernetes.client.CoreV1Api``\nthe executor should use, for deployments that mint their own credentials. When set it\nreplaces the default client construction entirely, so ``in_cluster``, ``cluster_context``,\n``config_file``, ``verify_ssl``, ``ssl_ca_cert``, ``enable_tcp_keepalive`` and\n``api_client_retry_configuration`` no longer apply. It is resolved in every process that\nneeds a client, including the pod watcher subprocess, so it must be importable wherever\nthe scheduler runs.\n",
+                        "description": "Import path of a zero-argument callable returning the ``kubernetes.client.CoreV1Api``\nthe executor should use, for deployments that mint their own credentials. Only the\nKubernetesExecutor consults this setting; other users of the Kubernetes client, such as\noperators, are unaffected. When set it replaces the executor's default client\nconstruction entirely, so ``in_cluster``, ``cluster_context``, ``config_file``,\n``verify_ssl``, ``ssl_ca_cert``, ``enable_tcp_keepalive`` and\n``api_client_retry_configuration`` no longer apply to the executor. It is resolved in\nevery process that needs a client, including the pod watcher subprocess, so it must be\nimportable wherever the scheduler runs.\n",
                         "version_added": "10.23.0",
                         "type": "string",
                         "example": "my_company.kubernetes.build_client",

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/get_provider_info.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/get_provider_info.py
@@ -273,7 +273,7 @@ def get_provider_info():
                         "default": None,
                     },
                     "client_factory": {
-                        "description": "Import path of a zero-argument callable returning the ``kubernetes.client.CoreV1Api``\nthe executor should use, for deployments that mint their own credentials. Only the\nKubernetesExecutor consults this setting; other users of the Kubernetes client, such as\noperators, are unaffected. When set it replaces the executor's default client\nconstruction entirely, so ``in_cluster``, ``cluster_context``, ``config_file``,\n``verify_ssl``, ``ssl_ca_cert``, ``enable_tcp_keepalive`` and\n``api_client_retry_configuration`` no longer apply to the executor. It is resolved in\nevery process that needs a client, including the pod watcher subprocess, so it must be\nimportable wherever the scheduler runs.\n",
+                        "description": "Import path of a zero-argument callable returning the ``kubernetes.client.CoreV1Api``\nthe executor should use, for deployments that mint their own credentials. When set it\nreplaces the default client construction entirely, so ``in_cluster``, ``cluster_context``,\n``config_file``, ``verify_ssl``, ``ssl_ca_cert``, ``enable_tcp_keepalive`` and\n``api_client_retry_configuration`` no longer apply. It is resolved in every process that\nneeds a client, including the pod watcher subprocess, so it must be importable wherever\nthe scheduler runs.\n",
                         "version_added": "10.23.0",
                         "type": "string",
                         "example": "my_company.kubernetes.build_client",

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/get_provider_info.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/get_provider_info.py
@@ -272,6 +272,13 @@ def get_provider_info():
                         "example": None,
                         "default": None,
                     },
+                    "client_factory": {
+                        "description": "Import path of a zero-argument callable returning the ``kubernetes.client.CoreV1Api``\nthe executor should use, for deployments that mint their own credentials. When set it\nreplaces the default client construction entirely, so ``in_cluster``, ``cluster_context``,\n``config_file``, ``verify_ssl``, ``ssl_ca_cert``, ``enable_tcp_keepalive`` and\n``api_client_retry_configuration`` no longer apply. It is resolved in every process that\nneeds a client, including the pod watcher subprocess, so it must be importable wherever\nthe scheduler runs.\n",
+                        "version_added": "10.23.0",
+                        "type": "string",
+                        "example": "my_company.kubernetes.build_client",
+                        "default": None,
+                    },
                     "kube_client_request_args": {
                         "description": "Keyword parameters to pass while calling a kubernetes client core_v1_api methods\nfrom Kubernetes Executor provided as a single line formatted JSON dictionary string.\nList of supported params are similar for all core_v1_apis, hence a single config\nvariable for all apis. See:\nhttps://raw.githubusercontent.com/kubernetes-client/python/41f11a09995efcd0142e25946adc7591431bfb2f/kubernetes/client/api/core_v1_api.py\n",
                         "version_added": None,

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kube_client.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kube_client.py
@@ -23,7 +23,6 @@ from typing import Any
 
 import urllib3.util
 
-from airflow.providers.common.compat.module_loading import import_string
 from airflow.providers.common.compat.sdk import conf
 
 log = logging.getLogger(__name__)
@@ -180,9 +179,9 @@ def get_kube_client(
     """
     # An import path rather than a callable, so that KubernetesJobWatcher can re-resolve it in
     # its own process, where the spawn start method would not carry a callable over.
-    client_factory = conf.get("kubernetes_executor", "client_factory", fallback=None)
-    if client_factory:
-        return import_string(client_factory)()
+    if client_factory := conf.getimport("kubernetes_executor", "client_factory", fallback=None):
+        return client_factory()
+
     if in_cluster is None:
         in_cluster = conf.getboolean("kubernetes_executor", "in_cluster")
     if not has_kubernetes:

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kube_client.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kube_client.py
@@ -168,6 +168,7 @@ def get_kube_client(
     in_cluster: bool | None = None,
     cluster_context: str | None = None,
     config_file: str | None = None,
+    use_client_factory: bool = False,
 ) -> client.CoreV1Api:
     """
     Retrieve Kubernetes client.
@@ -175,11 +176,15 @@ def get_kube_client(
     :param in_cluster: whether we are in cluster
     :param cluster_context: context of the cluster
     :param config_file: configuration file
+    :param use_client_factory: whether to honour the ``client_factory`` setting; only the
+        KubernetesExecutor passes this, so other callers are unaffected by the setting
     :return: kubernetes client
     """
     # An import path rather than a callable, so that KubernetesJobWatcher can re-resolve it in
     # its own process, where the spawn start method would not carry a callable over.
-    if client_factory := conf.getimport("kubernetes_executor", "client_factory", fallback=None):
+    if use_client_factory and (
+        client_factory := conf.getimport("kubernetes_executor", "client_factory", fallback=None)
+    ):
         return client_factory()
 
     if in_cluster is None:

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kube_client.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kube_client.py
@@ -23,6 +23,7 @@ from typing import Any
 
 import urllib3.util
 
+from airflow.providers.common.compat.module_loading import import_string
 from airflow.providers.common.compat.sdk import conf
 
 log = logging.getLogger(__name__)
@@ -177,6 +178,11 @@ def get_kube_client(
     :param config_file: configuration file
     :return: kubernetes client
     """
+    # An import path rather than a callable, so that KubernetesJobWatcher can re-resolve it in
+    # its own process, where the spawn start method would not carry a callable over.
+    client_factory = conf.get("kubernetes_executor", "client_factory", fallback=None)
+    if client_factory:
+        return import_string(client_factory)()
     if in_cluster is None:
         in_cluster = conf.getboolean("kubernetes_executor", "in_cluster")
     if not has_kubernetes:

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kube_client.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kube_client.py
@@ -176,7 +176,7 @@ def get_kube_client(
     :param in_cluster: whether we are in cluster
     :param cluster_context: context of the cluster
     :param config_file: configuration file
-    :param use_client_factory: whether to honour the ``client_factory`` setting; only the
+    :param use_client_factory: whether to honor the ``client_factory`` setting; only the
         KubernetesExecutor passes this, so other callers are unaffected by the setting
     :return: kubernetes client
     """

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_client.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_client.py
@@ -48,7 +48,7 @@ class TestClient:
     @mock.patch("airflow.providers.cncf.kubernetes.kube_client.config")
     @mock.patch("airflow.providers.cncf.kubernetes.kube_client.conf")
     def test_load_config_disable_ssl(self, conf, config):
-        conf.get.return_value = None
+        conf.getimport.return_value = None
         conf.getboolean.return_value = False
         conf.getjson.return_value = {"total": 3, "backoff_factor": 0.5}
         client = get_kube_client(in_cluster=False)
@@ -58,9 +58,8 @@ class TestClient:
     @mock.patch("airflow.providers.cncf.kubernetes.kube_client.config")
     @mock.patch("airflow.providers.cncf.kubernetes.kube_client.conf")
     def test_load_config_ssl_ca_cert(self, conf, config):
-        conf.get.side_effect = lambda section, key, **kwargs: (
-            "/path/to/ca.crt" if key == "ssl_ca_cert" else None
-        )
+        conf.getimport.return_value = None
+        conf.get.return_value = "/path/to/ca.crt"
         conf.getjson.return_value = {"total": 3, "backoff_factor": 0.5}
         client = get_kube_client(in_cluster=False)
         conf.get.assert_called_with("kubernetes_executor", "ssl_ca_cert")

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_client.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_client.py
@@ -48,6 +48,7 @@ class TestClient:
     @mock.patch("airflow.providers.cncf.kubernetes.kube_client.config")
     @mock.patch("airflow.providers.cncf.kubernetes.kube_client.conf")
     def test_load_config_disable_ssl(self, conf, config):
+        conf.get.return_value = None
         conf.getboolean.return_value = False
         conf.getjson.return_value = {"total": 3, "backoff_factor": 0.5}
         client = get_kube_client(in_cluster=False)
@@ -57,7 +58,9 @@ class TestClient:
     @mock.patch("airflow.providers.cncf.kubernetes.kube_client.config")
     @mock.patch("airflow.providers.cncf.kubernetes.kube_client.conf")
     def test_load_config_ssl_ca_cert(self, conf, config):
-        conf.get.return_value = "/path/to/ca.crt"
+        conf.get.side_effect = lambda section, key, **kwargs: (
+            "/path/to/ca.crt" if key == "ssl_ca_cert" else None
+        )
         conf.getjson.return_value = {"total": 3, "backoff_factor": 0.5}
         client = get_kube_client(in_cluster=False)
         conf.get.assert_called_with("kubernetes_executor", "ssl_ca_cert")

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_kube_client.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_kube_client.py
@@ -61,16 +61,31 @@ class TestKubeClientFactory:
     @mock.patch("kubernetes.config.load_incluster_config")
     def test_factory_replaces_default_client_construction(self, mock_incluster, mock_kube_config):
         with conf_vars({("kubernetes_executor", "client_factory"): f"{__name__}.build_fake_client"}):
-            client = get_kube_client()
+            client = get_kube_client(use_client_factory=True)
 
         assert client == FACTORY_MARKER
         mock_incluster.assert_not_called()
         mock_kube_config.assert_not_called()
 
+    def test_factory_is_ignored_unless_caller_opts_in(self):
+        with (
+            conf_vars(
+                {
+                    ("kubernetes_executor", "client_factory"): f"{__name__}.build_fake_client",
+                    ("kubernetes_executor", "enable_tcp_keepalive"): "False",
+                }
+            ),
+            mock.patch("kubernetes.config.load_incluster_config") as mock_loader,
+        ):
+            client = get_kube_client(in_cluster=True)
+
+        assert client != FACTORY_MARKER
+        mock_loader.assert_called_once()
+
     def test_unimportable_factory_raises(self):
         with conf_vars({("kubernetes_executor", "client_factory"): "no.such.module.build_client"}):
             with pytest.raises(AirflowConfigException):
-                get_kube_client()
+                get_kube_client(use_client_factory=True)
 
     def test_factory_is_resolved_from_config_in_a_separate_interpreter(self, tmp_path, monkeypatch):
         """
@@ -99,7 +114,7 @@ class TestKubeClientFactory:
                 sys.executable,
                 "-c",
                 "from airflow.providers.cncf.kubernetes.kube_client import get_kube_client;"
-                "print(get_kube_client())",
+                "print(get_kube_client(use_client_factory=True))",
             ],
             capture_output=True,
             text=True,

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_kube_client.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_kube_client.py
@@ -16,13 +16,98 @@
 # under the License.
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
+import textwrap
 from unittest import mock
 
 import pytest
 
-from airflow.providers.cncf.kubernetes.kube_client import _TimeoutAsyncK8sApiClient, get_async_kube_client
+from airflow.providers.cncf.kubernetes.kube_client import (
+    _TimeoutAsyncK8sApiClient,
+    get_async_kube_client,
+    get_kube_client,
+)
 
 from tests_common.test_utils.config import conf_vars
+
+FACTORY_MARKER = "client-from-factory"
+
+
+def build_fake_client():
+    return FACTORY_MARKER
+
+
+class TestKubeClientFactory:
+    @pytest.mark.parametrize(
+        ("kwargs", "loader"),
+        [
+            ({"in_cluster": True}, "load_incluster_config"),
+            ({"in_cluster": False, "config_file": "/does/not/exist"}, "load_kube_config"),
+        ],
+    )
+    def test_default_client_is_built_when_factory_unset(self, kwargs, loader):
+        with (
+            conf_vars({("kubernetes_executor", "enable_tcp_keepalive"): "False"}),
+            mock.patch(f"kubernetes.config.{loader}") as mock_loader,
+        ):
+            get_kube_client(**kwargs)
+
+        mock_loader.assert_called_once()
+
+    @mock.patch("kubernetes.config.load_kube_config")
+    @mock.patch("kubernetes.config.load_incluster_config")
+    def test_factory_replaces_default_client_construction(self, mock_incluster, mock_kube_config):
+        with conf_vars({("kubernetes_executor", "client_factory"): f"{__name__}.build_fake_client"}):
+            client = get_kube_client()
+
+        assert client == FACTORY_MARKER
+        mock_incluster.assert_not_called()
+        mock_kube_config.assert_not_called()
+
+    def test_unimportable_factory_raises(self):
+        with conf_vars({("kubernetes_executor", "client_factory"): "no.such.module.build_client"}):
+            with pytest.raises(ImportError):
+                get_kube_client()
+
+    def test_factory_is_resolved_from_config_in_a_separate_interpreter(self, tmp_path, monkeypatch):
+        """
+        KubernetesJobWatcher builds its client in its own process, which under the spawn start
+        method shares no objects with the scheduler. Resolving the import path there has to work
+        from configuration alone.
+        """
+        (tmp_path / "kube_client_factory_fixture.py").write_text(
+            textwrap.dedent(
+                f"""
+                def build_fake_client():
+                    return "{FACTORY_MARKER}"
+                """
+            )
+        )
+        monkeypatch.setenv(
+            "PYTHONPATH", os.pathsep.join(filter(None, [str(tmp_path), os.environ.get("PYTHONPATH", "")]))
+        )
+        monkeypatch.setenv(
+            "AIRFLOW__KUBERNETES_EXECUTOR__CLIENT_FACTORY",
+            "kube_client_factory_fixture.build_fake_client",
+        )
+
+        child = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from airflow.providers.cncf.kubernetes.kube_client import get_kube_client;"
+                "print(get_kube_client())",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+
+        assert child.returncode == 0, child.stderr
+        assert FACTORY_MARKER in child.stdout
 
 
 class TestGetAsyncKubeClient:

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_kube_client.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_kube_client.py
@@ -29,6 +29,7 @@ from airflow.providers.cncf.kubernetes.kube_client import (
     get_async_kube_client,
     get_kube_client,
 )
+from airflow.providers.common.compat.sdk import AirflowConfigException
 
 from tests_common.test_utils.config import conf_vars
 
@@ -68,7 +69,7 @@ class TestKubeClientFactory:
 
     def test_unimportable_factory_raises(self):
         with conf_vars({("kubernetes_executor", "client_factory"): "no.such.module.build_client"}):
-            with pytest.raises(ImportError):
+            with pytest.raises(AirflowConfigException):
                 get_kube_client()
 
     def test_factory_is_resolved_from_config_in_a_separate_interpreter(self, tmp_path, monkeypatch):


### PR DESCRIPTION
Adds an optional `[kubernetes_executor] client_factory` setting: the import path of a function that returns the Kubernetes client the KubernetesExecutor uses. Unset by default, and when unset nothing changes. The factory resolves per team.

Today the executor can build its client two ways: an in-cluster service account token, or a kubeconfig. If your cluster hands out short-lived credentials, there is no point at which you can give the executor a client you built yourself, so you end up refreshing credentials underneath a client you do not own. The same gap on the hook path has produced repeated credential-refresh bugs ([#61737](https://github.com/apache/airflow/issues/61737) still open, [#57585](https://github.com/apache/airflow/issues/57585) and [#64657](https://github.com/apache/airflow/issues/64657) each patched on their own terms). Those run through `KubernetesHook` and are untouched here; this closes the gap on the executor path, where every client already comes from one function, and the hook path can adopt the same seam as a follow-up.

The setting holds an import path rather than a callable because `KubernetesJobWatcher` runs in its own process under the spawn start method, so each process resolves the factory from configuration for itself. When set, the factory owns client construction, so the client-construction options (`in_cluster`, `config_file`, `verify_ssl`, and friends) stop applying. Since it is only an import path, `cncf.kubernetes` gains no dependency on any other provider.

Some context about why: we're creating an EksExecutor which will wrap around KubernetesExecutor and handle authentication in-process. The change in this PR helps us avoid the class of errors noted above.