### PR TITLE
Fix invalid command path in permissions-cleanup help examples

### DIFF
--- a/providers/fab/src/airflow/providers/fab/cli/definition.py
+++ b/providers/fab/src/airflow/providers/fab/cli/definition.py
@@ -286,13 +286,13 @@ PERMISSIONS_CLEANUP_COMMAND = ActionCommand(
     epilog=(
         "examples:\n"
         "To see what orphaned permissions would be cleaned up:\n"
-        "    $ airflow fab-auth-manager permissions-cleanup --dry-run\n"
+        "    $ airflow permissions-cleanup --dry-run\n"
         "To clean up all orphaned permissions:\n"
-        "    $ airflow fab-auth-manager permissions-cleanup\n"
+        "    $ airflow permissions-cleanup\n"
         "To clean up permissions for specific DAG:\n"
-        "    $ airflow fab-auth-manager permissions-cleanup --dag-id my_dag\n"
+        "    $ airflow permissions-cleanup --dag-id my_dag\n"
         "To clean up without confirmation:\n"
-        "    $ airflow fab-auth-manager permissions-cleanup --yes"
+        "    $ airflow permissions-cleanup --yes"
     ),
 )
 

--- a/providers/fab/tests/unit/fab/cli/test_definition.py
+++ b/providers/fab/tests/unit/fab/cli/test_definition.py
@@ -16,11 +16,29 @@
 # under the License.
 from __future__ import annotations
 
+import shlex
+
+import pytest
+
 from airflow.providers.fab.cli.definition import (
+    PERMISSIONS_CLEANUP_COMMAND,
     ROLES_COMMANDS,
     SYNC_PERM_COMMAND,
     USERS_COMMANDS,
+    get_parser,
 )
+
+
+def _extract_epilog_examples(command):
+    examples = []
+    for line in (command.epilog or "").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("$ airflow "):
+            examples.append(stripped.removeprefix("$ "))
+    if not examples:
+        # An empty parametrize set is silently skipped, which would hide the loss of this guard.
+        raise ValueError(f"No '$ airflow ...' example found in the {command.name} epilog")
+    return examples
 
 
 class TestCliDefinition:
@@ -32,3 +50,10 @@ class TestCliDefinition:
 
     def test_sync_perm_command(self):
         assert SYNC_PERM_COMMAND.name == "sync-perm"
+
+    @pytest.mark.parametrize(
+        "example", _extract_epilog_examples(PERMISSIONS_CLEANUP_COMMAND), ids=lambda e: e
+    )
+    def test_permissions_cleanup_epilog_examples_are_runnable(self, example):
+        args = get_parser().parse_args(shlex.split(example)[1:])
+        assert args.subcommand == PERMISSIONS_CLEANUP_COMMAND.name


### PR DESCRIPTION
## Why

All four examples in `airflow permissions-cleanup --help` tell the user to run the
command under a `fab-auth-manager` group:

```
$ airflow permissions-cleanup --help
...
examples:
To see what orphaned permissions would be cleaned up:
    $ airflow fab-auth-manager permissions-cleanup --dry-run
```

That group does not exist. `get_fab_cli_commands()` registers
`PERMISSIONS_CLEANUP_COMMAND` as a bare `ActionCommand`, so it is mounted at the top
level alongside `sync-perm`. Copying any example straight out of the help output
fails:

```
$ airflow fab-auth-manager permissions-cleanup --dry-run
airflow command error: argument GROUP_OR_COMMAND: invalid choice: 'fab-auth-manager'
    (choose from ... permissions-cleanup ... sync-perm ...), see help above.
```

The wrong prefix has been there since the command was added in #54528, and
`fab-auth-manager` appears nowhere else in the tree — it was never a real group.
The person reading this help text is by definition the one who does not already
know the right invocation.

## What

- `providers/fab/src/airflow/providers/fab/cli/definition.py` — drop the
  `fab-auth-manager` prefix from the four epilog examples.
- `providers/fab/tests/unit/fab/cli/test_definition.py` — parse every
  `$ airflow ...` line of the epilog with the real FAB parser instead of asserting on
  the literal string, so a future example that names a non-existent command fails the
  test. The extraction helper raises when it finds no examples: an empty
  `parametrize` set is reported as skipped, which would quietly retire the guard if
  the epilog were ever reformatted.
