### PR TITLE
Fix missing task display name and map index in API audit logs

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/logging/decorators.py
+++ b/airflow-core/src/airflow/api_fastapi/logging/decorators.py
@@ -181,6 +181,20 @@ def _resolve_team_name(params: dict, *, session: Session) -> str | None:
     return None
 
 
+def _extract_map_index(params: dict) -> int | None:
+    """
+    Return the map index named in the request, or ``None`` if it is missing or invalid.
+
+    ``action_logging`` commits the audit row before the endpoint validates the request, so this
+    function has to reject bad values.
+    """
+    try:
+        map_index = int(params["map_index"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    return map_index if -1 <= map_index < 2**31 else None
+
+
 def action_logging(event: str | None = None):
     async def log_action(
         request: Request,
@@ -261,6 +275,7 @@ def action_logging(event: str | None = None):
             task_id=params.get("task_id"),
             dag_id=params.get("dag_id"),
             run_id=params.get("run_id") or params.get("dag_run_id"),
+            map_index=_extract_map_index(params),
             team_name=_resolve_team_name(params, session=session),
         )
 

--- a/airflow-core/src/airflow/models/log.py
+++ b/airflow-core/src/airflow/models/log.py
@@ -71,7 +71,10 @@ class Log(Base):
         "TaskInstance",
         viewonly=True,
         foreign_keys=[dag_id, task_id, run_id, map_index],
-        primaryjoin="and_(Log.dag_id == TaskInstance.dag_id, Log.task_id == TaskInstance.task_id, Log.run_id == TaskInstance.run_id, Log.map_index == TaskInstance.map_index)",
+        # The REST API leaves map_index empty when the request does not include one, and its older
+        # audit rows never have it. Treat a missing map_index as -1 so those rows still join to
+        # the unmapped task instance, which is where task_display_name comes from.
+        primaryjoin="and_(Log.dag_id == TaskInstance.dag_id, Log.task_id == TaskInstance.task_id, Log.run_id == TaskInstance.run_id, func.coalesce(Log.map_index, -1) == TaskInstance.map_index)",
         lazy="raise",
     )
 

--- a/airflow-core/tests/unit/api_fastapi/logging/test_decorators.py
+++ b/airflow-core/tests/unit/api_fastapi/logging/test_decorators.py
@@ -360,6 +360,42 @@ class TestActionLoggingTeamName:
         assert logged.team_name is None
 
 
+class TestActionLoggingMapIndex:
+    """The map index a request names is recorded on the Log row, so the row can be matched to the
+    task instance the request acted on."""
+
+    @staticmethod
+    def _log_action(scope):
+        request = Request({"type": "http", "method": "PATCH", "headers": [], "query_string": b"", **scope})
+        session = MagicMock(spec=Session)
+
+        asyncio.run(action_logging(event="patch_task_instance")(request=request, session=session, user=None))
+
+        (logged,) = session.add.call_args.args
+        return logged
+
+    @pytest.mark.parametrize(
+        ("scope", "expected_map_index"),
+        [
+            pytest.param({"path_params": {"map_index": "2"}}, 2, id="path"),
+            pytest.param({"query_string": b"map_index=-1"}, -1, id="query"),
+        ],
+    )
+    def test_map_index_is_taken_from_the_request(self, scope, expected_map_index):
+        assert self._log_action(scope).map_index == expected_map_index
+
+    @pytest.mark.parametrize(
+        "query_string",
+        [
+            pytest.param(b"map_index=first", id="not-an-integer"),
+            pytest.param(b"map_index=-2", id="below-an-unmapped-task"),
+            pytest.param(b"map_index=2147483648", id="larger-than-the-column"),
+        ],
+    )
+    def test_a_value_no_task_instance_can_have_is_not_recorded(self, query_string):
+        assert self._log_action({"query_string": query_string}).map_index is None
+
+
 @pytest.mark.db_test
 class TestActionLoggingResourceTeamName:
     """An action that names no team -- a deletion, or a patch leaving ``team_name`` out -- takes the

--- a/airflow-core/tests/unit/models/test_log.py
+++ b/airflow-core/tests/unit/models/test_log.py
@@ -116,6 +116,22 @@ class TestLogTaskInstanceReproduction:
         assert loaded_log2.task_instance.dag_id == "dag_2"
         assert loaded_log2.task_instance.run_id == ti2.run_id
 
+    def test_log_without_map_index_joins_the_unmapped_task_instance(self, dag_maker, session):
+        with dag_maker("dag_without_map_index", session=session):
+            EmptyOperator(task_id="task_1")
+
+        ti = dag_maker.create_dagrun().get_task_instance("task_1")
+        log = Log(event="test_event", dag_id=ti.dag_id, task_id=ti.task_id, run_id=ti.run_id)
+        session.add(log)
+        session.commit()
+
+        stmt = select(Log).where(Log.id == log.id).options(joinedload(Log.task_instance))
+        loaded_log = session.scalar(stmt)
+
+        assert loaded_log.map_index is None
+        assert loaded_log.task_instance is not None
+        assert loaded_log.task_instance.id == ti.id
+
 
 DAG_IN_TEAM = "dag_owned_by_a_team"
 


### PR DESCRIPTION
## Why

- `GET /api/v2/eventLogs` returns `task_display_name: null` for REST API actions on a single task instance, such as marking it as success from the UI.
- #59973 made `Log.task_instance` join on `dag_id`, `task_id`, `run_id` and `map_index`, but `action_logging` never stores `map_index`. These rows have a NULL map index and can never match a task instance.
- The same rows show an empty Map Index column in the UI audit log, and filtering by map index does not find them.


## How

- `action_logging` records the map index from the request path, query or body. It commits the row before the endpoint validates the request, so it leaves out any value that is not an integer, is below -1, or does not fit the column.
- Each audit row still matches at most one task instance, because `(dag_id, task_id, run_id, map_index)` is unique. This keeps the fix from #59973, which stopped one audit row from matching every task instance with the same task_id.

## Verification

- Unit test: `uv run --frozen --project airflow-core pytest airflow-core/tests/unit/models/test_log.py airflow-core/tests/unit/api_fastapi/logging/test_decorators.py airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_event_logs.py airflow-core/tests/unit/api_fastapi/core_api/services/public/test_event_logs.py`
- Integration test:

1. Add demo dag

```bash
mkdir -p files/dags
cat > files/dags/audit_log_map_index_demo.py <<'EOF'
from __future__ import annotations

from airflow.sdk import dag, task


@dag(schedule=None, tags=["audit-log-demo"])
def audit_log_map_index_demo():
    @task(task_display_name="Load orders")
    def load_orders():
        return "orders loaded"

    @task(task_display_name="Load shard")
    def load_shard(shard: int):
        return shard

    load_orders()
    load_shard.expand(shard=[0, 1, 2])


audit_log_map_index_demo()
EOF
```

2. Start Airflow

```
breeze start-airflow --db-reset
```

3. Trigger Dag and mark "Load shard" as failed.
4. Check audit log.

On main branch, the `Map Index` column is empty although `map_index` is in `Extra` field. The API shows null for `map_index` and `task_display_name` fields.

<img width="1312" height="171" alt="Screenshot 2026-09-12 at 1 18 43 PM" src="https://github.com/user-attachments/assets/4e0f9adc-7b9c-4ce2-820d-a4eeba39809b" />
<img width="1265" height="305" alt="Screenshot 2026-09-12 at 1 19 11 PM" src="https://github.com/user-attachments/assets/580589ff-842a-40c1-b359-388819d1de03" />


On this branch, we get expected values.
<img width="1312" height="172" alt="Screenshot 2026-09-12 at 1 21 41 PM" src="https://github.com/user-attachments/assets/4cb8e1d6-f717-497f-b636-795427ac7128" />
<img width="1263" height="301" alt="Screenshot 2026-09-12 at 1 21 53 PM" src="https://github.com/user-attachments/assets/9f28a563-10c2-420f-a58c-e65b87df049b" />

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
