### PR TITLE
Report the missing secret id when Google get_secret raises NotFound

### DIFF
--- a/providers/google/src/airflow/providers/google/common/utils/get_secret.py
+++ b/providers/google/src/airflow/providers/google/common/utils/get_secret.py
@@ -28,4 +28,5 @@ def get_secret(secret_id: str) -> str:
     hook = GoogleCloudSecretManagerHook()
     if hook.secret_exists(secret_id=secret_id):
         return hook.access_secret(secret_id=secret_id).payload.data.decode()
-    raise NotFound("The secret '%s' not found", secret_id)
+    msg = f"The secret '{secret_id}' not found"
+    raise NotFound(msg)

--- a/providers/google/tests/system/google/ads/example_ads.py
+++ b/providers/google/tests/system/google/ads/example_ads.py
@@ -38,8 +38,6 @@ import logging
 import os
 from datetime import datetime
 
-from google.cloud.exceptions import NotFound
-
 try:
     from airflow.sdk import task
 except ImportError:
@@ -48,8 +46,8 @@ except ImportError:
 from airflow.models.dag import DAG
 from airflow.providers.google.ads.operators.ads import GoogleAdsListAccountsOperator
 from airflow.providers.google.ads.transfers.ads_to_gcs import GoogleAdsToGcsOperator
-from airflow.providers.google.cloud.hooks.secret_manager import GoogleCloudSecretManagerHook
 from airflow.providers.google.cloud.operators.gcs import GCSCreateBucketOperator, GCSDeleteBucketOperator
+from airflow.providers.google.common.utils.get_secret import get_secret
 
 try:
     from airflow.sdk import TriggerRule
@@ -112,13 +110,6 @@ FIELDS_TO_EXTRACT = [
 # [END howto_google_ads_env_variables]
 
 log = logging.getLogger(__name__)
-
-
-def get_secret(secret_id: str) -> str:
-    hook = GoogleCloudSecretManagerHook()
-    if hook.secret_exists(secret_id=secret_id):
-        return hook.access_secret(secret_id=secret_id).payload.data.decode()
-    raise NotFound("The secret '%s' not found", secret_id)
 
 
 with DAG(

--- a/providers/google/tests/unit/google/common/utils/test_get_secret.py
+++ b/providers/google/tests/unit/google/common/utils/test_get_secret.py
@@ -58,7 +58,7 @@ class TestGetSecret:
 
         secret_id = "non-existent-secret"
 
-        with pytest.raises(NotFound):
+        with pytest.raises(NotFound, match=f"The secret '{secret_id}' not found"):
             get_secret(secret_id=secret_id)
 
         mock_hook_class.assert_called_once()


### PR DESCRIPTION
## Summary

`get_secret` passed the secret id as a second positional argument to `NotFound`. That argument is `errors`, not a format argument — `google.api_core` renders only the status code and `message`, and silently drops `errors` entries that do not expose `.code` and `.message`.

So the placeholder was never filled and the id never surfaced anywhere:

```
404 The secret '%s' not found
```

Which secret is missing is the only detail that makes the error actionable.

## Change

- Interpolate `secret_id` into the message.
- Point `example_ads.py` at the shared helper rather than its own copy, which carried the same bug.
- Tighten the existing not-found test with `match=`, which the old message fails.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
