### PR TITLE
Fix BaseBotoWaiter deferrable test failing without aiobotocore

### DIFF
--- a/providers/amazon/tests/unit/amazon/aws/waiters/test_base_waiter.py
+++ b/providers/amazon/tests/unit/amazon/aws/waiters/test_base_waiter.py
@@ -78,20 +78,30 @@ class TestBaseBotoWaiter:
         )
         assert result is waiter_instance
 
-    @mock.patch("aiobotocore.waiter.create_waiter_with_client")
-    def test_waiter_deferrable(self, mock_async_create_waiter, mock_client):
-        async_waiter_instance = mock.MagicMock()
-        mock_async_create_waiter.return_value = async_waiter_instance
-
+    @mock.patch.object(BaseBotoWaiter, "_get_async_waiter_with_client", autospec=True)
+    def test_waiter_deferrable(self, mock_get_async_waiter, mock_client):
         boto_waiter = BaseBotoWaiter(
             client=mock_client, model_config=SAMPLE_WAITER_MODEL_CONFIG, deferrable=True
         )
         result = boto_waiter.waiter("sample_waiter")
 
+        mock_get_async_waiter.assert_called_once_with(boto_waiter, waiter_name="sample_waiter")
+        assert result is mock_get_async_waiter.return_value
+
+    def test_get_async_waiter_with_client(self, mock_client):
+        # aiobotocore is an optional extra, so it has to be imported inside the test
+        pytest.importorskip("aiobotocore")
+
+        boto_waiter = BaseBotoWaiter(
+            client=mock_client, model_config=SAMPLE_WAITER_MODEL_CONFIG, deferrable=True
+        )
+        with mock.patch("aiobotocore.waiter.create_waiter_with_client") as mock_async_create_waiter:
+            result = boto_waiter.waiter("sample_waiter")
+
         mock_async_create_waiter.assert_called_once_with(
             waiter_name="sample_waiter", waiter_model=boto_waiter.model, client=mock_client
         )
-        assert result is async_waiter_instance
+        assert result is mock_async_create_waiter.return_value
 
     def test_waiter_with_real_botocore_creation(self, mock_client):
         boto_waiter = BaseBotoWaiter(


### PR DESCRIPTION
## Why
https://github.com/apache/airflow/actions/runs/34665058109/job/103477119282?pr=71403

The LatestBoto CI step deliberately uninstalls aiobotocore so the Amazon provider is exercised against the newest botocore, which aiobotocore's own pin would otherwise hold back.

## What
- `test_waiter_deferrable` now patches `BaseBotoWaiter._get_async_waiter_with_client` (`autospec=True`) and asserts the deferrable branch delegates to it. It exercises Airflow's own dispatch and runs everywhere, with or without aiobotocore.
- `test_get_async_waiter_with_client` keeps the real assertion against `aiobotocore.waiter.create_waiter_with_client` behind `pytest.importorskip("aiobotocore")`, so the coverage stays in normal environments and is skipped — not failed — in the Latest Boto step.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: [Claude] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
