### PR TITLE
Carry the lint/type config for the ruff 0.16.6 and mypy 2.3.1 bump

### DIFF
--- a/.github/workflows/publish-docs-to-s3.yml
+++ b/.github/workflows/publish-docs-to-s3.yml
@@ -88,7 +88,7 @@ jobs:
       AIRFLOW_VERSION: ${{ inputs.airflow-version || '' }}
       APPLY_COMMITS: ${{ inputs.apply-commits || '' }}
     outputs:
-      include-docs: ${{ inputs.include-docs == 'all' && '' || inputs.include-docs }}
+      include-docs: ${{ case(inputs.include-docs == 'all', '', inputs.include-docs) }}
       destination-location: ${{ steps.parameters.outputs.destination-location }}
       destination: ${{ steps.parameters.outputs.destination }}
       extra-build-options: ${{ steps.parameters.outputs.extra-build-options }}

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -142,8 +142,8 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.job-timeout-minutes) }}
     # yamllint disable rule:line-length
     name: "\
-      ${{ inputs.test-scope == 'All' && '' || inputs.test-scope == 'Quarantined' && 'Qrnt' || inputs.test-scope }}\
-      ${{ inputs.test-scope == 'All' && '' || '-' }}\
+      ${{ case(inputs.test-scope == 'Quarantined', 'Qrnt', inputs.test-scope == 'All', '', inputs.test-scope) }}\
+      ${{ case(inputs.test-scope == 'All', '', '-') }}\
       ${{ inputs.test-group == 'providers' && 'prov' || inputs.test-group}}:\
       ${{ inputs.test-name }}${{ inputs.test-name-separator }}${{ matrix.backend-version }}:\
       ${{ matrix.python-version}}:${{ matrix.test-types.description }}"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -19,3 +19,21 @@
 rules:
   secrets-outside-env:
     disable: true
+  # This audit wants every in-repo `uses: ./...` rewritten to GitHub's
+  # self-repository form (`uses: $/...`). Two things outside this repository's
+  # control block that, and both were confirmed by pushing the conversion:
+  #
+  #  * `$/` makes the runner fetch apache/airflow as an action repository, and
+  #    that download cannot materialise the symlinks this repository commits --
+  #    it aborts on `.claude/skills/airflow-translations`, whose target is not
+  #    tracked, before any job runs.
+  #  * ASF infrastructure's allowlist check does not recognise the syntax and
+  #    reports every `$/...` reference as an action missing from the allowlist.
+  #
+  # The audit's own threat model -- a privileged workflow loading a local action
+  # out of a checkout untrusted code could have altered first -- does not reach
+  # us either, since no Airflow workflow runs on `pull_request_target` or
+  # `workflow_run`. Revisit if the symlinks go away and ASF Infra teaches the
+  # allowlist about `$/`.
+  self-repository:
+    disable: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -596,6 +596,10 @@ extend-exclude = [
 [tool.ruff.lint]
 typing-modules = ["airflow.typing_compat"]
 external = ["MIG"]
+# Pin the base rule set instead of inheriting Ruff's default, which Ruff changes
+# between releases (0.16 widened it from ~250 to ~510 rules). Everything Airflow
+# actually opts into lives in extend-select below.
+select = ["E4", "E7", "E9", "F"]
 extend-select = [
     # Enable entire ruff rule section
     "I", # Missing required import (auto-fixable)
@@ -704,6 +708,13 @@ ignore = [
     "COM812",
     "COM819",
     "E501", # Formatted code may exceed the line length, leading to line-too-long (E501) errors.
+    # New in Ruff 0.16, inside sections Airflow selects wholesale. Deferred so a tooling
+    # bump does not also carry semantic changes; both need per-site judgement.
+    "ISC004", # Implicit string concat in a collection literal; 109 sites, unsafe autofix
+    # LOG004 is not a mechanical replacement: switching to `.error()` where an exception is
+    # in flight silently drops the traceback, while leaving `.exception()` where none is
+    # only prints a bare `NoneType: None`. Review already caught one bad guess in 13.
+    "LOG004", # `.exception()` outside an exception handler; 13 sites
 ]
 unfixable = [
     # PT022 replace empty `yield` to empty `return`. Might be fixed with a combination of PLR1711

--- a/shared/plugins_manager/src/airflow_shared/plugins_manager/plugins_manager.py
+++ b/shared/plugins_manager/src/airflow_shared/plugins_manager/plugins_manager.py
@@ -177,7 +177,8 @@ def is_valid_plugin(plugin_obj) -> bool:
     )
 
     if is_airflow_plugin and plugin_obj.__name__ != "AirflowPlugin":
-        plugin_obj.validate()
+        # Validated as an AirflowPlugin subclass by name above; mypy can't narrow a name-based check.
+        plugin_obj.validate()  # type: ignore[attr-defined]
         return True
     return False
 

--- a/task-sdk/src/airflow/sdk/execution_time/schema/AGENTS.md
+++ b/task-sdk/src/airflow/sdk/execution_time/schema/AGENTS.md
@@ -87,7 +87,7 @@ head shape *is* the schema for the new body.
    `versions/__init__.py`:
 
    ```python
-   Version("2026-06-16", AddRetryDelay, AddSentryTraceField),
+   (Version("2026-06-16", AddRetryDelay, AddSentryTraceField),)
    ```
 
 4. The `generate-supervisor-schemas-snapshot` prek hook will


### PR DESCRIPTION
#73042 bumped ruff (`0.15.17`->`0.16.6`) and mypy (`2.1.0`->`2.3.1`) on `v3-3-test`, but not the companion config/fixes that keep static checks green — those live in separate `main` PRs. As a result, the 3.3.2 sync PR #72946 (which runs `prek --all-files` against the full diff vs stable) fails across **ruff**, **ruff-format**, **mypy**, and **zizmor**.

Root cause: without the pinned base lint rule set, ruff 0.16 falls back to its widened default (~510 rules) and reports **6278 errors**; its `B010` autofix rewrites the `setattr` calls on the fake modules in the devel-common tests, which then trips mypy's `attr-defined` check. Pinning the base set clears both at once.

**Changes (each mirrors main unless noted):**
- `pyproject.toml`: pin the ruff base rule set `select = ["E4", "E7", "E9", "F"]` and defer `ISC004`/`LOG004` — from #70725. Collapses 6278 -> 0.
- `.github/zizmor.yml`: disable the `self-repository` audit — from main's config.
- `.github/workflows/run-unit-tests.yml` + `publish-docs-to-s3.yml`: rewrite unsound ternaries to `case(...)` — backport of #69026.
- `shared/.../plugins_manager.py`: `# type: ignore[attr-defined]` on the name-validated `AirflowPlugin.validate()` call (local — this code was refactored away on main, so no backport exists).
- `task-sdk/.../schema/AGENTS.md`: ruff-format a doc code snippet.

This is the companion migration that should have accompanied #73042's toolchain bump; it unblocks the 3.3.2rc1 sync PR #72946.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)