### PR TITLE
Keep the Python 3.14 patchlevel pin up to date

### DIFF
--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -905,7 +905,7 @@ ALL_PYTHON_VERSION_TO_PATCHLEVEL_VERSION: dict[str, str] = {
     "3.11": "3.11.16",
     "3.12": "3.12.14",
     "3.13": "3.13.15",
-    "3.14": "3.14.3",
+    "3.14": "3.14.7",
 }
 
 # Number of slices for low dep tests

--- a/scripts/ci/prek/upgrade_important_versions.py
+++ b/scripts/ci/prek/upgrade_important_versions.py
@@ -46,6 +46,7 @@ from common_prek_utils import (
     AIRFLOW_CORE_ROOT_PATH,
     AIRFLOW_ROOT_PATH,
     console,
+    read_allowed_python_major_minor_versions,
     read_default_python_major_minor_version_for_images,
     retrieve_gh_token,
 )
@@ -769,7 +770,10 @@ UPGRADE_PROTOC: bool = get_env_bool("UPGRADE_PROTOC")
 UPGRADE_OPENAPI_GENERATOR: bool = get_env_bool("UPGRADE_OPENAPI_GENERATOR")
 UPGRADE_SPHINX_AIRFLOW_THEME: bool = get_env_bool("UPGRADE_SPHINX_AIRFLOW_THEME")
 
-ALL_PYTHON_MAJOR_MINOR_VERSIONS = ["3.10", "3.11", "3.12", "3.13"]
+# Read from global_constants.py rather than repeating the list here. A hard-coded copy silently
+# stops upgrading the versions it does not know about: 3.14 was added to Airflow in March 2026 and
+# its pinned patchlevel was never bumped afterwards, because this list still ended at 3.13.
+ALL_PYTHON_MAJOR_MINOR_VERSIONS = read_allowed_python_major_minor_versions()
 DEFAULT_PROD_IMAGE_PYTHON_VERSION = read_default_python_major_minor_version_for_images()
 
 


### PR DESCRIPTION
`scripts/ci/prek/upgrade_important_versions.py` kept its own hard-coded list of the Python major/minor
versions it maintains:

```python
ALL_PYTHON_MAJOR_MINOR_VERSIONS = ["3.10", "3.11", "3.12", "3.13"]
```

while `global_constants.py` has had all five since Python 3.14 was added in #63520 (March 2026). That PR
added `"3.14": "3.14.3"` to `ALL_PYTHON_VERSION_TO_PATCHLEVEL_VERSION` but did not touch this list, so the
bumper has never once looked at 3.14 — the pin has been frozen at `3.14.3` for roughly six months while
3.10 through 3.13 kept moving.

The list now comes from `global_constants.py` through the existing
`read_allowed_python_major_minor_versions()` helper, which the same module already uses for
`DEFAULT_PYTHON_MAJOR_MINOR_VERSION_FOR_IMAGES` — so the duplication had no reason to exist, and the next
Python version added to Airflow is picked up automatically rather than needing a second edit nobody
remembers to make.

The stale pin is corrected in the same change: `3.14.3` → `3.14.7`, which is the latest 3.14 on
python.org.

##### Verification

* `read_allowed_python_major_minor_versions()` returns `['3.10', '3.11', '3.12', '3.13', '3.14']`.
* `ruff check` clean on both files.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DcRW9x8n7Jor7ftsKFxQHD
