### PR TITLE
Speed up the event logs API by loading only display names

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/event_logs.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/event_logs.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 from fastapi import Depends, HTTPException, status
 from sqlalchemy import select
@@ -50,9 +50,28 @@ from airflow.api_fastapi.core_api.security import (
     requires_access_event_log,
 )
 from airflow.api_fastapi.core_api.services.public.event_logs import event_log_to_response
-from airflow.models import Log
+from airflow.models import DagModel, Log, TaskInstance
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm.interfaces import LoaderOption
 
 event_logs_router = AirflowRouter(tags=["Event Log"], prefix="/eventLogs")
+
+
+def _eager_load_display_names() -> tuple[LoaderOption, ...]:
+    """
+    Load only the columns that EventLogResponse reads from an event log's Dag and task instance.
+
+    The query also loads ``task_id`` because ``task_display_name`` falls back to it.
+    Without ``raiseload``, it would still join ``dag_run`` and select all of its columns, since
+    ``TaskInstance.dag_run`` is ``lazy="joined"``.
+    """
+    return (
+        joinedload(Log.task_instance)
+        .load_only(TaskInstance._task_display_property_value, TaskInstance.task_id)
+        .raiseload(TaskInstance.dag_run),
+        joinedload(Log.dag_model).load_only(DagModel._dag_display_property_value),
+    )
 
 
 @event_logs_router.get(
@@ -71,9 +90,7 @@ def get_event_log(
         # that bypass Log.__init__ (which always sets dttm = timezone.utcnow()).
         # Making EventLogResponse.when nullable would be a breaking API contract change for
         # clients that currently rely on `when` always being present.
-        select(Log)
-        .where(Log.id == event_log_id, Log.dttm.is_not(None))
-        .options(joinedload(Log.task_instance), joinedload(Log.dag_model))
+        select(Log).where(Log.id == event_log_id, Log.dttm.is_not(None)).options(*_eager_load_display_names())
     )
     if event_log is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"The Event Log with id: `{event_log_id}` not found")
@@ -187,9 +204,7 @@ def get_event_logs(
         # that bypass Log.__init__ (which always sets dttm = timezone.utcnow()).
         # Making EventLogResponse.when nullable would be a breaking API contract change for
         # clients that currently rely on `when` always being present.
-        select(Log)
-        .where(Log.dttm.is_not(None))
-        .options(joinedload(Log.task_instance), joinedload(Log.dag_model))
+        select(Log).where(Log.dttm.is_not(None)).options(*_eager_load_display_names())
     )
     event_logs_select, total_entries = paginated_select(
         statement=query,

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_event_logs.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_event_logs.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import re
 from datetime import datetime, timezone
 from unittest import mock
 
@@ -30,7 +31,7 @@ from airflow.api_fastapi.auth.managers.models.resource_details import (
 from airflow.models.log import Log
 from airflow.utils.session import NEW_SESSION, provide_session
 
-from tests_common.test_utils.asserts import assert_queries_count
+from tests_common.test_utils.asserts import assert_queries_count, capture_orm_selects
 from tests_common.test_utils.db import clear_db_logs, clear_db_runs
 from tests_common.test_utils.format_datetime import from_datetime_to_zulu, from_datetime_to_zulu_without_ms
 
@@ -56,6 +57,18 @@ EVENT_WITHOUT_DTTM = "EVENT_WITHOUT_DTTM"
 EVENT_NON_EXISTED_ID = 9999
 TEAM_EVENT = "TEAM_EVENT"
 TEAM_NAME = "TEST_TEAM"
+
+
+def _assert_selects_only_display_name_columns(statements: list[str]) -> None:
+    (sql,) = [sql for sql in statements if "task_instance_1" in sql]
+    select_clause = sql.split(" FROM ", 1)[0]
+    assert set(re.findall(r"\bdag_1\.(\w+)", select_clause)) == {"dag_id", "dag_display_name"}
+    assert set(re.findall(r"\btask_instance_1\.(\w+)", select_clause)) == {
+        "id",
+        "task_id",
+        "task_display_name",
+    }
+    assert "dag_run" not in sql
 
 
 class TestEventLogsEndpoint:
@@ -198,6 +211,13 @@ class TestGetEventLog(TestEventLogsEndpoint):
         }
 
         assert response.json() == expected_json
+
+    def test_get_event_log_selects_only_display_name_columns(self, test_client, setup):
+        with capture_orm_selects("log") as statements:
+            response = test_client.get(f"/eventLogs/{setup[TASK_INSTANCE_EVENT].id}")
+
+        assert response.status_code == 200
+        _assert_selects_only_display_name_columns(statements)
 
     def test_get_event_log_returns_the_recorded_team(self, test_client, session):
         event_log = Log(event="cli_triggerer", team_name=TEAM_NAME)
@@ -425,6 +445,13 @@ class TestGetEventLogs(TestEventLogsEndpoint):
         assert resp_json["total_entries"] == expected_total_entries
         for event_log, expected_event in zip(resp_json["event_logs"], expected_events):
             assert event_log["event"] == expected_event
+
+    def test_get_event_logs_selects_only_display_name_columns(self, test_client):
+        with capture_orm_selects("log") as statements:
+            response = test_client.get("/eventLogs")
+
+        assert response.status_code == 200
+        _assert_selects_only_display_name_columns(statements)
 
     @provide_session
     def test_get_event_logs_excludes_logs_without_dttm(


### PR DESCRIPTION
## Why

- `GET /eventLogs` and `GET /eventLogs/{event_log_id}` use only `dag_display_name` and `task_display_name` from the joined Dag and task instance, but the query selected every column of both tables.
- `TaskInstance.dag_run` is `lazy="joined"`, so the query also joined `dag_run` and selected all of its columns. Nothing in the response reads them.

## How

- Load only `dag_display_name` from `dag`, and only `task_display_name` and `task_id` from `task_instance`. `task_id` is needed because an empty `task_display_name` falls back to it.
- Add `raiseload` on `TaskInstance.dag_run` so the query no longer joins `dag_run`. Accessing it later raises an error instead of running an extra query.

## Verification

- `uv run --frozen --project airflow-core pytest airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_event_logs.py`

## Benchmark

A script runs both versions of the query on the same data. Each scenario has 1,500 task instances and 3,075 event logs, and each each value is the median of 40 runs per version, measured after 5 warm-up rounds.

| Scenario | Page size | Endpoint p50 | ORM query p50 |
|---|---|---|---|
| No executor_config | 50 | 14.4 → 12.8 ms (1.1x) | 3.0 → 1.4 ms (2.1x) |
| No executor_config | 100 | 17.3 → 14.4 ms (1.2x) | 5.0 → 2.2 ms (2.3x) |
| KubernetesExecutor `pod_override` | 50 | 23.6 → 14.0 ms (1.7x) | 10.3 → 1.5 ms (7.0x) |
| KubernetesExecutor `pod_override` | 100 | 32.8 → 14.6 ms (2.3x) | 21.8 → 2.7 ms (8.0x) |

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
