### PR TITLE
Fix airflow standalone announcing readiness before the API server is up

### DIFF
--- a/airflow-core/src/airflow/cli/commands/standalone_command.py
+++ b/airflow-core/src/airflow/cli/commands/standalone_command.py
@@ -62,6 +62,7 @@ class StandaloneCommand:
         self.output_queue = deque()
         self.ready_time = None
         self.ready_delay = 3
+        self.api_server_port = None
 
     @providers_configuration_loaded
     def run(self):
@@ -69,6 +70,7 @@ class StandaloneCommand:
         # Silence built-in logging at INFO
         logging.getLogger("").setLevel(logging.WARNING)
         # Startup checks and prep
+        self.api_server_port = conf.getint("api", "port")
         env = self.calculate_env()
         self.find_user_info()
         self.initialize_database()
@@ -226,10 +228,12 @@ class StandaloneCommand:
         """
         Detect when all Airflow components are ready to serve.
 
-        For now, it's simply time-based.
+        Ready means the API server accepts connections and the scheduler, Dag
+        processor and triggerer are all heartbeating.
         """
         return (
-            self.job_running(SchedulerJobRunner)
+            self.port_open(self.api_server_port)
+            and self.job_running(SchedulerJobRunner)
             and self.job_running(DagProcessorJobRunner)
             and self.job_running(TriggererJobRunner)
         )
@@ -238,7 +242,7 @@ class StandaloneCommand:
         """
         Check if the given port is listening on the local machine.
 
-        Used to tell if webserver is alive.
+        Used to tell if the API server is alive.
         """
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/airflow-core/tests/unit/cli/commands/test_standalone_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_standalone_command.py
@@ -33,6 +33,8 @@ from airflow.executors.executor_constants import (
     LOCAL_EXECUTOR,
 )
 
+from tests_common.test_utils.config import conf_vars
+
 
 class TestStandaloneCommand:
     @pytest.mark.parametrize(
@@ -196,18 +198,37 @@ class TestStandaloneCommand:
         result = StandaloneCommand().job_running(mock.Mock(job_type="scheduler"))
         assert result is True
 
-    def test_is_ready_true_when_all_components_running(self, monkeypatch):
+    @pytest.mark.parametrize(
+        ("api_server_listening", "jobs_running", "expected"),
+        [
+            pytest.param(True, [True, True, True], True, id="every-component-ready"),
+            pytest.param(True, [True, False], False, id="component-not-heartbeating"),
+            pytest.param(False, [], False, id="api-server-port-closed"),
+        ],
+    )
+    def test_is_ready(self, monkeypatch, api_server_listening, jobs_running, expected):
         cmd = StandaloneCommand()
-        monkeypatch.setattr(cmd, "job_running", lambda *_: True)
+        cmd.api_server_port = 9999
+        port_open = mock.Mock(return_value=api_server_listening)
+        jobs = iter(jobs_running)
+        monkeypatch.setattr(cmd, "port_open", port_open)
+        monkeypatch.setattr(cmd, "job_running", lambda *_: next(jobs))
 
-        assert cmd.is_ready() is True
+        assert cmd.is_ready() is expected
+        port_open.assert_called_once_with(9999)
 
-    def test_is_ready_false_when_any_component_missing(self, monkeypatch):
+    @conf_vars({("api", "port"): "9999"})
+    @mock.patch("airflow.cli.commands.standalone_command.SubCommand", autospec=True)
+    @mock.patch.object(StandaloneCommand, "initialize_database")
+    @mock.patch.object(StandaloneCommand, "find_user_info")
+    @mock.patch.object(StandaloneCommand, "calculate_env", return_value={})
+    @mock.patch.object(StandaloneCommand, "print_output")
+    def test_run_resolves_the_api_server_port_from_config(self, *_):
         cmd = StandaloneCommand()
-        calls = iter([True, False, True])
-        monkeypatch.setattr(cmd, "job_running", lambda *_: next(calls))
+        with mock.patch.object(cmd, "update_output", side_effect=KeyboardInterrupt):
+            cmd.run()
 
-        assert cmd.is_ready() is False
+        assert cmd.api_server_port == 9999
 
     @pytest.mark.parametrize("exc", [OSError, ValueError])
     def test_port_open_returns_false_on_errors(self, monkeypatch, exc):


### PR DESCRIPTION
## Why

`airflow standalone` prints "Airflow is ready" without checking the component that serves the UI. `is_ready()` only looks at the scheduler, Dag processor and triggerer heartbeats, so the banner fires while the API server is still importing the app and binding its port. Developers follow the banner to the browser and get a connection refused.

The check is not new. `is_ready()` gated on the port from the command's introduction in #15826, and #20505 later fixed it to read the configured port instead of a hard-coded 8080. #46942 ("Remove old UI and webserver") then deleted the attribute holding the port but left the call that read it, so `is_ready()` raised `AttributeError`; the follow-up hot-fix #47145 resolved that by deleting the call rather than repointing it at the renamed `[api] port`. `port_open` and its two tests have been unreachable since.

## What

`airflow-core/src/airflow/cli/commands/standalone_command.py`:

- `is_ready()` gates on `port_open` again, first in the chain so the three heartbeat queries are skipped while the API server is still coming up.
- `run()` resolves `[api] port` once at startup, matching the shape the pre-#47145 code used. Keeping the lookup out of the poll loop matters: `conf.getint` raises on a malformed value, the loop only handles `KeyboardInterrupt`, and the `command.stop()` / `command.join()` shutdown sits after the `try` rather than in a `finally`, so an escape would leave all four components running as orphans. With the lookup in `run()`, a bad `[api] port` fails before anything is spawned.
- Two stale docstrings corrected: `is_ready()` claimed to be time-based, which it has not been since #15826, and `port_open` still referred to the webserver.

`airflow-core/tests/unit/cli/commands/test_standalone_command.py`: the `is_ready` tests are consolidated into one parametrized test covering port-open, a component not heartbeating, and port-closed. It asserts `port_open` is called with the resolved port, and the port-closed case passes an empty iterator so the short-circuit is pinned. A new test covers the config resolution in `run()`. Reverting the source change fails all four.

### Deliberately not in this PR

`port_open` is restored as it was, so its pre-existing limitations come back with it and are worth a maintainer's call:

- It probes `127.0.0.1` over IPv4 and ignores `[api] host`. The default `0.0.0.0` is fine, but a user who binds a specific non-loopback address would never see the banner.
- A TCP accept proves something is listening, not that it is this standalone's API server. A stale process holding the port still yields a ready banner.
- With `[api] workers > 1` or `server_type = gunicorn` the parent binds before workers import the app, so the accept precedes app readiness.

All three point at the same deeper fix: polling `GET /api/v2/monitor/health`, which is already the idiom in the Helm chart, breeze, and `dev/verify_*_rc.sh`, and which would subsume the heartbeat checks too. That is a larger change than restoring a lost gate, so I have kept it out.

Separately, `ready_time` latches and is never re-evaluated, so the banner still makes a 3-second-stale claim, and standalone never notices a component dying. Both are pre-existing and unchanged here.

`.github/workflows/basic-tests.yml` greps this banner, so that job now genuinely depends on the API server binding.

### How to test

Run `airflow standalone` and confirm the banner appears only once `http://localhost:8080` actually answers.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
