### PR TITLE
Speed up airflow dags list on deployments with many Dags

### DIFF
--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -31,6 +31,7 @@ import sys
 from typing import TYPE_CHECKING, cast
 
 from sqlalchemy import func, select
+from sqlalchemy.orm import selectinload
 
 from airflow._shared.timezones import timezone
 from airflow.api.client import get_current_api_client
@@ -78,6 +79,9 @@ log = logging.getLogger(__name__)
 
 # Chunk size for bulk delete.
 _RUN_CHUNK_SIZE = 500
+
+# Chunk size for looking up Dags by id.
+_DAG_CHUNK_SIZE = 500
 
 
 @deprecated_for_airflowctl("airflowctl dags trigger")
@@ -595,15 +599,6 @@ def dag_list_dags(args, *, session: Session = NEW_SESSION) -> None:
             file=sys.stderr,
         )
 
-    def get_dag_detail(dag: DAG) -> dict:
-        if dag_model := DagModel.get_dagmodel(dag.dag_id, session=session):
-            dag_detail = DAGResponse.model_validate(dag_model, from_attributes=True).model_dump()
-        else:
-            dag_detail = _get_dagbag_dag_details(dag)
-        if not cols:
-            return dag_detail
-        return {col: dag_detail[col] for col in cols if col in DAG_DETAIL_FIELDS}
-
     def filter_dags_by_bundle(dags: Iterable[DAG], bundle_names: list[str] | None) -> Iterable[DAG]:
         """Filter DAGs based on the specified bundle name, if provided."""
         if not bundle_names:
@@ -615,11 +610,32 @@ def dag_list_dags(args, *, session: Session = NEW_SESSION) -> None:
         )
         return (dag for dag in dags if dag.dag_id in selected_dag_ids)
 
+    dags_to_show = sorted(
+        filter_dags_by_bundle(dags_list, args.bundle_name if not args.local else None),
+        key=operator.attrgetter("dag_id"),
+    )
+    # Chunked so the IN clause stays under the backend's bind parameter cap on deployments
+    # with many Dags (SQLite allows 32766, PostgreSQL 65535).
+    dag_models: dict[str, DagModel] = {}
+    for dag_id_chunk in chunks([dag.dag_id for dag in dags_to_show], _DAG_CHUNK_SIZE):
+        dag_models.update(
+            (dag_model.dag_id, dag_model)
+            for dag_model in session.scalars(
+                select(DagModel).options(selectinload(DagModel.tags)).where(DagModel.dag_id.in_(dag_id_chunk))
+            )
+        )
+
+    def get_dag_detail(dag: DAG) -> dict:
+        if dag_model := dag_models.get(dag.dag_id):
+            dag_detail = DAGResponse.model_validate(dag_model, from_attributes=True).model_dump()
+        else:
+            dag_detail = _get_dagbag_dag_details(dag)
+        if not cols:
+            return dag_detail
+        return {col: dag_detail[col] for col in cols if col in DAG_DETAIL_FIELDS}
+
     AirflowConsole().print_as(
-        data=sorted(
-            filter_dags_by_bundle(dags_list, args.bundle_name if not args.local else None),
-            key=operator.attrgetter("dag_id"),
-        ),
+        data=dags_to_show,
         output=args.output,
         mapper=get_dag_detail,
     )

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -55,6 +55,7 @@ from airflow.utils.session import create_session
 from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.types import DagRunType
 
+from tests_common.test_utils.asserts import count_queries
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.db import (
@@ -63,6 +64,7 @@ from tests_common.test_utils.db import (
     clear_db_runs,
     parse_and_sync_to_db,
 )
+from tests_common.test_utils.stream_capture_manager import StdoutCaptureManager
 from unit.models import TEST_DAGS_FOLDER
 
 DEFAULT_DATE = timezone.make_aware(datetime(2015, 1, 1), timezone=timezone.utc)
@@ -379,6 +381,48 @@ class TestCliDags:
         with stdout_capture as temp_stdout:
             dag_command.dag_list_dags(args)
             assert json.loads(temp_stdout.getvalue()) == [{"dag_id": "test_dag_versions"}]
+
+        # Rebuild Test DB for other tests
+        self.setup_class()
+
+    def test_cli_list_dags_does_not_query_per_dag(self):
+        def count_list_dags_queries(dag_count: int) -> int:
+            clear_db_dags()
+            for i in range(dag_count):
+                with DAG(
+                    f"test_query_count_{i}", schedule=None, start_date=DEFAULT_DATE, tags=["a", "b"]
+                ) as dag:
+                    EmptyOperator(task_id="task1")
+                sync_dag_to_db(dag)
+
+            args = self.parser.parse_args(["dags", "list", "--output", "json"])
+            with count_queries() as result, StdoutCaptureManager() as temp_stdout:
+                dag_command.dag_list_dags(args)
+            assert len(json.loads(temp_stdout.getvalue())) == dag_count
+            return sum(result.values())
+
+        assert count_list_dags_queries(2) == count_list_dags_queries(6)
+
+        # Rebuild Test DB for other tests
+        self.setup_class()
+
+    @mock.patch("airflow.cli.commands.dag_command._DAG_CHUNK_SIZE", 2)
+    def test_cli_list_dags_lists_every_dag_when_lookup_is_chunked(self, stdout_capture):
+        clear_db_dags()
+        for i in range(5):
+            with DAG(f"test_chunked_{i}", schedule=None, start_date=DEFAULT_DATE) as dag:
+                EmptyOperator(task_id="task1")
+            sync_dag_to_db(dag)
+
+        args = self.parser.parse_args(["dags", "list", "--columns", "dag_id,is_paused", "--output", "json"])
+        with stdout_capture as temp_stdout:
+            dag_command.dag_list_dags(args)
+
+        rows = json.loads(temp_stdout.getvalue())
+        assert [row["dag_id"] for row in rows] == [f"test_chunked_{i}" for i in range(5)]
+        # Only DagModel carries is_paused; the dagbag fallback leaves it None, so this catches a
+        # chunked lookup that drops Dags from the prefetch map.
+        assert all(row["is_paused"] is not None for row in rows)
 
         # Rebuild Test DB for other tests
         self.setup_class()


### PR DESCRIPTION
## Why

`airflow dags list` issued two extra queries for every Dag it printed. `get_dag_detail` is
passed to `AirflowConsole.print_as` as the row mapper, so it runs once per Dag, and each call
did a `DagModel.get_dagmodel()` lookup plus a lazy load of `DagModel.tags` when `DAGResponse`
serialised the row.

The command therefore cost `2N` round trips on a deployment with `N` Dags — measured at 24
queries for 2 Dags and 32 for 6, i.e. exactly two per Dag — which is worst on the installations
where listing Dags is least convenient to do any other way.

## What

`dag_list_dags` in `airflow-core/src/airflow/cli/commands/dag_command.py` now materialises the
sorted, bundle-filtered Dag list first and prefetches the matching `DagModel` rows into a dict
keyed by `dag_id`, with `selectinload(DagModel.tags)` covering the second lazy load. The mapper
reads from that dict; the dagbag fallback for Dags absent from the `dag` table is unchanged, and
so is the command's output.

The prefetch is chunked at 500 ids using the `chunks()` helper already used in this file for
`_RUN_CHUNK_SIZE`. A single unchunked `IN` would exceed the backend bind parameter cap
(SQLite 32766, PostgreSQL 65535) and fail outright on very large installations, which the
per-Dag lookup never did.

Two tests in `airflow-core/tests/unit/cli/commands/test_dag_command.py`:
`test_cli_list_dags_does_not_query_per_dag` asserts the query count is the same for 2 and 6 Dags,
and `test_cli_list_dags_lists_every_dag_when_lookup_is_chunked` patches the chunk size to 2 and
checks every Dag still comes back with a non-null `is_paused` — a column only the prefetched
`DagModel` can supply, so it fails if chunking drops rows.
