### PR TITLE
Add redis_conn_id to RedisKeySensor and RedisPubSubSensor template_fields

### DIFF
--- a/providers/redis/src/airflow/providers/redis/sensors/redis_key.py
+++ b/providers/redis/src/airflow/providers/redis/sensors/redis_key.py
@@ -28,9 +28,13 @@ if TYPE_CHECKING:
 
 
 class RedisKeySensor(BaseSensorOperator):
-    """Checks for the existence of a key in a Redis."""
+    """
+    Checks for the existence of a key in a Redis.
 
-    template_fields: Sequence[str] = ("key",)
+    :param redis_conn_id: the redis connection id (templated)
+    """
+
+    template_fields: Sequence[str] = ("key", "redis_conn_id")
     ui_color = "#f0eee4"
 
     def __init__(self, *, key: str, redis_conn_id: str, **kwargs) -> None:

--- a/providers/redis/src/airflow/providers/redis/sensors/redis_pub_sub.py
+++ b/providers/redis/src/airflow/providers/redis/sensors/redis_pub_sub.py
@@ -33,10 +33,10 @@ class RedisPubSubSensor(BaseSensorOperator):
     Redis sensor for reading a message from pub sub channels.
 
     :param channels: The channels to be subscribed to (templated)
-    :param redis_conn_id: the redis connection id
+    :param redis_conn_id: the redis connection id (templated)
     """
 
-    template_fields: Sequence[str] = ("channels",)
+    template_fields: Sequence[str] = ("channels", "redis_conn_id")
     ui_color = "#f0eee4"
 
     def __init__(self, *, channels: list[str] | str, redis_conn_id: str, **kwargs) -> None:


### PR DESCRIPTION
Both Redis sensors take `redis_conn_id` and build the hook from it, but neither lists it in `template_fields`, so a Jinja connection id is never rendered:

```python
sensor = RedisKeySensor(key="k", redis_conn_id="redis_{{ ds }}", task_id="t", dag=dag)
sensor.render_template_fields({"ds": "2017-01-01"})
sensor.redis_conn_id   # 'redis_{{ ds }}' on main, so the first poke raises
                       # AirflowNotFoundException
```

`RedisPublishOperator` got this in #72883. These two sensors are the only other classes in the provider declaring `template_fields` — `AwaitMessageTrigger` is a `BaseTrigger` and gets rendered values — so this finishes the Redis slice of #35259.

Not the no-op that closed #70638: that one was a no-op because `aws_template_fields()` already unions `aws_conn_id` in. Redis has no such helper, both tuples are plain literals, and neither `__init__` does anything but assign. @potiuk pointed at this case when closing it — the remaining work being in providers with no `aws_template_fields` equivalent.

No test here: #72883 was submitted with one and the review was "This test is not needed", so it merged without. Glad to add them in the shape approved on #72582 if you'd prefer.

Checked locally:

- `pytest providers/redis/tests/unit/redis/` — `33 passed, 1 skipped`
- `ruff check` / `ruff format --check` — clean
- prek passes except `check-template-fields-valid`, which needs Breeze and won't run on the host. Ran the script it wraps directly instead — `scripts/in_container/run_template_fields_check.py` on both files, exit 0.

Part of #35259.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

I reviewed the change myself before opening this.
