### PR TITLE
Fix zizmor ref-version-mismatch on the allowlist-check action pin

### DIFF
--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -31,4 +31,5 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - uses: apache/infrastructure-actions/allowlist-check@ec1b354a0455b41001d77473236d02a0ee0adba4  # main
+      # yamllint disable-line rule:line-length
+      - uses: apache/infrastructure-actions/allowlist-check@61dcea11f19e2bbe1263f14d72235e8da17d3ad0  # allowlist-check/v1.0.0


### PR DESCRIPTION
After the ruff/mypy static-check restore (#73046), the 3.3.2 sync PR #72946 still had one static-check failure: zizmor's **online** `ref-version-mismatch` audit on `.github/workflows/asf-allowlist-check.yml`.

The `apache/infrastructure-actions/allowlist-check` action was pinned to a hash carrying a `# main` comment — a branch, not a version — which the audit flags. (Local/offline zizmor runs miss this; it only surfaces in CI's online run, which is why #73046 shipped with it still red.)

Fix: pin to the released `allowlist-check/v1.0.0` tag, matching `main` (backport of the relevant line from #70623 "Pin apache/infrastructure-actions to its released tags").

Verified with the prek zizmor hook run online (`GH_TOKEN=… prek run zizmor --all-files`): **Passed**. This was the last static-check failure blocking a clean 3.3.2rc1 sync PR.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)