### PR TITLE
Helm: hash only the config data in checksum/* pod annotations

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -1219,3 +1219,12 @@ Usage:
           path: namespace
   {{- end }}
 {{- end -}}
+
+{{/*
+ Compute a ConfigMap or Secret checksum from its data only, for the checksum/* pod annotations.
+ The full manifest carries the helm.sh/chart label, which changes on every chart version bump and
+ would restart every Airflow component on upgrade even when no configuration changed.
+ */}}
+{{- define "airflow.configMapOrSecretContentHash" -}}
+{{ pick (include (print .ctx.Template.BasePath .name) .ctx | fromYaml) "data" "stringData" | toYaml | sha256sum }}
+{{- end -}}

--- a/chart/templates/api-server/api-server-deployment.yaml
+++ b/chart/templates/api-server/api-server-deployment.yaml
@@ -84,16 +84,16 @@ spec:
           {{- mustMerge .Values.apiServer.labels .Values.labels | toYaml | nindent 8 }}
         {{- end }}
       annotations:
-        checksum/metadata-secret: {{ include (print $.Template.BasePath "/secrets/metadata-connection-secret.yaml") . | sha256sum }}
-        checksum/pgbouncer-config-secret: {{ include (print $.Template.BasePath "/secrets/pgbouncer-config-secret.yaml") . | sha256sum }}
-        checksum/airflow-config: {{ include (print $.Template.BasePath "/configmaps/configmap.yaml") . | sha256sum }}
+        checksum/metadata-secret: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets/metadata-connection-secret.yaml") }}
+        checksum/pgbouncer-config-secret: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets/pgbouncer-config-secret.yaml") }}
+        checksum/airflow-config: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/configmaps/configmap.yaml") }}
         {{- if and .Values.apiServer.apiServerConfig (not .Values.apiServer.apiServerConfigConfigMapName) }}
-        checksum/api-server-config: {{ include (print $.Template.BasePath "/configmaps/api-server-configmap.yaml") . | sha256sum }}
+        checksum/api-server-config: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/configmaps/api-server-configmap.yaml") }}
         {{- end }}
-        checksum/extra-configmaps: {{ include (print $.Template.BasePath "/configmaps/extra-configmaps.yaml") . | sha256sum }}
-        checksum/extra-secrets: {{ include (print $.Template.BasePath "/secrets/extra-secrets.yaml") . | sha256sum }}
+        checksum/extra-configmaps: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/configmaps/extra-configmaps.yaml") }}
+        checksum/extra-secrets: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets/extra-secrets.yaml") }}
         {{- if not .Values.jwtSecretName }}
-        checksum/jwt-secret: {{ include (print $.Template.BasePath "/secrets/jwt-secret.yaml") . | sha256sum }}
+        checksum/jwt-secret: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets/jwt-secret.yaml") }}
         {{- end }}
         {{- if .Values.airflowPodAnnotations }}
           {{- tpl (toYaml .Values.airflowPodAnnotations) . | nindent 8 }}

--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -70,11 +70,11 @@ spec:
           {{- mustMerge .Values.dagProcessor.labels .Values.labels | toYaml | nindent 8 }}
         {{- end }}
       annotations:
-        checksum/metadata-secret: {{ include (print $.Template.BasePath "/secrets/metadata-connection-secret.yaml") . | sha256sum }}
-        checksum/pgbouncer-config-secret: {{ include (print $.Template.BasePath "/secrets/pgbouncer-config-secret.yaml") . | sha256sum }}
-        checksum/airflow-config: {{ include (print $.Template.BasePath "/configmaps/configmap.yaml") . | sha256sum }}
-        checksum/extra-configmaps: {{ include (print $.Template.BasePath "/configmaps/extra-configmaps.yaml") . | sha256sum }}
-        checksum/extra-secrets: {{ include (print $.Template.BasePath "/secrets/extra-secrets.yaml") . | sha256sum }}
+        checksum/metadata-secret: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets/metadata-connection-secret.yaml") }}
+        checksum/pgbouncer-config-secret: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets/pgbouncer-config-secret.yaml") }}
+        checksum/airflow-config: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/configmaps/configmap.yaml") }}
+        checksum/extra-configmaps: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/configmaps/extra-configmaps.yaml") }}
+        checksum/extra-secrets: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets/extra-secrets.yaml") }}
         {{- if .Values.dagProcessor.safeToEvict }}
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         {{- end }}

--- a/chart/templates/flower/flower-deployment.yaml
+++ b/chart/templates/flower/flower-deployment.yaml
@@ -65,8 +65,8 @@ spec:
           {{- mustMerge .Values.flower.labels .Values.labels | toYaml | nindent 8 }}
         {{- end }}
       annotations:
-        checksum/airflow-config: {{ include (print $.Template.BasePath "/configmaps/configmap.yaml") . | sha256sum }}
-        checksum/flower-secret: {{ include (print $.Template.BasePath "/secrets/flower-secret.yaml") . | sha256sum }}
+        checksum/airflow-config: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/configmaps/configmap.yaml") }}
+        checksum/flower-secret: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets/flower-secret.yaml") }}
         {{- if or .Values.airflowPodAnnotations .Values.flower.podAnnotations }}
           {{- tpl (mustMerge .Values.flower.podAnnotations .Values.airflowPodAnnotations | toYaml) . | nindent 8 }}
         {{- end }}

--- a/chart/templates/otel-collector/otel-collector-deployment.yaml
+++ b/chart/templates/otel-collector/otel-collector-deployment.yaml
@@ -62,7 +62,7 @@ spec:
           {{- mustMerge .Values.otelCollector.labels .Values.labels | toYaml | nindent 8 }}
         {{- end }}
       annotations:
-        checksum/otel-collector-config: {{ include (print $.Template.BasePath "/configmaps/otel-collector-configmap.yaml") . | sha256sum }}
+        checksum/otel-collector-config: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/configmaps/otel-collector-configmap.yaml") }}
         {{- with .Values.otelCollector.podAnnotations }}
           {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}

--- a/chart/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -71,8 +71,8 @@ spec:
           {{- mustMerge .Values.pgbouncer.labels .Values.labels | toYaml | nindent 8 }}
         {{- end }}
       annotations:
-        checksum/pgbouncer-config-secret: {{ include (print $.Template.BasePath "/secrets/pgbouncer-config-secret.yaml") . | sha256sum }}
-        checksum/pgbouncer-certificates-secret: {{ include (print $.Template.BasePath "/secrets/pgbouncer-certificates-secret.yaml") . | sha256sum }}
+        checksum/pgbouncer-config-secret: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets/pgbouncer-config-secret.yaml") }}
+        checksum/pgbouncer-certificates-secret: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets/pgbouncer-certificates-secret.yaml") }}
         {{- if .Values.pgbouncer.podAnnotations }}
           {{- tpl (toYaml .Values.pgbouncer.podAnnotations) . | nindent 8 }}
         {{- end }}

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -87,14 +87,14 @@ spec:
           {{- mustMerge .Values.scheduler.labels .Values.labels | toYaml | nindent 8 }}
         {{- end }}
       annotations:
-        checksum/metadata-secret: {{ include (print $.Template.BasePath "/secrets/metadata-connection-secret.yaml") . | sha256sum }}
-        checksum/result-backend-secret: {{ include (print $.Template.BasePath "/secrets/result-backend-connection-secret.yaml") . | sha256sum }}
-        checksum/pgbouncer-config-secret: {{ include (print $.Template.BasePath "/secrets/pgbouncer-config-secret.yaml") . | sha256sum }}
-        checksum/airflow-config: {{ include (print $.Template.BasePath "/configmaps/configmap.yaml") . | sha256sum }}
-        checksum/extra-configmaps: {{ include (print $.Template.BasePath "/configmaps/extra-configmaps.yaml") . | sha256sum }}
-        checksum/extra-secrets: {{ include (print $.Template.BasePath "/secrets/extra-secrets.yaml") . | sha256sum }}
+        checksum/metadata-secret: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets/metadata-connection-secret.yaml") }}
+        checksum/result-backend-secret: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets/result-backend-connection-secret.yaml") }}
+        checksum/pgbouncer-config-secret: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets/pgbouncer-config-secret.yaml") }}
+        checksum/airflow-config: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/configmaps/configmap.yaml") }}
+        checksum/extra-configmaps: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/configmaps/extra-configmaps.yaml") }}
+        checksum/extra-secrets: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets/extra-secrets.yaml") }}
         {{- if and .Values.apiServer.enabled (not .Values.jwtSecretName) }}
-        checksum/jwt-secret: {{ include (print $.Template.BasePath "/secrets/jwt-secret.yaml") . | sha256sum }}
+        checksum/jwt-secret: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets/jwt-secret.yaml") }}
         {{- end }}
         {{- if .Values.scheduler.safeToEvict }}
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -66,7 +66,7 @@ spec:
         {{- end }}
       {{- if or .Values.statsd.extraMappings .Values.statsd.podAnnotations }}
       annotations:
-        checksum/statsd-config: {{ include (print $.Template.BasePath "/configmaps/statsd-configmap.yaml") . | sha256sum }}
+        checksum/statsd-config: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/configmaps/statsd-configmap.yaml") }}
         {{- if .Values.statsd.podAnnotations }}
           {{- tpl (toYaml .Values.statsd.podAnnotations) . | nindent 8 }}
         {{- end }}

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -84,11 +84,11 @@ spec:
           {{- mustMerge .Values.triggerer.labels .Values.labels | toYaml | nindent 8 }}
         {{- end }}
       annotations:
-        checksum/metadata-secret: {{ include (print $.Template.BasePath "/secrets/metadata-connection-secret.yaml") . | sha256sum }}
-        checksum/pgbouncer-config-secret: {{ include (print $.Template.BasePath "/secrets/pgbouncer-config-secret.yaml") . | sha256sum }}
-        checksum/airflow-config: {{ include (print $.Template.BasePath "/configmaps/configmap.yaml") . | sha256sum }}
-        checksum/extra-configmaps: {{ include (print $.Template.BasePath "/configmaps/extra-configmaps.yaml") . | sha256sum }}
-        checksum/extra-secrets: {{ include (print $.Template.BasePath "/secrets/extra-secrets.yaml") . | sha256sum }}
+        checksum/metadata-secret: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets/metadata-connection-secret.yaml") }}
+        checksum/pgbouncer-config-secret: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets/pgbouncer-config-secret.yaml") }}
+        checksum/airflow-config: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/configmaps/configmap.yaml") }}
+        checksum/extra-configmaps: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/configmaps/extra-configmaps.yaml") }}
+        checksum/extra-secrets: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets/extra-secrets.yaml") }}
         {{- if .Values.triggerer.safeToEvict }}
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         {{- end }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -113,13 +113,13 @@ spec:
           {{- mustMerge .Values.workers.celery.labels .Values.labels | toYaml | nindent 8 }}
         {{- end }}
       annotations:
-        checksum/metadata-secret: {{ include (print $.Template.BasePath "/secrets/metadata-connection-secret.yaml") . | sha256sum }}
-        checksum/result-backend-secret: {{ include (print $.Template.BasePath "/secrets/result-backend-connection-secret.yaml") . | sha256sum }}
-        checksum/pgbouncer-config-secret: {{ include (print $.Template.BasePath "/secrets/pgbouncer-config-secret.yaml") . | sha256sum }}
-        checksum/kerberos-keytab: {{ include (print $.Template.BasePath "/secrets/kerberos-keytab-secret.yaml") . | sha256sum }}
-        checksum/airflow-config: {{ include (print $.Template.BasePath "/configmaps/configmap.yaml") . | sha256sum }}
-        checksum/extra-configmaps: {{ include (print $.Template.BasePath "/configmaps/extra-configmaps.yaml") . | sha256sum }}
-        checksum/extra-secrets: {{ include (print $.Template.BasePath "/secrets/extra-secrets.yaml") . | sha256sum }}
+        checksum/metadata-secret: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets/metadata-connection-secret.yaml") }}
+        checksum/result-backend-secret: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets/result-backend-connection-secret.yaml") }}
+        checksum/pgbouncer-config-secret: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets/pgbouncer-config-secret.yaml") }}
+        checksum/kerberos-keytab: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets/kerberos-keytab-secret.yaml") }}
+        checksum/airflow-config: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/configmaps/configmap.yaml") }}
+        checksum/extra-configmaps: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/configmaps/extra-configmaps.yaml") }}
+        checksum/extra-secrets: {{ include "airflow.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets/extra-secrets.yaml") }}
         {{- if $podAnnotations }}
           {{- tpl (toYaml $podAnnotations) . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
The `checksum/*` pod annotations hash the entire rendered ConfigMap or Secret, and the manifest's `metadata.labels` include `helm.sh/chart`. That value changes on every chart version bump, so every Airflow component is restarted on `helm upgrade` even when no configuration has changed.

This adds an `airflow.configMapOrSecretContentHash` helper that hashes only the `data`/`stringData` sections, and uses it for all 37 `checksum/*` annotations across the api-server, scheduler, dag-processor, triggerer, worker, flower, statsd, otel-collector and pgbouncer templates.

Rendering the chart at 2.0.0 against a bumped version with identical values is now byte-identical, while changing `config.core.parallelism` still moves `checksum/airflow-config`. The full helm test suite passes (2155 tests).

The same fix was recently made in the argo-cd chart (argoproj/argo-helm#4044); the loki chart uses the same data-only hashing.

Unrelated, but found while testing: `checksum/jwt-secret` is unstable on every render, and even differs between two pods in the same render, because `chart/templates/secrets/jwt-secret.yaml` defaults to `randAlphaNum 128` and each `include` re-evaluates it. With `jwtSecret` unset those pods restart on every upgrade regardless of this change. Happy to open a separate issue or PR for that.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 5 (Claude Code)

Generated-by: Claude Opus 5 (Claude Code) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)