### PR TITLE
Add archive staging support to S3DagBundle

### DIFF
--- a/providers/amazon/docs/bundles/index.rst
+++ b/providers/amazon/docs/bundles/index.rst
@@ -75,7 +75,7 @@ automatically falls back to the per-object sync of ``prefix``.
       }
     ]'
 
-Publishing the archive is the deployer's responsibility. The archive members must be laid out exactly as
+Publishing the archive is the responsibility of your deployment process. The archive members must be laid out exactly as
 the objects under ``prefix``, so both staging strategies produce the same local tree — for example, in the
 same CI job that syncs the Dags:
 

--- a/providers/amazon/docs/bundles/index.rst
+++ b/providers/amazon/docs/bundles/index.rst
@@ -45,3 +45,45 @@ Example of using the S3DagBundle:
         }
       }
     ]'
+
+Staging from a single archive object
+------------------------------------
+
+By default the bundle is staged by downloading every object under ``prefix`` one at a time. Each object
+costs a full request round-trip, so bundles made of many small files can take a long time to stage — a cost
+paid by every component that stages the bundle, which with ephemeral workers (e.g. KubernetesExecutor task
+pods) means on every task start.
+
+Setting the optional ``archive_key`` stages the bundle from a single ``.tar.gz`` object instead: one
+``HEAD`` request to detect changes (unchanged archives are not re-downloaded), one ``GET`` to fetch it, then
+a local unpack and an atomic swap into place. If the archive cannot be fetched or unpacked, staging
+automatically falls back to the per-object sync of ``prefix``.
+
+.. code-block:: bash
+
+    export AIRFLOW__DAG_PROCESSOR__DAG_BUNDLE_CONFIG_LIST='[
+      {
+        "name": "my-s3-dags",
+        "classpath": "airflow.providers.amazon.aws.bundles.s3.S3DagBundle",
+        "kwargs": {
+          "aws_conn_id": "aws_default",
+          "bucket_name": "my-airflow-bucket",
+          "prefix": "dags/",
+          "archive_key": "bundle-archives/dags.tar.gz",
+          "refresh_interval": 60
+        }
+      }
+    ]'
+
+Publishing the archive is the deployer's responsibility. The archive members must be laid out exactly as
+the objects under ``prefix``, so both staging strategies produce the same local tree — for example, in the
+same CI job that syncs the Dags:
+
+.. code-block:: bash
+
+    tar -C ./dags -czf dags.tar.gz .
+    aws s3 cp dags.tar.gz s3://my-airflow-bucket/bundle-archives/dags.tar.gz
+
+.. note::
+    Keep the archive outside the ``prefix`` location, otherwise a ``aws s3 sync --delete`` of the Dag
+    files may remove it.

--- a/providers/amazon/src/airflow/providers/amazon/aws/bundles/s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/bundles/s3.py
@@ -17,6 +17,10 @@
 from __future__ import annotations
 
 import os
+import shutil
+import tarfile
+import tempfile
+import uuid
 from pathlib import Path
 
 import structlog
@@ -37,9 +41,18 @@ class S3DagBundle(BaseDagBundle):
     :param bucket_name: The name of the S3 bucket containing the Dag files.
     :param prefix:  Optional subdirectory within the S3 bucket where the Dags are stored.
                     If None, Dags are assumed to be at the root of the bucket (Optional).
+    :param archive_key: Optional S3 key of a ``.tar.gz`` archive containing the same files as
+                    ``prefix``. When set, the bundle is staged by downloading this single object and
+                    unpacking it locally, instead of downloading the prefix one object at a time.
+                    Staging falls back to the per-object sync of ``prefix`` if the archive cannot be
+                    fetched or unpacked. The archive members must be laid out exactly as the objects
+                    under ``prefix`` (e.g. created with ``tar -C <dags_dir> -czf dags.tar.gz .``) so
+                    both staging strategies produce the same tree (Optional).
     """
 
     supports_versioning = False
+
+    archive_etag_marker = ".airflow_bundle_archive_etag"
 
     def __init__(
         self,
@@ -47,12 +60,14 @@ class S3DagBundle(BaseDagBundle):
         aws_conn_id: str = AwsBaseHook.default_conn_name,
         bucket_name: str,
         prefix: str = "",
+        archive_key: str | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.aws_conn_id = aws_conn_id
         self.bucket_name = bucket_name
         self.prefix = prefix
+        self.archive_key = archive_key
         # Local path where S3 Dags are downloaded
         self.s3_dags_dir: Path = self.base_dir
 
@@ -62,6 +77,7 @@ class S3DagBundle(BaseDagBundle):
             version=self.version,
             bucket_name=self.bucket_name,
             prefix=self.prefix,
+            archive_key=self.archive_key,
             aws_conn_id=self.aws_conn_id,
         )
         self._s3_hook: S3Hook | None = None
@@ -78,8 +94,20 @@ class S3DagBundle(BaseDagBundle):
             if not self.s3_hook.check_for_bucket(bucket_name=self.bucket_name):
                 raise AirflowException(f"S3 bucket '{self.bucket_name}' does not exist.")
 
-            if self.prefix:
-                # don't check when prefix is ""
+            archive_exists = self.archive_key is not None and self.s3_hook.check_for_key(
+                key=self.archive_key, bucket_name=self.bucket_name
+            )
+            if self.archive_key and not archive_exists:
+                self._log.warning(
+                    "S3 archive 's3://%s/%s' does not exist. Falling back to syncing "
+                    "'s3://%s/%s' object by object.",
+                    self.bucket_name,
+                    self.archive_key,
+                    self.bucket_name,
+                    self.prefix,
+                )
+            if self.prefix and not archive_exists:
+                # don't check when prefix is "", or when staging will use the archive anyway
                 if not self.s3_hook.check_for_prefix(
                     bucket_name=self.bucket_name, prefix=self.prefix, delimiter="/"
                 ):
@@ -107,6 +135,7 @@ class S3DagBundle(BaseDagBundle):
             f"name={self.name!r}, "
             f"bucket_name={self.bucket_name!r}, "
             f"prefix={self.prefix!r}, "
+            f"archive_key={self.archive_key!r}, "
             f"version={self.version!r}"
             f")>"
         )
@@ -126,6 +155,20 @@ class S3DagBundle(BaseDagBundle):
             raise AirflowException("Refreshing a specific version is not supported")
 
         with self.lock():
+            if self.archive_key:
+                try:
+                    self._refresh_from_archive()
+                    return
+                except Exception:
+                    self._log.warning(
+                        "Downloading Dag bundle archive 's3://%s/%s' failed. Falling back to "
+                        "syncing 's3://%s/%s' object by object.",
+                        self.bucket_name,
+                        self.archive_key,
+                        self.bucket_name,
+                        self.prefix,
+                        exc_info=True,
+                    )
             self._log.debug(
                 "Downloading Dags from s3://%s/%s to %s", self.bucket_name, self.prefix, self.s3_dags_dir
             )
@@ -135,6 +178,54 @@ class S3DagBundle(BaseDagBundle):
                 local_dir=self.s3_dags_dir,
                 delete_stale=True,
             )
+
+    def _refresh_from_archive(self) -> None:
+        """Stage the Dag bundle by downloading and unpacking the single archive object."""
+        client = self.s3_hook.get_conn()
+        head = client.head_object(Bucket=self.bucket_name, Key=self.archive_key)
+        etag: str = head.get("ETag", "")
+
+        marker = self.s3_dags_dir / self.archive_etag_marker
+        if etag and marker.is_file() and marker.read_text() == etag:
+            self._log.debug(
+                "Dag bundle archive 's3://%s/%s' is unchanged (ETag %s), skipping staging",
+                self.bucket_name,
+                self.archive_key,
+                etag,
+            )
+            return
+
+        staging_dir = Path(tempfile.mkdtemp(dir=self.s3_dags_dir.parent, prefix=".s3-archive-staging-"))
+        try:
+            archive_path = staging_dir / "_bundle_archive"
+            client.download_file(self.bucket_name, self.archive_key, os.fspath(archive_path))
+
+            unpack_dir = staging_dir / "unpacked"
+            unpack_dir.mkdir()
+            with tarfile.open(archive_path, "r:*") as tar:
+                tar.extractall(unpack_dir, filter="data")
+            archive_path.unlink()
+
+            if etag:
+                (unpack_dir / self.archive_etag_marker).write_text(etag)
+
+            # Swap the freshly unpacked tree into place so a partially staged
+            # bundle is never observable at self.s3_dags_dir.
+            old_dir = self.s3_dags_dir.parent / f".s3-archive-old-{uuid.uuid4().hex}"
+            if self.s3_dags_dir.exists():
+                self.s3_dags_dir.rename(old_dir)
+            unpack_dir.rename(self.s3_dags_dir)
+            shutil.rmtree(old_dir, ignore_errors=True)
+
+            self._log.debug(
+                "Staged Dag bundle from archive 's3://%s/%s' (%s bytes) to %s",
+                self.bucket_name,
+                self.archive_key,
+                head.get("ContentLength"),
+                self.s3_dags_dir,
+            )
+        finally:
+            shutil.rmtree(staging_dir, ignore_errors=True)
 
     def view_url(self, version: str | None = None) -> str | None:
         """

--- a/providers/amazon/tests/unit/amazon/aws/bundles/test_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/bundles/test_s3.py
@@ -16,7 +16,9 @@
 # under the License.
 from __future__ import annotations
 
+import io
 import os
+import tarfile
 from unittest.mock import MagicMock, call
 
 import boto3
@@ -35,6 +37,19 @@ AWS_CONN_ID_REGION = "eu-central-1"
 AWS_CONN_ID_DEFAULT = "aws_default"
 S3_BUCKET_NAME = "my-airflow-dags-bucket"
 S3_BUCKET_PREFIX = "project1/dags"
+S3_ARCHIVE_KEY = "bundle-archives/dags.tar.gz"
+
+
+def _make_archive(files: dict[str, bytes]) -> bytes:
+    """Build an in-memory .tar.gz with the given member name -> content mapping."""
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+        for name, data in files.items():
+            tar_info = tarfile.TarInfo(name=name)
+            tar_info.size = len(data)
+            tar.addfile(tar_info, io.BytesIO(data))
+    return buffer.getvalue()
+
 
 if airflow.version.version.strip().startswith("3"):
     from airflow.providers.amazon.aws.bundles.s3 import S3DagBundle
@@ -221,3 +236,95 @@ class TestS3DagBundle:
         bundle.refresh()
         assert bundle._log.debug.call_count == 2
         assert bundle._log.debug.call_args_list == [download_log_call, download_log_call]
+
+    def _archive_bundle(self) -> S3DagBundle:
+        return S3DagBundle(
+            name="test",
+            aws_conn_id=AWS_CONN_ID_WITH_REGION,
+            prefix=S3_BUCKET_PREFIX,
+            archive_key=S3_ARCHIVE_KEY,
+            bucket_name=S3_BUCKET_NAME,
+        )
+
+    def test_refresh_from_archive(self, s3_bucket, s3_client):
+        archive = _make_archive({"dag_01.py": b"test data", "subproject1/dag_a.py": b"test data"})
+        s3_client.put_object(Bucket=S3_BUCKET_NAME, Key=S3_ARCHIVE_KEY, Body=archive)
+
+        bundle = self._archive_bundle()
+        bundle.initialize()
+
+        assert (bundle.path / "dag_01.py").is_file()
+        assert (bundle.path / "subproject1" / "dag_a.py").is_file()
+        assert (bundle.path / bundle.archive_etag_marker).is_file()
+        # dag_02.py exists under the prefix but not in the archive: staging used
+        # the archive, not the per-object sync
+        assert not (bundle.path / "dag_02.py").exists()
+
+    def test_refresh_from_archive_skips_staging_when_etag_unchanged(self, s3_bucket, s3_client):
+        archive = _make_archive({"dag_01.py": b"test data"})
+        s3_client.put_object(Bucket=S3_BUCKET_NAME, Key=S3_ARCHIVE_KEY, Body=archive)
+
+        bundle = self._archive_bundle()
+        bundle.initialize()
+
+        # A local sentinel file would be wiped by the swap of a re-staged tree
+        sentinel = bundle.path / "sentinel.txt"
+        sentinel.write_text("still here")
+        bundle.refresh()
+        assert sentinel.is_file()
+
+        # A changed archive (new ETag) re-stages: additions appear, removed
+        # members and local strays disappear with the swapped tree
+        updated = _make_archive({"dag_new.py": b"test data"})
+        s3_client.put_object(Bucket=S3_BUCKET_NAME, Key=S3_ARCHIVE_KEY, Body=updated)
+        bundle.refresh()
+        assert (bundle.path / "dag_new.py").is_file()
+        assert not (bundle.path / "dag_01.py").exists()
+        assert not sentinel.exists()
+
+    def test_refresh_from_archive_without_prefix_objects(self, mocked_s3_resource, s3_client):
+        # Bucket contains only the archive - no objects under the prefix at all
+        mocked_s3_resource.create_bucket(Bucket=S3_BUCKET_NAME)
+        archive = _make_archive({"dag_01.py": b"test data"})
+        s3_client.put_object(Bucket=S3_BUCKET_NAME, Key=S3_ARCHIVE_KEY, Body=archive)
+
+        bundle = self._archive_bundle()
+        # succeeds: the prefix-existence check does not apply when staging from the archive
+        bundle.initialize()
+        assert (bundle.path / "dag_01.py").is_file()
+
+    def test_refresh_falls_back_to_sync_when_archive_corrupt(self, s3_bucket, s3_client):
+        s3_client.put_object(Bucket=S3_BUCKET_NAME, Key=S3_ARCHIVE_KEY, Body=b"this is not a tarball")
+
+        bundle = self._archive_bundle()
+        bundle.initialize()
+
+        # per-object sync of the prefix staged the Dags instead
+        assert (bundle.path / "dag_01.py").is_file()
+        assert (bundle.path / "dag_02.py").is_file()
+        assert (bundle.path / "subproject1" / "dag_a.py").is_file()
+        assert not (bundle.path / bundle.archive_etag_marker).exists()
+
+    def test_refresh_falls_back_to_sync_when_archive_missing(self, s3_bucket, s3_client):
+        bundle = self._archive_bundle()
+        bundle.initialize()
+
+        assert (bundle.path / "dag_01.py").is_file()
+        assert (bundle.path / "dag_02.py").is_file()
+        assert not (bundle.path / bundle.archive_etag_marker).exists()
+
+    def test_fallback_sync_clears_etag_marker(self, s3_bucket, s3_client):
+        archive = _make_archive({"dag_01.py": b"test data"})
+        s3_client.put_object(Bucket=S3_BUCKET_NAME, Key=S3_ARCHIVE_KEY, Body=archive)
+
+        bundle = self._archive_bundle()
+        bundle.initialize()
+        assert (bundle.path / bundle.archive_etag_marker).is_file()
+
+        # Archive disappears: refresh falls back to the per-object sync, which
+        # must remove the marker so a re-published identical archive is not
+        # wrongly skipped later
+        s3_client.delete_object(Bucket=S3_BUCKET_NAME, Key=S3_ARCHIVE_KEY)
+        bundle.refresh()
+        assert (bundle.path / "dag_02.py").is_file()
+        assert not (bundle.path / bundle.archive_etag_marker).exists()


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

closes: #73010

`S3DagBundle` stages the bundle by downloading the prefix one object at a time (`S3Hook.sync_to_local_dir`), so a bundle of N small files costs ~N GET (+N HEAD) sequential requests on every component that stages it. Under KubernetesExecutor every task instance is a fresh pod with an empty bundle directory, which puts the full staging cost on the critical path of every task start (~20+ s for a 400-file bundle against real S3), and even a steady-state "nothing changed" refresh still pays a full per-object walk.

This PR adds an opt-in `archive_key` kwarg to `S3DagBundle`: when set, `refresh()` stages the bundle from a single `.tar.gz` object instead — one `HEAD` (skipped staging entirely when the ETag matches the last staged archive), one `GET`, a safe unpack (`tarfile` with `filter="data"`), and an atomic rename swap so a partially staged tree is never observable. On any archive problem (missing object, corrupt tar, unpack error) staging falls back to the existing per-object sync of `prefix`, so the worst case is exactly the current behavior. Publishing the archive is the deployer's job (documented: `tar -C dags . | aws s3 cp` in the same CI that syncs the prefix).

Measured with the reproduction environment from the issue (fully local: Airflow 3 + MinIO, identical 400-file / ~3 MiB file set — https://github.com/aoelvp94/airflow-s3-dag-bundle-staging-demo):

| staging strategy | wall-clock (median) | requests served |
|---|---:|---:|
| per-object sync | 15.8 s | 802 |
| single archive | 1.5 s | 5 |

Design notes:

* One class, opt-in: no `archive_key` ⇒ nothing changes. `prefix` keeps its meaning as the fallback source, and `_initialize()` skips the prefix-existence check only when the archive exists (archive-only buckets work; missing archives warn and validate/stage from the prefix as today).
* The local ETag marker lives inside the bundle directory, so a fallback per-object sync (`delete_stale=True`) removes it — a later re-published archive can never be wrongly skipped against a stale marker.
* Deletions need no reconciliation logic in the archive path: the unpacked tree replaces the previous one wholesale.
* The staging strategy is provider-agnostic; if there is interest, the same shape could be extracted for the GCS bundle (and the proposed Azure Blob bundle in #67016) in a follow-up.

Covered by 6 new unit tests (moto): archive staging, ETag skip + re-staging on change, archive-only bucket, fallback on corrupt and on missing archive, and marker cleanup after fallback. Docs updated in `providers/amazon/docs/bundles/index.rst`. `prek` static checks pass locally.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions) — all code, tests, and docs were reviewed by the author, and static checks plus the provider unit test suite were run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
