### PR TITLE
Move retry policy decision outside post execute log group block

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1815,6 +1815,8 @@ def _evaluate_retry_policy(
             context=context,
         )
         if decision.reason:
+            # Close the group so the retry policy decision is not hidden inside "Post Execute".
+            log.info("::endgroup::")
             log.info("Retry policy decision", action=decision.action.value, reason=decision.reason)
         return decision
     except Exception:

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -1271,6 +1271,42 @@ def test_run_emits_post_execute_group_before_xcom_push(create_runtime_ti, mock_s
     assert call_order.index("::group::Post Execute") < call_order.index("Pushing xcom")
 
 
+def test_retry_policy_decision_logged_outside_post_execute_group(create_runtime_ti, mock_supervisor_comms):
+    """The retry policy decision log line closes the 'Post Execute' group instead of nesting inside it."""
+    call_order: list[str] = []
+    tracked = {"::group::Post Execute", "::endgroup::", "Retry policy decision"}
+
+    class _FailPolicy(RetryPolicy):
+        def evaluate(self, exception, try_number, max_tries, context=None):
+            return RetryDecision(action=RetryAction.FAIL, reason="auth error, do not retry")
+
+    class _AlwaysFails(BaseOperator):
+        def execute(self, context):
+            raise RuntimeError("boom")
+
+    task = _AlwaysFails(task_id="fail_policy_task", retry_policy=_FailPolicy())
+    ti = create_runtime_ti(task=task, should_retry=True)
+    log = mock.MagicMock(spec=["info", "debug", "warning", "error", "exception", "bind"])
+
+    def tracking_info(msg, *args, **kwargs):
+        if msg in tracked:
+            call_order.append(msg)
+
+    log.info.side_effect = tracking_info
+
+    state, msg, error = run(ti, context=ti.get_template_context(), log=log)
+    finalize(ti, state=state, context=ti.get_template_context(), log=log)
+
+    # No reopened "Post Execute", only finalize() ::endgroup:: follows the retry policy decision.
+    assert call_order == [
+        "::endgroup::",
+        "::group::Post Execute",
+        "::endgroup::",
+        "Retry policy decision",
+        "::endgroup::",
+    ]
+
+
 def test_finalize_emits_endgroup(create_runtime_ti, mock_supervisor_comms):
     """finalize() closes the post-execute log group but does not open it."""
     task = BaseOperator(task_id="some_task")


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

### What

When a retry policy is configured, the decision it makes ("retry" or "fail", and why) is only ever logged as a single `structlog` line: `"Retry policy decision"`. That line renders inside the `::group::Post Execute` collapsed section of the task log viewer, so a Dag author or a user viewing logs has to expand a collapsed group to see why their task did or didn't retry, which is the one place this information surfaces today.

### Current behaviour

`_evaluate_retry_policy` logs the decision unconditionally after the `Post Execute` group is opened by the calling exception handler, so the log viewer hides it by default.

### Proposed change

Close the `Post Execute` group immediately before logging the retry decision, so the line renders visibly instead of nested inside a collapsed section. Nothing meaningful is logged between the retry decision and the end of the task run in any failure path (`_finalize_task_failure` logs nothing, and `run()`'s finally block only logs on rare supervisor-send failures), so the group is left closed rather than reopened.


### Testing

- Ran the `example_llm_retry_policy` DAG

Before: 

<img width="2501" height="1003" alt="image" src="https://github.com/user-attachments/assets/62990938-e069-46de-b886-8be56062aed9" />


<img width="2501" height="1003" alt="image" src="https://github.com/user-attachments/assets/c0ff4747-7131-43e2-ad08-f679e1d4383b" />



Now:

<img width="2501" height="1003" alt="image" src="https://github.com/user-attachments/assets/cffbb617-80b2-44b6-b116-c869935fa607" />


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
