### PR TITLE
Remove airflow info `--file-io` as `file.io` dropped anonymous uploads

### DIFF
--- a/airflow-core/newsfragments/73054.significant.rst
+++ b/airflow-core/newsfragments/73054.significant.rst
@@ -1,0 +1,13 @@
+Removed the ``--file-io`` option from the ``airflow info`` command
+
+``--file-io`` uploaded the report to file.io and printed a shareable link. file.io no longer
+accepts anonymous uploads, so the option could not succeed; it also ended in an unhandled
+traceback rather than reporting the failure.
+
+Redirect the output instead::
+
+    airflow info --anonymize > airflow-info.txt
+
+Note that ``--file-io`` applied ``--anonymize`` implicitly. Pass ``--anonymize`` explicitly when
+sharing a report: plain ``airflow info`` prints connection strings, including passwords, in
+cleartext.

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -922,9 +922,6 @@ ARG_ANONYMIZE = Arg(
     help="Minimize any personal identifiable information. Use it when sharing output with others.",
     action="store_true",
 )
-ARG_FILE_IO = Arg(
-    ("--file-io",), help="Send output to file.io service and returns link.", action="store_true"
-)
 
 # config
 ARG_SECTION = Arg(
@@ -2327,7 +2324,6 @@ core_commands: list[CLICommand] = [
         func=lazy_load_command("airflow.cli.commands.info_command.show_info"),
         args=(
             ARG_ANONYMIZE,
-            ARG_FILE_IO,
             ARG_VERBOSE,
             ARG_OUTPUT,
         ),

--- a/airflow-core/src/airflow/cli/commands/info_command.py
+++ b/airflow-core/src/airflow/cli/commands/info_command.py
@@ -306,7 +306,7 @@ class AirflowInfo:
     def _providers_info(self):
         return [(p.data["package-name"], p.version) for p in ProvidersManager().providers.values()]
 
-    def show(self, output: str, console: AirflowConsole | None = None) -> None:
+    def show(self, output: str) -> None:
         """Show information about Airflow instance."""
         all_info = {
             "Apache Airflow": self._airflow_info,
@@ -316,7 +316,7 @@ class AirflowInfo:
             "Providers info": self._providers_info,
         }
 
-        console = console or AirflowConsole(show_header=False)
+        console = AirflowConsole(show_header=False)
         if output in ("table", "plain"):
             # Show each info as table with key, value column
             for key, info in all_info.items():

--- a/airflow-core/src/airflow/cli/commands/info_command.py
+++ b/airflow-core/src/airflow/cli/commands/info_command.py
@@ -28,9 +28,6 @@ from enum import Enum
 from typing import Protocol
 from urllib.parse import urlsplit, urlunsplit
 
-import httpx
-import tenacity
-
 from airflow import configuration
 from airflow.cli.simple_table import AirflowConsole
 from airflow.dag_processing.bundles.manager import DagBundlesManager
@@ -39,8 +36,6 @@ from airflow.utils.cli import suppress_logs_and_warning
 from airflow.utils.platform import getuser
 from airflow.utils.providers_configuration_loader import providers_configuration_loaded
 from airflow.version import version as airflow_version
-
-log = logging.getLogger(__name__)
 
 
 class Anonymizer(Protocol):
@@ -333,58 +328,10 @@ class AirflowInfo:
                 data=[{k.lower().replace(" ", "_"): dict(v)} for k, v in all_info.items()], output=output
             )
 
-    def render_text(self, output: str) -> str:
-        """Export the info to string."""
-        # The text is uploaded as a file: no escape codes, fixed width regardless of the terminal.
-        console = AirflowConsole(color_system=None, width=200)
-        with console.capture() as capture:
-            self.show(output=output, console=console)
-        return capture.get()
-
-
-class FileIoException(Exception):
-    """Raises when error happens in FileIo.io integration."""
-
-
-@tenacity.retry(
-    stop=tenacity.stop_after_attempt(5),
-    wait=tenacity.wait_exponential(multiplier=1, max=10),
-    retry=tenacity.retry_if_exception_type(FileIoException),
-    before=tenacity.before_log(log, logging.DEBUG),
-    after=tenacity.after_log(log, logging.DEBUG),
-)
-def _upload_text_to_fileio(content):
-    """Upload text file to File.io service and return link."""
-    resp = httpx.post("https://file.io", content=content)
-    if resp.status_code not in [200, 201]:
-        print(resp.json())
-        raise FileIoException("Failed to send report to file.io service.")
-    try:
-        return resp.json()["link"]
-    except ValueError as e:
-        log.debug(e)
-        raise FileIoException("Failed to send report to file.io service.")
-
-
-def _send_report_to_fileio(info):
-    print("Uploading report to file.io service.")
-    try:
-        link = _upload_text_to_fileio(str(info))
-        print("Report uploaded.")
-        print(link)
-        print()
-    except FileIoException as ex:
-        print(str(ex))
-
 
 @suppress_logs_and_warning
 @providers_configuration_loaded
 def show_info(args):
     """Show information related to Airflow, system and other."""
-    # Enforce anonymization, when file_io upload is tuned on.
-    anonymizer = PiiAnonymizer() if args.anonymize or args.file_io else NullAnonymizer()
-    info = AirflowInfo(anonymizer)
-    if args.file_io:
-        _send_report_to_fileio(info.render_text(args.output))
-    else:
-        info.show(args.output)
+    anonymizer = PiiAnonymizer() if args.anonymize else NullAnonymizer()
+    AirflowInfo(anonymizer).show(args.output)

--- a/airflow-core/tests/unit/cli/commands/test_info_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_info_command.py
@@ -16,9 +16,11 @@
 # under the License.
 from __future__ import annotations
 
+import contextlib
 import importlib
 import logging
 import os
+from io import StringIO
 
 import pytest
 
@@ -162,8 +164,11 @@ class TestAirflowInfo:
 
     def test_file_io_flag_is_rejected(self):
         # --file-io uploaded the report to file.io, which stopped accepting anonymous
-        # uploads; the flag is gone rather than failing on every invocation.
-        with pytest.raises(SystemExit) as exc_info:
-            self.parser.parse_args(["info", "--file-io"])
+        # uploads; the flag is gone rather than failing on every invocation. Pin the
+        # message, not just the exit code: argparse exits 2 for a missing subcommand too.
+        with contextlib.redirect_stderr(StringIO()) as stderr:
+            with pytest.raises(SystemExit) as exc_info:
+                self.parser.parse_args(["info", "--file-io"])
 
         assert exc_info.value.code == 2
+        assert "unrecognized arguments: --file-io" in stderr.getvalue()

--- a/airflow-core/tests/unit/cli/commands/test_info_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_info_command.py
@@ -19,9 +19,7 @@ from __future__ import annotations
 import importlib
 import logging
 import os
-from unittest import mock
 
-import httpx
 import pytest
 
 from airflow.cli import cli_parser
@@ -162,39 +160,10 @@ class TestAirflowInfo:
         assert airflow_version in output
         assert "postgresql+psycopg2://p...s:PASSWORD@postgres/airflow" in output
 
-    @mock.patch.dict(os.environ, {"FORCE_COLOR": "1", "TERM": "xterm-256color"})
-    def test_render_text_stays_plain_on_a_color_terminal(self):
-        instance = info_command.AirflowInfo(info_command.NullAnonymizer())
+    def test_file_io_flag_is_rejected(self):
+        # --file-io uploaded the report to file.io, which stopped accepting anonymous
+        # uploads; the flag is gone rather than failing on every invocation.
+        with pytest.raises(SystemExit) as exc_info:
+            self.parser.parse_args(["info", "--file-io"])
 
-        rendered = instance.render_text("table")
-
-        assert airflow_version in rendered
-        assert "\x1b[" not in rendered
-
-
-@pytest.fixture
-def setup_parser():
-    return cli_parser.get_parser()
-
-
-class TestInfoCommandMockHttpx:
-    @conf_vars(
-        {
-            ("database", "sql_alchemy_conn"): "postgresql+psycopg2://postgres:airflow@postgres/airflow",
-        }
-    )
-    def test_show_info_anonymize_fileio(self, setup_parser, cleanup_providers_manager, stdout_capture):
-        with mock.patch("airflow.cli.commands.info_command.httpx.post") as post:
-            post.return_value = httpx.Response(
-                status_code=200,
-                json={
-                    "success": True,
-                    "key": "f9U3zs3I",
-                    "link": "https://file.io/TEST",
-                    "expiry": "14 days",
-                },
-            )
-            with stdout_capture as stdout:
-                info_command.show_info(setup_parser.parse_args(["info", "--file-io", "--anonymize"]))
-            assert "https://file.io/TEST" in stdout.getvalue()
-            assert airflow_version in post.call_args.kwargs["content"]
+        assert exc_info.value.code == 2


### PR DESCRIPTION
`airflow info --file-io` uploaded the info report to file.io and printed a shareable link. It can no longer succeed, and when it fails it crashes instead of reporting the failure.

**file.io stopped accepting anonymous uploads.** `POST https://file.io` returns a Cloudflare `301` to `https://www.file.io/`, which is a static site answering only `GET`/`HEAD`/`OPTIONS`, and the `POST` gets a `405`. That holds for the exact request file.io's own [developer docs](https://www.file.io/developers) still document (`multipart/form-data` with a `file` field), so that page describes an endpoint that is no longer wired up. The site's own uploader has moved to LimeWire: `www.file.io` loads `js/lw_upload.js`, which pulls `limewire.com/file-sharing-lib/file-sharing-lib.es.js`, posts to `api.limewire.com`, and sends users to `limewire.com/auth` for an account. Airflow posts anonymously with no credentials, so no request it can make will succeed.

**The failure was also unhandled.** The error body is HTML, so `resp.json()` in the failure branch raised `json.JSONDecodeError` before reaching the intended `raise FileIoException(...)` on the next line. `tenacity` retried only `FileIoException` and `_send_report_to_fileio` caught only that, so the command ended in a traceback rather than the intended `Failed to send report to file.io service.` message.

## Design rationale

**Why remove rather than deprecate**, which is what the issue thread proposed. A deprecation cycle buys users time to migrate off working behaviour onto something else. There is no working behaviour here and nothing to migrate to, so the cycle would only mean a release where the flag warns that it is deprecated and then crashes anyway. The CLI is also explicitly outside the compatibility promise that would otherwise require the cycle: `public-airflow-interface.rst` says the CLI may change "in details (such as output format and available flags)" and points programmatic users at the REST API.

**Nothing replaces it.** Pointing the flag at another anonymous upload host reproduces exactly what broke: core would depend on a third-party pastebin that can disappear without notice. That it died silently, with the breakage surfacing only now, is the argument against having had the dependency at all.

This also removes `render_text`, which existed only to produce the uploaded report body, along with the `httpx` and `tenacity` imports that `info_command.py` used only for the upload.

## Migration

`airflow info --file-io` now exits with `unrecognized arguments: --file-io`. Redirect the report and share it yourself:

```console
$ airflow info --anonymize > airflow-info.txt
```

`--anonymize` is unchanged, but note it was applied *implicitly* by `--file-io`, so pass it explicitly when sharing a report.

Closes #73045
