### PR TITLE
Fail Gemini batch job operators when the job does not succeed

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/gen_ai.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/gen_ai.py
@@ -487,7 +487,6 @@ class GenAIGeminiCreateBatchJobOperator(GoogleCloudBaseOperator):
                     BatchJobStatus.EXPIRED.value,
                     BatchJobStatus.CANCELLED.value,
                 ]:
-                    self.log.error("Job execution was not completed!")
                     break
                 self.log.info(
                     "Waiting for job execution, polling interval: %s seconds, current state: %s",
@@ -497,6 +496,8 @@ class GenAIGeminiCreateBatchJobOperator(GoogleCloudBaseOperator):
                 time.sleep(polling_interval)
         except Exception:
             raise AirflowException("Something went wrong during waiting of the batch job.")
+        if job.state.name != BatchJobStatus.SUCCEEDED.value:
+            raise RuntimeError(f"Job {job.name} execution was not completed! state: {job.state.name}")
         return job
 
     def _validate_results_folder(self):
@@ -937,7 +938,6 @@ class GenAIGeminiCreateEmbeddingsBatchJobOperator(GoogleCloudBaseOperator):
                     BatchJobStatus.EXPIRED.value,
                     BatchJobStatus.CANCELLED.value,
                 ]:
-                    self.log.error("Job execution was not completed!")
                     break
                 self.log.info(
                     "Waiting for job execution, polling interval: %s seconds, current state: %s",
@@ -947,6 +947,8 @@ class GenAIGeminiCreateEmbeddingsBatchJobOperator(GoogleCloudBaseOperator):
                 time.sleep(polling_interval)
         except Exception as e:
             raise AirflowException("Something went wrong during waiting of the batch job: %s", e)
+        if job.state.name != BatchJobStatus.SUCCEEDED.value:
+            raise RuntimeError(f"Job {job.name} execution was not completed! state: {job.state.name}")
         return job
 
     def _validate_results_folder(self):

--- a/providers/google/tests/unit/google/cloud/operators/test_gen_ai.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_gen_ai.py
@@ -21,10 +21,12 @@ from unittest import mock
 import pytest
 from google.genai.errors import ClientError
 from google.genai.types import (
+    BatchJob,
     Content,
     CreateCachedContentConfig,
     GenerateContentConfig,
     GoogleSearch,
+    JobState,
     Part,
     Tool,
     TuningDataset,
@@ -500,6 +502,34 @@ class TestGenAIGeminiCreateBatchJobOperator:
         with pytest.raises(AirflowException):
             op._wait_until_complete(job=mock.MagicMock())
 
+    @pytest.mark.parametrize(
+        "job_state",
+        [JobState.JOB_STATE_FAILED, JobState.JOB_STATE_EXPIRED, JobState.JOB_STATE_CANCELLED],
+    )
+    @mock.patch(GEN_AI_PATH.format("GenAIGeminiAPIHook"), autospec=True)
+    def test_execute_wait_until_complete_unsuccessful_job_raises_runtime_error(self, mock_hook, job_state):
+        mock_hook.return_value.get_batch_job.return_value = BatchJob(
+            name=TEST_BATCH_JOB_NAME, state=job_state
+        )
+        op = GenAIGeminiCreateBatchJobOperator(
+            task_id=TASK_ID,
+            project_id=GCP_PROJECT,
+            location=GCP_LOCATION,
+            model=TEST_GEMINI_MODEL,
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+            input_source=TEST_BATCH_JOB_INLINED_REQUESTS,
+            gemini_api_key=TEST_GEMINI_API_KEY,
+            wait_until_complete=True,
+            deferrable=False,
+        )
+
+        with pytest.raises(
+            RuntimeError,
+            match=f"Job {TEST_BATCH_JOB_NAME} execution was not completed! state: {job_state.name}",
+        ):
+            op.execute(context={"ti": mock.Mock(spec_set=["xcom_push"])})
+
     @mock.patch(GEN_AI_PATH.format("GenAIGeminiAPIHook"))
     def test_execute_exception_error_raises_airflow_exception(self, mock_hook):
         op = GenAIGeminiCreateBatchJobOperator(
@@ -899,6 +929,34 @@ class TestGenAIGeminiCreateEmbeddingsBatchJobOperator:
 
         with pytest.raises(AirflowException):
             op._wait_until_complete(job=mock.MagicMock())
+
+    @pytest.mark.parametrize(
+        "job_state",
+        [JobState.JOB_STATE_FAILED, JobState.JOB_STATE_EXPIRED, JobState.JOB_STATE_CANCELLED],
+    )
+    @mock.patch(GEN_AI_PATH.format("GenAIGeminiAPIHook"), autospec=True)
+    def test_execute_wait_until_complete_unsuccessful_job_raises_runtime_error(self, mock_hook, job_state):
+        mock_hook.return_value.get_batch_job.return_value = BatchJob(
+            name=TEST_BATCH_JOB_NAME, state=job_state
+        )
+        op = GenAIGeminiCreateEmbeddingsBatchJobOperator(
+            task_id=TASK_ID,
+            project_id=GCP_PROJECT,
+            location=GCP_LOCATION,
+            input_source=TEST_EMBEDDINGS_JOB_INLINED_REQUESTS,
+            model=EMBEDDING_MODEL,
+            gemini_api_key=TEST_GEMINI_API_KEY,
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+            wait_until_complete=True,
+            deferrable=False,
+        )
+
+        with pytest.raises(
+            RuntimeError,
+            match=f"Job {TEST_BATCH_JOB_NAME} execution was not completed! state: {job_state.name}",
+        ):
+            op.execute(context={"ti": mock.Mock(spec_set=["xcom_push"])})
 
     @mock.patch(GEN_AI_PATH.format("GenAIGeminiAPIHook"))
     def test_execute_exception_error_raises_airflow_exception(self, mock_hook):


### PR DESCRIPTION
## Why

- When a batch job ends as `JOB_STATE_FAILED`, `JOB_STATE_EXPIRED`, or `JOB_STATE_CANCELLED`, `GenAIGeminiCreateBatchJobOperator` and `GenAIGeminiCreateEmbeddingsBatchJobOperator` handle it differently depending on the mode:
  - `deferrable=True`: the trigger sends an error event and `execute_complete` raises `AirflowException`. The task fails, and downstream tasks do not run.
  - `deferrable=False` with `wait_until_complete=True`: `_wait_until_complete` only logs an error and returns the job. `execute()` then returns normally, so the task succeeds and downstream tasks run.

## How

- `_wait_until_complete` raises `RuntimeError` with the job name and final state when the job did not succeed.

## Verification

- `uv run --frozen --project providers/google pytest providers/google/tests/unit/google/cloud/operators/test_gen_ai.py`

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
