### PR TITLE
Stop defaulting PsrpOperator task_id to cmdlet

### DIFF
--- a/providers/microsoft/psrp/docs/changelog.rst
+++ b/providers/microsoft/psrp/docs/changelog.rst
@@ -27,6 +27,17 @@
 Changelog
 ---------
 
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+* ``Stop defaulting PsrpOperator task_id to cmdlet``
+
+  ``PsrpOperator`` no longer uses ``cmdlet`` as the default ``task_id``; ``task_id`` is now required, as
+  on every other operator. ``cmdlet`` is a template field rendered after the constructor runs, so the
+  default read the un-rendered value. To keep the existing task identity (history, logs, XComs), pass
+  ``task_id`` explicitly with the same value as ``cmdlet``, for example
+  ``PsrpOperator(task_id="Get-Process", cmdlet="Get-Process", psrp_conn_id="psrp_default")``.
+
 3.2.7
 .....
 

--- a/providers/microsoft/psrp/src/airflow/providers/microsoft/psrp/operators/psrp.py
+++ b/providers/microsoft/psrp/src/airflow/providers/microsoft/psrp/operators/psrp.py
@@ -55,9 +55,7 @@ class PsrpOperator(BaseOperator):
     :param psrp_conn_id: connection id
     :param command: command to execute on remote host. (templated)
     :param powershell: powershell to execute on remote host. (templated)
-    :param cmdlet:
-        cmdlet to execute on remote host (templated). Also used as the default
-        value for `task_id`.
+    :param cmdlet: cmdlet to execute on remote host (templated).
     :param arguments:
         When using the `cmdlet` or `powershell` option, use `arguments` to
         provide arguments (templated).
@@ -112,8 +110,6 @@ class PsrpOperator(BaseOperator):
             raise ValueError("Arguments only allowed with 'powershell' or 'cmdlet'")
         if parameters is not None and powershell is None and cmdlet is None:
             raise ValueError("Parameters only allowed with 'powershell' or 'cmdlet'")
-        if cmdlet:
-            kwargs.setdefault("task_id", cmdlet)
         super().__init__(**kwargs)
         self.conn_id = psrp_conn_id
         self.command = command

--- a/providers/microsoft/psrp/tests/unit/microsoft/psrp/operators/test_psrp.py
+++ b/providers/microsoft/psrp/tests/unit/microsoft/psrp/operators/test_psrp.py
@@ -68,9 +68,9 @@ class TestPsrpOperator:
     def test_empty_option_counts_as_provided(self, kwargs):
         PsrpOperator(task_id="test_task_id", psrp_conn_id=CONNECTION_ID, **kwargs)
 
-    def test_cmdlet_task_id_default(self):
-        operator = PsrpOperator(cmdlet="Invoke-Foo", psrp_conn_id=CONNECTION_ID)
-        assert operator.task_id == "Invoke-Foo"
+    def test_cmdlet_requires_explicit_task_id(self):
+        with pytest.raises(TypeError, match="task_id"):
+            PsrpOperator(cmdlet="Invoke-Foo", psrp_conn_id=CONNECTION_ID)
 
     @patch(f"{PsrpOperator.__module__}.PsrpHook")
     def test_command_rendering_to_empty_dispatches_as_command(self, hook_impl):
@@ -152,14 +152,14 @@ class TestPsrpOperator:
         assert ps.mock_calls == expected_ps_calls
 
     def test_securestring_sandboxed(self):
-        op = PsrpOperator(psrp_conn_id=CONNECTION_ID, cmdlet="test")
+        op = PsrpOperator(task_id="test", psrp_conn_id=CONNECTION_ID, cmdlet="test")
         template = op.get_template_env().from_string("{{ 'foo' | securestring }}")
         with pytest.raises(AirflowException):
             template.render()
 
     @patch.object(BaseOperator, "get_template_env")
     def test_securestring_native(self, get_template_env):
-        op = PsrpOperator(psrp_conn_id=CONNECTION_ID, cmdlet="test")
+        op = PsrpOperator(task_id="test", psrp_conn_id=CONNECTION_ID, cmdlet="test")
         get_template_env.return_value = NativeEnvironment()
         template = op.get_template_env().from_string("{{ 'foo' | securestring }}")
         rendered = template.render()

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -16,4 +16,3 @@ providers/google/src/airflow/providers/google/cloud/operators/functions.py::Clou
 providers/google/src/airflow/providers/google/cloud/operators/gcs.py::GCSFileTransformOperator
 providers/google/src/airflow/providers/google/cloud/sensors/bigquery_dts.py::BigQueryDataTransferServiceTransferRunSensor
 providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py::CloudComposerExternalTaskSensor
-providers/microsoft/psrp/src/airflow/providers/microsoft/psrp/operators/psrp.py::PsrpOperator


### PR DESCRIPTION
related: #70296

## Human Summary
This completes the template field handling within the PsrpOperator so we'll be able to remove it from the burn-down list.
The problem here is that that when `cmldet` is rendered, then the default read will become the un-rendered Jinja value within `task_id`.
I'm concerned that slow deprecation in this case will be less visible than break (it will appear in the logs, but not in the UI) - so I'd rather go with hard removal and a breaking change to get done with it.
I've added a changelog note that explains what should be changed (adjustment should be simple).

## AI Summary
<details><summary>Click here</summary>
`PsrpOperator` no longer derives `task_id` from `cmdlet`; `task_id` is now required, as on every other operator.

`cmdlet` is a template field, rendered after the constructor runs, so the default read the un-rendered Jinja value. It was the last construction-time read keeping `PsrpOperator` in `validate_operators_init_exemptions.txt`, and it cannot move to `execute()` because `task_id` must exist before `BaseOperator.__init__`. #70347 deliberately kept the default because dropping it changes task identity for Dags that relied on it, and deferred the removal to a separate change; this is that follow-up.

This is a breaking change for Dags that omitted `task_id` when using `cmdlet`. Those Dags now fail at import with a missing `task_id` error, and keep their existing task identity by passing `task_id` explicitly with the cmdlet name. A note is added under the changelog header so the release manager cuts a major version.
</details>

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5.1)

Generated-by: Claude Code (Fable 5.1) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)