### PR TITLE
Restore static checks on v3-3-test

### DIFF
--- a/.github/workflows/publish-docs-to-s3.yml
+++ b/.github/workflows/publish-docs-to-s3.yml
@@ -88,7 +88,7 @@ jobs:
       AIRFLOW_VERSION: ${{ inputs.airflow-version || '' }}
       APPLY_COMMITS: ${{ inputs.apply-commits || '' }}
     outputs:
-      include-docs: ${{ inputs.include-docs == 'all' && '' || inputs.include-docs }}
+      include-docs: ${{ case(inputs.include-docs == 'all', '', inputs.include-docs) }}
       destination-location: ${{ steps.parameters.outputs.destination-location }}
       destination: ${{ steps.parameters.outputs.destination }}
       extra-build-options: ${{ steps.parameters.outputs.extra-build-options }}

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -142,8 +142,8 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.job-timeout-minutes) }}
     # yamllint disable rule:line-length
     name: "\
-      ${{ inputs.test-scope == 'All' && '' || inputs.test-scope == 'Quarantined' && 'Qrnt' || inputs.test-scope }}\
-      ${{ inputs.test-scope == 'All' && '' || '-' }}\
+      ${{ case(inputs.test-scope == 'Quarantined', 'Qrnt', inputs.test-scope == 'All', '', inputs.test-scope) }}\
+      ${{ case(inputs.test-scope == 'All', '', '-') }}\
       ${{ inputs.test-group == 'providers' && 'prov' || inputs.test-group}}:\
       ${{ inputs.test-name }}${{ inputs.test-name-separator }}${{ matrix.backend-version }}:\
       ${{ matrix.python-version}}:${{ matrix.test-types.description }}"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -19,3 +19,21 @@
 rules:
   secrets-outside-env:
     disable: true
+  # This audit wants every in-repo `uses: ./...` rewritten to GitHub's
+  # self-repository form (`uses: $/...`). Two things outside this repository's
+  # control block that, and both were confirmed by pushing the conversion:
+  #
+  #  * `$/` makes the runner fetch apache/airflow as an action repository, and
+  #    that download cannot materialise the symlinks this repository commits --
+  #    it aborts on `.claude/skills/airflow-translations`, whose target is not
+  #    tracked, before any job runs.
+  #  * ASF infrastructure's allowlist check does not recognise the syntax and
+  #    reports every `$/...` reference as an action missing from the allowlist.
+  #
+  # The audit's own threat model -- a privileged workflow loading a local action
+  # out of a checkout untrusted code could have altered first -- does not reach
+  # us either, since no Airflow workflow runs on `pull_request_target` or
+  # `workflow_run`. Revisit if the symlinks go away and ASF Infra teaches the
+  # allowlist about `$/`.
+  self-repository:
+    disable: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -596,6 +596,10 @@ extend-exclude = [
 [tool.ruff.lint]
 typing-modules = ["airflow.typing_compat"]
 external = ["MIG"]
+# Pin the base rule set instead of inheriting Ruff's default, which Ruff changes
+# between releases (0.16 widened it from ~250 to ~510 rules). Everything Airflow
+# actually opts into lives in extend-select below.
+select = ["E4", "E7", "E9", "F"]
 extend-select = [
     # Enable entire ruff rule section
     "I", # Missing required import (auto-fixable)
@@ -704,6 +708,13 @@ ignore = [
     "COM812",
     "COM819",
     "E501", # Formatted code may exceed the line length, leading to line-too-long (E501) errors.
+    # New in Ruff 0.16, inside sections Airflow selects wholesale. Deferred so a tooling
+    # bump does not also carry semantic changes; both need per-site judgement.
+    "ISC004", # Implicit string concat in a collection literal; 109 sites, unsafe autofix
+    # LOG004 is not a mechanical replacement: switching to `.error()` where an exception is
+    # in flight silently drops the traceback, while leaving `.exception()` where none is
+    # only prints a bare `NoneType: None`. Review already caught one bad guess in 13.
+    "LOG004", # `.exception()` outside an exception handler; 13 sites
 ]
 unfixable = [
     # PT022 replace empty `yield` to empty `return`. Might be fixed with a combination of PLR1711

--- a/shared/plugins_manager/src/airflow_shared/plugins_manager/plugins_manager.py
+++ b/shared/plugins_manager/src/airflow_shared/plugins_manager/plugins_manager.py
@@ -28,7 +28,7 @@ import os
 import sys
 import types
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     if sys.version_info >= (3, 12):
@@ -177,7 +177,9 @@ def is_valid_plugin(plugin_obj) -> bool:
     )
 
     if is_airflow_plugin and plugin_obj.__name__ != "AirflowPlugin":
-        plugin_obj.validate()
+        # The MRO check above establishes this by name; `inspect.isclass` only narrows to
+        # `type[object]`, which does not carry `validate`.
+        cast("type[AirflowPlugin]", plugin_obj).validate()
         return True
     return False
 

--- a/task-sdk/src/airflow/sdk/execution_time/schema/AGENTS.md
+++ b/task-sdk/src/airflow/sdk/execution_time/schema/AGENTS.md
@@ -83,11 +83,14 @@ head shape *is* the schema for the new body.
        )
    ```
 
-3. Reference the new `VersionChange` from the bundle in
-   `versions/__init__.py`:
+3. Reference the new `VersionChange` from the bundle returned by
+   `get_bundle()` in `versions/__init__.py`:
 
    ```python
-   Version("2026-06-16", AddRetryDelay, AddSentryTraceField),
+   return VersionBundle(
+       HeadVersion(),
+       Version("2026-06-16", AddRetryDelay, AddSentryTraceField),
+   )
    ```
 
 4. The `generate-supervisor-schemas-snapshot` prek hook will


### PR DESCRIPTION
Static checks have been red on this branch since #73042 upgraded the CI environment. That bump brought
ruff 0.15.17 → 0.16.6 and zizmor → 1.30.0, but not the changes `main` made alongside those upgrades, so
every `prek --all-files` run since fails. It surfaces on the release sync PR (#72946), whose "CI image
checks / Static checks" job runs `prek --all-files`:

| Hook | CI result |
| --- | --- |
| `ruff` | 6278 errors (915 fixed, 5363 remaining) |
| `ruff-format` | 103 files reformatted |
| `mypy-devel-common` | 14 errors |
| `mypy-shared-plugins_manager` | 1 error |
| `zizmor` | exit 12 |

Four of those five have a single cause.

##### Ruff's default rule set

Ruff 0.16 widened its default rule set from roughly 250 to 510 rules. #70725 pinned the base set on `main`
precisely so that a tooling bump cannot quietly enable rules nobody opted into, and was never backported
here. Without the pin ruff reports 6278 violations, and two other hooks fail as a consequence rather than
on their own merits:

* `ruff --fix` rewrites `setattr(module, "attr", value)` to `module.attr = value` under B010. That is what
  `mypy-devel-common`'s 14 `Module has no attribute` errors are - mypy is reading code ruff rewrote
  moments earlier, not code in the repository.
* Reformatting those 915 rewrites is what makes `ruff-format` report 103 files. With the rule set pinned,
  ruff changes nothing and one genuine file remains, fixed here by taking `main`'s rewrite of the snippet
  in `schema/AGENTS.md` - a bare `Version(...),` is a tuple to the 0.16 formatter, which parenthesises it.

##### Zizmor 1.30 audits

* `self-repository` wants every `uses: ./...` rewritten to `uses: $/...`. `main` disables it with a
  documented rationale: `$/` makes the runner fetch the repository as an action and that download cannot
  materialise this repository's committed symlinks, and ASF infrastructure's allowlist check does not
  recognise the syntax. The config block is copied verbatim.
* `unsound-ternary` points at a real bug rather than a style preference: `x == 'All' && '' || y` never
  evaluates to the empty string, because `''` is falsy and the expression falls through to `y`. `main`
  already rewrote these three sites with `case()`, which is what this backports.

##### The one genuine type error

`shared/plugins_manager`'s `plugin_obj.validate()` fails because `inspect.isclass` narrows only to
`type[object]`. `main` carries the `cast` and the comment explaining why the preceding MRO check makes it
sound; that is backported unchanged.

##### Verification

All five hooks pass locally after the change, and nothing else is modified by running them:

```
Run 'ruff' for extremely fast Python linting..............................Passed
Run 'ruff format'.........................................................Passed
Run zizmor to check for github workflow syntax errors.....................Passed
Run mypy for devel-common.................................................Passed
Run mypy for shared-plugins_manager.......................................Passed
```

Note the two mypy hooks run against the CI image in CI and a local virtualenv outside it, so their local
pass is weaker evidence than the other three. The `shared-plugins_manager` fix is a `cast`, which does not
depend on the environment, and `devel-common` was only ever failing on ruff-rewritten code.

##### Follow-up

`main` and `v3-3-test` having drifted on lint configuration is what let this through: the version bumper
upgraded the tools on both branches, but the accompanying fixes only ever landed on one. Worth considering
whether those bumps should be blocked on an `--all-files` run of the branch they target.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DcRW9x8n7Jor7ftsKFxQHD
