### PR TITLE
Allowing for Task State Store to be used on the Triggerer

### DIFF
--- a/airflow-core/docs/core-concepts/task-state-store.rst
+++ b/airflow-core/docs/core-concepts/task-state-store.rst
@@ -152,6 +152,52 @@ Async counterparts of ``get``, ``set``, ``delete``, and ``clear`` for use inside
 
 Calling the synchronous ``get``/``set``/``delete``/``clear`` from inside an ``async`` task blocks the event loop and defeats the concurrency the coroutine was written for. Use the ``a``-prefixed methods there instead.
 
+Using ``task_state_store`` inside a Trigger
+-------------------------------------------
+
+A trigger belonging to a deferred task can read and write that task's state store from within ``run()``. The triggerer injects ``self.task_state_store`` before ``run()`` is called, scoped to the task instance that deferred, which is the same namespace the operator's ``execute()`` and ``execute_complete()`` see. It is not available during ``__init__`` or ``serialize()``, only from within ``run()``.
+
+It is ``None`` on a trigger with no task instance (an asset watcher), which reaches asset state through ``self.asset_state_store`` instead (see :doc:`asset-state-store`).
+
+.. code-block:: python
+
+    import asyncio
+    from collections.abc import AsyncIterator
+    from typing import Any
+
+    from airflow.triggers.base import BaseEventTrigger, TriggerEvent
+
+
+    class WaitForJobTrigger(BaseEventTrigger):
+        def __init__(self, job_id: str, waiter_delay: int, **kwargs):
+            super().__init__(**kwargs)
+            self.job_id = job_id
+            self.waiter_delay = waiter_delay
+
+        def serialize(self) -> tuple[str, dict[str, Any]]:
+            return (
+                f"{self.__class__.__module__}.{self.__class__.__qualname__}",
+                {"job_id": self.job_id, "waiter_delay": self.waiter_delay},
+            )
+
+        async def run(self) -> AsyncIterator[TriggerEvent]:
+            # Record job id before the first poll, so a triggerer restart reconnects to it instead of resubmitting
+            await self.task_state_store.aset("external_id", self.job_id)
+
+            while True:
+                status = await self._poll_status(self.job_id)
+                if status in ("SUCCEEDED", "FAILED"):
+                    yield TriggerEvent({"status": status, "job_id": self.job_id})
+                    return
+
+                await asyncio.sleep(self.waiter_delay)
+
+``run()`` is a coroutine, and every trigger on a triggerer shares one event loop, so use the async accessors there. The synchronous methods also work, but they hold the loop for the whole round-trip to the API server.
+
+.. note::
+
+    ``retention`` on ``set``/``aset`` behaves the same as it does in a task, and a trigger that writes a key its operator later reads should agree with that operator on the key name (the two share one namespace).
+
 Some Example Use Cases
 ----------------------
 
@@ -285,7 +331,7 @@ If the worker process crashes, the task instance is retried. Task store data wri
 Deferrable tasks
 ~~~~~~~~~~~~~~~~
 
-Once a task defers, the Triggerer handles continuity across poke cycles. Use task state store in deferrable tasks only when you need to survive an operator-initiated clear, not for normal poke continuity.
+Once a task defers, the Triggerer handles continuity across poke cycles, so there is no need to checkpoint every poke to the task state store. Reach for it when the state has to outlive the trigger itself: surviving an operator-initiated clear, or letting a triggerer restart reconnect to an already-submitted remote job rather than resubmitting it. The trigger writes that state through ``self.task_state_store`` (see `Using task_state_store inside a Trigger`_), into the same namespace the operator reads in ``execute_complete()``.
 
 
 Mapped tasks

--- a/airflow-core/newsfragments/72851.feature.rst
+++ b/airflow-core/newsfragments/72851.feature.rst
@@ -1,0 +1,1 @@
+Triggers of deferred tasks can now read and write their task instance's task state store via ``self.task_state_store``.

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -65,11 +65,13 @@ from airflow.sdk.execution_time.comms import (
     AssetStateStoreResult,
     ClearAssetStateStoreByName,
     ClearAssetStateStoreByUri,
+    ClearTaskStateStore,
     CommsDecoder,
     ConnectionResult,
     DagRunStateResult,
     DeleteAssetStateStoreByName,
     DeleteAssetStateStoreByUri,
+    DeleteTaskStateStore,
     DeleteVariable,
     DeleteXCom,
     DRCount,
@@ -82,6 +84,7 @@ from airflow.sdk.execution_time.comms import (
     GetHITLDetailResponse,
     GetPreviousTI,
     GetTaskStates,
+    GetTaskStateStore,
     GetTICount,
     GetVariable,
     GetVariableKeys,
@@ -91,8 +94,10 @@ from airflow.sdk.execution_time.comms import (
     PutVariable,
     SetAssetStateStoreByName,
     SetAssetStateStoreByUri,
+    SetTaskStateStore,
     SetXCom,
     TaskStatesResult,
+    TaskStateStoreResult,
     TICount,
     UpdateHITLDetail,
     VariableKeysResult,
@@ -101,12 +106,14 @@ from airflow.sdk.execution_time.comms import (
     _new_encoder,
     _RequestFrame,
 )
-from airflow.sdk.execution_time.context import AssetStateStoreAccessors
+from airflow.sdk.execution_time.context import AssetStateStoreAccessors, TaskStateStoreAccessor
 from airflow.sdk.execution_time.request_handlers import (
     handle_clear_asset_state_store_by_name,
     handle_clear_asset_state_store_by_uri,
+    handle_clear_task_state_store,
     handle_delete_asset_state_store_by_name,
     handle_delete_asset_state_store_by_uri,
+    handle_delete_task_state_store,
     handle_delete_variable,
     handle_delete_xcom,
     handle_get_asset_state_store_by_name,
@@ -115,6 +122,7 @@ from airflow.sdk.execution_time.request_handlers import (
     handle_get_dag_run_state,
     handle_get_dr_count,
     handle_get_previous_ti,
+    handle_get_task_state_store,
     handle_get_task_states,
     handle_get_ti_count,
     handle_get_variable,
@@ -124,10 +132,12 @@ from airflow.sdk.execution_time.request_handlers import (
     handle_put_variable,
     handle_set_asset_state_store_by_name,
     handle_set_asset_state_store_by_uri,
+    handle_set_task_state_store,
     handle_set_xcom,
 )
 from airflow.sdk.execution_time.supervisor import WatchedSubprocess, make_buffered_socket_reader
 from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
+from airflow.sdk.state import TaskScope
 from airflow.serialization.serialized_objects import DagSerialization
 from airflow.triggers.base import BaseEventTrigger, BaseTrigger, DiscrimatedTriggerEvent, TriggerEvent
 from airflow.triggers.shared_stream import SharedStreamManager
@@ -372,6 +382,7 @@ ToTriggerRunner = Annotated[
     | TICount
     | TaskStatesResult
     | AssetStateStoreResult
+    | TaskStateStoreResult
     | HITLDetailResponseResult
     | ErrorResponse
     | OKResponse,
@@ -403,6 +414,10 @@ ToTriggerSupervisor = Annotated[
     | GetAssetStateStoreByUri
     | SetAssetStateStoreByName
     | SetAssetStateStoreByUri
+    | ClearTaskStateStore
+    | DeleteTaskStateStore
+    | GetTaskStateStore
+    | SetTaskStateStore
     | GetDagRunState
     | GetDRCount
     | GetPreviousTI
@@ -681,6 +696,17 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
             resp = OKResponse(ok=True)
         elif isinstance(msg, SetAssetStateStoreByUri):
             handle_set_asset_state_store_by_uri(self.client, msg)
+            resp = OKResponse(ok=True)
+        elif isinstance(msg, ClearTaskStateStore):
+            handle_clear_task_state_store(self.client, msg)
+            resp = OKResponse(ok=True)
+        elif isinstance(msg, DeleteTaskStateStore):
+            handle_delete_task_state_store(self.client, msg)
+            resp = OKResponse(ok=True)
+        elif isinstance(msg, GetTaskStateStore):
+            resp, dump_opts = handle_get_task_state_store(self.client, msg)
+        elif isinstance(msg, SetTaskStateStore):
+            handle_set_task_state_store(self.client, msg)
             resp = OKResponse(ok=True)
         else:
             raise ValueError(f"Unknown message type {type(msg)}")
@@ -1409,6 +1435,17 @@ class TriggerRunner:
             trigger_instance.trigger_id = trigger_id
             trigger_instance.triggerer_job_id = self.job_id
             trigger_instance.timeout_after = workload.timeout_after
+
+            if (ti := workload.ti) is not None:
+                trigger_instance.task_state_store = TaskStateStoreAccessor(
+                    ti_id=ti.id,
+                    scope=TaskScope(
+                        dag_id=ti.dag_id,
+                        run_id=ti.run_id,
+                        task_id=ti.task_id,
+                        map_index=ti.map_index,
+                    ),
+                )
 
             if isinstance(trigger_instance, BaseEventTrigger) and workload.watched_assets:
                 trigger_instance.asset_state_store = AssetStateStoreAccessors(

--- a/airflow-core/src/airflow/triggers/base.py
+++ b/airflow-core/src/airflow/triggers/base.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     from airflow.models.mappedoperator import MappedOperator
     from airflow.models.taskinstance import TaskInstance
     from airflow.sdk.definitions.context import Context
-    from airflow.sdk.execution_time.context import AssetStateStoreAccessors
+    from airflow.sdk.execution_time.context import AssetStateStoreAccessors, TaskStateStoreAccessor
     from airflow.serialization.serialized_objects import SerializedBaseOperator
     from airflow.triggers.shared_stream import SharedStreamProducer
 
@@ -88,6 +88,9 @@ class BaseTrigger(abc.ABC, Templater, LoggingMixin):
     # ``CallbackTrigger`` set this in their ``__init__``, see `trigger_queue_inherited_from_task`.
     # Declared as a class attribute since many provider triggers don't call ``super().__init__()``.
     queue: str | None = None
+
+    # Injected by the triggerer before run() is called, scoped to the task instance that deferred
+    task_state_store: TaskStateStoreAccessor | None = None
 
     def __init__(self, **kwargs):
         super().__init__()

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -78,27 +78,37 @@ from airflow.providers.standard.triggers.file import FileDeleteTrigger
 from airflow.providers.standard.triggers.temporal import DateTimeTrigger, TimeDeltaTrigger
 from airflow.sdk import DAG, Asset, BaseHook, BaseOperator
 from airflow.sdk.api.client import Client
-from airflow.sdk.api.datamodels._generated import AssetStateStoreResponse
+from airflow.sdk.api.datamodels._generated import AssetStateStoreResponse, TaskStateStoreResponse
 from airflow.sdk.exceptions import ErrorType
 from airflow.sdk.execution_time import supervisor
 from airflow.sdk.execution_time.comms import (
     AssetStateStoreResult,
     ClearAssetStateStoreByName,
     ClearAssetStateStoreByUri,
+    ClearTaskStateStore,
     DeleteAssetStateStoreByName,
     DeleteAssetStateStoreByUri,
+    DeleteTaskStateStore,
     ErrorResponse,
     GetAssetStateStoreByName,
     GetAssetStateStoreByUri,
+    GetTaskStateStore,
     OKResponse,
     SetAssetStateStoreByName,
     SetAssetStateStoreByUri,
+    SetTaskStateStore,
+    TaskStateStoreResult,
     ToSupervisor,
     ToTask,
     _RequestFrame,
     _ResponseFrame,
 )
-from airflow.sdk.execution_time.context import AssetStateStoreAccessors
+from airflow.sdk.execution_time.context import (
+    NEVER_EXPIRE,
+    AssetStateStoreAccessors,
+    TaskStateStoreAccessor,
+)
+from airflow.sdk.state import TaskScope
 from airflow.serialization.serialized_objects import LazyDeserializedDAG
 from airflow.triggers.base import BaseEventTrigger, BaseTrigger, TriggerEvent
 from airflow.triggers.shared_stream import SharedStreamProducer
@@ -1015,6 +1025,245 @@ async def test_create_triggers_asset_state_store_accessor_reads_and_writes(
 
     runner.triggers[14]["task"].cancel()
     await runner.cleanup_finished_triggers()
+
+
+@pytest.fixture
+def make_deferred_trigger():
+    """Factory fixture: call with a list to get a BaseTrigger subclass that appends each new instance."""
+
+    def factory(injected_instances):
+        class DeferredTrigger(BaseTrigger):
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+                injected_instances.append(self)
+
+            def serialize(self):
+                return (f"{type(self).__module__}.{type(self).__qualname__}", {})
+
+            async def run(self):
+                yield TriggerEvent("done")
+
+        return DeferredTrigger
+
+    return factory
+
+
+def _ti_dto(map_index=-1):
+    return TaskInstanceDTO(
+        id=uuid.uuid4(),
+        dag_version_id=uuid.uuid4(),
+        task_id="my_task",
+        dag_id="test_dag",
+        run_id="test_run",
+        try_number=1,
+        map_index=map_index,
+        pool_slots=1,
+        queue="default",
+        priority_weight=1,
+    )
+
+
+@pytest.mark.asyncio
+@patch("airflow.jobs.triggerer_job_runner.TriggerRunner.get_trigger_by_classpath")
+async def test_create_triggers_injects_task_state_store_scoped_to_the_deferring_ti(
+    mock_get_classpath, session, make_deferred_trigger
+):
+    """task_state_store is populated, and scoped to the task instance that deferred."""
+    injected_instances = []
+    mock_get_classpath.return_value = make_deferred_trigger(injected_instances)
+    ti = _ti_dto(map_index=3)
+
+    runner = TriggerRunner()
+    runner.to_create.append(
+        workloads.RunTrigger.model_construct(
+            id=20,
+            ti=ti,
+            classpath="fake.DeferredTrigger",
+            encrypted_kwargs="{}",
+        )
+    )
+
+    await runner.create_triggers()
+
+    assert len(injected_instances) == 1
+    store = injected_instances[0].task_state_store
+    assert isinstance(store, TaskStateStoreAccessor)
+    assert store._ti_id == ti.id
+    assert store._scope == TaskScope(dag_id="test_dag", run_id="test_run", task_id="my_task", map_index=3)
+
+    runner.triggers[20]["task"].cancel()
+    await runner.cleanup_finished_triggers()
+
+
+@pytest.mark.asyncio
+@patch("airflow.jobs.triggerer_job_runner.TriggerRunner.get_trigger_by_classpath")
+async def test_create_triggers_task_state_store_none_for_watcher(
+    mock_get_classpath, session, make_watcher_trigger
+):
+    """A watcher has no task instance, so there is nothing to scope a task store to."""
+    injected_instances = []
+    mock_get_classpath.return_value = make_watcher_trigger(injected_instances)
+
+    runner = TriggerRunner()
+    runner.to_create.append(
+        workloads.RunTrigger.model_construct(
+            id=22,
+            ti=None,
+            classpath="fake.WatcherTrigger",
+            encrypted_kwargs="{}",
+            watched_assets={"asset_a": "s3://bucket/a"},
+        )
+    )
+
+    await runner.create_triggers()
+
+    assert injected_instances[0].task_state_store is None
+
+    runner.triggers[22]["task"].cancel()
+    await runner.cleanup_finished_triggers()
+
+
+@pytest.mark.asyncio
+@patch("airflow.jobs.triggerer_job_runner.TriggerRunner.get_trigger_by_classpath")
+async def test_create_triggers_task_state_store_accessor_reads_and_writes(
+    mock_get_classpath, session, mock_supervisor_comms, make_deferred_trigger
+):
+    """task_state_store accessor sends correct SUPERVISOR_COMMS messages on get() and set()."""
+    injected_instances = []
+    mock_get_classpath.return_value = make_deferred_trigger(injected_instances)
+    ti = _ti_dto()
+
+    runner = TriggerRunner()
+    runner.to_create.append(
+        workloads.RunTrigger.model_construct(
+            id=23,
+            ti=ti,
+            classpath="fake.DeferredTrigger",
+            encrypted_kwargs="{}",
+        )
+    )
+
+    await runner.create_triggers()
+
+    store = injected_instances[0].task_state_store
+
+    mock_supervisor_comms.send.return_value = TaskStateStoreResult(value="job-123")
+    assert store.get("external_id") == "job-123"
+    mock_supervisor_comms.send.assert_called_with(GetTaskStateStore(ti_id=ti.id, key="external_id"))
+
+    store.set("external_id", "job-456", retention=NEVER_EXPIRE)
+    mock_supervisor_comms.send.assert_called_with(
+        SetTaskStateStore(ti_id=ti.id, key="external_id", value="job-456", expires_at=None)
+    )
+
+    runner.triggers[23]["task"].cancel()
+    await runner.cleanup_finished_triggers()
+
+
+@pytest.mark.asyncio
+@patch("airflow.jobs.triggerer_job_runner.TriggerRunner.get_trigger_by_classpath")
+async def test_create_triggers_task_state_store_accessor_awaits_async_methods(
+    mock_get_classpath, session, mock_supervisor_comms, make_deferred_trigger
+):
+    """The async accessors reach the supervisor through asend, so a trigger's run() never blocks the loop."""
+    injected_instances = []
+    mock_get_classpath.return_value = make_deferred_trigger(injected_instances)
+    ti = _ti_dto()
+
+    runner = TriggerRunner()
+    runner.to_create.append(
+        workloads.RunTrigger.model_construct(
+            id=24,
+            ti=ti,
+            classpath="fake.DeferredTrigger",
+            encrypted_kwargs="{}",
+        )
+    )
+
+    await runner.create_triggers()
+
+    store = injected_instances[0].task_state_store
+
+    mock_supervisor_comms.asend.return_value = TaskStateStoreResult(value="job-123")
+    assert await store.aget("external_id") == "job-123"
+    mock_supervisor_comms.asend.assert_awaited_with(GetTaskStateStore(ti_id=ti.id, key="external_id"))
+
+    await store.aset("external_id", "job-456", retention=NEVER_EXPIRE)
+    mock_supervisor_comms.asend.assert_awaited_with(
+        SetTaskStateStore(ti_id=ti.id, key="external_id", value="job-456", expires_at=None)
+    )
+
+    await store.adelete("external_id")
+    mock_supervisor_comms.asend.assert_awaited_with(DeleteTaskStateStore(ti_id=ti.id, key="external_id"))
+
+    await store.aclear()
+    mock_supervisor_comms.asend.assert_awaited_with(ClearTaskStateStore(ti_id=ti.id))
+
+    runner.triggers[24]["task"].cancel()
+    await runner.cleanup_finished_triggers()
+
+
+class TestTriggerSupervisorTaskStateStore:
+    """Supervisor side of the task-state-store round trip, mirroring the asset tests below."""
+
+    @pytest.fixture
+    def supervisor(self, jobless_supervisor, mocker):
+        jobless_supervisor.client = mocker.MagicMock(spec=Client)
+        mocker.patch.object(TriggerRunnerSupervisor, "send_msg")
+        return jobless_supervisor
+
+    @staticmethod
+    def _handle(supervisor, msg):
+        supervisor._handle_request(msg, log=MagicMock(spec=FilteringBoundLogger), req_id=7)
+
+    def test_get_wraps_response_and_replies(self, supervisor):
+        ti_id = uuid.uuid4()
+        supervisor.client.task_state_store.get.return_value = TaskStateStoreResponse(value="job-123")
+
+        self._handle(supervisor, GetTaskStateStore(ti_id=ti_id, key="external_id"))
+
+        supervisor.client.task_state_store.get.assert_called_once_with(ti_id, "external_id")
+        supervisor.send_msg.assert_called_once_with(
+            TaskStateStoreResult(value="job-123"), request_id=7, error=None
+        )
+
+    def test_get_passes_through_not_found_error(self, supervisor):
+        err = ErrorResponse(error=ErrorType.TASK_STORE_NOT_FOUND, detail={"key": "external_id"})
+        supervisor.client.task_state_store.get.return_value = err
+
+        self._handle(supervisor, GetTaskStateStore(ti_id=uuid.uuid4(), key="external_id"))
+
+        supervisor.send_msg.assert_called_once_with(err, request_id=7, error=None)
+
+    def test_set(self, supervisor):
+        ti_id = uuid.uuid4()
+        expires_at = timezone.utcnow()
+
+        self._handle(
+            supervisor,
+            SetTaskStateStore(ti_id=ti_id, key="external_id", value="job-123", expires_at=expires_at),
+        )
+
+        supervisor.client.task_state_store.set.assert_called_once_with(
+            ti_id, "external_id", "job-123", expires_at=expires_at
+        )
+        supervisor.send_msg.assert_called_once_with(OKResponse(ok=True), request_id=7, error=None)
+
+    def test_delete(self, supervisor):
+        ti_id = uuid.uuid4()
+
+        self._handle(supervisor, DeleteTaskStateStore(ti_id=ti_id, key="external_id"))
+
+        supervisor.client.task_state_store.delete.assert_called_once_with(ti_id, "external_id")
+        supervisor.send_msg.assert_called_once_with(OKResponse(ok=True), request_id=7, error=None)
+
+    def test_clear(self, supervisor):
+        ti_id = uuid.uuid4()
+
+        self._handle(supervisor, ClearTaskStateStore(ti_id=ti_id))
+
+        supervisor.client.task_state_store.clear.assert_called_once_with(ti_id)
+        supervisor.send_msg.assert_called_once_with(OKResponse(ok=True), request_id=7, error=None)
 
 
 class TestTriggerSupervisorAssetStateStore:

--- a/airflow-core/tests/unit/triggers/test_base_trigger.py
+++ b/airflow-core/tests/unit/triggers/test_base_trigger.py
@@ -22,7 +22,7 @@ from unittest.mock import create_autospec
 import pytest
 
 from airflow.sdk.bases.operator import BaseOperator
-from airflow.sdk.execution_time.context import AssetStateStoreAccessors
+from airflow.sdk.execution_time.context import AssetStateStoreAccessors, TaskStateStoreAccessor
 from airflow.triggers.base import BaseEventTrigger, BaseTrigger, StartTriggerArgs, TriggerEvent
 
 
@@ -276,6 +276,40 @@ def test_base_event_trigger_asset_state_store_independent_across_instances():
     b = _PlainEventTrigger(name="b")
     a.asset_state_store = create_autospec(AssetStateStoreAccessors, instance=True)
     assert b.asset_state_store is None
+
+
+def test_base_trigger_task_state_store_initialized_to_none():
+    """task_state_store is None before the triggerer injects one."""
+    trigger = DummyTrigger(name="Dummy Trigger")
+
+    assert trigger.task_state_store is None
+
+
+def test_base_trigger_task_state_store_can_be_set():
+    """task_state_store can be set once the Trigger is initialized."""
+    trigger = DummyTrigger(name="Dummy Trigger")
+
+    mock_store = create_autospec(TaskStateStoreAccessor, instance=True)
+    trigger.task_state_store = mock_store
+
+    assert trigger.task_state_store is mock_store
+
+
+def test_base_trigger_task_state_store_independent_across_instances():
+    """a.task_state_store does not impact b.task_state_store."""
+    a = DummyTrigger(name="Dummy Trigger")
+    b = DummyTrigger(name="Dummy Trigger")
+
+    a.task_state_store = create_autospec(TaskStateStoreAccessor, instance=True)
+
+    assert b.task_state_store is None
+
+
+def test_task_state_store_defaults_to_none_without_super_init():
+    """Being a class attribute is what keeps it readable on triggers that skip super().__init__()."""
+    trigger = _TriggerWithoutSuperInit(queue_url="https://sqs.example.com/queue")
+
+    assert trigger.task_state_store is None
 
 
 def test_create_shared_stream_producer_raises_by_default():

--- a/task-sdk/src/airflow/sdk/execution_time/request_handlers.py
+++ b/task-sdk/src/airflow/sdk/execution_time/request_handlers.py
@@ -35,6 +35,7 @@ from airflow.sdk.api.datamodels._generated import (
     ConnectionResponse,
     DagRunStateResponse,
     TaskStatesResponse,
+    TaskStateStoreResponse,
     VariableResponse,
     XComResponse,
     XComSequenceIndexResponse,
@@ -44,10 +45,12 @@ from airflow.sdk.execution_time.comms import (
     AssetStateStoreResult,
     ClearAssetStateStoreByName,
     ClearAssetStateStoreByUri,
+    ClearTaskStateStore,
     ConnectionResult,
     DagRunStateResult,
     DeleteAssetStateStoreByName,
     DeleteAssetStateStoreByUri,
+    DeleteTaskStateStore,
     DeleteVariable,
     DeleteXCom,
     GetAssetStateStoreByName,
@@ -58,6 +61,7 @@ from airflow.sdk.execution_time.comms import (
     GetPreviousDagRun,
     GetPreviousTI,
     GetTaskStates,
+    GetTaskStateStore,
     GetTICount,
     GetVariable,
     GetVariableKeys,
@@ -70,8 +74,10 @@ from airflow.sdk.execution_time.comms import (
     PutVariable,
     SetAssetStateStoreByName,
     SetAssetStateStoreByUri,
+    SetTaskStateStore,
     SetXCom,
     TaskStatesResult,
+    TaskStateStoreResult,
     VariableKeysResult,
     VariableResult,
     XComResult,
@@ -282,6 +288,38 @@ def handle_get_xcom(client: Client, msg: GetXCom) -> tuple[BaseModel | None, dic
         xcom_result = XComResult.from_xcom_response(xcom)
         return xcom_result, {"exclude_unset": True}
     return xcom, {}
+
+
+def handle_get_task_state_store(
+    client: Client, msg: GetTaskStateStore
+) -> tuple[BaseModel | None, dict[str, bool]]:
+    task_state = client.task_state_store.get(msg.ti_id, msg.key)
+
+    if isinstance(task_state, TaskStateStoreResponse):
+        return TaskStateStoreResult.from_task_state_store_response(task_state), {}
+
+    return task_state, {}
+
+
+def handle_set_task_state_store(
+    client: Client, msg: SetTaskStateStore
+) -> tuple[BaseModel | None, dict[str, bool]]:
+    client.task_state_store.set(msg.ti_id, msg.key, msg.value, expires_at=msg.expires_at)
+    return None, {}
+
+
+def handle_delete_task_state_store(
+    client: Client, msg: DeleteTaskStateStore
+) -> tuple[BaseModel | None, dict[str, bool]]:
+    client.task_state_store.delete(msg.ti_id, msg.key)
+    return None, {}
+
+
+def handle_clear_task_state_store(
+    client: Client, msg: ClearTaskStateStore
+) -> tuple[BaseModel | None, dict[str, bool]]:
+    client.task_state_store.clear(msg.ti_id)
+    return None, {}
 
 
 def handle_get_asset_state_store_by_name(

--- a/task-sdk/tests/task_sdk/execution_time/test_request_handlers.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_request_handlers.py
@@ -16,34 +16,45 @@
 # under the License.
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from unittest.mock import MagicMock
+from uuid import uuid4
 
 import pytest
 
 from airflow.sdk.api import client as sdk_client
-from airflow.sdk.api.datamodels._generated import AssetStateStoreResponse
+from airflow.sdk.api.datamodels._generated import AssetStateStoreResponse, TaskStateStoreResponse
 from airflow.sdk.exceptions import ErrorType
 from airflow.sdk.execution_time.comms import (
     AssetStateStoreResult,
     ClearAssetStateStoreByName,
     ClearAssetStateStoreByUri,
+    ClearTaskStateStore,
     DeleteAssetStateStoreByName,
     DeleteAssetStateStoreByUri,
+    DeleteTaskStateStore,
     ErrorResponse,
     GetAssetStateStoreByName,
     GetAssetStateStoreByUri,
+    GetTaskStateStore,
     SetAssetStateStoreByName,
     SetAssetStateStoreByUri,
+    SetTaskStateStore,
+    TaskStateStoreResult,
 )
 from airflow.sdk.execution_time.request_handlers import (
     handle_clear_asset_state_store_by_name,
     handle_clear_asset_state_store_by_uri,
+    handle_clear_task_state_store,
     handle_delete_asset_state_store_by_name,
     handle_delete_asset_state_store_by_uri,
+    handle_delete_task_state_store,
     handle_get_asset_state_store_by_name,
     handle_get_asset_state_store_by_uri,
+    handle_get_task_state_store,
     handle_set_asset_state_store_by_name,
     handle_set_asset_state_store_by_uri,
+    handle_set_task_state_store,
 )
 
 
@@ -163,5 +174,66 @@ def test_asset_store_delegates_to_client(client, handler, msg, call_kwargs, meth
     result, dump_opts = handler(client, msg(**call_kwargs))
 
     getattr(client.asset_state_store, method).assert_called_once_with(**call_kwargs)
+    assert result is None
+    assert dump_opts == {}
+
+
+def test_get_task_state_store_wraps_response_as_result(client):
+    ti_id = uuid4()
+    client.task_state_store.get.return_value = TaskStateStoreResponse(value="job-123")
+
+    result, dump_opts = handle_get_task_state_store(client, GetTaskStateStore(ti_id=ti_id, key="external_id"))
+
+    client.task_state_store.get.assert_called_once_with(ti_id, "external_id")
+    assert result == TaskStateStoreResult(value="job-123")
+    assert dump_opts == {}
+
+
+def test_get_task_state_store_passes_through_error_response(client):
+    err = ErrorResponse(error=ErrorType.TASK_STORE_NOT_FOUND, detail={"key": "external_id"})
+    client.task_state_store.get.return_value = err
+
+    result, dump_opts = handle_get_task_state_store(
+        client, GetTaskStateStore(ti_id=uuid4(), key="external_id")
+    )
+
+    assert result is err
+    assert dump_opts == {}
+
+
+def test_set_task_state_store_delegates_to_client(client):
+    ti_id = uuid4()
+    expires_at = datetime(2026, 6, 11, tzinfo=timezone.utc)
+
+    result, dump_opts = handle_set_task_state_store(
+        client,
+        SetTaskStateStore(ti_id=ti_id, key="external_id", value="job-123", expires_at=expires_at),
+    )
+
+    client.task_state_store.set.assert_called_once_with(
+        ti_id, "external_id", "job-123", expires_at=expires_at
+    )
+    assert result is None
+    assert dump_opts == {}
+
+
+def test_delete_task_state_store_delegates_to_client(client):
+    ti_id = uuid4()
+
+    result, dump_opts = handle_delete_task_state_store(
+        client, DeleteTaskStateStore(ti_id=ti_id, key="external_id")
+    )
+
+    client.task_state_store.delete.assert_called_once_with(ti_id, "external_id")
+    assert result is None
+    assert dump_opts == {}
+
+
+def test_clear_task_state_store_delegates_to_client(client):
+    ti_id = uuid4()
+
+    result, dump_opts = handle_clear_task_state_store(client, ClearTaskStateStore(ti_id=ti_id))
+
+    client.task_state_store.clear.assert_called_once_with(ti_id)
     assert result is None
     assert dump_opts == {}


### PR DESCRIPTION
… to be used on the Triggerer

## Description

This PR allows for the `TaskStateStoreAccessor` methods to be used on the Triggerer. A similar PR was opened to allow for `AssetStateStoreAccessor` methods to be used on the Triggerer when AIP-103 was being rolled out. This PR does something similar for Task State Store.

Both sync and async methods can be used on the Triggerer. Ideally, a user would leverage the asynchronous methods to prevent blocker operations.

## Use Cases

This functionality would allow for the following:

- "Durable execution"-like behavior for deferrable Operators
- "Durable execution"-like behavior for deferrable Sensors
- Allowing for deferred operations to survive a Triggerer crash

## Testing

To test these changes, the following was done:

- Authored and executed unit tests covering all changes made in this PR
- Testing E2E with a Trigger that writes data to Task state store (Trigger to be added below).

### Trigger for E2E Testing

```python
class GenericTrigger(BaseTrigger):
    def __init__(self, random_number, waiter_delay, **kwargs):
        super().__init__(**kwargs)

        self.random_number = random_number
        self.waiter_delay = waiter_delay

    def serialize(self) -> tuple[str, dict[str, Any]]:
        """Serialize the Trigger, including the func, params, and waiter_delay."""
        return (
            self.__class__.__module__ + "." + self.__class__.__qualname__,
            {
                "random_number": self.random_number,
                "waiter_delay": self.waiter_delay,
            },
        )

    async def run(self) -> AsyncIterator[TriggerEvent]:
        """Logic that fires a TriggerEvent."""
        task_state_store = self.task_state_store

        while True:
            # Get the previous number
            last_result = task_state_store.get("result", -1)  # Synchronous just to illustrate

            # Create a new number
            result = random.randint(0, 5)
            task_state_store.aset("result", result)

            if result == self.random_number:
                yield TriggerEvent({"status": "success", "result": result})
                break

            await asyncio.sleep(self.waiter_delay)
```

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Unit-tests written by: [Claude Opus 5] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

