### PR TITLE
Fix extra Dag versions from template field callables if paths change

### DIFF
--- a/airflow-core/src/airflow/serialization/helpers.py
+++ b/airflow-core/src/airflow/serialization/helpers.py
@@ -89,8 +89,9 @@ def serialize_template_field(template_field: Any, name: str) -> str | dict | lis
             return serialize_object(obj.to_dict())
 
         if callable(obj):
-            # Use qualified name; default repr embeds memory addresses, which would change the DAG hash on every parse
-            return f"<callable {qualname(obj, True)}>"
+            # The default repr includes a memory address, and a Dag file's module name includes a hash of the
+            # file path. Leave both out so the Dag hash does not change between parses or when the file moves.
+            return f"<callable {qualname(obj, exclude_module=True)}>"
 
         # A custom __str__ or __repr__ is treated as an intentional textual representation
         # supplied by the author and used as-is.
@@ -100,7 +101,7 @@ def serialize_template_field(template_field: Any, name: str) -> str | dict | lis
         # Otherwise fall back to a qualname marker. The default object repr is
         # `<ClassName object at 0x...>`, which embeds a memory address that flips per process
         # and would break DAG hash stability — use the class qualname instead.
-        return f"<{qualname(type(obj), True)} object>"
+        return f"<{qualname(type(obj), exclude_module=True)} object>"
 
     max_length = conf.getint("core", "max_templated_field_length")
 

--- a/airflow-core/tests/unit/serialization/test_dag_serialization.py
+++ b/airflow-core/tests/unit/serialization/test_dag_serialization.py
@@ -1749,11 +1749,11 @@ class TestStringifiedDAGs:
         serialized_task = OperatorSerialization.serialize_operator(task)
         assert (
             serialized_task.get("arg1")
-            == "<callable unit.serialization.test_dag_serialization.TestStringifiedDAGs.test_template_field_via_callable_serialization.<locals>.fn_template_field_callable>"
+            == "<callable TestStringifiedDAGs.test_template_field_via_callable_serialization.<locals>.fn_template_field_callable>"
         )
         assert (
             serialized_task.get("arg2")
-            == "<callable unit.serialization.test_dag_serialization.TestStringifiedDAGs.test_template_field_via_callable_serialization.<locals>.fn_returns_callable.<locals>.get_arg>"
+            == "<callable TestStringifiedDAGs.test_template_field_via_callable_serialization.<locals>.fn_returns_callable.<locals>.get_arg>"
         )
 
     def test_task_group_serialization(self):

--- a/airflow-core/tests/unit/serialization/test_helpers.py
+++ b/airflow-core/tests/unit/serialization/test_helpers.py
@@ -23,6 +23,7 @@ import pytest
 from airflow.sdk.definitions._internal.types import SET_DURING_EXECUTION
 from airflow.serialization.definitions.notset import NOTSET
 from airflow.serialization.helpers import serialize_template_field
+from airflow.utils.file import get_unique_dag_module_name
 
 
 def test_serialize_template_field_with_very_small_max_length(monkeypatch):
@@ -295,6 +296,28 @@ def test_serialize_template_field_plain_object_has_no_memory_address():
     assert isinstance(result, str)
     assert "at 0x" not in result
     assert "Opaque" in result
+
+
+def _clean_rows(rows):
+    return rows
+
+
+class _LoadSettings:
+    pass
+
+
+@pytest.mark.parametrize(
+    "dag_file", ["/opt/airflow/releases/41/dags/etl.py", "/opt/airflow/releases/42/dags/etl.py"]
+)
+def test_serialize_template_field_markers_leave_out_dag_file_module(monkeypatch, dag_file):
+    """Markers for callables and objects defined in a Dag file must not depend on the file path."""
+    module_name = get_unique_dag_module_name(dag_file)
+    monkeypatch.setattr(_clean_rows, "__module__", module_name)
+    monkeypatch.setattr(_LoadSettings, "__module__", module_name)
+
+    result = serialize_template_field({"transform": _clean_rows, "settings": _LoadSettings()}, "op_kwargs")
+
+    assert result == {"settings": "<_LoadSettings object>", "transform": "<callable _clean_rows>"}
 
 
 def test_serialize_template_field_plain_object_repr_preserved_when_custom():

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1310,8 +1310,9 @@ def _serialize_template_field(
             return serialize_object(obj.to_dict())
 
         if callable(obj):
-            # Use qualified name; default repr embeds memory addresses, which would change the DAG hash on every parse
-            return f"<callable {qualname(obj, True)}>"
+            # The default repr includes a memory address, and a Dag file's module name includes a hash of the
+            # file path. Leave both out so the Dag hash does not change between parses or when the file moves.
+            return f"<callable {qualname(obj, exclude_module=True)}>"
 
         # A custom __str__ or __repr__ is treated as an intentional textual representation
         # supplied by the author and used as-is.
@@ -1321,7 +1322,7 @@ def _serialize_template_field(
         # Otherwise fall back to a qualname marker. The default object repr is
         # `<ClassName object at 0x...>`, which embeds a memory address that flips per process
         # and would break DAG hash stability — use the class qualname instead.
-        return f"<{qualname(type(obj), True)} object>"
+        return f"<{qualname(type(obj), exclude_module=True)} object>"
 
     max_length = conf.getint("core", "max_templated_field_length")
 

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -179,6 +179,7 @@ from airflow.sdk.execution_time.task_runner import (
     _register_deserialization_allowed_classes,
     _run_execute_callable,
     _serialize_outlet_events,
+    _serialize_template_field,
     _xcom_push,
     detail_span,
     finalize,
@@ -192,6 +193,7 @@ from airflow.sdk.serde import deserialize
 from airflow.triggers.base import BaseEventTrigger, BaseTrigger, TriggerEvent
 from airflow.triggers.callback import CallbackTrigger
 from airflow.triggers.testing import SuccessTrigger
+from airflow.utils.file import get_unique_dag_module_name
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.mock_operators import AirflowLink
@@ -3745,6 +3747,28 @@ class TestRuntimeTaskInstance:
         )
         assert response.dag_id == "test_dag"
         assert response.is_paused is False
+
+
+def _clean_rows(rows):
+    return rows
+
+
+class _LoadSettings:
+    pass
+
+
+@pytest.mark.parametrize(
+    "dag_file", ["/opt/airflow/releases/41/dags/etl.py", "/opt/airflow/releases/42/dags/etl.py"]
+)
+def test_serialize_template_field_markers_leave_out_dag_file_module(monkeypatch, dag_file):
+    """Markers for callables and objects defined in a Dag file must not depend on the file path."""
+    module_name = get_unique_dag_module_name(dag_file)
+    monkeypatch.setattr(_clean_rows, "__module__", module_name)
+    monkeypatch.setattr(_LoadSettings, "__module__", module_name)
+
+    result = _serialize_template_field({"transform": _clean_rows, "settings": _LoadSettings()}, "op_kwargs")
+
+    assert result == {"settings": "<_LoadSettings object>", "transform": "<callable _clean_rows>"}
 
 
 class TestXComAfterTaskExecution:


### PR DESCRIPTION
## Why

- `serialize_template_field()` writes a callable as `<callable {module}.{qualname}>` and a plain object as `<{module}.{qualname} object>`. For a function or class defined in the Dag file, the marker includes the path-based module name, which ends up in the Dag hash.
- If the bundle path changes between deployments, the hash changes even though the Dag code stays the same. When the current version already has task instances, each of these deployments creates a new Dag version.

## How

- Follow #60799 to pass `exclude_module=True` to `qualname()` for both markers.

## Verification

- Unit test:
  - `uv run --frozen --project airflow-core pytest airflow-core/tests/unit/serialization/test_helpers.py airflow-core/tests/unit/serialization/test_dag_serialization.py airflow-core/tests/unit/models/test_renderedtifields.py`
  - `breeze run pytest task-sdk/tests/task_sdk/execution_time/test_task_runner.py`
- Integration test:

1. Setup

```sh
mkdir -p files/template-field-demo

cat > files/template-field-demo/etl.py <<'EOF'
from __future__ import annotations

import pendulum

from airflow.providers.standard.operators.python import PythonOperator
from airflow.sdk import DAG


def clean_rows(rows):
    return [row.strip() for row in rows]


class LoadSettings:
    batch_size = 500


def load(transform, settings):
    print(transform([" a ", " b "]), settings.batch_size)


with DAG(dag_id="etl", start_date=pendulum.datetime(2026, 1, 1, tz="UTC"), schedule=None):
    PythonOperator(
        task_id="load",
        python_callable=load,
        op_kwargs={"transform": clean_rows, "settings": LoadSettings()},
    )
EOF

cat > files/template-field-demo/show_state.py <<'EOF'
import sys

from sqlalchemy import select

from airflow.models.dag_version import DagVersion
from airflow.models.serialized_dag import SerializedDagModel
from airflow.utils.session import create_session

with create_session() as session:
    versions = session.scalars(
        select(DagVersion.version_number).where(DagVersion.dag_id == "etl").order_by(DagVersion.version_number)
    ).all()
    op_kwargs = SerializedDagModel.get("etl", session=session).data["dag"]["tasks"][0]["__var"]["op_kwargs"]

print(f"{sys.argv[1]}: Dag versions = {versions}")
print(f"  op_kwargs = {op_kwargs}")
EOF

cat > files/template-field-demo/deploy.sh <<'EOF'
set -euo pipefail
export AIRFLOW__CORE__LOAD_EXAMPLES=False
# Write each re-serialization right away instead of waiting 30 seconds between writes.
export AIRFLOW__CORE__MIN_SERIALIZED_DAG_UPDATE_INTERVAL=0
demo=/files/template-field-demo

quiet() { "$@" > /tmp/demo-command.log 2>&1 || { cat /tmp/demo-command.log; exit 1; }; }

quiet airflow db migrate
rm -rf "${demo}/releases"
for release in 41 42 43; do
  # Deploy the same Dag file to a new directory, like a versioned deployment does.
  bundle_path="${demo}/releases/release-${release}"
  mkdir -p "${bundle_path}"
  cp "${demo}/etl.py" "${bundle_path}/etl.py"
  export AIRFLOW__DAG_PROCESSOR__DAG_BUNDLE_CONFIG_LIST="[{\"name\": \"etl-bundle\", \"classpath\": \"airflow.dag_processing.bundles.local.LocalDagBundle\", \"kwargs\": {\"path\": \"${bundle_path}\"}}]"
  quiet airflow dags reserialize --bundle-name etl-bundle
  python "${demo}/show_state.py" "release-${release}"
  # Run the Dag once, so the next deployment cannot update this version in place.
  quiet airflow dags trigger etl --run-id "manual__release-${release}"
done
EOF
```

2. Run demo script

```sh
breeze run --backend sqlite bash /files/template-field-demo/deploy.sh
```

On main branch, it bumps dag version with different paths.

```text
release-41: Dag versions = [1]
  op_kwargs = {'settings': '<unusual_prefix_b258b7f6578d0fef91ba779c52c32ad43a0d96b1_etl.LoadSettings object>', 'transform': '<callable unusual_prefix_b258b7f6578d0fef91ba779c52c32ad43a0d96b1_etl.clean_rows>'}
release-42: Dag versions = [1, 2]
  op_kwargs = {'settings': '<unusual_prefix_30d5abbd19b0bdd47056ee70d929329f050eff4c_etl.LoadSettings object>', 'transform': '<callable unusual_prefix_30d5abbd19b0bdd47056ee70d929329f050eff4c_etl.clean_rows>'}
release-43: Dag versions = [1, 2, 3]
  op_kwargs = {'settings': '<unusual_prefix_c6581b5a63a06e6a67c32562fc5425e66cef00de_etl.LoadSettings object>', 'transform': '<callable unusual_prefix_c6581b5a63a06e6a67c32562fc5425e66cef00de_etl.clean_rows>'}
```

On this PR, it shows same version.

```text
release-41: Dag versions = [1]
  op_kwargs = {'settings': '<LoadSettings object>', 'transform': '<callable clean_rows>'}
release-42: Dag versions = [1]
  op_kwargs = {'settings': '<LoadSettings object>', 'transform': '<callable clean_rows>'}
release-43: Dag versions = [1]
  op_kwargs = {'settings': '<LoadSettings object>', 'transform': '<callable clean_rows>'}
```
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
