### PR TITLE
Fix Dags staying blocked by max_active_runs until the next parse

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2976,11 +2976,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             session.flush()
             self.log.info("Run %s of %s has timed-out", dag_run.run_id, dag_run.dag_id)
 
-            if dag_run.state in State.finished_dr_states and dag_run.run_type in (
-                DagRunType.SCHEDULED,
-                DagRunType.MANUAL,
-                DagRunType.ASSET_TRIGGERED,
-            ):
+            if dag_run.state in State.finished_dr_states and dag_run.run_type != DagRunType.BACKFILL_JOB:
                 self._set_exceeds_max_active_runs(dag_model=dag_model, session=session)
 
             dag_run_reloaded = session.scalar(
@@ -3040,11 +3036,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         # TODO[HA]: Rename update_state -> schedule_dag_run, ?? something else?
         schedulable_tis, callback_to_run = dag_run.update_state(session=session, execute_callbacks=False)
 
-        if dag_run.state in State.finished_dr_states and dag_run.run_type in (
-            DagRunType.SCHEDULED,
-            DagRunType.MANUAL,
-            DagRunType.ASSET_TRIGGERED,
-        ):
+        if dag_run.state in State.finished_dr_states and dag_run.run_type != DagRunType.BACKFILL_JOB:
             self._set_exceeds_max_active_runs(dag_model=dag_model, session=session)
 
         # This will do one query per dag run. We "could" build up a complex

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -5594,6 +5594,7 @@ class TestSchedulerJob:
         )
         assert actual == expected
 
+    @pytest.mark.parametrize("timed_out", [False, True], ids=["finished", "timed_out"])
     @pytest.mark.parametrize(
         ("run_type", "expected"),
         [
@@ -5601,19 +5602,26 @@ class TestSchedulerJob:
             (DagRunType.SCHEDULED, True),
             (DagRunType.BACKFILL_JOB, False),
             (DagRunType.ASSET_TRIGGERED, True),
+            (DagRunType.OPERATOR_TRIGGERED, True),
+            (DagRunType.ASSET_MATERIALIZATION, True),
         ],
         ids=[
             DagRunType.MANUAL.name,
             DagRunType.SCHEDULED.name,
             DagRunType.BACKFILL_JOB.name,
             DagRunType.ASSET_TRIGGERED.name,
+            DagRunType.OPERATOR_TRIGGERED.name,
+            DagRunType.ASSET_MATERIALIZATION.name,
         ],
     )
-    def test_should_update_dag_next_dagruns_after_run_type(self, run_type, expected, session, dag_maker):
+    def test_should_update_dag_next_dagruns_after_run_type(
+        self, run_type, expected, timed_out, session, dag_maker
+    ):
         """Test that whether next dag run is updated depends on run type"""
         with dag_maker(
             schedule="*/1 * * * *",
             max_active_runs=3,
+            dagrun_timeout=datetime.timedelta(seconds=60),
         ):
             EmptyOperator(task_id="dummy")
 
@@ -5621,7 +5629,7 @@ class TestSchedulerJob:
             run_id="run",
             run_type=run_type,
             logical_date=DEFAULT_DATE,
-            start_date=timezone.utcnow(),
+            start_date=timezone.utcnow() - datetime.timedelta(days=1) if timed_out else timezone.utcnow(),
             state=State.SUCCESS,
             session=session,
         )


### PR DESCRIPTION
## Why

- The scheduler recomputes `DagModel.exceeds_max_non_backfill` when a Dag run finishes, but only for `scheduled`, `manual` and `asset_triggered` runs.
- `asset_materialization` (#62276) and `operator_triggered` (#63733) came after #60006 introduced that list, and were never added to it.
- When one of these runs is the last active run of a Dag at its `max_active_runs` limit, the flag stays `True` after the run finishes. The scheduler skips the Dag until the Dag processor parses the file again, so scheduled and asset-triggered runs start late.

## How

- Recompute the flag for every finished run except backfill runs, which matches what the flag counts.

## Verification

- Unit test: `breeze run pytest airflow-core/tests/unit/jobs/test_scheduler_job.py`
- Integration test:

1. Setup

```sh
mkdir -p files/dags
cat > files/dags/demo_dags.py <<'EOF'
from __future__ import annotations

import datetime

from airflow.providers.standard.operators.bash import BashOperator
from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunOperator
from airflow.sdk import DAG

START = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)

with DAG(dag_id="demo_child", schedule="* * * * *", start_date=START, catchup=False, max_active_runs=1):
    BashOperator(task_id="work", bash_command="sleep 60")

with DAG(dag_id="demo_parent", schedule=None, start_date=START, catchup=False):
    TriggerDagRunOperator(
        task_id="trigger_child",
        trigger_dag_id="demo_child",
        trigger_run_id="triggered_by_parent",
    )
EOF
```

2. Start Airflow

```sh
breeze shell --backend sqlite
```

```sh
export AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=sqlite:////tmp/demo.db
export AIRFLOW__CORE__LOAD_EXAMPLES=False
export AIRFLOW__DAG_PROCESSOR__MIN_FILE_PROCESS_INTERVAL=600
airflow standalone > /tmp/standalone.log 2>&1 &
```

3. Trigger Dag

```
airflow dags list
airflow dags unpause demo_parent
airflow dags unpause demo_child
```

Run this until a `scheduled__...` run is `running`:

```bash
airflow dags list-runs demo_child
```

Trigger `demo_parent`. Its run of `demo_child` queues behind the running scheduled run.

```bash
airflow dags trigger demo_parent
```

On main branch, after `triggered_by_parent` is `success`, the next run is not scheduled on the next minute. The scheduler skips `demo_child` until the Dag processor parses the file again.

```text
dag_id     | run_id                 | state   | run_after             | logical_date           | start_date            | end_date
===========+========================+=========+=======================+========================+=======================+========================
demo_child | scheduled__2026-09-12T | success | 2026-09-12T11:35:00+0 | 2026-09-12T11:35:00+00 | 2026-09-12T11:35:42.6 | 2026-09-12T11:36:43.762
           | 11:35:00+00:00         |         | 0:00                  | :00                    | 14960+00:00           | 543+00:00
demo_child | triggered_by_parent    | success | 2026-09-12T11:26:17.9 | 2026-09-12T11:26:17.76 | 2026-09-12T11:27:02.6 | 2026-09-12T11:28:03.737
           |                        |         | 12138+00:00           | 8602+00:00             | 28857+00:00           | 794+00:00
demo_child | scheduled__2026-09-12T | success | 2026-09-12T11:25:00+0 | 2026-09-12T11:25:00+00 | 2026-09-12T11:25:58.5 | 2026-09-12T11:27:01.604
           | 11:25:00+00:00         |         | 0:00                  | :00                    | 15063+00:00           | 410+00:00
```

On this branch, the next run is scheduled as expected.

```text
dag_id     | run_id                 | state   | run_after             | logical_date           | start_date            | end_date
===========+========================+=========+=======================+========================+=======================+========================
demo_child | scheduled__2026-09-12T | success | 2026-09-12T12:17:00+0 | 2026-09-12T12:17:00+00 | 2026-09-12T12:18:17.1 | 2026-09-12T12:19:18.314
           | 12:17:00+00:00         |         | 0:00                  | :00                    | 51901+00:00           | 029+00:00
demo_child | triggered_by_parent    | success | 2026-09-12T12:16:44.2 | 2026-09-12T12:16:44.10 | 2026-09-12T12:17:14.9 | 2026-09-12T12:18:16.125
           |                        |         | 88514+00:00           | 9705+00:00             | 91149+00:00           | 626+00:00
demo_child | scheduled__2026-09-12T | success | 2026-09-12T12:16:00+0 | 2026-09-12T12:16:00+00 | 2026-09-12T12:16:11.0 | 2026-09-12T12:17:13.975
           | 12:16:00+00:00         |         | 0:00                  | :00                    | 11254+00:00           | 608+00:00
```
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
