### PR TITLE
Fix airflow dags next-execution crashing on --field data_interval.start

### DIFF
--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -22,13 +22,14 @@ from __future__ import annotations
 import ast
 import datetime
 import errno
+import functools
 import json
 import logging
 import operator
 import re
 import subprocess
 import sys
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from sqlalchemy import func, select
 
@@ -63,7 +64,7 @@ from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.types import DagRunType
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator
+    from collections.abc import Callable, Iterable, Iterator
 
     from graphviz.dot import Dot
     from sqlalchemy.orm import Session
@@ -442,6 +443,23 @@ def dag_state(args, *, session: Session = NEW_SESSION) -> None:
         print(dr.state)
 
 
+def _get_schedule_field(field: str, info: DagRunInfo) -> Any:
+    """
+    Resolve the dotted ``--field`` *field* on *info*, yielding None if a parent is absent.
+
+    ``--field`` offers every field any schedule can produce, so a Dag can always be
+    asked for a name its own schedule leaves empty — ``data_interval`` is None on a
+    partitioned Dag. Degrade to None there, as :attr:`DagRunInfo.logical_date` already
+    does for the very same interval.
+    """
+    value: Any = info
+    for name in field.split("."):
+        value = getattr(value, name)
+        if value is None:
+            return None
+    return value
+
+
 @deprecated_for_airflowctl("airflowctl dags next-execution")
 @cli_utils.action_cli
 @providers_configuration_loaded
@@ -512,8 +530,9 @@ def dag_next_execution(args) -> None:
         AirflowConsole().print_as_table(rows)
         return
 
+    getter: Callable[[DagRunInfo], Any]
     if args.field:
-        getter = operator.attrgetter(args.field)
+        getter = functools.partial(_get_schedule_field, args.field)
     elif last_parsed_dag.timetable_partitioned:
         getter = operator.attrgetter("partition_key")
     else:

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -316,6 +316,35 @@ class TestCliDags:
         clear_db_dags()
         self.setup_class()
 
+    @conf_vars({("core", "load_examples"): "false"})
+    @pytest.mark.parametrize("field", ["data_interval.start", "data_interval.end"])
+    def test_next_execution_data_interval_field_on_partitioned_dag(self, field, tmp_path, stdout_capture):
+        dag_id = "partitioned_data_interval_field"
+        file_content = os.linesep.join(
+            [
+                "from airflow import DAG",
+                "from airflow.providers.standard.operators.empty import EmptyOperator",
+                "from airflow.timetables.trigger import CronPartitionTimetable",
+                "from datetime import timedelta; from pendulum import today",
+                f"dag = DAG('{dag_id}', start_date=today(tz='UTC') + timedelta(days=-5),"
+                " schedule=CronPartitionTimetable('0 0 * * *', timezone='UTC'), catchup=False)",
+                "task = EmptyOperator(task_id='empty_task', dag=dag)",
+            ]
+        )
+        (tmp_path / f"{dag_id}.py").write_text(file_content)
+        with time_machine.travel(DEFAULT_DATE):
+            clear_db_dags()
+            parse_and_sync_to_db(tmp_path)
+
+        args = self.parser.parse_args(["dags", "next-execution", dag_id, "--field", field])
+        with stdout_capture as temp_stdout:
+            dag_command.dag_next_execution(args)
+            out = temp_stdout.getvalue()
+        assert out.splitlines() == ["None"]
+
+        clear_db_dags()
+        self.setup_class()
+
     def test_cli_report(self, stdout_capture):
         args = self.parser.parse_args(["dags", "report", "--output", "json"])
         with stdout_capture as temp_stdout:


### PR DESCRIPTION
## Why

`airflow dags next-execution <dag_id> --field data_interval.start` crashes with a bare
`AttributeError: 'NoneType' object has no attribute 'start'` on a Dag using a partitioned
timetable.

`--field` accepts the union of every field any schedule can produce
(`airflow-core/src/airflow/cli/cli_config.py` `ARG_FIELD` choices), so a Dag can
always be asked for a name its own schedule leaves empty: `DagRunInfo.data_interval` is
`None` for a partitioned timetable, and `operator.attrgetter("data_interval.start")` walks
straight into it.

Every neighbouring combination already degrades to `None` instead of raising — asking a
cron Dag for `--field partition_key` prints `None`, and so does `--field logical_date` on a
partitioned Dag, which is defined as exactly `data_interval.start if data_interval else None`.
So the same value crashes under one name and prints `None` under the other.

## What

`airflow-core/src/airflow/cli/commands/dag_command.py` — the `--field` path now resolves the
dotted name through `_get_schedule_field`, which stops and yields `None` as soon as the chain
runs out. The `--table` path is unchanged: it picks its column set from
`timetable_partitioned`, so it never asks for a field the Dag cannot have.

Output for every field a Dag's schedule does populate is unchanged.

`airflow-core/tests/unit/cli/commands/test_dag_command.py` — a parametrized test over
`data_interval.start` / `data_interval.end` against a `CronPartitionTimetable` Dag, asserting
`None` is printed. Both parametrizations fail with the `AttributeError` without this change.