### PR TITLE
Fix `DocumentLoaderOperator` validation errors naming the wrong argument

### DIFF
--- a/providers/common/ai/src/airflow/providers/common/ai/operators/document_loader.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/document_loader.py
@@ -76,9 +76,11 @@ class DocumentLoaderOperator(BaseOperator):
         ``google_cloud_default``, ...). Ignored for local paths.
     :param source_bytes: Raw file bytes, typically from XCom.
     :param file_type: File extension hint (e.g. ``".pdf"``). Required when
-        using ``source_bytes``, since bytes carry no extension to detect --
-        omitting it is a Dag-parse-time error. Optional with ``source_path``,
-        where it overrides auto-detection.
+        using ``source_bytes``, since bytes carry no extension to detect.
+        Omitting it is rejected when the operator is constructed -- Dag parse
+        time for a regular task, run time for a mapped one, since ``expand()``
+        validates argument names only and defers construction to ``unmap()``.
+        Optional with ``source_path``, where it overrides auto-detection.
     :param parser: Parsing backend selection. ``"auto"`` (default) picks the
         backend from the file extension.
     :param file_extensions: When ``source_path`` is a directory or glob,

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/document_loader.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/document_loader.py
@@ -75,9 +75,10 @@ class DocumentLoaderOperator(BaseOperator):
         ``ObjectStoragePath`` for cloud URIs (``aws_default``,
         ``google_cloud_default``, ...). Ignored for local paths.
     :param source_bytes: Raw file bytes, typically from XCom.
-    :param file_type: File extension hint when using ``source_bytes``
-        (e.g. ``".pdf"``). Also accepted with ``source_path`` to override
-        auto-detection.
+    :param file_type: File extension hint (e.g. ``".pdf"``). Required when
+        using ``source_bytes``, since bytes carry no extension to detect --
+        omitting it is a Dag-parse-time error. Optional with ``source_path``,
+        where it overrides auto-detection.
     :param parser: Parsing backend selection. ``"auto"`` (default) picks the
         backend from the file extension.
     :param file_extensions: When ``source_path`` is a directory or glob,
@@ -140,6 +141,8 @@ class DocumentLoaderOperator(BaseOperator):
             raise ValueError("Provide exactly one of 'source_path' or 'source_bytes', not both.")
         if source_path is None and source_bytes is None:
             raise ValueError("Provide exactly one of 'source_path' or 'source_bytes'.")
+        if source_bytes is not None and file_type is None:
+            raise ValueError("'file_type' is required when using 'source_bytes' (e.g. '.pdf').")
         self.source_path = source_path
         self.source_conn_id = source_conn_id
         self.source_bytes = source_bytes
@@ -152,15 +155,21 @@ class DocumentLoaderOperator(BaseOperator):
         self.json_text_field = json_text_field
 
     def execute(self, context: Context) -> list[dict[str, Any]]:
-        # file_type and source_path can each be *supplied* (as non-None argument) yet still
-        # render to None. These aren't provision checks (that already happened in __init__);
-        # they guard the rendered value itself, since _parse_bytes/_resolve_files need a real
-        # value to work with. Checking this in __init__ would validate the unrendered template
-        # string instead of the value actually used here.
+        # Provision -- whether an argument was supplied at all -- is settled in __init__.
+        # Both guards below exist for a different reason: file_type and source_path are
+        # template fields, so a supplied argument can still arrive here as None once it has
+        # been rendered. __init__ cannot catch that, because it only ever sees the unrendered
+        # template string; _parse_bytes and _resolve_files need the rendered value to be real.
         if self.source_bytes is not None and self.file_type is None:
-            raise ValueError("'file_type' is required when using 'source_bytes' (e.g. '.pdf').")
+            raise ValueError(
+                "'file_type' was supplied but rendered to None. Check the template or the "
+                "upstream XCom value it resolves from."
+            )
         if self.source_bytes is None and self.source_path is None:
-            raise ValueError("Provide exactly one of 'source_path' or 'source_bytes'.")
+            raise ValueError(
+                "'source_path' was supplied but rendered to None. Check the template or the "
+                "upstream XCom value it resolves from."
+            )
 
         if self.source_bytes is not None:
             if TYPE_CHECKING:

--- a/providers/common/ai/tests/unit/common/ai/operators/test_document_loader.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_document_loader.py
@@ -23,28 +23,26 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from airflow.providers.common.ai.operators.document_loader import DocumentLoaderOperator
+from airflow.sdk import DAG
 
 
 class TestDocumentLoaderInit:
     def test_template_fields_render_source_path_and_metadata(self):
-        """
-        Behavioral check that the templated fields actually get rendered.
-        Replaces the previous tautological assertion that just round-tripped
-        the class attribute.
-        """
+        """The templated fields are substituted by render_template_fields, not merely listed."""
         op = DocumentLoaderOperator(
             task_id="test",
             source_path="/data/{{ ds }}/*.pdf",
-            file_type="{{ var.value.preferred_ext }}",
+            file_type="{{ params.preferred_ext }}",
             metadata_fields={"run_id": "{{ run_id }}"},
         )
-        # Make sure each one is in template_fields so render_template_fields
-        # would substitute them.
-        assert "source_path" in op.template_fields
-        assert "file_type" in op.template_fields
-        assert "file_extensions" in op.template_fields
-        assert "parser" in op.template_fields
-        assert "metadata_fields" in op.template_fields
+
+        op.render_template_fields(
+            context={"ds": "2026-01-01", "run_id": "manual__1", "params": {"preferred_ext": ".pdf"}}
+        )
+
+        assert op.source_path == "/data/2026-01-01/*.pdf"
+        assert op.file_type == ".pdf"
+        assert op.metadata_fields == {"run_id": "manual__1"}
         # source_bytes intentionally not templated -- Jinja stringifies bytes
         # to their repr, which would break binary parsing.
         assert "source_bytes" not in op.template_fields
@@ -58,23 +56,40 @@ class TestDocumentLoaderInit:
         with pytest.raises(ValueError, match="Provide exactly one"):
             DocumentLoaderOperator(task_id="test")
 
-    def test_source_bytes_without_file_type_raises(self):
-        # file_type is a template field, so this check only fires at execute() time.
-        op = DocumentLoaderOperator(task_id="test", source_bytes=b"hello")
-        with pytest.raises(ValueError, match="file_type"):
+    def test_source_bytes_without_file_type_raises_at_construction(self):
+        # Whether file_type was supplied at all is knowable without rendering, so it is a
+        # Dag-parse-time error like the source_path/source_bytes pair above it.
+        with pytest.raises(ValueError, match="'file_type' is required"):
+            DocumentLoaderOperator(task_id="test", source_bytes=b"hello")
+
+    def test_empty_bytes_without_file_type_raises_at_construction(self):
+        with pytest.raises(ValueError, match="'file_type' is required"):
+            DocumentLoaderOperator(task_id="test", source_bytes=b"")
+
+    def test_source_path_rendering_to_none_raises(self):
+        """A supplied source_path that renders to None raises ValueError, not TypeError.
+
+        Driven through real templating rather than by assigning the attribute, so the test
+        fails if the field ever stops being rendered.
+        """
+        with DAG(dag_id="native", schedule=None, render_template_as_native_obj=True):
+            op = DocumentLoaderOperator(task_id="test", source_path="{{ none }}")
+
+        op.render_template_fields(context={})
+        assert op.source_path is None
+
+        with pytest.raises(ValueError, match="'source_path' was supplied but rendered to None"):
             op.execute(context={})
 
-    def test_empty_bytes_without_file_type_raises(self):
-        op = DocumentLoaderOperator(task_id="test", source_bytes=b"")
-        with pytest.raises(ValueError, match="file_type"):
-            op.execute(context={})
+    def test_file_type_rendering_to_none_raises(self):
+        """file_type passes the __init__ guard when supplied, then renders away to None."""
+        with DAG(dag_id="native", schedule=None, render_template_as_native_obj=True):
+            op = DocumentLoaderOperator(task_id="test", source_bytes=b"hello", file_type="{{ none }}")
 
-    def test_source_path_none_after_render_raises(self):
-        # source_path can render to None even when supplied -- must raise ValueError,
-        # not a TypeError from _resolve_files.
-        op = DocumentLoaderOperator(task_id="test", source_path="{{ none }}")
-        op.source_path = None  # simulate the rendered value, bypassing real templating
-        with pytest.raises(ValueError, match="Provide exactly one"):
+        op.render_template_fields(context={})
+        assert op.file_type is None
+
+        with pytest.raises(ValueError, match="'file_type' was supplied but rendered to None"):
             op.execute(context={})
 
 


### PR DESCRIPTION
`DocumentLoaderOperator` reported the wrong argument in two of its checks.

A Dag passing `source_path="{{ ... }}"` where the template renders to `None` was told to
"Provide exactly one of 'source_path' or 'source_bytes'" -- advice it had already followed.
`__init__` settles provision, so the only way to reach that check is a *supplied* field that
rendered away. Both messages now name the field that rendered to `None` and point at the
template or the upstream XCom value behind it. Remove either guard and the same input
fails instead with `TypeError: argument of type 'NoneType' is not iterable` out of
`_resolve_files`, or `AttributeError: 'NoneType' object has no attribute 'startswith'` out
of `_parse_bytes`.

`file_type` is required with `source_bytes`, and whether it was supplied is knowable without
rendering, so that check moves to `__init__` beside the `source_path`/`source_bytes` pair --
the same Dag-parse-time direction as #70628, applied to the argument it left behind. A
`file_type` supplied as a template string is non-`None` at construction, so it still passes
`__init__` and is re-checked after rendering. The only newly-rejected Dag is
`DocumentLoaderOperator(source_bytes=...)` with no `file_type` at all, which could never have
succeeded at run time either.

That wording holds for a regular task. `expand()` validates argument names only and defers
construction to `unmap()`, so for a mapped task the check fires on the worker instead, and the
docstring says so rather than promising parse time everywhere.

On a Dag that passes `source_bytes` with no `file_type`, that is the difference between a Dag
that looks healthy until someone runs it and one that is rejected on sight. Before, it imports
cleanly and the only two import errors present are Airflow's own `first.py` / `broken.py`
fixtures:

![Before: the Dag imports cleanly and Airflow reports two unrelated import errors](https://github.com/user-attachments/assets/81549538-76d4-4688-b941-24dfde9e2efc)

After, the same file is rejected in `__init__`, at parse time:

![After: the Dag is rejected at parse time with the file_type error raised in __init__](https://github.com/user-attachments/assets/b02356fd-5451-41cd-8e45-c278195a55eb)

The comment above those checks claimed provision "already happened in `__init__`" for both
fields, which was never true of `file_type` -- `__init__` had no `file_type` check. #70503
designates this file the reference other operators copy, so the comment now describes the
split it actually implements.

`test_source_path_none_after_render_raises` set the state with `op.source_path = None`, which
passes whether or not the field is still rendered at all. It now drives the same state through
real templating under `render_template_as_native_obj`, and the template-fields test renders
its fields instead of asserting tuple membership.

Related to #70628 and #70503.
